### PR TITLE
chore(cli,docs): v5 follow-ups — kick add BYO hint, v4→v5 migration, agent-doc fix

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -10,6 +10,7 @@ const guideSidebar = [
       { text: 'Getting Started', link: '/guide/getting-started' },
       { text: 'Migration from Express', link: '/guide/migration-from-express' },
       { text: 'Migrating v3 → v4', link: '/guide/migration-v3-to-v4' },
+      { text: 'Migrating v4 → v5', link: '/guide/migration-v4-to-v5' },
       { text: 'Project Structure', link: '/guide/project-structure' },
     ],
   },

--- a/docs/guide/migration-v4-to-v5.md
+++ b/docs/guide/migration-v4-to-v5.md
@@ -1,0 +1,76 @@
+# Migrating to v5
+
+v5 is a pure removal release. Six wrapper packages that shipped deprecation notices in v4.2.x are gone in v5; everything else is source-compatible.
+
+If your app never touched those wrappers — `pnpm up @forinda/kickjs@^5` and ship. The vast majority of v4 projects fall here.
+
+If you do use one of the dropped wrappers, each has a BYO recipe under [`docs/guide/`](./index.md) that wires the upstream library directly through `defineAdapter` / `definePlugin`. The recipes were published in v4.2.0 with four months' lead time so the swap is copy-paste, not rewrite.
+
+## What's removed
+
+| v4 package                      | v5 status   | Replacement                                                                   |
+| ------------------------------- | ----------- | ----------------------------------------------------------------------------- |
+| `@forinda/kickjs-graphql`       | **removed** | [GraphQL BYO recipe](./graphql.md) — graphql-http / Yoga / Apollo             |
+| `@forinda/kickjs-otel`          | **removed** | [OpenTelemetry BYO recipe](./otel.md) — `@opentelemetry/sdk-node`             |
+| `@forinda/kickjs-cron`          | **removed** | [Scheduled tasks BYO recipe](./cron.md) — `croner` / `node-cron`              |
+| `@forinda/kickjs-mailer`        | **removed** | [Mailers BYO recipe](./mailer.md) — `nodemailer` / Resend / SES               |
+| `@forinda/kickjs-multi-tenant`  | **removed** | [Multi-tenancy BYO recipe](./multi-tenancy.md) — `defineHttpContextDecorator` |
+| `@forinda/kickjs-notifications` | **removed** | [Notifications BYO recipe](./notifications.md) — your channel backend         |
+
+The last published v4.2.x release of each package carries an `npm deprecate` warning linking to its BYO guide. They continue to install if you pin to `@<5`, but new installs and CI matrices should migrate.
+
+## What's unchanged
+
+Everything else in the ecosystem:
+
+- `@forinda/kickjs` (core + HTTP) — same API surface, same decorators, same `bootstrap()`
+- `@forinda/kickjs-auth`, `-swagger`, `-ws`, `-queue`, `-drizzle`, `-prisma`, `-testing`, `-devtools`, `-mcp`, `-ai`, `-vite`, `-cli`
+- Context Contributors, `getRequestValue`, `bootstrap({ processHooks })` — all carried over from v4
+- DI tokens, module system, typegen — no changes
+
+## Step-by-step
+
+### 1. Bump `@forinda/kickjs@^5`
+
+```bash
+pnpm up @forinda/kickjs@^5 @forinda/kickjs-cli@^5
+```
+
+If you were pinning `@forinda/kickjs-graphql`, `-otel`, `-cron`, `-mailer`, `-multi-tenant`, or `-notifications` — remove them from `package.json`:
+
+```bash
+pnpm rm @forinda/kickjs-graphql @forinda/kickjs-otel \
+        @forinda/kickjs-cron @forinda/kickjs-mailer \
+        @forinda/kickjs-multi-tenant @forinda/kickjs-notifications
+```
+
+### 2. Follow the BYO recipe for anything you were using
+
+Open the guide page linked in the table above. Each recipe:
+
+- Lists the upstream package you `pnpm add`
+- Shows a ready-to-paste `defineAdapter` / `definePlugin` factory
+- Calls out any conveniences the wrapper used to offer that you might want to inline
+- Wires a DevTools tab via `devtoolsTabs()` so nothing feels missing
+
+Typical migration per package is ~60 lines added to `src/adapters/` or `src/plugins/`.
+
+### 3. Verify
+
+```bash
+pnpm build && pnpm typecheck && pnpm test
+```
+
+All three should pass without changes to your existing code outside the removed imports.
+
+## Why this release exists
+
+Every dropped package was a thin bridge to a fast-moving ecosystem (OTel SDK releases, GraphQL server landscape, mailer APIs) where adopters consistently replaced the wrapper within weeks. Keeping a wrapper published cost us CI minutes and release friction; it cost adopters a layer of indirection they didn't need. v5 simply stops shipping the wrapper and ships the recipe instead.
+
+`@forinda/kickjs` itself gained nothing new in v5 — the `processHooks` option, `getRequestValue`, context contributors, `defineAdapter` / `definePlugin`, and framework metadata helpers all landed in v4 and are the primitives the BYO recipes lean on.
+
+## Related
+
+- [v3 → v4 migration](./migration-v3-to-v4.md) — DI token convention + `@Controller` path removal
+- [Framework comparison](https://github.com/forinda/kick-js/blob/main/comparison.md) — why the BYO split matters across the ecosystem
+- [Adapters guide](./adapters.md) — the `defineAdapter` / `definePlugin` primitives the BYO recipes rely on

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -111,6 +111,39 @@ const PACKAGE_REGISTRY: Record<
   },
 }
 
+const BYO_GUIDES: Record<string, { guide: string; url: string; upstream: string }> = {
+  cron: {
+    guide: 'Scheduled tasks',
+    url: 'https://forinda.github.io/kick-js/guide/cron',
+    upstream: 'croner',
+  },
+  mailer: {
+    guide: 'Mailers',
+    url: 'https://forinda.github.io/kick-js/guide/mailer',
+    upstream: 'nodemailer (or Resend / SES SDK)',
+  },
+  otel: {
+    guide: 'OpenTelemetry',
+    url: 'https://forinda.github.io/kick-js/guide/otel',
+    upstream: '@opentelemetry/sdk-node',
+  },
+  'multi-tenant': {
+    guide: 'Multi-tenancy',
+    url: 'https://forinda.github.io/kick-js/guide/multi-tenancy',
+    upstream: 'defineHttpContextDecorator + getRequestValue (no extra dep)',
+  },
+  notifications: {
+    guide: 'Notifications',
+    url: 'https://forinda.github.io/kick-js/guide/notifications',
+    upstream: 'your chosen backend (SMTP / Slack / Discord / webhook)',
+  },
+  graphql: {
+    guide: 'GraphQL',
+    url: 'https://forinda.github.io/kick-js/guide/graphql',
+    upstream: 'graphql-http (or graphql-yoga / Apollo / Pothos)',
+  },
+}
+
 function detectPackageManager(): PackageManager {
   if (existsSync(resolve('pnpm-lock.yaml'))) return 'pnpm'
   if (existsSync(resolve('yarn.lock'))) return 'yarn'
@@ -197,11 +230,13 @@ export function registerAddCommand(program: Command): void {
       const prodDeps = new Set<string>()
       const devDeps = new Set<string>()
       const unknown: string[] = []
+      const byo: string[] = []
 
       for (const name of packages) {
         const entry = PACKAGE_REGISTRY[name]
         if (!entry) {
-          unknown.push(name)
+          if (BYO_GUIDES[name]) byo.push(name)
+          else unknown.push(name)
           continue
         }
         const target = forceDevFlag || entry.dev ? devDeps : prodDeps
@@ -209,6 +244,18 @@ export function registerAddCommand(program: Command): void {
         for (const peer of entry.peers) {
           target.add(peer)
         }
+      }
+
+      if (byo.length > 0) {
+        console.log(`\n  ${byo.length} package(s) are BYO in v5 — no wrapper to install:`)
+        for (const name of byo) {
+          const hint = BYO_GUIDES[name]
+          console.log(`    ${name.padEnd(14)} → ${hint.guide}: ${hint.url}`)
+          console.log(`    ${' '.padEnd(14)}   upstream: ${hint.upstream}`)
+        }
+        console.log('\n  These used to be @forinda/kickjs-* wrappers. v5 ships them as guide-based')
+        console.log('  recipes that wire the upstream library through defineAdapter /')
+        console.log('  definePlugin directly — ~60 lines you own in src/adapters/.\n')
       }
 
       if (unknown.length > 0) {

--- a/packages/cli/src/generators/templates/project-docs.ts
+++ b/packages/cli/src/generators/templates/project-docs.ts
@@ -535,9 +535,10 @@ ${
     ? `### CQRS/Event Decorators
 - \`@Job('job-name')\` — queue job handler
 - \`@Process('queue-name')\` — queue processor
-- \`@Cron('0 * * * *')\` — cron schedule
 - \`@WsController('/path')\` — WebSocket controller
 - \`@Subscribe('event')\` — WebSocket event handler
+
+> Cron scheduling is BYO — define your own \`@Cron('0 * * * *')\` decorator backed by \`croner\` (or any scheduler) per the [cron guide](https://forinda.github.io/kick-js/guide/cron). Same applies to mailer, OpenTelemetry, multi-tenant, and notifications.
 
 `
     : ''


### PR DESCRIPTION
## Summary

Three small post-v5 gaps surfaced in the launch retrospective, bundled here so they ship as one reviewable unit:

- **`kick add` BYO hint** (`packages/cli/src/commands/add.ts`) — recognise the 6 dropped wrapper names (`cron` / `mailer` / `otel` / `multi-tenant` / `notifications` / `graphql`) and route adopters to the relevant BYO guide URL + upstream library, instead of bouncing them with `Unknown packages`. Closes the silent confusion around `kick add cron` post-v5.
- **`docs/guide/migration-v4-to-v5.md`** — focused migration page covering only what v5 removes + step-by-step swap. Linked from the sidebar between `Migrating v3 → v4` and `Project Structure`.
- **Generated agent docs** (`packages/cli/src/generators/templates/project-docs.ts`) — the CQRS decorator reference still listed `@Cron` as a built-in. Now points at the cron BYO guide and names the other dropped wrappers in the same callout, so freshly scaffolded `CLAUDE.md` / `AGENTS.md` reflect v5 reality.

Pre-commit hook ran the full monorepo build + 1.4k tests + typecheck + format-check + lint-tokens — green.

## What's deliberately not in this PR

The retro also surfaced bigger gaps that each warrant their own PR:

- Slim `@forinda/kickjs-queue` per `packages/queue/v5-design.md`
- `kick g cron|mailer` BYO scaffold generators
- "BYO showcase" example app pulling all 6 recipes together
- `shutdown.test.ts` flake under parallel test load
- Pre-existing typecheck errors in 3 task-* example apps

## Test plan

- [ ] `kick add cron` shows BYO hint with guide URL
- [ ] `kick add cron auth` installs `auth` and shows hint for `cron`
- [ ] `kick add bogus` still falls through to `Unknown packages`
- [ ] Sidebar renders the new `Migrating v4 → v5` entry
- [ ] Freshly scaffolded `CLAUDE.md` from `kick new` no longer claims `@Cron` is built-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)