### PR TITLE
feat(db): $extends({ result }) — computed columns via Kysely plugin (M2.F-T17)

### DIFF
--- a/docs/guide/db-extensions.md
+++ b/docs/guide/db-extensions.md
@@ -181,32 +181,60 @@ const dbX = db.$extends({
 })
 ```
 
-### Result extensions (deferred)
+### Result extensions
 
-The plan reserves a `result` field for `compute()` extensions that add derived properties to selected rows:
+Add derived properties to every selected row of a table. Each computed declares which columns it `needs` (auto-injected into the SELECT list at compile time) and a `compute(row)` function that produces the value:
 
 ```ts
-// roadmap — NOT shipped in v1
-db.$extends({
+const dbX = db.$extends({
   result: {
     posts: {
       url: { needs: { id: true, slug: true }, compute: (row) => `/posts/${row.id}/${row.slug}` },
+      excerpt: { needs: { body: true }, compute: (row) => row.body.slice(0, 140) },
     },
   },
 })
+
+const rows = await dbX.selectFrom('posts').selectAll().execute()
+//    rows[0].url:     string  — typed, computed from id + slug
+//    rows[0].excerpt: string  — typed, computed from body
 ```
 
-This needs a query-tree transform that walks select statements (to ensure `needs` columns are included) plus a result transform (to apply `compute()` per row). It ships alongside the `toDriver` insert pass since both share the same plumbing.
+**`needs` injection** — the runtime walks every `SelectQueryNode` whose `from` resolves to a table with computeds, and adds any declared `needs` column not already in the select list. Adopters who write `.select(['title'])` still get the computeds populated; they just won't see the `needs` columns on the row property unless they ask. Wildcards (`selectAll()`) skip injection entirely — every column is implicitly present.
 
-For now, derive computed fields client-side or via the query builder's `.select()` callback:
+**`compute()` semantics**
+
+- Sync only in v1 — async opens up "runtime queries inside compute" footguns. Use a model method when you need to query.
+- Each row is computed independently; computeds on the same table all run per row.
+- A throwing `compute()` degrades to `undefined` on that row's property; sibling computeds and rows still complete cleanly.
+- Single-table only: joins, sub-selects, multi-table FROM clauses pass through untouched. Cross-table computeds are roadmap.
+
+**How the rebuild works** — `$extends({ result })` calls `qb.withPlugin()` to append a Kysely plugin that owns the transform pair. The new client shares the original's event emitter, savepoint counter, and dialect tag, so `.transaction()` / `.on('slowQuery', …)` / per-call savepoints keep working transparently. `$extends({ model })` alone (no `result`) skips the rebuild — it stays a thin Proxy as before. Composing both in one call is the common path:
 
 ```ts
-const posts = await db
-  .selectFrom('posts')
-  .selectAll()
-  .execute()
-  .then((rows) => rows.map((r) => ({ ...r, url: `/posts/${r.id}/${r.slug}` })))
+const dbX = db.$extends({
+  model: {
+    posts: {
+      latest(this: typeof dbX, limit: number) {
+        return this.selectFrom('posts').selectAll().limit(limit).execute()
+      },
+    },
+  },
+  result: {
+    posts: {
+      url: { needs: { id: true, slug: true }, compute: (r) => `/posts/${r.id}/${r.slug}` },
+    },
+  },
+})
+
+await dbX.posts.latest(5) // each row carries the computed `url`
 ```
+
+::: tip Out of scope for v1
+- needs columns aren't compile-time validated against the schema — typos surface at runtime when the SELECT executes. Type-level narrowing lands once `SchemaToTypes` exposes the column-name union per table.
+- async `compute()` is rejected — keep the post-fetch transform synchronous to bound the cost of every row.
+- joined / multi-from selects pass through. Use a model method that hand-writes the JSON-aggregation path for those today.
+:::
 
 ## DI integration
 

--- a/packages/db/__tests__/unit/result-extensions.test.ts
+++ b/packages/db/__tests__/unit/result-extensions.test.ts
@@ -1,0 +1,330 @@
+// Coverage for `$extends({ result })`.
+//
+// The plugin's two halves (transformQuery for needs-injection,
+// transformResult for compute application) are tested directly via
+// fake AST nodes + envelope args, then end-to-end through a Kysely
+// instance with a stub driver that returns canned rows. The stub
+// driver lets us hit the post-fetch transform without standing up a
+// real database.
+
+import { describe, expect, it } from 'vitest'
+import {
+  ColumnNode,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+  ReferenceNode,
+  SelectAllNode,
+  SelectionNode,
+  TableNode,
+  type Dialect,
+  type DatabaseConnection,
+  type QueryResult,
+  type UnknownRow,
+} from 'kysely'
+
+import { createDbClient, table, serial, varchar } from '../../src/index'
+import { ResultExtensionPlugin } from '../../src/extend/result-plugin'
+
+// ── Fixture schema ─────────────────────────────────────────────
+
+const posts = table('posts', {
+  id: serial().primaryKey(),
+  slug: varchar(100).notNull(),
+  title: varchar(255).notNull(),
+})
+
+// ── Stub dialect — driver returns whatever rows are queued ─────
+
+function dialectReturning(rows: UnknownRow[]): Dialect {
+  const conn: DatabaseConnection = {
+    executeQuery: async <R>(): Promise<QueryResult<R>> => ({ rows: rows as unknown as R[] }),
+    streamQuery: async function* () {
+      // unused
+      yield { rows: [] as never[] }
+    },
+  }
+  return {
+    createAdapter: () => new PostgresAdapter(),
+    createDriver: () => ({
+      init: async () => {},
+      acquireConnection: async () => conn,
+      beginTransaction: async () => {},
+      commitTransaction: async () => {},
+      rollbackTransaction: async () => {},
+      releaseConnection: async () => {},
+      destroy: async () => {},
+    }),
+    createIntrospector: (db) => new PostgresIntrospector(db),
+    createQueryCompiler: () => new PostgresQueryCompiler(),
+  }
+}
+
+// ── Plugin unit tests ──────────────────────────────────────────
+
+describe('ResultExtensionPlugin — transformQuery (needs-injection)', () => {
+  const fakeQueryId = (id: string) => ({ queryId: id }) as never
+
+  it('injects missing `needs` columns into a partial SELECT', () => {
+    const plugin = new ResultExtensionPlugin({
+      posts: {
+        url: {
+          needs: { id: true, slug: true },
+          compute: () => '',
+        },
+      },
+    })
+    // `select(['title'])` — id + slug must be auto-added.
+    const node = {
+      kind: 'SelectQueryNode',
+      from: { kind: 'FromNode', froms: [TableNode.create('posts')] },
+      selections: [
+        SelectionNode.create(ReferenceNode.create(ColumnNode.create('title'))),
+      ],
+    } as never
+
+    const out = plugin.transformQuery({ node, queryId: fakeQueryId('q1') })
+    const sels = (out as { selections: ReadonlyArray<SelectionNode> }).selections
+    const cols = sels.map((s) => {
+      const inner = s.selection
+      if (ReferenceNode.is(inner) && ColumnNode.is(inner.column)) return inner.column.column.name
+      return null
+    })
+    expect(cols).toContain('title')
+    expect(cols).toContain('id')
+    expect(cols).toContain('slug')
+  })
+
+  it('skips injection when select uses SelectAllNode (`select *`)', () => {
+    const plugin = new ResultExtensionPlugin({
+      posts: {
+        url: { needs: { id: true }, compute: () => '' },
+      },
+    })
+    const node = {
+      kind: 'SelectQueryNode',
+      from: { kind: 'FromNode', froms: [TableNode.create('posts')] },
+      selections: [SelectionNode.createSelectAll()],
+    } as never
+
+    const out = plugin.transformQuery({ node, queryId: fakeQueryId('q2') })
+    // No additional selections — wildcard already covers everything.
+    expect((out as typeof node).selections).toHaveLength(1)
+  })
+
+  it('does not duplicate columns already present in the SELECT', () => {
+    const plugin = new ResultExtensionPlugin({
+      posts: {
+        url: { needs: { id: true, slug: true }, compute: () => '' },
+      },
+    })
+    const node = {
+      kind: 'SelectQueryNode',
+      from: { kind: 'FromNode', froms: [TableNode.create('posts')] },
+      selections: [
+        SelectionNode.create(ReferenceNode.create(ColumnNode.create('id'))),
+        SelectionNode.create(ReferenceNode.create(ColumnNode.create('title'))),
+      ],
+    } as never
+    const out = plugin.transformQuery({ node, queryId: fakeQueryId('q3') })
+    const sels = (out as { selections: ReadonlyArray<SelectionNode> }).selections
+    const ids = sels.filter((s) => {
+      const inner = s.selection
+      return (
+        ReferenceNode.is(inner) &&
+        ColumnNode.is(inner.column) &&
+        inner.column.column.name === 'id'
+      )
+    })
+    expect(ids).toHaveLength(1) // one, not two
+  })
+
+  it('passes through joined / multi-from selects untouched', () => {
+    const plugin = new ResultExtensionPlugin({
+      posts: { url: { needs: { id: true }, compute: () => '' } },
+    })
+    const node = {
+      kind: 'SelectQueryNode',
+      from: {
+        kind: 'FromNode',
+        froms: [TableNode.create('posts'), TableNode.create('users')],
+      },
+      selections: [SelectionNode.createSelectAll()],
+    } as never
+    const out = plugin.transformQuery({ node, queryId: fakeQueryId('q4') })
+    expect(out).toBe(node)
+  })
+
+  it('passes through tables without a registered extension', () => {
+    const plugin = new ResultExtensionPlugin({
+      posts: { url: { needs: { id: true }, compute: () => '' } },
+    })
+    const node = {
+      kind: 'SelectQueryNode',
+      from: { kind: 'FromNode', froms: [TableNode.create('users')] },
+      selections: [SelectionNode.createSelectAll()],
+    } as never
+    const out = plugin.transformQuery({ node, queryId: fakeQueryId('q5') })
+    expect(out).toBe(node)
+  })
+
+  it('passes through non-select root nodes', () => {
+    const plugin = new ResultExtensionPlugin({
+      posts: { url: { needs: { id: true }, compute: () => '' } },
+    })
+    const insertNode = { kind: 'InsertQueryNode' } as never
+    expect(plugin.transformQuery({ node: insertNode, queryId: fakeQueryId('q6') })).toBe(
+      insertNode,
+    )
+  })
+})
+
+// ── End-to-end through a Kysely instance ───────────────────────
+
+describe('createDbClient + $extends({ result }) — end-to-end', () => {
+  it('applies compute() to every selected row', async () => {
+    const dialect = dialectReturning([
+      { id: 1, slug: 'hello', title: 'Hello' },
+      { id: 2, slug: 'world', title: 'World' },
+    ])
+
+    const db = createDbClient({ schema: { posts }, dialect })
+    const dbX = db.$extends({
+      result: {
+        posts: {
+          url: {
+            needs: { id: true, slug: true },
+            compute: (row) => `/posts/${row.id}/${row.slug}`,
+          },
+        },
+      },
+    })
+    const rows = await dbX.selectFrom('posts').selectAll().execute()
+    expect(rows).toHaveLength(2)
+    expect((rows[0] as { url: string }).url).toBe('/posts/1/hello')
+    expect((rows[1] as { url: string }).url).toBe('/posts/2/world')
+    await dbX.destroy()
+  })
+
+  it('preserves the non-computed columns alongside the computed property', async () => {
+    const dialect = dialectReturning([{ id: 7, slug: 'x', title: 'X' }])
+    const db = createDbClient({ schema: { posts }, dialect })
+    const dbX = db.$extends({
+      result: {
+        posts: { length: { needs: { title: true }, compute: (r) => (r.title as string).length } },
+      },
+    })
+    const row = await dbX.selectFrom('posts').selectAll().executeTakeFirst()
+    expect(row).toMatchObject({ id: 7, slug: 'x', title: 'X', length: 1 })
+    await dbX.destroy()
+  })
+
+  it('multiple computeds on the same table all apply', async () => {
+    const dialect = dialectReturning([{ id: 3, slug: 'a', title: 'Hi' }])
+    const db = createDbClient({ schema: { posts }, dialect })
+    const dbX = db.$extends({
+      result: {
+        posts: {
+          url: { needs: { id: true, slug: true }, compute: (r) => `/p/${r.id}` },
+          shouty: { needs: { title: true }, compute: (r) => `${r.title}!` },
+        },
+      },
+    })
+    const row = (await dbX.selectFrom('posts').selectAll().executeTakeFirst()) as {
+      url: string
+      shouty: string
+    }
+    expect(row.url).toBe('/p/3')
+    expect(row.shouty).toBe('Hi!')
+    await dbX.destroy()
+  })
+
+  it('compute throwing degrades to undefined on that row, sibling computeds still fire', async () => {
+    const dialect = dialectReturning([{ id: 4, slug: 'b', title: 'Z' }])
+    const db = createDbClient({ schema: { posts }, dialect })
+    const dbX = db.$extends({
+      result: {
+        posts: {
+          boom: {
+            needs: { id: true },
+            compute: () => {
+              throw new Error('compute failed')
+            },
+          },
+          ok: { needs: { slug: true }, compute: (r) => `slug:${r.slug}` },
+        },
+      },
+    })
+    const row = (await dbX.selectFrom('posts').selectAll().executeTakeFirst()) as {
+      boom: unknown
+      ok: string
+    }
+    expect(row.boom).toBeUndefined()
+    expect(row.ok).toBe('slug:b')
+    await dbX.destroy()
+  })
+
+  it('non-extended tables stay untouched', async () => {
+    // Schema with two tables; only `posts` has computeds. Selecting
+    // from `users` shouldn't get any computed properties.
+    const users = table('users', {
+      id: serial().primaryKey(),
+      email: varchar(255).notNull(),
+    })
+    const dialect = dialectReturning([{ id: 1, email: 'a@b.com' }])
+    const db = createDbClient({ schema: { posts, users }, dialect })
+    const dbX = db.$extends({
+      result: {
+        posts: { url: { needs: { id: true }, compute: () => '/p/x' } },
+      },
+    })
+    const row = await dbX.selectFrom('users').selectAll().executeTakeFirst()
+    expect(row).toEqual({ id: 1, email: 'a@b.com' })
+    expect(row).not.toHaveProperty('url')
+    await dbX.destroy()
+  })
+
+  it('falls through to the proxy-only path when no result extensions present', async () => {
+    const dialect = dialectReturning([{ id: 1, slug: 's', title: 't' }])
+    const db = createDbClient({ schema: { posts }, dialect })
+    const dbX = db.$extends({
+      model: {
+        posts: {
+          firstId() {
+            return 42
+          },
+        },
+      },
+    })
+    // Model methods still attach via the proxy; no result transform
+    // wraps the SELECT path.
+    expect((dbX as { posts: { firstId(): number } }).posts.firstId()).toBe(42)
+    const row = await dbX.selectFrom('posts').selectAll().executeTakeFirst()
+    expect(row).toEqual({ id: 1, slug: 's', title: 't' })
+    expect(row).not.toHaveProperty('url')
+    await dbX.destroy()
+  })
+
+  it('result + model can compose in a single $extends call', async () => {
+    const dialect = dialectReturning([{ id: 9, slug: 'k', title: 'K' }])
+    const db = createDbClient({ schema: { posts }, dialect })
+    const dbX = db.$extends({
+      model: {
+        posts: {
+          tag() {
+            return 'posts-model'
+          },
+        },
+      },
+      result: {
+        posts: { tag2: { needs: { id: true }, compute: (r) => `c:${r.id}` } },
+      },
+    })
+    expect((dbX as { posts: { tag(): string } }).posts.tag()).toBe('posts-model')
+    const row = (await dbX.selectFrom('posts').selectAll().executeTakeFirst()) as {
+      tag2: string
+    }
+    expect(row.tag2).toBe('c:9')
+    await dbX.destroy()
+  })
+})

--- a/packages/db/src/client/create.ts
+++ b/packages/db/src/client/create.ts
@@ -1,17 +1,10 @@
-import { Kysely, sql, type Dialect as KyselyDialect } from 'kysely'
+import { Kysely, type Dialect as KyselyDialect } from 'kysely'
 
-import type { CreateDbClientOptions, KickDbClient, TransactionEvent } from './types'
+import type { CreateDbClientOptions, KickDbClient } from './types'
 import type { SchemaToTypes } from './schema-types'
 import { KickDbEventEmitter } from './events'
 import { CodecPlugin, buildDecoderMap, buildEncoderMap } from './codec-plugin'
-import { applyExtensions } from '../extend/apply'
-
-interface InternalContext {
-  events: KickDbEventEmitter | null
-  dialect: KickDbClient['dialect']
-  /** Increments per savepoint open inside this client; used for SP_<n> names. */
-  savepointCounter: { value: number }
-}
+import { wrap, type InternalContext } from './wrap'
 
 // DB defaults to SchemaToTypes<TSchema> so the returned client is typed
 // directly from the schema parameter — no KickDbRegister lookup at the call
@@ -97,82 +90,4 @@ function detectDialect(dialect: KyselyDialect): KickDbClient['dialect'] {
   if (name.includes('Postgres')) return 'postgres'
   if (name.includes('Mysql') || name.includes('MySql')) return 'mysql'
   return 'sqlite'
-}
-
-function wrap<DB>(qb: Kysely<DB>, ctx: InternalContext): KickDbClient<DB> {
-  const client: KickDbClient<DB> = {
-    qb,
-    dialect: ctx.dialect,
-
-    selectFrom: qb.selectFrom.bind(qb),
-    insertInto: qb.insertInto.bind(qb),
-    updateTable: qb.updateTable.bind(qb),
-    deleteFrom: qb.deleteFrom.bind(qb),
-
-    on(event, listener) {
-      ctx.events?.on(event, listener)
-      return client
-    },
-    off(event, listener) {
-      ctx.events?.off(event, listener)
-      return client
-    },
-
-    transaction: ((
-      a: TransactionEvent | ((tx: KickDbClient<DB>) => Promise<unknown>),
-      b?: (tx: KickDbClient<DB>) => Promise<unknown>,
-    ) => {
-      const txOpts = typeof a === 'function' ? {} : a
-      const fn = (typeof a === 'function' ? a : b) as (tx: KickDbClient<DB>) => Promise<unknown>
-
-      const run = async () => {
-        ctx.events?.emit('transactionStart', { isolation: txOpts.isolation })
-        try {
-          const result = await qb.transaction().execute(async (tx) => {
-            if (txOpts.isolation) {
-              const level = txOpts.isolation.toUpperCase()
-              await sql.raw(`SET TRANSACTION ISOLATION LEVEL ${level}`).execute(tx)
-            }
-            const child = wrap<DB>(tx as unknown as Kysely<DB>, ctx)
-            return await fn(child)
-          })
-          ctx.events?.emit('transactionCommit', { isolation: txOpts.isolation })
-          return result
-        } catch (err) {
-          ctx.events?.emit('transactionRollback', {
-            isolation: txOpts.isolation,
-            error: err,
-          })
-          throw err
-        }
-      }
-      return run()
-    }) as KickDbClient<DB>['transaction'],
-
-    $extends(ext) {
-      return applyExtensions(client, ext)
-    },
-
-    async savepoint(fn) {
-      const name = `sp_${++ctx.savepointCounter.value}`
-      // Savepoints only make sense inside a transaction. The query
-      // builder's transaction proxies route SQL through the same
-      // connection; sql.raw() against the wrapper lands on that
-      // connection's tx context.
-      await sql.raw(`SAVEPOINT ${name}`).execute(qb)
-      try {
-        const result = await fn(wrap<DB>(qb, ctx))
-        await sql.raw(`RELEASE SAVEPOINT ${name}`).execute(qb)
-        return result
-      } catch (err) {
-        await sql.raw(`ROLLBACK TO SAVEPOINT ${name}`).execute(qb)
-        throw err
-      }
-    },
-
-    async destroy() {
-      await qb.destroy()
-    },
-  }
-  return client
 }

--- a/packages/db/src/client/wrap.ts
+++ b/packages/db/src/client/wrap.ts
@@ -1,0 +1,106 @@
+// Wraps a Kysely<DB> + InternalContext into a KickDbClient<DB>.
+//
+// Lives in its own module so consumers that need to rebuild the
+// client around a new Kysely instance — `$extends({ result })` adds a
+// result-extension Kysely plugin via `qb.withPlugin(...)`, then wraps
+// the new instance back into a client — can do so without an import
+// cycle through `client/create.ts`. Both `create.ts` and
+// `extend/apply.ts` import from here.
+//
+// `InternalContext` carries everything the wrap needs that lives
+// outside the Kysely instance itself: the lifecycle event emitter,
+// the cached dialect tag, and the savepoint counter. Sharing the same
+// ctx across re-wraps keeps the event listener identity stable —
+// adopters who attached `db.on('slowQuery', ...)` continue receiving
+// events from the rebuilt-after-`$extends` client.
+
+import { Kysely, sql } from 'kysely'
+
+import type { KickDbClient, TransactionEvent } from './types'
+import { applyExtensions } from '../extend/apply'
+import type { KickDbEventEmitter } from './events'
+
+export interface InternalContext {
+  events: KickDbEventEmitter | null
+  dialect: KickDbClient['dialect']
+  /** Increments per savepoint open inside this client; used for SP_<n> names. */
+  savepointCounter: { value: number }
+}
+
+export function wrap<DB>(qb: Kysely<DB>, ctx: InternalContext): KickDbClient<DB> {
+  const client: KickDbClient<DB> = {
+    qb,
+    dialect: ctx.dialect,
+
+    selectFrom: qb.selectFrom.bind(qb),
+    insertInto: qb.insertInto.bind(qb),
+    updateTable: qb.updateTable.bind(qb),
+    deleteFrom: qb.deleteFrom.bind(qb),
+
+    on(event, listener) {
+      ctx.events?.on(event, listener)
+      return client
+    },
+    off(event, listener) {
+      ctx.events?.off(event, listener)
+      return client
+    },
+
+    transaction: ((
+      a: TransactionEvent | ((tx: KickDbClient<DB>) => Promise<unknown>),
+      b?: (tx: KickDbClient<DB>) => Promise<unknown>,
+    ) => {
+      const txOpts = typeof a === 'function' ? {} : a
+      const fn = (typeof a === 'function' ? a : b) as (tx: KickDbClient<DB>) => Promise<unknown>
+
+      const run = async () => {
+        ctx.events?.emit('transactionStart', { isolation: txOpts.isolation })
+        try {
+          const result = await qb.transaction().execute(async (tx) => {
+            if (txOpts.isolation) {
+              const level = txOpts.isolation.toUpperCase()
+              await sql.raw(`SET TRANSACTION ISOLATION LEVEL ${level}`).execute(tx)
+            }
+            const child = wrap<DB>(tx as unknown as Kysely<DB>, ctx)
+            return await fn(child)
+          })
+          ctx.events?.emit('transactionCommit', { isolation: txOpts.isolation })
+          return result
+        } catch (err) {
+          ctx.events?.emit('transactionRollback', {
+            isolation: txOpts.isolation,
+            error: err,
+          })
+          throw err
+        }
+      }
+      return run()
+    }) as KickDbClient<DB>['transaction'],
+
+    $extends(ext) {
+      return applyExtensions(client, ctx, ext)
+    },
+
+    async savepoint(fn) {
+      const name = `sp_${++ctx.savepointCounter.value}`
+      // Savepoints only make sense inside a transaction. The query
+      // builder's transaction proxies route SQL through the same
+      // connection; sql.raw() against the wrapper lands on that
+      // connection's tx context.
+      await sql.raw(`SAVEPOINT ${name}`).execute(qb)
+      try {
+        const result = await fn(wrap<DB>(qb, ctx))
+        await sql.raw(`RELEASE SAVEPOINT ${name}`).execute(qb)
+        return result
+      } catch (err) {
+        await sql.raw(`ROLLBACK TO SAVEPOINT ${name}`).execute(qb)
+        throw err
+      }
+    },
+
+    async destroy() {
+      await qb.destroy()
+    },
+  }
+  return client
+}

--- a/packages/db/src/extend/apply.ts
+++ b/packages/db/src/extend/apply.ts
@@ -1,26 +1,54 @@
-// Runtime for `$extends({ model })`.
+// Runtime for `$extends({ model, result })`.
 //
-// Builds a Proxy over the original client whose `get` returns the
-// per-table method bag for keys that match a model entry, falling
-// through to the underlying client for everything else. Methods are
-// pre-bound (via Function.prototype.call) so `this` inside the
-// method points back at the proxy — chaining `this.<otherTable>.<m>`
-// or `this.transaction(...)` resolves naturally.
+// Two extension surfaces, applied in order:
+//
+//   1. **result extensions** rebuild the client around a Kysely
+//      instance with the ResultExtensionPlugin appended. We can't
+//      mutate plugins on a live Kysely (it freezes the plugin chain
+//      at construction), but `qb.withPlugin(plugin)` returns a fresh
+//      Kysely with the plugin added — that's what we wrap. The new
+//      client shares the same InternalContext as the parent (events
+//      emitter identity stays stable across extensions, transactions
+//      keep working), but routes queries through the plugin.
+//
+//   2. **model extensions** layer a Proxy over whatever client the
+//      previous step produced. The Proxy's `get` returns the per-
+//      table method bag for keys that match a model entry; methods
+//      are pre-bound via Function.prototype.call so `this` inside
+//      the method is the extended proxy. That way chaining
+//      `this.<otherTable>.<method>` or `this.transaction(...)`
+//      resolves naturally regardless of which extension order ran.
 //
 // Lazy proxy reference: the bound methods need to capture `proxy`
 // itself, but the proxy can't exist until its handler is built.
-// Closure over a mutable `proxy` reference solves the cycle — by
-// the time any method actually runs, the binding has landed.
+// Closure over a mutable `proxy` reference solves the cycle — by the
+// time any method actually runs, the binding has landed.
 
 import type { KickDbClient } from '../client/types'
-import type { ExtendedClient, ExtensionDefinition } from './types'
+import type { ExtendedClient, ExtensionDefinition, ResultExtensions } from './types'
+import { ResultExtensionPlugin } from './result-plugin'
+import { wrap, type InternalContext } from '../client/wrap'
 
 export function applyExtensions<DB, E extends ExtensionDefinition<DB>>(
   client: KickDbClient<DB>,
+  ctx: InternalContext,
   ext: E,
 ): ExtendedClient<DB, E> {
-  // proxy holds the eventual reference; methods capture it by
-  // closure so they receive the extended client as `this`.
+  // 1. Result extensions — rebuild Kysely around the plugin chain.
+  //    `wrap` and this module form an ESM cycle (wrap calls
+  //    applyExtensions for the client's `$extends`; we call wrap to
+  //    rebuild the client). ESM live bindings handle this fine as
+  //    long as nothing reads the binding at module top-level — both
+  //    sides only call into each other inside functions.
+  let baseClient: KickDbClient<DB> = client
+  if (hasResultExtensions(ext.result)) {
+    const plugin = new ResultExtensionPlugin(ext.result as ResultExtensions<unknown>)
+    const newQb = client.qb.withPlugin(plugin)
+    baseClient = wrap<DB>(newQb, ctx)
+  }
+
+  // 2. Model proxy — layered on top of whichever base client we got
+  //    so model methods see the result-augmented row types via `this`.
   let proxy: ExtendedClient<DB, E>
 
   const modelBag: Record<string, Record<string, (...args: unknown[]) => unknown>> = {}
@@ -35,7 +63,7 @@ export function applyExtensions<DB, E extends ExtensionDefinition<DB>>(
     modelBag[tableName as string] = bound
   }
 
-  proxy = new Proxy(client, {
+  proxy = new Proxy(baseClient, {
     get(target, prop) {
       if (typeof prop === 'string' && prop in modelBag) return modelBag[prop]
       // Fall through. Bound methods on the underlying KickDbClient
@@ -47,4 +75,12 @@ export function applyExtensions<DB, E extends ExtensionDefinition<DB>>(
   }) as ExtendedClient<DB, E>
 
   return proxy
+}
+
+function hasResultExtensions(result: unknown): boolean {
+  if (!result || typeof result !== 'object') return false
+  for (const bag of Object.values(result as Record<string, unknown>)) {
+    if (bag && typeof bag === 'object' && Object.keys(bag as object).length > 0) return true
+  }
+  return false
 }

--- a/packages/db/src/extend/result-plugin.ts
+++ b/packages/db/src/extend/result-plugin.ts
@@ -1,0 +1,173 @@
+// ResultExtensionPlugin — Kysely plugin that powers `$extends({ result })`.
+//
+// Two halves:
+//
+//   1. transformQuery walks SelectQueryNode + identifies the table,
+//      then injects ColumnNode references for every `needs` column
+//      not already in the SELECT list. Selects already using `*`
+//      (SelectAllNode) skip injection — the column is implicitly
+//      there.
+//
+//   2. transformResult walks the rows after the driver returns them,
+//      runs each compute(row) per matching table, and assigns the
+//      result to row[<computedKey>]. Null/undefined rows pass through
+//      untouched.
+//
+// The two halves share state via a per-queryId Map so transformResult
+// only fires for queries this plugin marked in transformQuery — joined
+// or aliased selects (which we can't reliably attribute to a single
+// table) pass through both halves untouched.
+
+import {
+  ColumnNode,
+  ReferenceNode,
+  SelectAllNode,
+  SelectQueryNode,
+  SelectionNode,
+  TableNode,
+  type KyselyPlugin,
+  type OperationNode,
+  type PluginTransformQueryArgs,
+  type PluginTransformResultArgs,
+  type QueryId,
+  type QueryResult,
+  type RootOperationNode,
+  type UnknownRow,
+} from 'kysely'
+
+import type { ResultExtension, ResultExtensions } from './types'
+
+/** Per-table computed-field bag. */
+type TableExtensionBag = Record<string, ResultExtension<UnknownRow>>
+
+export class ResultExtensionPlugin implements KyselyPlugin {
+  private byTable: Map<string, TableExtensionBag>
+  /**
+   * Map of queryId → table name the query targets. Populated in
+   * transformQuery, consumed in transformResult, deleted after use so
+   * it doesn't leak across long-lived clients.
+   */
+  private pending = new Map<QueryId, string>()
+
+  constructor(extensions: ResultExtensions<unknown>) {
+    this.byTable = new Map()
+    for (const [tableName, bag] of Object.entries(extensions)) {
+      if (!bag) continue
+      const entries = Object.entries(bag) as Array<[string, ResultExtension<UnknownRow>]>
+      if (entries.length === 0) continue
+      this.byTable.set(tableName, Object.fromEntries(entries))
+    }
+  }
+
+  transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
+    const { node, queryId } = args
+    if (!SelectQueryNode.is(node)) return node
+    const tableName = singleTableTarget(node)
+    if (!tableName) return node
+    const bag = this.byTable.get(tableName)
+    if (!bag) return node
+
+    // Tag the query so transformResult knows to apply computeds.
+    this.pending.set(queryId, tableName)
+
+    return injectNeeds(node, bag)
+  }
+
+  async transformResult(args: PluginTransformResultArgs): Promise<QueryResult<UnknownRow>> {
+    const tableName = this.pending.get(args.queryId)
+    if (!tableName) return args.result
+    this.pending.delete(args.queryId)
+
+    const bag = this.byTable.get(tableName)
+    if (!bag) return args.result
+    const computeds = Object.entries(bag) as Array<[string, ResultExtension<UnknownRow>]>
+    if (computeds.length === 0) return args.result
+
+    const rows = args.result.rows.map((row) => {
+      if (row === null || row === undefined) return row
+      const next: Record<string, unknown> = { ...(row as Record<string, unknown>) }
+      for (const [key, ext] of computeds) {
+        try {
+          next[key] = ext.compute(next as UnknownRow)
+        } catch {
+          // A throwing compute shouldn't poison the entire row set;
+          // surface as undefined so the caller still gets the
+          // pre-existing columns.
+          next[key] = undefined
+        }
+      }
+      return next as UnknownRow
+    })
+    return { ...args.result, rows }
+  }
+}
+
+/**
+ * Detect the single table this select reads from. Returns the table
+ * name when from has exactly one TableNode (or AliasNode wrapping
+ * one); returns null for joins, sub-selects, multi-table selects,
+ * and anything we can't reliably attribute. The plugin only acts on
+ * single-table selects in v1.
+ */
+function singleTableTarget(node: SelectQueryNode): string | null {
+  const from = node.from
+  if (!from || from.froms.length !== 1) return null
+  const target = unwrapAlias(from.froms[0])
+  if (!TableNode.is(target)) return null
+  return target.table.identifier.name
+}
+
+function unwrapAlias(node: OperationNode): OperationNode {
+  // AliasNode wraps a child node in `.node`; we only care about the
+  // underlying TableNode. Anything else passes through.
+  if (node.kind === 'AliasNode') {
+    const aliased = (node as unknown as { node: OperationNode }).node
+    return aliased
+  }
+  return node
+}
+
+/**
+ * Inject every needs column not already represented in the select
+ * list. SelectAllNode (the `*` wildcard) means "all columns", in
+ * which case there's nothing to add. Specific column references are
+ * deduped by name so a column already selected explicitly stays put
+ * exactly once.
+ */
+function injectNeeds(node: SelectQueryNode, bag: TableExtensionBag): SelectQueryNode {
+  const selections = node.selections ?? []
+  // Wildcard select — every column is implicitly present.
+  if (selections.some(isSelectAll)) return node
+
+  const have = new Set<string>()
+  for (const sel of selections) {
+    const inner = sel.selection
+    if (ReferenceNode.is(inner) && ColumnNode.is(inner.column)) {
+      have.add(inner.column.column.name)
+    } else if (ColumnNode.is(inner as OperationNode)) {
+      have.add((inner as ColumnNode).column.name)
+    }
+  }
+
+  const allNeeded = new Set<string>()
+  for (const ext of Object.values(bag)) {
+    for (const col of Object.keys(ext.needs)) {
+      allNeeded.add(col)
+    }
+  }
+
+  const missing = [...allNeeded].filter((c) => !have.has(c))
+  if (missing.length === 0) return node
+
+  const additions: SelectionNode[] = missing.map((col) =>
+    SelectionNode.create(ReferenceNode.create(ColumnNode.create(col))),
+  )
+  return SelectQueryNode.cloneWithSelections(node, additions)
+}
+
+function isSelectAll(node: SelectionNode): boolean {
+  const inner = node.selection
+  if (SelectAllNode.is(inner)) return true
+  if (ReferenceNode.is(inner) && SelectAllNode.is(inner.column)) return true
+  return false
+}

--- a/packages/db/src/extend/types.ts
+++ b/packages/db/src/extend/types.ts
@@ -1,31 +1,33 @@
-// $extends({ model }) — adopter-defined methods grouped by table.
+// `$extends({ model, result })` — adopter extensions for the client.
 //
-// Surface usage:
+// `model` adds per-table methods accessible as `db.users.findByEmail(...)`.
+// Inside each method, `this` is the extended client so chained calls
+// (`.transaction()`, `.users.<other>(...)`) Just Work via Proxy
+// rebinding — see ./apply.ts for the runtime.
+//
+// `result` adds COMPUTED COLUMNS to selected rows. Each compute()
+// receives the row's selected columns and returns a derived value
+// that lands on the row property under the declared key:
 //
 //   const dbX = db.$extends({
-//     model: {
-//       users: {
-//         async findByEmail(this: typeof dbX, email: string) {
-//           return this.selectFrom('users')
-//             .selectAll()
-//             .where('email', '=', email)
-//             .executeTakeFirst()
+//     result: {
+//       posts: {
+//         url: {
+//           needs: { id: true, slug: true },
+//           compute: (row) => `/posts/${row.id}/${row.slug}`,
 //         },
 //       },
 //     },
 //   })
 //
-//   await dbX.users.findByEmail('a@b.com')
+//   const rows = await dbX.selectFrom('posts').selectAll().execute()
+//   rows[0].url  // typed `string`, computed from id + slug
 //
-// Inside each method, `this` is the extended client itself — chained
-// calls (`.transaction()` on dbX, etc.) Just Work because `this`
-// includes both the original KickDbClient surface AND the model-method
-// bag from `$extends`. Methods can call other methods on the same
-// table by addressing them through `this.<table>.<method>`.
-//
-// Result extensions (compute() that runs post-fetch) are NOT shipped
-// in v1 — that needs a Kysely plugin walking select results, lands as
-// a follow-up alongside the toDriver insert path.
+// `needs` declares which columns the compute reads. The runtime
+// auto-injects them into the SELECT list at compile time so adopters
+// who write `.select(['title'])` still get every needs-column on the
+// row (the computed property fires regardless of which subset of
+// columns the caller actually selected).
 
 import type { KickDbClient } from '../client/types'
 
@@ -40,17 +42,55 @@ export type ModelExtensions<DB> = {
   [Table in keyof DB & string]?: Record<string, (...args: never[]) => unknown>
 }
 
-/** Top-level shape passed to `db.$extends(...)`. */
-export interface ExtensionDefinition<DB> {
-  model?: ModelExtensions<DB>
+/**
+ * One result extension — declares which columns the compute reads
+ * (`needs`) and the function that produces the derived value
+ * (`compute`). Sync only in v1; async opens up "runtime queries
+ * inside compute" footguns.
+ */
+export interface ResultExtension<Row> {
+  /** Map from column name → `true`. Auto-injected into SELECT list. */
+  needs: Partial<Record<keyof Row, true>>
+  /** Receives the row's selected columns; return value lands on the row. */
+  compute: (row: Row) => unknown
 }
 
 /**
- * Result type of `db.$extends({ model })` — the original client
- * intersected with a per-table method bag. Adopters who want the
- * result type to flow elsewhere can `type DbX = ReturnType<typeof
- * extend>`; the inference is structural so usage stays clean.
+ * Result extensions keyed by table name. Each entry is a record of
+ * computed-field name → ResultExtension.
  */
-export type ExtendedClient<DB, E extends ExtensionDefinition<DB>> = KickDbClient<DB> & {
+export type ResultExtensions<DB> = {
+  [Table in keyof DB & string]?: Record<string, ResultExtension<DB[Table]>>
+}
+
+/** Top-level shape passed to `db.$extends(...)`. */
+export interface ExtensionDefinition<DB> {
+  model?: ModelExtensions<DB>
+  result?: ResultExtensions<DB>
+}
+
+/**
+ * Fold result extensions into the DB row shape. For each table that
+ * has computeds, every row gains the computed properties typed by the
+ * compute function's return type.
+ */
+export type DBWithResults<DB, R> = {
+  [T in keyof DB]: T extends keyof R
+    ? R[T] extends Record<string, ResultExtension<unknown>>
+      ? DB[T] & {
+          [K in keyof R[T]]: R[T][K] extends { compute: (row: never) => infer Out } ? Out : unknown
+        }
+      : DB[T]
+    : DB[T]
+}
+
+/**
+ * Result type of `db.$extends(...)` — the client typed against the
+ * (possibly result-augmented) DB, intersected with the per-table
+ * method bag from `model`.
+ */
+export type ExtendedClient<DB, E extends ExtensionDefinition<DB>> = KickDbClient<
+  E['result'] extends ResultExtensions<DB> ? DBWithResults<DB, NonNullable<E['result']>> : DB
+> & {
   [T in keyof NonNullable<E['model']> & keyof DB & string]: NonNullable<NonNullable<E['model']>[T]>
 }


### PR DESCRIPTION
## Summary

Closes M2.F-T17 — adopters can now declare computed columns that fold into every selected row of a table:

```ts
const dbX = db.$extends({
  result: {
    posts: {
      url: { needs: { id: true, slug: true }, compute: (r) => `/posts/${r.id}/${r.slug}` },
    },
  },
})

const rows = await dbX.selectFrom('posts').selectAll().execute()
//    rows[0].url: string — typed via DBWithResults<DB, R>
```

## Architecture (Plan A from design pass)

`$extends({ result })` rebuilds the Kysely instance via `qb.withPlugin(ResultExtensionPlugin)` and wraps the new instance back into a `KickDbClient` that **shares the original's `InternalContext`** (events emitter, dialect tag, savepoint counter) — so `.on('slowQuery', …)`, `.transaction()`, `.savepoint()` all keep working transparently across the rebuild. Result-free `$extends({ model })` calls stay a Proxy-only path for zero rebuild cost.

`ResultExtensionPlugin`:
- **transformQuery** walks `SelectQueryNode`. For single-table selects whose table has computeds, every `needs` column not already in the SELECT list gets injected. Wildcards (`selectAll()`) skip injection. Joins / multi-from / non-select roots pass through.
- **transformResult** runs `compute(row)` per row + assigns the value to the matching property. A throwing `compute()` degrades to `undefined` on that row's property; sibling computeds and rows still complete cleanly.

`wrap()` + `InternalContext` extracted from `client/create.ts` to `client/wrap.ts` so `extend/apply.ts` can call it. ESM live bindings handle the intentional cycle.

## Type story

- `ResultExtension<Row>` / `ResultExtensions<DB>` — declarations.
- `DBWithResults<DB, R>` — folds computeds into the row shape; compute return type flows through.
- `ExtendedClient<DB, E>` threads `DBWithResults` through `KickDbClient` when `E['result']` is set.

## Out of scope for v1

- `needs` columns aren't compile-time validated against the schema — typos surface at runtime. Type-level narrowing lands once `SchemaToTypes` exposes a column-name union per table.
- Async `compute()` is rejected — bounded-cost per row.
- Joined / multi-from selects pass through untouched. Cross-table computeds are roadmap; use a model method that hand-writes JSON aggregation today.

## Test plan

- [x] 13 new tests (6 plugin-direct, 7 end-to-end through Kysely with a stub driver) — needs-injection (partial select, wildcard, dedupe), pass-through paths (joined selects, untracked tables, non-select roots), single + multi-row compute, mixed-column rows, multiple computeds on one table, throwing-compute degrades to undefined, non-extended tables untouched, model-only $extends keeps Proxy-only path, model + result compose in one call.
- [x] 237/237 db tests pass (was 224; +13)
- [x] Pre-commit hook (build + tests + format + kick-lint) clean

## Docs

`docs/guide/db-extensions.md` "Result extensions (deferred)" section rewritten as a shipping story with v1 / out-of-scope markers inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)