### PR TITLE
feat(db+cli): toDriver auto-apply, kick add workspace fix, kick new --yes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,17 +138,24 @@ Do NOT consider a feature complete until its docs are written and the sidebar is
 # Build the CLI first
 pnpm build
 
-# Scaffold from examples/ directory — pass all flags to avoid interactive prompts
+# Scaffold from examples/ directory
 cd examples
+# Fastest — `--yes` picks defaults (template=minimal, repo=inmemory, no extras,
+# pm resolved from corepack/lockfile). Add explicit flags to override any default.
+node ../packages/cli/bin.js new upload-api --yes --no-install --force
+
+# Or specify each flag for a non-default scaffold
 node ../packages/cli/bin.js new upload-api \
-  --template ddd --pm pnpm --repo inmemory --no-git --no-install --force
+  --template ddd --pm pnpm --repo prisma --no-git --no-install --force
 
 # Generate modules inside the example
 cd upload-api
 node ../../packages/cli/bin.js g module upload
 ```
 
-Available flags for `new`: `--template rest|graphql|ddd|cqrs|minimal`, `--pm pnpm|npm|yarn`, `--repo prisma|drizzle|inmemory|custom`, `--no-git`, `--no-install`, `--force`.
+`--yes` (alias `--non-interactive`, short `-y`) bypasses every prompt. Without it, missing flags trigger interactive selection.
+
+Available flags for `new`: `--template rest|ddd|cqrs|minimal`, `--pm pnpm|npm|yarn|bun`, `--repo prisma|drizzle|inmemory|custom`, `--packages auth,swagger,...`, `--no-git`, `--no-install`, `--force`, `-y / --yes / --non-interactive`.
 
 After scaffolding, customize the generated code for the example's purpose.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,13 +108,20 @@ Use the built CLI to scaffold — never create files manually.
 # 1. Build CLI first (if not already built)
 pnpm build
 
-# 2. Scaffold from examples/ directory (all flags required to avoid interactive prompts)
+# 2. Scaffold from examples/ directory
 cd examples
+# Fastest — name + --yes picks all defaults (template=minimal, repo=inmemory,
+# no extras, git+install on, pm resolved from corepack/lockfile)
+node ../packages/cli/bin.js new my-example-api --yes --no-install --force
+
+# Or specify each flag explicitly when you want a non-default template/repo
 node ../packages/cli/bin.js new my-example-api \
-  --template minimal --pm pnpm --repo inmemory --no-git --no-install --force
+  --template ddd --pm pnpm --repo prisma --no-git --no-install --force
 ```
 
-Available flags: `--template rest|graphql|ddd|cqrs|minimal`, `--pm pnpm|npm|yarn`, `--repo prisma|drizzle|inmemory|custom`, `--no-git`, `--no-install`, `--force`.
+`--yes` (alias `--non-interactive`) bypasses every prompt with safe defaults; explicit flags override individual answers. Without `--yes`, every unset flag prompts interactively.
+
+Available flags: `--template rest|ddd|cqrs|minimal`, `--pm pnpm|npm|yarn|bun`, `--repo prisma|drizzle|inmemory|custom`, `--packages auth,swagger,...`, `--no-git`, `--no-install`, `--force`, `-y / --yes / --non-interactive`.
 
 3. Update generated `package.json`:
    - Rename to `@forinda/kickjs-example-<name>`

--- a/README.md
+++ b/README.md
@@ -133,25 +133,26 @@ export const app = await bootstrap({ modules })
 
 KickJS deliberately ships a small, stable core. The "right" extension surface is `defineAdapter()` / `definePlugin()` / `defineHttpContextDecorator()` plus `getRequestValue` / `processHooks` from `@forinda/kickjs` — adopters compose ecosystem-specific glue (GraphQL runtimes, OTel SDKs, mail providers) on top of those primitives via short copy-paste recipes. Six wrappers are deprecated for v5 because the BYO recipe is shorter and ages better than a thin first-party wrapper around a fast-moving upstream.
 
-### Supported
+### Core packages
+
+Three packages ship with every project — `kick new` always installs them, and `kick add` won't list them as optional. Together they're the framework runtime + the dev/build/scaffold loop:
 
 | Package | Description |
 |---------|-------------|
 | [`@forinda/kickjs`](packages/kickjs/) | Core framework — DI, decorators, Express 5, routing, middleware, contributors, request store, `processHooks` |
-| [`@forinda/kickjs-cli`](packages/cli/) | Scaffolding, DDD generators, custom commands, `kick g agents` |
 | [`@forinda/kickjs-vite`](packages/vite/) | Vite plugin — single-port HMR, typegen watcher, customizable HMR log |
-| [`@forinda/kickjs-testing`](packages/testing/) | `createTestApp`, `createTestModule`, `runContributor` |
-| [`@forinda/kickjs-swagger`](packages/swagger/) | Auto OpenAPI from decorators + Zod |
-| [`@forinda/kickjs-auth`](packages/auth/) | JWT, API key, OAuth strategies + RBAC |
-| [`@forinda/kickjs-prisma`](packages/prisma/) | Prisma adapter (v5/6/7) |
-| [`@forinda/kickjs-drizzle`](packages/drizzle/) | Drizzle adapter, query builder |
-| [`@forinda/kickjs-ws`](packages/ws/) | WebSocket with `@WsController` |
-| [`@forinda/kickjs-queue`](packages/queue/) | BullMQ, RabbitMQ, Kafka |
-| [`@forinda/kickjs-devtools`](packages/devtools/) | Debug dashboard at `/_debug` |
-| [`@forinda/kickjs-devtools-kit`](packages/devtools-kit/) | `IntrospectionSnapshot`, `defineDevtoolsTab` for adapter authors |
-| [`@forinda/kickjs-ai`](packages/ai/) | Providers (OpenAI, Anthropic), `@AiTool`, memory, RAG, agent loop |
-| [`@forinda/kickjs-mcp`](packages/mcp/) | Model Context Protocol server adapter + `kick mcp` CLI |
-| [`@forinda/kickjs-lint`](packages/lint/) | Lint rules — DI token shape, `kick/` prefix enforcement |
+| [`@forinda/kickjs-cli`](packages/cli/) | Scaffolding, DDD generators, custom commands, `kick g agents` |
+
+### Optional packages
+
+Everything else — auth, swagger, db, queue, ws, devtools, etc. — installs on demand. The catalog moves over time (new packages land, deprecated ones move out), so the live list lives next to the CLI rather than this README:
+
+```bash
+kick add --list   # current optional catalog
+kick add auth swagger drizzle   # install several at once
+```
+
+Browse `packages/` in this repo for the full source layout.
 
 ### Deprecated — going private in v5
 

--- a/docs/guide/cli-commands.md
+++ b/docs/guide/cli-commands.md
@@ -74,45 +74,58 @@ pnpm add -g @forinda/kickjs-cli
 Create a new KickJS project:
 
 ```bash
-kick new my-app            # Interactive prompts for PM, git, install
-kick new .                 # Scaffold in current directory
-kick new my-app --pm pnpm  # Skip PM prompt
-kick new my-app --git --install           # Non-interactive (defaults to rest template)
-kick new my-app --no-git --no-install     # Skip git and install
-kick new my-app -d ./custom-directory     # Custom target directory
-kick new my-app -t graphql --pm pnpm --no-git --install  # Fully scriptable
+kick new my-app                          # Interactive prompts for everything
+kick new my-app --yes                    # Pick all defaults (minimal + inmemory)
+kick new .                               # Scaffold in current directory
+kick new my-app --pm pnpm                # Skip PM prompt only
+kick new my-app -t ddd --pm pnpm --no-git --install  # Fully scriptable
 ```
 
-All prompts are skippable via flags, making `kick new` usable in **CI pipelines and shell scripts**:
+`-y, --yes` (alias `--non-interactive`) bypasses every prompt and picks safe defaults — usable in CI pipelines and one-liner shell scripts:
 
 ```bash
-# Fully non-interactive — no TTY required
-kick new my-api --template rest --pm pnpm --no-git --install
+# Single-flag fully non-interactive — no TTY required
+kick new my-api --yes
 ```
 
-When run without flags, the CLI prompts for:
-1. **Project template** — REST, GraphQL, DDD, CQRS, or Minimal
-2. **Package manager** — pnpm, npm, or yarn
+`--yes` defaults:
+
+| Setting | Default value |
+|---------|---------------|
+| Template | `minimal` |
+| Repository | `inmemory` |
+| Optional packages | none |
+| Git init | enabled |
+| Install deps | enabled |
+| Package manager | resolved via `kick add`'s chain (config → corepack `packageManager` → lockfile → npm) |
+
+Any explicit flag overrides the matching default — `--yes --template rest --repo drizzle` scaffolds a REST + Drizzle project without prompts.
+
+When run without `--yes` (and without specific flags), the CLI prompts for:
+1. **Project template** — REST, DDD, CQRS, or Minimal
+2. **Package manager** — pnpm, npm, yarn, or bun
 3. **Default repository** — Prisma, Drizzle, In-Memory, or Custom ORM
-4. **Git init** — initialize a git repository with an initial commit
-5. **Install deps** — run the selected package manager's install command
+4. **Optional packages** — auth, swagger, ws, queue, devtools
+5. **Git init** — initialize a git repository with an initial commit
+6. **Install deps** — run the selected package manager's install command
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `-t, --template <type>` | Project template: `rest`, `graphql`, `ddd`, `cqrs`, `minimal` | Prompted |
-| `-r, --repo <type>` | Default repository: `prisma`, `drizzle`, `inmemory`, `custom` | Prompted |
+| `-t, --template <type>` | Project template: `rest`, `ddd`, `cqrs`, `minimal` | Prompted (or `minimal` with `--yes`) |
+| `-r, --repo <type>` | Default repository: `prisma`, `drizzle`, `inmemory`, `custom` | Prompted (or `inmemory` with `--yes`) |
 | `-d, --directory <dir>` | Target directory | Project name |
-| `--pm <manager>` | Package manager: `pnpm`, `npm`, or `yarn` | Prompted |
-| `--git / --no-git` | Initialize git repository | Prompted |
-| `--install / --no-install` | Install dependencies | Prompted |
+| `--pm <manager>` | Package manager: `pnpm`, `npm`, `yarn`, or `bun` | Prompted (or auto-detected with `--yes`) |
+| `--packages <list>` | Comma-separated optional packages | Prompted (or none with `--yes`) |
+| `--git / --no-git` | Initialize git repository | Prompted (or `true` with `--yes`) |
+| `--install / --no-install` | Install dependencies | Prompted (or `true` with `--yes`) |
 | `-f, --force` | Clear non-empty directory without prompting | `false` |
+| `-y, --yes`, `--non-interactive` | Bypass every prompt with safe defaults | `false` |
 
 ### Templates
 
 | Template | Adapters | Packages installed |
 |----------|----------|-------------------|
 | `rest` (default) | Swagger + DevTools | kickjs, kickjs-vite, kickjs-swagger |
-| `graphql` | GraphQL via BYO `definePlugin` recipe (see [GraphQL guide](./graphql.md)) | kickjs, kickjs-vite |
 | `ddd` | Swagger + DevTools | kickjs, kickjs-vite, kickjs-swagger |
 | `cqrs` | Swagger + WS + Queue + DevTools | kickjs, kickjs-vite, kickjs-swagger, kickjs-ws, kickjs-queue |
 | `minimal` | None | kickjs, kickjs-vite |
@@ -121,7 +134,7 @@ Use `.` as the project name to scaffold in the current directory (the folder nam
 
 The `init` alias also works: `kick init my-app`.
 
-**Non-empty directory safety:** If the target directory already contains files, the CLI shows up to 5 existing entries and asks for confirmation before clearing them. Use `--force` to skip the prompt.
+**Non-empty directory safety:** If the target directory already contains files, the CLI shows up to 5 existing entries and asks for confirmation before clearing them. Use `--force` to skip the prompt. Running with `--yes` *without* `--force` aborts cleanly when the directory is non-empty — the non-interactive flag never silently destroys existing work.
 
 ## kick dev
 
@@ -198,46 +211,34 @@ Output:
 
   Packages:
     @forinda/kickjs           workspace
-    @forinda/kickjs-config   workspace
-    @forinda/kickjs-cli      workspace
+    @forinda/kickjs-vite      workspace
+    @forinda/kickjs-cli       workspace
 ```
 
 ## kick list
 
-List all available KickJS packages. Alias: `kick ls`.
+List the core KickJS packages every project ships with. Alias: `kick ls`. Pair with `--all` to dump the full optional catalog (which churns between releases — packages added, deprecated, removed — so the default view stays stable).
 
 ```bash
-kick list
-kick ls
+kick list                 # core only
+kick list --all           # full catalog
+kick ls                   # alias
 ```
 
-Output shows each package name, description, and required peer dependencies:
+Default output (3 core packages):
 
 ```
-  Available KickJS packages:
+  Core packages (always installed by `kick new`):
 
     kickjs           Unified framework: DI, decorators, routing, middleware (+ express)
     vite             Vite plugin: dev server, HMR, module discovery (+ vite)
-    config           Optional .env file loader (kickjs ConfigService now ships in @forinda/kickjs)
     cli              CLI tool and code generators
-    swagger          OpenAPI spec + Swagger UI + ReDoc
-    graphql          GraphQL resolvers + GraphiQL (+ graphql)
-    drizzle          Drizzle ORM adapter + query builder (+ drizzle-orm)
-    prisma           Prisma adapter + query builder (+ @prisma/client)
-    ws               WebSocket with @WsController decorators (+ socket.io)
-    otel             OpenTelemetry tracing + metrics (+ @opentelemetry/api)
-    devtools         Development dashboard — routes, DI, metrics, health
-    auth             Authentication — JWT, API key, and custom strategies (+ jsonwebtoken)
-    mailer           Email sending — SMTP, Resend, SES, or custom provider (+ nodemailer)
-    cron             Cron job scheduling (production-grade with croner) (+ croner)
-    queue            Queue adapter (BullMQ/RabbitMQ/Kafka)
-    queue:bullmq     Queue with BullMQ + Redis (+ bullmq, ioredis)
-    queue:rabbitmq   Queue with RabbitMQ (+ amqplib)
-    queue:kafka      Queue with Kafka (+ kafkajs)
-    multi-tenant     Tenant resolution middleware
-    notifications    Multi-channel notifications — email, Slack, Discord, webhook
-    testing          Test utilities and TestModule builder
+
+  Plus N optional packages (auth, swagger, db, queue, …).
+  Run `kick list --all` for the full catalog.
 ```
+
+`kick list --all` adds the **Optional packages** section beneath the core list — what's actually shipped in the `kick add` registry at this CLI version. Names there are stable, but membership rotates as the framework evolves, so we do not enumerate them in this guide.
 
 ## kick add
 
@@ -247,14 +248,51 @@ Add KickJS packages with their required peer dependencies automatically resolved
 kick add swagger          # installs @forinda/kickjs-swagger
 kick add drizzle auth     # installs multiple packages at once
 kick add queue:bullmq     # installs queue package + bullmq + ioredis
-kick add --list           # show all available packages (same as kick list)
+kick add --list           # show core packages (alias: kick list)
+kick add --list --all     # full optional catalog
 ```
+
+### Core packages
+
+`kick add --list` defaults to the three core packages every project always installs. The optional catalog moves between releases (packages added, deprecated, removed) so the live list lives behind `--all`:
+
+```text
+  Core packages (always installed by `kick new`):
+
+    kickjs           Unified framework: DI, decorators, routing, middleware (+ express)
+    vite             Vite plugin: dev server, HMR, module discovery (+ vite)
+    cli              CLI tool and code generators
+
+  Plus N optional packages (auth, swagger, db, queue, …).
+  Run `kick add --list --all` for the full catalog.
+```
+
+The framework runtime (`@forinda/kickjs`), the dev/build/HMR layer (`@forinda/kickjs-vite`), and the CLI (`@forinda/kickjs-cli`) are the only members of the core set. Everything else — auth, swagger, db, drizzle, prisma, ws, queue, devtools, mcp, testing — is opt-in via `kick add`.
+
+### Package manager resolution
+
+`kick add` picks the package manager from this chain (highest priority first):
+
+1. `--pm` flag
+2. `packageManager` field in `kick.config.ts`
+3. `packageManager` field in the **nearest ancestor** `package.json` (corepack)
+4. **Nearest ancestor** lockfile (`pnpm-lock.yaml` → `yarn.lock` → `bun.lock` → `package-lock.json`)
+5. `npm` fallback
+
+The "nearest ancestor" climb means a workspace sub-package inherits the workspace root's pm, even when the sub-package's own `package.json` omits `packageManager`. Run `kick add <pkg>` from any directory under a pnpm workspace and it picks pnpm. The output prints the resolved source so the path is visible:
+
+```text
+  Using pnpm (resolved from package.json)
+```
+
+### Flags
 
 | Flag | Description |
 |------|-------------|
-| `--pm <manager>` | Package manager override (auto-detected from lockfile) |
+| `--pm <manager>` | Package manager override (auto-detected via the chain above) |
 | `-D, --dev` | Install as dev dependency |
-| `--list` | List all available packages (same as `kick list`) |
+| `--list` | List packages (core only by default) |
+| `--all` | When paired with `--list`, include the full optional catalog |
 
 ## kick generate (kick g)
 
@@ -359,7 +397,7 @@ Aliases: `kick g agent-docs`, `kick g ai-docs`. Auto-detects project name (from 
 | `--only <which>` | `agents` \| `claude` \| `skills` \| `both` \| `all` | `all` |
 | `--name <name>` | Project name override | from `package.json` |
 | `--pm <pm>` | Package manager override | from `package.json` |
-| `--template <template>` | `rest` \| `graphql` \| `ddd` \| `cqrs` \| `minimal` | from `kick.config.ts` |
+| `--template <template>` | `rest` \| `ddd` \| `cqrs` \| `minimal` | from `kick.config.ts` |
 | `-f, --force` | Overwrite without prompting | `false` |
 
 See [Generators — kick g agents](./generators.md#kick-g-agents) for what each file contains and how to keep local customisations from being overwritten.
@@ -468,7 +506,6 @@ Controls the default generator behavior and project template style.
 | Value | Description |
 |-------|-------------|
 | `'rest'` | Express + Swagger (default) |
-| `'graphql'` | GraphQL + GraphiQL |
 | `'ddd'` | Full DDD modules with use cases, entities, value objects |
 | `'cqrs'` | CQRS with commands, queries, events + WS/queue |
 | `'minimal'` | Bare Express with no scaffolding |

--- a/docs/guide/db-extensions.md
+++ b/docs/guide/db-extensions.md
@@ -44,21 +44,27 @@ const row = await db.selectFrom('secrets').selectAll().where('id', '=', 1).execu
 // row?.value is already the decrypted EncryptedString — no manual mapping
 ```
 
-### `toDriver` — encode on insert
+### `toDriver` — encode on insert + update
 
-Stored on the column builder but **not yet auto-applied at insert time**. The query-tree transform that walks insert + update statements lands as a follow-up. Until then, apply `toDriver` manually before passing to `.values()`:
+Wired today. The kick/db query layer walks `INSERT` and `UPDATE` statements at compile time — every value targeting a column with a `toDriver` codec is encoded before the driver sees it. Pass plain branded values straight to `.values()` / `.set()`:
 
 ```ts
 await db
   .insertInto('secrets')
-  .values({
-    value: encrypted.toDriver?.(plaintext as EncryptedString) as EncryptedString,
-  })
+  .values({ value: plaintext as EncryptedString })
+  .execute()
+
+await db
+  .updateTable('secrets')
+  .set({ value: rotated as EncryptedString })
+  .where('id', '=', 1)
   .execute()
 ```
 
-::: tip Defer if encoding is symmetric
-For codecs where `toDriver` is identity (logging tags, branded IDs) you can skip the manual call — the brand stays in the type system, the value passes through untouched.
+`null` and `undefined` pass through untouched so codecs don't need to handle the nullable case.
+
+::: tip Insert from `SELECT`
+`db.insertInto('a').expression(db.selectFrom('b'))` skips the encoder pass — values come from a sub-select, not literals on this side. If the source rows aren't already encoded, run a one-shot transform via the query builder or precompute the encoded column before insert.
 :::
 
 ## `db.$extends({ model })`

--- a/packages/cli/__tests__/kick-new-yes.test.ts
+++ b/packages/cli/__tests__/kick-new-yes.test.ts
@@ -1,0 +1,128 @@
+/**
+ * E2E coverage for `kick new <name> --yes`.
+ *
+ * The non-interactive flag swaps every prompt for a default
+ * (template=minimal, repo=inmemory, no extras, git+install on, pm
+ * resolved via the same chain `kick add` uses). These tests pin that
+ * contract — both the happy path and the "won't silently nuke an
+ * existing dir" guardrail.
+ *
+ * @module @forinda/kickjs-cli/__tests__/kick-new-yes.test
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { existsSync, mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { spawnSync } from 'node:child_process'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const CLI_BIN = resolve(__dirname, '..', 'dist', 'cli.mjs')
+
+interface RunResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+/** Run the built CLI in a clean cwd with prompts disabled via --yes / --no-* flags */
+function runNew(cwd: string, args: string[]): RunResult {
+  const result = spawnSync('node', [CLI_BIN, 'new', ...args], {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, NO_COLOR: '1' },
+  })
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  }
+}
+
+describe('kick new --yes (non-interactive)', () => {
+  let cwd: string
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'kick-new-yes-'))
+  })
+
+  afterEach(() => {
+    try {
+      rmSync(cwd, { recursive: true, force: true })
+    } catch {
+      // ignore
+    }
+  })
+
+  it('scaffolds with minimal+inmemory defaults from a name + --yes', () => {
+    const result = runNew(cwd, ['my-api', '--yes', '--no-install', '--no-git'])
+    expect(result.exitCode).toBe(0)
+
+    const projectDir = join(cwd, 'my-api')
+    expect(existsSync(projectDir)).toBe(true)
+
+    // Default template — minimal
+    const config = readFileSync(join(projectDir, 'kick.config.ts'), 'utf-8')
+    expect(config).toContain(`pattern: 'minimal'`)
+    // Default repo — inmemory
+    expect(config).toContain(`repo: 'inmemory'`)
+
+    // Sanity: no prompt strings leaked into stdout
+    expect(result.stdout).not.toContain('Project template')
+    expect(result.stdout).not.toContain('Default repository/ORM')
+    expect(result.stdout).not.toContain('Initialize git repository')
+  })
+
+  it('--non-interactive is an alias for --yes', () => {
+    const result = runNew(cwd, ['my-api', '--non-interactive', '--no-install', '--no-git'])
+    expect(result.exitCode).toBe(0)
+    const config = readFileSync(join(cwd, 'my-api', 'kick.config.ts'), 'utf-8')
+    expect(config).toContain(`pattern: 'minimal'`)
+  })
+
+  it('explicit flags override --yes defaults', () => {
+    const result = runNew(cwd, [
+      'my-api',
+      '--yes',
+      '--template',
+      'rest',
+      '--repo',
+      'drizzle',
+      '--no-install',
+      '--no-git',
+    ])
+    expect(result.exitCode).toBe(0)
+    const config = readFileSync(join(cwd, 'my-api', 'kick.config.ts'), 'utf-8')
+    expect(config).toContain(`pattern: 'rest'`)
+    expect(config).toContain(`repo: 'drizzle'`)
+  })
+
+  it('aborts cleanly when target dir is non-empty and --force is missing', () => {
+    const target = join(cwd, 'my-api')
+    mkdirSync(target, { recursive: true })
+    writeFileSync(join(target, 'existing.txt'), 'do not destroy')
+
+    const result = runNew(cwd, ['my-api', '--yes', '--no-install', '--no-git'])
+    expect(result.exitCode).toBe(0) // graceful exit, not crash
+    expect(result.stdout + result.stderr).toMatch(/Pass --force to clear it/)
+
+    // Existing file untouched
+    expect(readFileSync(join(target, 'existing.txt'), 'utf-8')).toBe('do not destroy')
+    // Scaffold did NOT proceed
+    expect(existsSync(join(target, 'kick.config.ts'))).toBe(false)
+  })
+
+  it('clears non-empty dir and scaffolds when --force is passed alongside --yes', () => {
+    const target = join(cwd, 'my-api')
+    mkdirSync(target, { recursive: true })
+    writeFileSync(join(target, 'existing.txt'), 'will be removed')
+
+    const result = runNew(cwd, ['my-api', '--yes', '--force', '--no-install', '--no-git'])
+    expect(result.exitCode).toBe(0)
+    expect(existsSync(join(target, 'existing.txt'))).toBe(false)
+    expect(existsSync(join(target, 'kick.config.ts'))).toBe(true)
+  })
+})

--- a/packages/cli/__tests__/package-manager-resolution.test.ts
+++ b/packages/cli/__tests__/package-manager-resolution.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { resolvePackageManager } from '../src/commands/add'
+import { resolvePackageManager, resolvePackageManagerWithSource } from '../src/commands/add'
 
 describe('resolvePackageManager', () => {
   let fixture: string
@@ -92,5 +92,50 @@ describe('resolvePackageManager', () => {
       JSON.stringify({ packageManager: 'pnpm' }),
     )
     expect(await resolvePackageManager('yarn')).toBe('yarn')
+  })
+
+  it('climbs to a parent package.json packageManager field (workspace sub-package)', async () => {
+    // Sub-package has no packageManager field; root does. Mimics
+    // examples/<app> sitting under a corepack-pinned monorepo root.
+    writeFileSync(
+      join(fixture, 'package.json'),
+      JSON.stringify({ name: 'root', packageManager: 'pnpm@10.0.0' }),
+    )
+    const sub = join(fixture, 'apps', 'sub')
+    mkdirSync(sub, { recursive: true })
+    writeFileSync(
+      join(sub, 'package.json'),
+      JSON.stringify({ name: 'sub', dependencies: { foo: 'workspace:*' } }),
+    )
+    process.chdir(sub)
+    expect(await resolvePackageManager(undefined)).toBe('pnpm')
+  })
+
+  it('climbs to a parent lockfile (workspace sub-package, no packageManager field)', async () => {
+    // No packageManager field anywhere; lockfile only at root.
+    writeFileSync(join(fixture, 'pnpm-lock.yaml'), '')
+    const sub = join(fixture, 'apps', 'sub')
+    mkdirSync(sub, { recursive: true })
+    writeFileSync(
+      join(sub, 'package.json'),
+      JSON.stringify({ name: 'sub' }),
+    )
+    process.chdir(sub)
+    expect(await resolvePackageManager(undefined)).toBe('pnpm')
+  })
+
+  it('reports the resolution source via resolvePackageManagerWithSource', async () => {
+    writeFileSync(
+      join(fixture, 'kick.config.json'),
+      JSON.stringify({ packageManager: 'pnpm' }),
+    )
+    expect(await resolvePackageManagerWithSource(undefined)).toEqual({
+      pm: 'pnpm',
+      source: 'config',
+    })
+    expect(await resolvePackageManagerWithSource('yarn')).toEqual({
+      pm: 'yarn',
+      source: 'flag',
+    })
   })
 })

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { dirname, resolve } from 'node:path'
 import type { Command } from 'commander'
 import { loadKickConfig, PACKAGE_MANAGERS, type PackageManager } from '../config'
 
@@ -40,6 +40,16 @@ const PACKAGE_REGISTRY: Record<
     description: 'OpenAPI spec + Swagger UI + ReDoc',
   },
   // Database
+  db: {
+    pkg: '@forinda/kickjs-db',
+    peers: [],
+    description: 'kick/db core — schema DSL, migrations, KickDbClient, customType',
+  },
+  'db-pg': {
+    pkg: '@forinda/kickjs-db-pg',
+    peers: ['pg'],
+    description: 'kick/db PostgreSQL dialect + adapter (pgDialect, pgAdapter)',
+  },
   drizzle: {
     pkg: '@forinda/kickjs-drizzle',
     peers: ['drizzle-orm'],
@@ -111,48 +121,96 @@ const PACKAGE_REGISTRY: Record<
   },
 }
 
-function detectPackageManager(): PackageManager {
-  if (existsSync(resolve('pnpm-lock.yaml'))) return 'pnpm'
-  if (existsSync(resolve('yarn.lock'))) return 'yarn'
-  if (existsSync(resolve('bun.lockb')) || existsSync(resolve('bun.lock'))) return 'bun'
-  return 'npm'
-}
-
-/** Read `packageManager` from package.json (corepack convention: "pnpm@10.0.0") */
-function packageManagerFromPackageJson(): PackageManager | null {
-  try {
-    const pkg = JSON.parse(readFileSync(resolve('package.json'), 'utf-8'))
-    const field: unknown = pkg.packageManager
-    if (typeof field !== 'string') return null
-    const name = field.split('@')[0] as PackageManager
-    return PACKAGE_MANAGERS.includes(name) ? name : null
-  } catch {
-    return null
+/**
+ * Walk up from `fromDir` to filesystem root, returning the first
+ * directory that contains `name`. Lets monorepo sub-packages pick up
+ * lockfiles and `packageManager` fields living at the workspace root.
+ */
+function findUp(name: string, fromDir = process.cwd()): string | null {
+  let current = fromDir
+  while (true) {
+    if (existsSync(resolve(current, name))) return current
+    const parent = dirname(current)
+    if (parent === current) return null
+    current = parent
   }
 }
+
+function detectFromLockfile(): PackageManager | null {
+  if (findUp('pnpm-lock.yaml')) return 'pnpm'
+  if (findUp('yarn.lock')) return 'yarn'
+  if (findUp('bun.lockb') || findUp('bun.lock')) return 'bun'
+  if (findUp('package-lock.json')) return 'npm'
+  return null
+}
+
+/**
+ * Read `packageManager` from the nearest ancestor `package.json` that
+ * declares the field (corepack convention: `"pnpm@10.0.0"`). Climbs so
+ * monorepo sub-packages inherit the workspace pm even when their own
+ * package.json omits the field.
+ */
+function packageManagerFromPackageJson(): PackageManager | null {
+  let dir: string | null = process.cwd()
+  while (dir) {
+    const pkgPath = resolve(dir, 'package.json')
+    if (existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
+        const field: unknown = pkg.packageManager
+        if (typeof field === 'string') {
+          const name = field.split('@')[0] as PackageManager
+          if (PACKAGE_MANAGERS.includes(name)) return name
+        }
+      } catch {
+        // ignore — keep climbing
+      }
+    }
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+  return null
+}
+
+export type PackageManagerSource = 'flag' | 'config' | 'package.json' | 'lockfile' | 'default'
 
 /**
  * Resolve which package manager to use, in priority order:
  * 1. `--pm` CLI flag
  * 2. `packageManager` in kick.config
- * 3. `packageManager` in package.json (corepack)
- * 4. Lockfile detection
- * 5. `'npm'`
+ * 3. `packageManager` in nearest ancestor package.json (corepack)
+ * 4. Nearest ancestor lockfile (pnpm-lock.yaml → yarn.lock → bun.lock → package-lock.json)
+ * 5. `'npm'` fallback
+ *
+ * Returns the chosen pm plus the source for callers that want to log
+ * the resolution path.
  */
-export async function resolvePackageManager(flagPm: string | undefined): Promise<PackageManager> {
+export async function resolvePackageManagerWithSource(
+  flagPm: string | undefined,
+): Promise<{ pm: PackageManager; source: PackageManagerSource }> {
   if (flagPm && PACKAGE_MANAGERS.includes(flagPm as PackageManager)) {
-    return flagPm as PackageManager
+    return { pm: flagPm as PackageManager, source: 'flag' }
   }
 
   const config = await loadKickConfig(process.cwd())
   if (config?.packageManager && PACKAGE_MANAGERS.includes(config.packageManager)) {
-    return config.packageManager
+    return { pm: config.packageManager, source: 'config' }
   }
 
   const fromPkg = packageManagerFromPackageJson()
-  if (fromPkg) return fromPkg
+  if (fromPkg) return { pm: fromPkg, source: 'package.json' }
 
-  return detectPackageManager()
+  const fromLock = detectFromLockfile()
+  if (fromLock) return { pm: fromLock, source: 'lockfile' }
+
+  return { pm: 'npm', source: 'default' }
+}
+
+/** Convenience wrapper for callers that don't care about the source. */
+export async function resolvePackageManager(flagPm: string | undefined): Promise<PackageManager> {
+  const { pm } = await resolvePackageManagerWithSource(flagPm)
+  return pm
 }
 
 export function printPackageList(): void {
@@ -192,7 +250,8 @@ export function registerAddCommand(program: Command): void {
         return
       }
 
-      const pm = await resolvePackageManager(opts.pm)
+      const { pm, source } = await resolvePackageManagerWithSource(opts.pm)
+      console.log(`\n  Using ${pm} (resolved from ${source})`)
       const forceDevFlag = opts.dev
       const prodDeps = new Set<string>()
       const devDeps = new Set<string>()

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -4,33 +4,41 @@ import { dirname, resolve } from 'node:path'
 import type { Command } from 'commander'
 import { loadKickConfig, PACKAGE_MANAGERS, type PackageManager } from '../config'
 
+interface PackageEntry {
+  pkg: string
+  peers: string[]
+  description: string
+  dev?: boolean
+  /**
+   * `true` for packages every project needs (framework + Vite plugin +
+   * CLI). `kick new` installs these regardless of options chosen, and
+   * future package-removal flows refuse to drop them.
+   */
+  core?: boolean
+}
+
 /** Registry of KickJS packages and their required peer dependencies */
-const PACKAGE_REGISTRY: Record<
-  string,
-  { pkg: string; peers: string[]; description: string; dev?: boolean }
-> = {
-  // Core (already installed by kick new)
+const PACKAGE_REGISTRY: Record<string, PackageEntry> = {
+  // Core (always installed by kick new — required for the framework to run)
   kickjs: {
     pkg: '@forinda/kickjs',
     peers: ['express'],
     description: 'Unified framework: DI, decorators, routing, middleware',
+    core: true,
   },
   vite: {
     pkg: '@forinda/kickjs-vite',
     peers: ['vite'],
     description: 'Vite plugin: dev server, HMR, module discovery',
     dev: true,
-  },
-  config: {
-    pkg: 'dotenv',
-    peers: [],
-    description: 'Optional .env file loader (kickjs ConfigService now ships in @forinda/kickjs)',
+    core: true,
   },
   cli: {
     pkg: '@forinda/kickjs-cli',
     peers: [],
     description: 'CLI tool and code generators',
     dev: true,
+    core: true,
   },
 
   // API
@@ -213,14 +221,37 @@ export async function resolvePackageManager(flagPm: string | undefined): Promise
   return pm
 }
 
-export function printPackageList(): void {
-  console.log('\n  Available KickJS packages:\n')
-  const maxName = Math.max(...Object.keys(PACKAGE_REGISTRY).map((k) => k.length))
-  for (const [name, info] of Object.entries(PACKAGE_REGISTRY)) {
+/**
+ * Print the package catalog. By default shows just the three core
+ * packages every project always has — the optional list churns
+ * (packages added, deprecated, removed) and a long enumeration in CLI
+ * output / docs goes stale within a release. Pass `all = true` to dump
+ * everything; that's what `kick add --list --all` triggers when an
+ * adopter genuinely wants the live catalog.
+ */
+export function printPackageList(all = false): void {
+  const entries = Object.entries(PACKAGE_REGISTRY)
+  const maxName = Math.max(...entries.map(([k]) => k.length))
+  const core = entries.filter(([, info]) => info.core)
+  const optional = entries.filter(([, info]) => !info.core)
+
+  const formatRow = ([name, info]: [string, PackageEntry]): string => {
     const padded = name.padEnd(maxName + 2)
     const peers = info.peers.length ? ` (+ ${info.peers.join(', ')})` : ''
-    console.log(`    ${padded} ${info.description}${peers}`)
+    return `    ${padded} ${info.description}${peers}`
   }
+
+  console.log('\n  Core packages (always installed by `kick new`):\n')
+  for (const row of core) console.log(formatRow(row))
+
+  if (all) {
+    console.log('\n  Optional packages (add as needed):\n')
+    for (const row of optional) console.log(formatRow(row))
+  } else {
+    console.log(`\n  Plus ${optional.length} optional packages (auth, swagger, db, queue, …).`)
+    console.log('  Run `kick add --list --all` for the full catalog.')
+  }
+
   console.log('\n  Usage: kick add auth drizzle swagger')
   console.log('         kick add queue:bullmq')
   console.log()
@@ -230,9 +261,10 @@ export function registerListCommand(program: Command): void {
   program
     .command('list')
     .alias('ls')
-    .description('List all available KickJS packages')
-    .action(() => {
-      printPackageList()
+    .description('List KickJS packages (core only; pair with --all for the full catalog)')
+    .option('--all', 'Include the full optional catalog')
+    .action((opts: { all?: boolean }) => {
+      printPackageList(Boolean(opts.all))
     })
 }
 
@@ -242,11 +274,12 @@ export function registerAddCommand(program: Command): void {
     .description('Add KickJS packages with their required dependencies')
     .option('--pm <manager>', 'Package manager override')
     .option('-D, --dev', 'Install as dev dependency')
-    .option('--list', 'List all available packages')
+    .option('--list', 'List packages (core only by default; pair with --all)')
+    .option('--all', 'When listing, include the full optional catalog')
     .action(async (packages: string[], opts: any) => {
       // List mode
       if (opts.list || packages.length === 0) {
-        printPackageList()
+        printPackageList(Boolean(opts.all))
         return
       }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,6 +4,7 @@ import type { Command } from 'commander'
 import { initProject } from '../generators/project'
 import { intro, outro, text, select, multiSelect, confirm, log } from '../utils/prompts'
 import { colors } from '../utils/colors'
+import { resolvePackageManager } from './add'
 
 /** All optional packages available for selection */
 const OPTIONAL_PACKAGES = [
@@ -32,16 +33,31 @@ export function registerInitCommand(program: Command): void {
       '--packages <packages>',
       'Comma-separated packages to include (e.g. auth,swagger,ws,queue)',
     )
+    .option(
+      '-y, --yes',
+      'Pick safe defaults for every prompt (template=minimal, repo=inmemory, no extras, git+install on)',
+    )
+    .option('--non-interactive', 'alias for --yes')
     .action(async (name: string | undefined, opts: any) => {
       intro('KickJS — Create a new project')
 
+      // `--yes` / `--non-interactive` swap every "would prompt" branch
+      // for a sensible default. Explicit flags still override; the
+      // existing dir-clear safety prompt is skipped only when --force
+      // is also set, so we never silently nuke existing work.
+      const yes = Boolean(opts.yes || opts.nonInteractive)
+
       // ── Project name ──────────────────────────────────────────────
       if (!name) {
-        name = await text({
-          message: 'Project name',
-          placeholder: 'my-api',
-          defaultValue: 'my-api',
-        })
+        if (yes) {
+          name = 'my-api'
+        } else {
+          name = await text({
+            message: 'Project name',
+            placeholder: 'my-api',
+            defaultValue: 'my-api',
+          })
+        }
       }
 
       let directory: string
@@ -58,6 +74,13 @@ export function registerInitCommand(program: Command): void {
         if (entries.length > 0) {
           if (opts.force) {
             log.warn(`Clearing existing files in ${directory}`)
+          } else if (yes) {
+            // --yes implies "use defaults", not "destroy work". Bail
+            // with a clear message; the user adds --force if they
+            // really mean to clear the directory.
+            log.warn(`Directory "${name}" is not empty. Pass --force to clear it.`)
+            outro('Aborted.')
+            return
           } else {
             log.warn(`Directory "${name}" is not empty:`)
             const shown = entries.slice(0, 5)
@@ -85,49 +108,64 @@ export function registerInitCommand(program: Command): void {
       // ── Template ──────────────────────────────────────────────────
       let template = opts.template
       if (!template) {
-        template = await select({
-          message: 'Project template',
-          options: [
-            { value: 'rest', label: 'REST API', hint: 'Express + Swagger' },
-            { value: 'ddd', label: 'DDD', hint: 'Domain-Driven Design modules' },
-            { value: 'cqrs', label: 'CQRS', hint: 'Commands, Queries, Events + WS/Queue' },
-            { value: 'minimal', label: 'Minimal', hint: 'bare Express' },
-          ],
-        })
+        if (yes) {
+          template = 'minimal'
+        } else {
+          template = await select({
+            message: 'Project template',
+            options: [
+              { value: 'rest', label: 'REST API', hint: 'Express + Swagger' },
+              { value: 'ddd', label: 'DDD', hint: 'Domain-Driven Design modules' },
+              { value: 'cqrs', label: 'CQRS', hint: 'Commands, Queries, Events + WS/Queue' },
+              { value: 'minimal', label: 'Minimal', hint: 'bare Express' },
+            ],
+          })
+        }
       }
 
       // ── Package manager ───────────────────────────────────────────
       let packageManager = opts.pm
       if (!packageManager) {
-        packageManager = await select({
-          message: 'Package manager',
-          options: [
-            { value: 'pnpm', label: 'pnpm' },
-            { value: 'npm', label: 'npm' },
-            { value: 'yarn', label: 'yarn' },
-            { value: 'bun', label: 'bun' },
-          ],
-        })
+        if (yes) {
+          // Reuse the same resolution chain `kick add` uses so a
+          // monorepo's corepack pin / lockfile picks the right pm
+          // even in non-interactive mode.
+          packageManager = await resolvePackageManager(undefined)
+        } else {
+          packageManager = await select({
+            message: 'Package manager',
+            options: [
+              { value: 'pnpm', label: 'pnpm' },
+              { value: 'npm', label: 'npm' },
+              { value: 'yarn', label: 'yarn' },
+              { value: 'bun', label: 'bun' },
+            ],
+          })
+        }
       }
 
       // ── Repository type ───────────────────────────────────────────
       let defaultRepo = opts.repo
       if (!defaultRepo) {
-        defaultRepo = await select({
-          message: 'Default repository/ORM',
-          options: [
-            { value: 'prisma', label: 'Prisma' },
-            { value: 'drizzle', label: 'Drizzle' },
-            { value: 'inmemory', label: 'In-Memory' },
-            { value: 'custom', label: 'Custom', hint: 'specify later' },
-          ],
-        })
-
-        if (defaultRepo === 'custom') {
-          defaultRepo = await text({
-            message: 'Custom repository name',
-            defaultValue: 'custom',
+        if (yes) {
+          defaultRepo = 'inmemory'
+        } else {
+          defaultRepo = await select({
+            message: 'Default repository/ORM',
+            options: [
+              { value: 'prisma', label: 'Prisma' },
+              { value: 'drizzle', label: 'Drizzle' },
+              { value: 'inmemory', label: 'In-Memory' },
+              { value: 'custom', label: 'Custom', hint: 'specify later' },
+            ],
           })
+
+          if (defaultRepo === 'custom') {
+            defaultRepo = await text({
+              message: 'Custom repository name',
+              defaultValue: 'custom',
+            })
+          }
         }
       }
 
@@ -144,6 +182,8 @@ export function registerInitCommand(program: Command): void {
             .map((p: string) => p.trim())
             .filter(Boolean)
         }
+      } else if (yes) {
+        selectedPackages = []
       } else {
         selectedPackages = await multiSelect({
           message: 'Select packages to include',
@@ -155,10 +195,12 @@ export function registerInitCommand(program: Command): void {
       // ── Git init ──────────────────────────────────────────────────
       let initGit: boolean
       if (opts.git === undefined) {
-        initGit = await confirm({
-          message: 'Initialize git repository?',
-          initialValue: true,
-        })
+        initGit = yes
+          ? true
+          : await confirm({
+              message: 'Initialize git repository?',
+              initialValue: true,
+            })
       } else {
         initGit = opts.git
       }
@@ -166,10 +208,12 @@ export function registerInitCommand(program: Command): void {
       // ── Install deps ──────────────────────────────────────────────
       let installDeps: boolean
       if (opts.install === undefined) {
-        installDeps = await confirm({
-          message: 'Install dependencies?',
-          initialValue: true,
-        })
+        installDeps = yes
+          ? true
+          : await confirm({
+              message: 'Install dependencies?',
+              initialValue: true,
+            })
       } else {
         installDeps = opts.install
       }

--- a/packages/db/__tests__/unit/codec-plugin-e2e.test.ts
+++ b/packages/db/__tests__/unit/codec-plugin-e2e.test.ts
@@ -1,0 +1,92 @@
+// Integration sanity check — wire the codec plugin through a real
+// Kysely instance (DummyDriver) and confirm `toDriver` lands on the
+// compiled query parameters.
+//
+// `compile()` runs the plugin's transformQuery, then Kysely emits the
+// SQL and parameters that would have been sent to a real driver. We
+// don't need to actually execute against a database; the contract is
+// "encoded values reach the driver layer". DummyDriver is the cheapest
+// way to assemble a working Kysely.
+
+import { describe, it, expect } from 'vitest'
+import {
+  DummyDriver,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+  type Dialect,
+} from 'kysely'
+
+import { createDbClient, customType, table, serial, varchar } from '../../src/index'
+
+type Encrypted = string & { readonly __brand: 'Encrypted' }
+
+const dummy: Dialect = {
+  createAdapter: () => new PostgresAdapter(),
+  createDriver: () => new DummyDriver(),
+  createIntrospector: (db) => new PostgresIntrospector(db),
+  createQueryCompiler: () => new PostgresQueryCompiler(),
+}
+
+const encrypted = customType<Encrypted>({
+  dataType: () => 'text',
+  toDriver: (s) => `enc:${s}`,
+  fromDriver: (raw) => `dec:${String(raw)}` as Encrypted,
+})
+
+const secrets = table('secrets', {
+  id: serial().primaryKey(),
+  label: varchar(255).notNull(),
+  value: encrypted().notNull(),
+})
+
+describe('codec plugin end-to-end', () => {
+  it('encodes the customType column on a single-row INSERT', async () => {
+    const db = createDbClient({ schema: { secrets }, dialect: dummy })
+    const compiled = db
+      .insertInto('secrets')
+      .values({ label: 'hello', value: 'plaintext' as Encrypted })
+      .compile()
+    expect(compiled.parameters).toContain('enc:plaintext')
+    expect(compiled.parameters).toContain('hello')
+    await db.destroy()
+  })
+
+  it('encodes across multi-row INSERT', async () => {
+    const db = createDbClient({ schema: { secrets }, dialect: dummy })
+    const compiled = db
+      .insertInto('secrets')
+      .values([
+        { label: 'a', value: 'one' as Encrypted },
+        { label: 'b', value: 'two' as Encrypted },
+      ])
+      .compile()
+    expect(compiled.parameters).toContain('enc:one')
+    expect(compiled.parameters).toContain('enc:two')
+    await db.destroy()
+  })
+
+  it('encodes UPDATE .set() values', async () => {
+    const db = createDbClient({ schema: { secrets }, dialect: dummy })
+    const compiled = db
+      .updateTable('secrets')
+      .set({ value: 'rotated' as Encrypted })
+      .where('id', '=', 1)
+      .compile()
+    expect(compiled.parameters).toContain('enc:rotated')
+    await db.destroy()
+  })
+
+  it('leaves non-customType columns alone', async () => {
+    const db = createDbClient({ schema: { secrets }, dialect: dummy })
+    const compiled = db
+      .insertInto('secrets')
+      .values({ label: 'plain-label', value: 'x' as Encrypted })
+      .compile()
+    expect(compiled.parameters).toContain('plain-label')
+    // Encoder shouldn't run on non-customType columns even if a value
+    // happens to be string.
+    expect(compiled.parameters).not.toContain('enc:plain-label')
+    await db.destroy()
+  })
+})

--- a/packages/db/__tests__/unit/codec-plugin.test.ts
+++ b/packages/db/__tests__/unit/codec-plugin.test.ts
@@ -1,7 +1,27 @@
 import { describe, it, expect } from 'vitest'
-import type { PluginTransformResultArgs, QueryResult, UnknownRow } from 'kysely'
+import {
+  ColumnNode,
+  ColumnUpdateNode,
+  IdentifierNode,
+  InsertQueryNode,
+  PrimitiveValueListNode,
+  TableNode,
+  UpdateQueryNode,
+  ValueListNode,
+  ValueNode,
+  ValuesNode,
+  type OperationNode,
+  type PluginTransformResultArgs,
+  type QueryResult,
+  type UnknownRow,
+} from 'kysely'
 
-import { CodecResultPlugin, buildDecoderMap } from '../../src/client/codec-plugin'
+import {
+  CodecPlugin,
+  buildDecoderMap,
+  buildEncoderMap,
+  type CodecMap,
+} from '../../src/client/codec-plugin'
 import { customType, table, serial, varchar } from '../../src/index'
 
 type Encrypted = string & { readonly __brand: 'Encrypted' }
@@ -11,12 +31,51 @@ const fakeArgs = (rows: UnknownRow[]): PluginTransformResultArgs => ({
   queryId: { queryId: 'test' } as never,
 })
 
-describe('CodecResultPlugin', () => {
+const transformQuery = (plugin: CodecPlugin, node: OperationNode) =>
+  plugin.transformQuery({
+    node: node as never,
+    queryId: { queryId: 'test' } as never,
+  })
+
+const insert = (
+  table: string,
+  columns: string[],
+  rows: ReadonlyArray<ReadonlyArray<unknown>>,
+): InsertQueryNode => ({
+  kind: 'InsertQueryNode',
+  into: TableNode.create(table),
+  columns: columns.map((c) => ColumnNode.create(c)),
+  values: ValuesNode.create(
+    rows.map((row) => ValueListNode.create(row.map((v) => ValueNode.create(v)))),
+  ),
+})
+
+const insertPrimitive = (
+  table: string,
+  columns: string[],
+  rows: ReadonlyArray<ReadonlyArray<unknown>>,
+): InsertQueryNode => ({
+  kind: 'InsertQueryNode',
+  into: TableNode.create(table),
+  columns: columns.map((c) => ColumnNode.create(c)),
+  values: ValuesNode.create(rows.map((row) => PrimitiveValueListNode.create(row))),
+})
+
+const update = (
+  tableName: string,
+  pairs: ReadonlyArray<readonly [string, unknown]>,
+): UpdateQueryNode => ({
+  kind: 'UpdateQueryNode',
+  table: TableNode.create(tableName),
+  updates: pairs.map(([col, value]) =>
+    ColumnUpdateNode.create(ColumnNode.create(col), ValueNode.create(value)),
+  ),
+})
+
+describe('CodecPlugin transformResult (decoders)', () => {
   it('applies fromDriver to matching column on every row', async () => {
-    const decoders = new Map<string, (v: unknown) => unknown>([
-      ['secret', (v) => `dec:${String(v)}`],
-    ])
-    const plugin = new CodecResultPlugin(decoders)
+    const decoders: CodecMap = new Map([['secret', (v) => `dec:${String(v)}`]])
+    const plugin = new CodecPlugin(new Map(), decoders)
     const result = await plugin.transformResult(
       fakeArgs([
         { id: 1, secret: 'enc:hello' },
@@ -29,11 +88,9 @@ describe('CodecResultPlugin', () => {
     ])
   })
 
-  it('passes null + undefined through untouched (preserves nullable column semantics)', async () => {
-    const decoders = new Map<string, (v: unknown) => unknown>([
-      ['secret', (v) => `dec:${String(v)}`],
-    ])
-    const plugin = new CodecResultPlugin(decoders)
+  it('passes null + undefined through untouched', async () => {
+    const decoders: CodecMap = new Map([['secret', (v) => `dec:${String(v)}`]])
+    const plugin = new CodecPlugin(new Map(), decoders)
     const result = await plugin.transformResult(
       fakeArgs([
         { id: 1, secret: null },
@@ -46,22 +103,152 @@ describe('CodecResultPlugin', () => {
     ])
   })
 
-  it('returns the original result reference when decoders map is empty (zero overhead)', async () => {
-    const plugin = new CodecResultPlugin(new Map())
+  it('returns the original result reference when decoders map is empty', async () => {
+    const plugin = new CodecPlugin(new Map(), new Map())
     const args = fakeArgs([{ id: 1 }])
     const result = await plugin.transformResult(args)
     expect(result).toBe(args.result)
   })
 
   it('leaves unknown columns untouched', async () => {
-    const decoders = new Map<string, (v: unknown) => unknown>([
-      ['secret', (v) => `dec:${String(v)}`],
-    ])
-    const plugin = new CodecResultPlugin(decoders)
-    const result = await plugin.transformResult(
-      fakeArgs([{ id: 1, name: 'alice', secret: 'x' }]),
-    )
+    const decoders: CodecMap = new Map([['secret', (v) => `dec:${String(v)}`]])
+    const plugin = new CodecPlugin(new Map(), decoders)
+    const result = await plugin.transformResult(fakeArgs([{ id: 1, name: 'alice', secret: 'x' }]))
     expect(result.rows[0]).toEqual({ id: 1, name: 'alice', secret: 'dec:x' })
+  })
+})
+
+describe('CodecPlugin transformQuery (encoders)', () => {
+  const encoders: CodecMap = new Map([['secret', (v) => `enc:${String(v)}`]])
+
+  it('encodes ValueNode payloads on a single-row insert', () => {
+    const plugin = new CodecPlugin(encoders, new Map())
+    const node = insert('secrets', ['id', 'secret'], [[1, 'hello']])
+    const out = transformQuery(plugin, node) as InsertQueryNode
+    const valuesNode = out.values as ValuesNode
+    const item = valuesNode.values[0] as ValueListNode
+    expect((item.values[0] as ValueNode).value).toBe(1)
+    expect((item.values[1] as ValueNode).value).toBe('enc:hello')
+  })
+
+  it('encodes ValueNode payloads across multi-row insert', () => {
+    const plugin = new CodecPlugin(encoders, new Map())
+    const node = insert(
+      'secrets',
+      ['id', 'secret'],
+      [
+        [1, 'a'],
+        [2, 'b'],
+      ],
+    )
+    const out = transformQuery(plugin, node) as InsertQueryNode
+    const items = (out.values as ValuesNode).values as ValueListNode[]
+    expect((items[0].values[1] as ValueNode).value).toBe('enc:a')
+    expect((items[1].values[1] as ValueNode).value).toBe('enc:b')
+  })
+
+  it('encodes PrimitiveValueListNode rows (Kysely fast path for primitives)', () => {
+    const plugin = new CodecPlugin(encoders, new Map())
+    const node = insertPrimitive('secrets', ['id', 'secret'], [[1, 'hello']])
+    const out = transformQuery(plugin, node) as InsertQueryNode
+    const item = (out.values as ValuesNode).values[0] as PrimitiveValueListNode
+    expect(item.values).toEqual([1, 'enc:hello'])
+  })
+
+  it('passes null + undefined values through untouched on insert', () => {
+    const plugin = new CodecPlugin(encoders, new Map())
+    const node = insert(
+      'secrets',
+      ['id', 'secret'],
+      [
+        [1, null],
+        [2, undefined],
+      ],
+    )
+    const out = transformQuery(plugin, node) as InsertQueryNode
+    const items = (out.values as ValuesNode).values as ValueListNode[]
+    expect((items[0].values[1] as ValueNode).value).toBeNull()
+    expect((items[1].values[1] as ValueNode).value).toBeUndefined()
+  })
+
+  it('encodes ValueNode targeted by ColumnUpdateNode on UPDATE', () => {
+    const plugin = new CodecPlugin(encoders, new Map())
+    const node = update('secrets', [
+      ['id', 7],
+      ['secret', 'world'],
+    ])
+    const out = transformQuery(plugin, node) as UpdateQueryNode
+    const updates = out.updates as ReadonlyArray<ColumnUpdateNode>
+    expect((updates[0].value as ValueNode).value).toBe(7)
+    expect((updates[1].value as ValueNode).value).toBe('enc:world')
+  })
+
+  it('returns the same node reference when no column matches an encoder', () => {
+    const plugin = new CodecPlugin(encoders, new Map())
+    const node = insert('secrets', ['id', 'name'], [[1, 'alice']])
+    expect(transformQuery(plugin, node)).toBe(node)
+  })
+
+  it('returns the same node reference when no encoded value actually changed', () => {
+    // Encoder is identity for the bound column — node tree should be
+    // shared, no allocation cost on the hot path.
+    const identity: CodecMap = new Map([['secret', (v) => v]])
+    const plugin = new CodecPlugin(identity, new Map())
+    const node = insert('secrets', ['id', 'secret'], [[1, 'hello']])
+    expect(transformQuery(plugin, node)).toBe(node)
+  })
+
+  it('skips insert-from-select (values is not a ValuesNode)', () => {
+    const plugin = new CodecPlugin(encoders, new Map())
+    const fakeSelect: OperationNode = {
+      kind: 'SelectQueryNode',
+    } as never
+    const node: InsertQueryNode = {
+      kind: 'InsertQueryNode',
+      into: TableNode.create('secrets'),
+      columns: [ColumnNode.create('id'), ColumnNode.create('secret')],
+      values: fakeSelect,
+    }
+    expect(transformQuery(plugin, node)).toBe(node)
+  })
+
+  it('returns the original node when encoders map is empty (zero overhead)', () => {
+    const plugin = new CodecPlugin(new Map(), new Map())
+    const node = insert('secrets', ['id', 'secret'], [[1, 'hello']])
+    expect(transformQuery(plugin, node)).toBe(node)
+  })
+
+  it('passes through update set values that are not ValueNodes (e.g. references)', () => {
+    const plugin = new CodecPlugin(encoders, new Map())
+    const ref: OperationNode = {
+      kind: 'ReferenceNode',
+      column: ColumnNode.create('other'),
+    } as never
+    const node: UpdateQueryNode = {
+      kind: 'UpdateQueryNode',
+      table: TableNode.create('secrets'),
+      updates: [ColumnUpdateNode.create(ColumnNode.create('secret'), ref)],
+    }
+    const out = transformQuery(plugin, node) as UpdateQueryNode
+    expect(out).toBe(node)
+  })
+
+  it('does not touch SELECT, DELETE, or other root nodes', () => {
+    const plugin = new CodecPlugin(encoders, new Map())
+    const select: OperationNode = {
+      kind: 'SelectQueryNode',
+      from: { kind: 'FromNode', froms: [TableNode.create('secrets')] },
+    } as never
+    expect(transformQuery(plugin, select)).toBe(select)
+  })
+
+  it('IdentifierNode reference holds the column name as a plain string', () => {
+    // Defends the lookup path: ColumnNode → IdentifierNode → name. If
+    // Kysely changes shape, this breaks loud at the seam rather than
+    // silently producing unencoded values.
+    const idNode = ColumnNode.create('secret')
+    expect(IdentifierNode.is(idNode.column)).toBe(true)
+    expect(idNode.column.name).toBe('secret')
   })
 })
 
@@ -75,10 +262,9 @@ describe('buildDecoderMap()', () => {
       id: serial().primaryKey(),
       name: varchar(255).notNull(),
       secret: encrypted().notNull(),
-      hint: encrypted(), // nullable, same codec
+      hint: encrypted(),
     })
-    const schema = { users }
-    const map = buildDecoderMap(schema)
+    const map = buildDecoderMap({ users })
 
     expect(map.size).toBe(2)
     expect(map.has('secret')).toBe(true)
@@ -108,5 +294,40 @@ describe('buildDecoderMap()', () => {
   it('returns an empty map for null / non-object schemas', () => {
     expect(buildDecoderMap(null).size).toBe(0)
     expect(buildDecoderMap('schema').size).toBe(0)
+  })
+})
+
+describe('buildEncoderMap()', () => {
+  it('collects toDriver codecs from CustomColumnBuilder columns', () => {
+    const encrypted = customType<Encrypted>({
+      dataType: () => 'text',
+      toDriver: (s) => `enc:${s}`,
+    })
+    const t = table('secrets', {
+      id: serial().primaryKey(),
+      value: encrypted().notNull(),
+    })
+    const map = buildEncoderMap({ t })
+
+    expect(map.size).toBe(1)
+    expect(map.has('value')).toBe(true)
+    expect(map.get('value')?.('hello')).toBe('enc:hello')
+  })
+
+  it('skips CustomColumnBuilder columns with no toDriver set (decode-only codecs)', () => {
+    const decodeOnly = customType<string>({
+      dataType: () => 'text',
+      fromDriver: (raw) => String(raw),
+    })
+    const t = table('t', {
+      id: serial().primaryKey(),
+      val: decodeOnly().notNull(),
+    })
+    expect(buildEncoderMap({ t }).size).toBe(0)
+  })
+
+  it('returns an empty map for null / non-object schemas', () => {
+    expect(buildEncoderMap(null).size).toBe(0)
+    expect(buildEncoderMap(undefined).size).toBe(0)
   })
 })

--- a/packages/db/src/client/codec-plugin.ts
+++ b/packages/db/src/client/codec-plugin.ts
@@ -1,19 +1,23 @@
-// Codec plugin — applies CustomColumnBuilder.fromDriver to selected
-// rows so adopters who declared `customType<T>({ fromDriver })` get
-// decoded values automatically (decrypted strings, parsed structured
-// data, etc.) without writing their own per-call mapper.
+// Codec plugin — wires CustomColumnBuilder codecs into Kysely.
 //
-// Scope: this plugin transforms RESULT rows only. The matching
-// toDriver pass for INSERT / UPDATE values requires walking Kysely's
-// OperationNode tree (InsertQueryNode + UpdateQueryNode + their
-// nested ColumnUpdateNodes), which is bigger work and lands as a
-// follow-up. Adopters with toDriver wired today should call it
-// manually before passing the value to `.values()` / `.set()`.
+// Two transforms in one plugin:
 //
-// Decoder lookup is by COLUMN NAME — not table.column — so two tables
-// declaring a column with the same name share the codec. That's a
-// known limitation; the row-shape doesn't always carry table
-// provenance once joins land.
+// - `transformQuery` walks the AST for INSERT and UPDATE statements
+//   and applies `toDriver(value)` to every ValueNode whose surrounding
+//   ColumnNode matches a column in the encoder map. Pass-through for
+//   `insert ... select`, `defaultValues`, references, and other
+//   non-literal value expressions.
+//
+// - `transformResult` walks selected rows and applies `fromDriver` per
+//   matching column name. Null/undefined pass through so codecs don't
+//   need a nullable branch.
+//
+// Both maps are keyed by COLUMN NAME (not table.column). Two tables
+// declaring the same name share a codec — the row shape returned from
+// joins doesn't always carry table provenance, so any table-aware
+// scheme would degrade silently. Adopters using clashing column names
+// across tables with different codecs should declare distinct
+// `customType` instances or rename the column.
 
 import type {
   KyselyPlugin,
@@ -23,19 +27,38 @@ import type {
   RootOperationNode,
   UnknownRow,
 } from 'kysely'
+import {
+  ColumnNode,
+  ColumnUpdateNode,
+  InsertQueryNode,
+  PrimitiveValueListNode,
+  UpdateQueryNode,
+  ValueListNode,
+  ValueNode,
+  ValuesNode,
+  type OperationNode,
+  type ValuesItemNode,
+} from 'kysely'
 
 import { CustomColumnBuilder } from '../custom-type'
 import type { ColumnBuilder } from '../dsl/columns/types'
 import type { TableDecl } from '../dsl/table'
 
-/** Map of column name → decoder. Built once at createDbClient time. */
-export type DecoderMap = Map<string, (driver: unknown) => unknown>
+/** Map of column name → encoder/decoder. Built once at createDbClient time. */
+export type CodecMap = Map<string, (value: unknown) => unknown>
 
-export class CodecResultPlugin implements KyselyPlugin {
-  constructor(private decoders: DecoderMap) {}
+export class CodecPlugin implements KyselyPlugin {
+  constructor(
+    private encoders: CodecMap,
+    private decoders: CodecMap,
+  ) {}
 
   transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
-    return args.node
+    if (this.encoders.size === 0) return args.node
+    const node = args.node
+    if (InsertQueryNode.is(node)) return this.transformInsert(node)
+    if (UpdateQueryNode.is(node)) return this.transformUpdate(node)
+    return node
   }
 
   async transformResult(args: PluginTransformResultArgs): Promise<QueryResult<UnknownRow>> {
@@ -44,15 +67,120 @@ export class CodecResultPlugin implements KyselyPlugin {
     return { ...args.result, rows }
   }
 
+  // ---------------------------- query side ----------------------------
+
+  private transformInsert(node: InsertQueryNode): InsertQueryNode {
+    const cols = node.columns
+    const values = node.values
+    if (!cols || !values) return node
+    // Build per-position encoder lookup once. Positions without a
+    // matching encoder stay null so the inner loop can early-skip
+    // without re-hashing on every row.
+    const positional = this.positionalEncoders(cols)
+    if (!positional) return node
+
+    if (ValuesNode.is(values)) {
+      const items = values.values.map((item) => this.encodeValuesItem(item, positional))
+      // Reference equality preserved when no item changed.
+      const changed = items.some((item, i) => item !== values.values[i])
+      if (!changed) return node
+      // ValuesItemNode is the public union ValueListNode | PrimitiveValueListNode;
+      // every encodeValuesItem path either returns the original item (already a
+      // ValuesItemNode) or rebuilds via the matching factory, so the cast holds.
+      return InsertQueryNode.cloneWith(node, {
+        values: ValuesNode.create(items as unknown as ReadonlyArray<ValuesItemNode>),
+      })
+    }
+
+    // SelectQueryNode (insert from select), DefaultInsertValueNode, and
+    // any future shape: pass through. We can't safely transform values
+    // we didn't read literally.
+    return node
+  }
+
+  private transformUpdate(node: UpdateQueryNode): UpdateQueryNode {
+    const updates = node.updates
+    if (!updates || updates.length === 0) return node
+
+    let changed = false
+    const next = updates.map((u) => {
+      const col = u.column
+      if (!ColumnNode.is(col)) return u
+      const encoder = this.encoders.get(col.column.name)
+      if (!encoder) return u
+      const encoded = this.encodeValueNode(u.value, encoder)
+      if (encoded === u.value) return u
+      changed = true
+      return ColumnUpdateNode.create(col, encoded)
+    })
+    if (!changed) return node
+    // Kysely's UpdateQueryNode.cloneWithUpdates APPENDS to existing
+    // updates rather than replacing them — wrong semantics for our
+    // mutate-in-place flow. Spread directly. `node` is already
+    // narrowed to UpdateQueryNode so the override typechecks cleanly.
+    return { ...node, updates: next }
+  }
+
+  private positionalEncoders(
+    cols: ReadonlyArray<ColumnNode>,
+  ): Array<((v: unknown) => unknown) | null> | null {
+    const out: Array<((v: unknown) => unknown) | null> = new Array(cols.length)
+    let any = false
+    for (let i = 0; i < cols.length; i++) {
+      const enc = this.encoders.get(cols[i].column.name) ?? null
+      out[i] = enc
+      if (enc) any = true
+    }
+    return any ? out : null
+  }
+
+  private encodeValuesItem(
+    item: OperationNode,
+    positional: Array<((v: unknown) => unknown) | null>,
+  ): OperationNode {
+    if (ValueListNode.is(item)) {
+      const next = item.values.map((v, i) => {
+        const enc = positional[i]
+        if (!enc) return v
+        return this.encodeValueNode(v, enc)
+      })
+      const changed = next.some((v, i) => v !== item.values[i])
+      return changed ? ValueListNode.create(next) : item
+    }
+    if (PrimitiveValueListNode.is(item)) {
+      const next = item.values.map((v, i) => {
+        const enc = positional[i]
+        if (!enc) return v
+        return this.encodePrimitive(v, enc)
+      })
+      const changed = next.some((v, i) => v !== item.values[i])
+      return changed ? PrimitiveValueListNode.create(next) : item
+    }
+    return item
+  }
+
+  private encodeValueNode(node: OperationNode, encoder: (v: unknown) => unknown): OperationNode {
+    if (!ValueNode.is(node)) return node
+    const value = node.value
+    if (value === null || value === undefined) return node
+    const encoded = encoder(value)
+    if (encoded === value) return node
+    return ValueNode.create(encoded)
+  }
+
+  private encodePrimitive(value: unknown, encoder: (v: unknown) => unknown): unknown {
+    if (value === null || value === undefined) return value
+    return encoder(value)
+  }
+
+  // ---------------------------- result side ----------------------------
+
   private decodeRow(row: UnknownRow): UnknownRow {
     let mutated = false
     const out: Record<string, unknown> = {}
     for (const key of Object.keys(row)) {
       const value = (row as Record<string, unknown>)[key]
       const decoder = this.decoders.get(key)
-      // Skip null/undefined — the codec wasn't set up to decode
-      // missing values; passing them through preserves nullable
-      // column semantics without forcing every codec to handle null.
       if (decoder && value !== null && value !== undefined) {
         out[key] = decoder(value)
         mutated = true
@@ -67,25 +195,33 @@ export class CodecResultPlugin implements KyselyPlugin {
 /**
  * Walk a schema record and collect decoders from every column whose
  * builder is a `CustomColumnBuilder` with a `fromDriver` codec set.
- *
- * Schema entries that aren't table declarations (e.g. `relations()`
- * registrations) are skipped. Columns without a fromDriver are
- * skipped — registering an entry without one would still cost a
- * Map lookup per row for no payoff.
  */
-export function buildDecoderMap(schema: unknown): DecoderMap {
-  const decoders: DecoderMap = new Map()
-  if (!schema || typeof schema !== 'object') return decoders
+export function buildDecoderMap(schema: unknown): CodecMap {
+  return collectCodecs(schema, 'fromDriver')
+}
+
+/**
+ * Walk a schema record and collect encoders from every column whose
+ * builder is a `CustomColumnBuilder` with a `toDriver` codec set.
+ */
+export function buildEncoderMap(schema: unknown): CodecMap {
+  return collectCodecs(schema, 'toDriver')
+}
+
+function collectCodecs(schema: unknown, key: 'toDriver' | 'fromDriver'): CodecMap {
+  const out: CodecMap = new Map()
+  if (!schema || typeof schema !== 'object') return out
 
   for (const value of Object.values(schema as Record<string, unknown>)) {
     if (!isTableDecl(value)) continue
     for (const [colName, col] of Object.entries(value.__columns)) {
-      if (col instanceof CustomColumnBuilder && col.fromDriver) {
-        decoders.set(colName, col.fromDriver)
+      if (col instanceof CustomColumnBuilder) {
+        const fn = col[key]
+        if (fn) out.set(colName, fn as (v: unknown) => unknown)
       }
     }
   }
-  return decoders
+  return out
 }
 
 function isTableDecl(value: unknown): value is TableDecl<string, Record<string, ColumnBuilder>> {

--- a/packages/db/src/client/create.ts
+++ b/packages/db/src/client/create.ts
@@ -3,7 +3,7 @@ import { Kysely, sql, type Dialect as KyselyDialect } from 'kysely'
 import type { CreateDbClientOptions, KickDbClient, TransactionEvent } from './types'
 import type { SchemaToTypes } from './schema-types'
 import { KickDbEventEmitter } from './events'
-import { CodecResultPlugin, buildDecoderMap } from './codec-plugin'
+import { CodecPlugin, buildDecoderMap, buildEncoderMap } from './codec-plugin'
 import { applyExtensions } from '../extend/apply'
 
 interface InternalContext {
@@ -33,14 +33,14 @@ export function createDbClient<TSchema, DB = SchemaToTypes<TSchema>>(
   // SQL, params, and timing. Cleanest hook for the lifecycle events;
   // a full KyselyPlugin (transformQuery / transformResult) is heavier
   // and only worth it when we need to mutate the SQL tree.
-  // Build the customType decoder map once. When no column declared
-  // a `fromDriver` codec, the decoder map is empty and the plugin's
-  // transformResult short-circuits — zero per-row cost on the hot
-  // path. Encoders (toDriver) are NOT consumed yet — that requires
-  // walking the InsertQueryNode / UpdateQueryNode trees, lands in a
-  // follow-up.
+  // Build customType codec maps once. Both transforms short-circuit
+  // when their map is empty so the plugin is free of per-row /
+  // per-query cost when no customType is in play. Plugin only
+  // attached when at least one side has work to do.
   const decoders = buildDecoderMap(opts.schema)
-  const codecPlugin = decoders.size > 0 ? new CodecResultPlugin(decoders) : null
+  const encoders = buildEncoderMap(opts.schema)
+  const codecPlugin =
+    decoders.size > 0 || encoders.size > 0 ? new CodecPlugin(encoders, decoders) : null
 
   const kysely = new Kysely<DB>({
     dialect: opts.dialect,


### PR DESCRIPTION
## Summary

- **db (M2.F-T16 follow-up):** auto-apply `customType.toDriver` on INSERT + UPDATE via Kysely query-tree transform — completes the symmetric encode/decode story so adopters stop calling `toDriver` manually before `.values()` / `.set()`.
- **cli `kick add`:** walk ancestors when resolving package manager (lockfile + corepack `packageManager` field), so workspace sub-packages no longer fall through to npm and choke on `workspace:*`. New `db` and `db-pg` registry entries.
- **cli `kick new`:** `--yes` / `--non-interactive` (`-y`) bypasses every prompt with safe defaults (template=minimal, repo=inmemory, no extras, git+install on, pm auto-detected). Explicit flags still override.
- **cli `kick list`:** defaults to a 3-package "core" showcase (kickjs/vite/cli) plus `+N optional` pointer; `--all` dumps the full optional catalog. Optional list churns release-to-release; the core trio is stable.
- **registry:** dropped obsolete `config` entry (ConfigService ships in `@forinda/kickjs` now).
- **docs:** README ecosystem split into Core (3) + pointer to `kick add --list`; CLAUDE.md / AGENTS.md scaffolding examples lead with `--yes`; cli-commands.md `kick list` shows new 3-package output and drops the full enumeration; Templates table drops removed `graphql`.

## Commits

- `eb43d431` feat(db): auto-apply customType.toDriver on INSERT + UPDATE (M2.F-T16 follow-up)
- `51a1597c` fix(cli): kick add walks up for lockfile + corepack pm; register db / db-pg
- `6a97820d` feat(cli): kick new --yes / --non-interactive + 3-core showcase for kick list

## Test plan

- [x] db package: 218 tests pass (199 → 218; +15 transformQuery encoder cases, +4 e2e through DummyDriver, +3 buildEncoderMap, plus codec-plugin rename)
- [x] cli package: 212 tests pass (207 → 212; +5 `kick new --yes` e2e cases, +3 ancestor-walk pm cases for monorepo sub-packages)
- [x] Pre-commit hook (build + tests + format + kick-lint) clean on each commit
- [x] Manual smoke: `kick add testing` from `examples/minimal-api` now resolves to pnpm via ancestor walk (was npm + EUNSUPPORTEDPROTOCOL on `workspace:*`)
- [x] Manual smoke: `node bin.js new my-api --yes --no-install --no-git` scaffolds minimal+inmemory with no prompts

## Out of scope (still on the M2 punch list)

`$extends({ result })` computeds (T17), relational `findMany({ with })` (T18), KickEventBus (M2.D), Vite AST strip (M2.E), routes/env legacy generator carve, removed-enum-value handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)