### PR TITLE
chore: add dev branch + pre-release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
     if: >
       (github.event_name == 'release' && github.event.release.target_commitish == 'main') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.ref == 'refs/heads/main') ||
-      startsWith(github.ref, 'refs/tags/v')
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -65,7 +65,26 @@ jobs:
       - name: Build
         run: pnpm turbo build --filter='./packages/*'
 
+      - name: Determine npm dist-tag
+        id: dist-tag
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG=""
+          if echo "$VERSION" | grep -q "-"; then
+            PRERELEASE="${VERSION#*-}"
+            PRERELEASE_TAG="${PRERELEASE%%.*}"
+            case "$PRERELEASE_TAG" in
+              alpha|beta|rc|next) TAG="$PRERELEASE_TAG" ;;
+              "") TAG="latest" ;;
+              *) TAG="$PRERELEASE_TAG" ;;
+            esac
+          else
+            TAG="latest"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Publishing $VERSION with tag: $TAG"
+
       - name: Publish framework packages
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm --filter='./packages/*' publish --access public --no-git-checks
+        run: pnpm --filter='./packages/*' publish --access public --no-git-checks --tag ${{ steps.dist-tag.outputs.tag }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,10 +229,10 @@ gh pr create --title "feat: print route table on startup" --body "Closes #31"
 
 ### Commit convention
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
-- `feat:` → minor version bump
-- `fix:` → patch version bump
-- `docs:`, `chore:`, `test:`, `ci:` → no version bump
+Follow [Conventional Commits](https://www.conventionalcommits.org/). Commit types categorize changes and guide the explicit version bump when running `node scripts/release.js <patch|minor|major>`:
+- `feat:` — generally corresponds to a minor version bump
+- `fix:` — generally corresponds to a patch version bump
+- `docs:`, `chore:`, `test:`, `ci:` — usually no version bump
 
 Reference issue numbers: `feat: add helmet middleware (#21)`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,9 +124,11 @@ Every controller method receives `ctx: RequestContext` with:
 ### Built-in Middleware
 
 ```ts
-import { helmet, cors, requestId, requestLogger, csrf, rateLimit, validate, upload } from '@forinda/kickjs-http'
+import express from 'express'
+import { bootstrap, helmet, cors, requestId, requestLogger, csrf, rateLimit } from '@forinda/kickjs-http'
 
 bootstrap({
+  modules: [/* your modules */],
   middleware: [
     helmet(),           // Security headers (X-Frame-Options, HSTS, etc.)
     cors({ origin: ['https://app.example.com'] }),  // CORS with spec-correct behavior
@@ -139,15 +141,22 @@ bootstrap({
 })
 ```
 
+Also available: `validate()` (Zod body/query/params), `upload()` (multer file handling), `session()` (cookie sessions).
+
 ### Git Workflow
 
-Use feature branches — never commit directly to `main`:
+Use feature branches — never commit directly to `main` or `dev`:
+- **Stable work** → branch from `main`, PR to `main`
+- **Experimental work** → branch from `dev`, PR to `dev`
+- **Promote** → PR `dev` → `main` when stable
+
 ```bash
+git checkout main && git pull origin main
 git checkout -b feat/my-feature
 # ... make changes ...
 git commit -m "feat: description (#issue)"
 git push -u origin feat/my-feature
-gh pr create
+gh pr create --base main
 ```
 
 ## CLI Architecture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,25 +169,50 @@ kickjs/
 
 We follow a **feature branch workflow**:
 
-1. **Main branch**:
-   - `main`: Stable, production-ready code. All PRs target `main`.
+1. **Long-lived branches**:
+   - `main`: Stable, production-ready code. Published as `latest` on npm.
+   - `dev`: Pre-release channel. Published as `alpha`/`beta` on npm.
 
-2. **Feature branches** (branched from `main`):
+2. **Feature branches** (auto-deleted after PR merge):
    - `feat/feature-name`: New features
    - `fix/bug-description`: Bug fixes
    - `docs/documentation-update`: Documentation updates
    - `chore/maintenance-task`: Maintenance, deps, CI
 
-Branches are auto-deleted after PR merge.
+### Release Channels
+
+| Target | Command | npm tag | Example |
+|--------|---------|---------|---------|
+| `main` | `pnpm release:patch` | `latest` | `1.4.1` |
+| `main` | `pnpm release:minor` | `latest` | `1.5.0` |
+| `dev` | `pnpm release:alpha` | `alpha` | `1.5.0-alpha.0` |
+| `dev` | `pnpm release:beta` | `beta` | `1.5.0-beta.0` |
+| `dev` | `node scripts/release.js prerelease --tag rc` | `rc` | `1.5.0-rc.0` |
+
+When `dev` is stable, create a PR to `main` and do a full release.
 
 ### Workflow Steps
 
-1. **Create a feature branch from main**:
-   ```bash
-   git checkout main
-   git pull origin main
-   git checkout -b feat/amazing-feature
-   ```
+**Stable work (target: main):**
+```bash
+git checkout main && git pull origin main
+git checkout -b feat/amazing-feature
+# ... make changes, commit, push ...
+gh pr create --base main
+```
+
+**Experimental work (target: dev):**
+```bash
+git checkout dev && git pull origin dev
+git checkout -b feat/experimental-feature
+# ... make changes, commit, push ...
+gh pr create --base dev
+```
+
+**Promote dev to main:**
+```bash
+gh pr create --base main --head dev --title "Release: merge dev into main"
+```
 
 2. **Make your changes**:
    - Write code following our standards

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,43 +19,68 @@
 5. GitHub `NPM_TOKEN` secret set (for CI-triggered publishes):
    - Repo Settings > Secrets > Actions > `NPM_TOKEN`
 
-## Release Commands
+## Interactive Release (recommended)
+
+Run the release script with no arguments for a guided experience:
 
 ```bash
-# Preview what will happen (no changes made)
-node scripts/release.js patch --dry-run
-node scripts/release.js minor --dry-run
-node scripts/release.js custom 0.3.0 --dry-run
+node scripts/release.js
+```
 
-# Patch release: 0.1.0 -> 0.1.1
-pnpm release:patch
+It will prompt you through:
+1. **Release type** — patch, minor, major, prerelease, or custom
+2. **Pre-release channel** — alpha, beta, rc (if prerelease)
+3. **Options** — dry run, push, publish, GitHub release
+4. **Confirmation** — review summary before executing
 
-# Minor release: 0.1.0 -> 0.2.0
-pnpm release:minor
+## Non-Interactive Commands
 
-# Major release: 0.1.0 -> 1.0.0
-pnpm release:major
+Pass arguments directly to skip prompts:
 
-# With GitHub release (creates gh release with release notes)
+```bash
+# Stable releases (from main)
+pnpm release:patch                    # 1.4.0 → 1.4.1
+pnpm release:minor                    # 1.4.0 → 1.5.0
+pnpm release:major                    # 1.4.0 → 2.0.0
+
+# With GitHub release
 pnpm release:patch:gh
 pnpm release:minor:gh
-pnpm release:major:gh
 
-# Pre-release: 0.1.0 -> 0.1.1-alpha.0
-pnpm release:alpha
-pnpm release:beta
+# Pre-releases (from main or dev)
+pnpm release:alpha                    # 1.4.0 → 1.4.1-alpha.0
+pnpm release:beta                     # 1.4.0 → 1.4.1-beta.0
+node scripts/release.js prerelease --tag rc   # 1.4.0 → 1.4.1-rc.0
 
 # Custom version
-node scripts/release.js custom 0.3.0
-node scripts/release.js custom 1.0.0-rc.1
+node scripts/release.js custom 2.0.0-rc.1
 
-# Custom version with GitHub release
-node scripts/release.js custom 0.3.0 --github-release
+# Preview (no changes)
+node scripts/release.js patch --dry-run
+```
+
+## Branching Model
+
+| Branch | Purpose | npm tag | Release from |
+|--------|---------|---------|--------------|
+| `main` | Stable releases | `latest` | `pnpm release:patch/minor/major` |
+| `dev` | Pre-releases | `alpha`/`beta`/`rc` | `pnpm release:alpha/beta` |
+
+**Flow:**
+1. Feature branches → PR → `dev` (experimental) or `main` (stable)
+2. Pre-release from `dev`: `pnpm release:alpha`
+3. When stable: PR `dev` → `main`, then `pnpm release:minor`
+
+Users install:
+```bash
+pnpm add @forinda/kickjs-core                    # latest stable
+pnpm add @forinda/kickjs-core@alpha              # latest alpha
+pnpm add @forinda/kickjs-core@1.5.0-beta.0       # specific pre-release
 ```
 
 ## What the Release Script Does
 
-1. **Bumps version** in all 12 `package.json` files (6 packages + 6 examples)
+1. **Bumps version** in all `package.json` files (19 packages + 10 examples)
 2. **Generates release notes** from git log with commit hashes and contributors
 3. **Builds** all packages (`pnpm build`)
 4. **Runs tests** (`pnpm test`)
@@ -63,7 +88,7 @@ node scripts/release.js custom 0.3.0 --github-release
 6. **Tags**: `vX.Y.Z` (annotated)
 7. **Pushes** to remote with tags
 8. **Creates GitHub release** (if `--github-release`) via `gh` CLI with release notes
-9. **Publishes** all 6 `@forinda/kickjs-*` packages to npm
+9. **Publishes** all `@forinda/kickjs-*` packages to npm with the correct dist-tag derived from the version (`latest` for stable, `alpha`/`beta`/`rc` for pre-releases) — both locally and in CI
 
 ## Options
 
@@ -111,10 +136,16 @@ pnpm release:major:gh    # breaking changes + GH release
 
 The GitHub Actions release workflow auto-publishes when:
 - A `v*` tag is pushed (triggered by the release script)
-- A GitHub Release is published manually
+- A GitHub Release targeting `main` is published manually
 - Manual dispatch with `publish: true`
 
-The CI runs `pnpm -r publish --access public --no-git-checks` using the `NPM_TOKEN` secret.
+Note: manual GitHub Releases targeting `dev` do not auto-publish — the workflow is gated on `target_commitish == 'main'`. Pre-releases from `dev` should be triggered via tags (`v*-alpha.*`, `v*-beta.*`).
+
+The CI auto-detects the npm dist-tag from the version:
+- `1.5.0` → publishes as `latest`
+- `1.5.0-alpha.0` → publishes as `alpha`
+- `1.5.0-beta.0` → publishes as `beta`
+- `1.5.0-rc.0` → publishes as `rc`
 
 ## Versioning Strategy
 
@@ -130,14 +161,18 @@ All packages use **lockstep versioning** — every package shares the same versi
 
 ## Published Packages
 
+All 19 `@forinda/kickjs-*` packages are published with lockstep versioning. Key packages:
+
 | Package | Description |
 |---------|-------------|
 | `@forinda/kickjs-core` | DI container, decorators, module system, logger |
-| `@forinda/kickjs-http` | Express 5 app, middleware, query parsing |
+| `@forinda/kickjs-http` | Express 5 app, middleware (helmet, cors, csrf, upload, rate-limit), query parsing |
 | `@forinda/kickjs-config` | Zod env validation, ConfigService |
 | `@forinda/kickjs-swagger` | OpenAPI spec, Swagger UI, ReDoc |
 | `@forinda/kickjs-cli` | CLI binary, generators, custom commands |
-| `@forinda/kickjs-testing` | Test utilities |
+| `@forinda/kickjs-testing` | Test utilities (createTestApp, createTestModule) |
+
+Plus: auth, cron, devtools, drizzle, graphql, mailer, multi-tenant, notifications, otel, prisma, queue, ws, vscode-extension
 
 Examples are **not published** — they exist for reference only.
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -104,6 +104,18 @@ function getCurrentVersion() {
   return readJson('packages/core/package.json').version
 }
 
+/** Derive the npm dist-tag from a version string */
+function getDistTag(version) {
+  if (!version.includes('-')) return 'latest'
+  const match = version.match(/-([0-9A-Za-z-]+)(?:\.|$)/)
+  if (!match) {
+    throw new Error(
+      `Unsupported prerelease version format "${version}". Expected a valid semver prerelease like "1.2.3-alpha" or "1.2.3-alpha.0".`,
+    )
+  }
+  return match[1]
+}
+
 function bumpVersion(current, type, tag = 'alpha') {
   const match = current.match(/^(\d+)\.(\d+)\.(\d+)(?:-([a-z]+)\.(\d+))?$/)
   if (!match) throw new Error(`Cannot parse version: ${current}`)
@@ -300,10 +312,142 @@ function generateReleaseNotes(version, fromRef) {
   return notes
 }
 
+// ── Interactive Prompt ──────────────────────────────────────────────────
+
+const readline = require('readline')
+
+function ask(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close()
+      resolve(answer.trim())
+    })
+  })
+}
+
+async function interactiveRelease() {
+  const currentVersion = getCurrentVersion()
+  const branch = exec('git branch --show-current')
+
+  console.log('\n🚀 KickJS Interactive Release')
+  console.log('='.repeat(50))
+  console.log(`  Current version: ${currentVersion}`)
+  console.log(`  Branch:          ${branch}`)
+  console.log(`  Packages:        ${PACKAGES.length} framework + ${EXAMPLES.length} examples`)
+  console.log('='.repeat(50))
+
+  // 1. Release type
+  console.log('\n  Release type:')
+  console.log('    1) patch       — Bug fixes')
+  console.log('    2) minor       — New features')
+  console.log('    3) major       — Breaking changes')
+  console.log('    4) prerelease  — Alpha/beta/rc')
+  console.log('    5) custom      — Set exact version')
+
+  const typeChoice = await ask('\n  Choose (1-5): ')
+  const typeMap = { '1': 'patch', '2': 'minor', '3': 'major', '4': 'prerelease', '5': 'custom' }
+  const releaseType = typeMap[typeChoice]
+  if (!releaseType) {
+    console.error('  Invalid choice.')
+    process.exit(1)
+  }
+
+  // 2. Pre-release tag (if prerelease)
+  let preTag = 'alpha'
+  if (releaseType === 'prerelease') {
+    console.log('\n  Pre-release channel:')
+    console.log('    1) alpha')
+    console.log('    2) beta')
+    console.log('    3) rc')
+    console.log('    4) custom')
+    const tagChoice = await ask('\n  Choose (1-4): ')
+    const tagMap = { '1': 'alpha', '2': 'beta', '3': 'rc' }
+    if (tagChoice === '4') {
+      preTag = await ask('  Custom tag: ')
+      if (!preTag || !/^[a-z]+$/.test(preTag)) {
+        console.error('  Invalid tag. Must be lowercase letters only (e.g. next, canary, dev).')
+        process.exit(1)
+      }
+    } else {
+      preTag = tagMap[tagChoice] || 'alpha'
+    }
+  }
+
+  // 3. Custom version (if custom)
+  let customVersion = null
+  if (releaseType === 'custom') {
+    customVersion = await ask('\n  Enter version (e.g. 2.0.0-rc.1): ')
+    if (!/^\d+\.\d+\.\d+(-[a-zA-Z0-9]+(\.\d+)?)?$/.test(customVersion)) {
+      console.error('  Invalid version format. Expected: X.Y.Z, X.Y.Z-tag, or X.Y.Z-tag.N (e.g. 2.0.0, 1.5.0-alpha, 1.5.0-rc.1)')
+      process.exit(1)
+    }
+  }
+
+  const nextVersion = releaseType === 'custom'
+    ? customVersion
+    : bumpVersion(currentVersion, releaseType, preTag)
+
+  // 4. Options
+  console.log(`\n  Version: ${currentVersion} → ${nextVersion}`)
+  const dryRunAnswer = await ask('  Dry run? (y/N): ')
+  const dryRun = dryRunAnswer.toLowerCase() === 'y'
+
+  // In dry-run mode, nothing is pushed or published — reflect that in the summary
+  let noPush = dryRun
+  let noPublish = dryRun
+  let githubRelease = false
+
+  if (!dryRun) {
+    const pushAnswer = await ask('  Push to remote? (Y/n): ')
+    noPush = pushAnswer.toLowerCase() === 'n'
+
+    const publishAnswer = await ask('  Publish to npm? (Y/n): ')
+    noPublish = publishAnswer.toLowerCase() === 'n'
+
+    const ghAnswer = await ask('  Create GitHub release? (Y/n): ')
+    githubRelease = ghAnswer.toLowerCase() !== 'n'
+  }
+
+  // Summary
+  console.log('\n' + '='.repeat(50))
+  console.log('  Release Summary:')
+  console.log(`    Type:            ${releaseType}${releaseType === 'prerelease' ? ` (${preTag})` : ''}`)
+  console.log(`    Version:         ${currentVersion} → ${nextVersion}`)
+  console.log(`    Dry run:         ${dryRun ? 'yes' : 'no'}`)
+  console.log(`    Push:            ${noPush ? 'no' : 'yes'}`)
+  console.log(`    Publish to npm:  ${noPublish ? 'no' : 'yes'}`)
+  console.log(`    GitHub release:  ${githubRelease ? 'yes' : 'no'}`)
+  console.log('='.repeat(50))
+
+  const confirm = await ask('\n  Proceed? (y/N): ')
+  if (confirm.toLowerCase() !== 'y') {
+    console.log('  Aborted.')
+    process.exit(0)
+  }
+
+  // Build the equivalent args and call main logic
+  const fakeArgs = [releaseType]
+  if (releaseType === 'custom') fakeArgs.push(nextVersion)
+  if (dryRun) fakeArgs.push('--dry-run')
+  if (noPush) fakeArgs.push('--no-push')
+  if (noPublish) fakeArgs.push('--no-publish')
+  if (githubRelease) fakeArgs.push('--github-release')
+  if (releaseType === 'prerelease') fakeArgs.push('--tag', preTag)
+
+  return fakeArgs
+}
+
 // ── Main ────────────────────────────────────────────────────────────────
 
-function main() {
-  const args = process.argv.slice(2)
+async function main() {
+  let args = process.argv.slice(2)
+
+  // Interactive mode when no args provided
+  if (args.length === 0) {
+    args = await interactiveRelease()
+  }
+
   const releaseType = args[0]
   const dryRun = args.includes('--dry-run')
   const noPush = args.includes('--no-push')
@@ -330,15 +474,22 @@ function main() {
     console.log('  --github-release   Create GitHub release via gh CLI')
     console.log('  --tag <name>       Prerelease tag (default: alpha)')
     console.log('  --from <ref>       Generate notes from this git ref\n')
+    console.log('Or run with no arguments for interactive mode.\n')
     console.log('Examples:')
+    console.log('  node scripts/release.js               # interactive')
     console.log('  node scripts/release.js patch')
     console.log('  node scripts/release.js minor --dry-run')
     console.log('  node scripts/release.js prerelease --tag beta')
-    console.log('  node scripts/release.js custom 1.0.0-rc.1\n')
-    console.log('Shorthand (from package.json):')
-    console.log('  pnpm release:patch')
-    console.log('  pnpm release:minor')
-    console.log('  pnpm release:major')
+    console.log('')
+    console.log('Shorthand via pnpm scripts:')
+    console.log('  pnpm release:patch       # patch bump')
+    console.log('  pnpm release:minor       # minor bump')
+    console.log('  pnpm release:major       # major bump')
+    console.log('  pnpm release:patch:gh    # patch + GitHub release')
+    console.log('  pnpm release:minor:gh    # minor + GitHub release')
+    console.log('  pnpm release:major:gh    # major + GitHub release')
+    console.log('  pnpm release:alpha       # alpha prerelease')
+    console.log('  pnpm release:beta        # beta prerelease')
     process.exit(1)
   }
 
@@ -368,9 +519,10 @@ function main() {
   // Pre-flight
   if (!dryRun) {
     const branch = exec('git branch --show-current')
-    if (branch !== 'main') {
-      console.error(`\nError: Releases must be made from the main branch. Current branch: ${branch}`)
-      console.error('  Merge your changes to main first, then run the release from there.')
+    const isPrerelease = nextVersion.includes('-')
+    const allowedBranches = isPrerelease ? ['main', 'dev'] : ['main']
+    if (!allowedBranches.includes(branch)) {
+      console.error(`\nError: ${isPrerelease ? 'Pre-releases' : 'Stable releases'} must be made from ${allowedBranches.join(' or ')}. Current branch: ${branch}`)
       process.exit(1)
     }
 
@@ -405,7 +557,7 @@ function main() {
     console.log(`  7. git tag v${nextVersion}`)
     if (!noPush) console.log('  8. git push --follow-tags')
     if (githubRelease) console.log(`  9. gh release create v${nextVersion} --title "v${nextVersion}" --notes-file RELEASE_NOTES_v${nextVersion}.md`)
-    if (!noPublish) console.log(`  ${githubRelease ? '10' : '9'}. pnpm --filter='./packages/*' publish --access public --no-git-checks`)
+    if (!noPublish) console.log(`  ${githubRelease ? '10' : '9'}. pnpm --filter='./packages/*' publish --access public --no-git-checks --tag ${getDistTag(nextVersion)}`)
     return
   }
 
@@ -499,7 +651,8 @@ function main() {
 
   // Publish
   if (!noPublish) {
-    run("pnpm --filter='./packages/*' publish --access public --no-git-checks", 'Publishing to npm')
+    const distTag = getDistTag(nextVersion)
+    run(`pnpm --filter='./packages/*' publish --access public --no-git-checks --tag ${distTag}`, `Publishing to npm (dist-tag: ${distTag})`)
   } else {
     console.log('\n  Skipped publish (--no-publish)')
   }
@@ -526,4 +679,7 @@ function main() {
   }
 }
 
-main()
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- Branching model: `main` (stable/latest) + `dev` (alpha/beta pre-releases)
- CI runs on both `main` and `dev` branches + PRs
- Release workflow auto-detects alpha/beta in version → publishes with correct npm dist-tag
- Updated CONTRIBUTING.md, CLAUDE.md, AGENTS.md with full workflow docs
- Fixed Copilot review comments (missing imports, clarified commit conventions)

## After merge
Create the `dev` branch:
```bash
git checkout main && git pull
git checkout -b dev && git push -u origin dev
```

## Test plan
- [x] Build passes
- [x] All tests pass
- [x] Format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)