### PR TITLE
fix(db): apply Copilot review feedback from PR #152 + variance-correct DBWithResults

### DIFF
--- a/docs/guide/db-extensions.md
+++ b/docs/guide/db-extensions.md
@@ -183,7 +183,7 @@ const dbX = db.$extends({
 
 ### Result extensions
 
-Add derived properties to every selected row of a table. Each computed declares which columns it `needs` (auto-injected into the SELECT list at compile time) and a `compute(row)` function that produces the value:
+Add derived properties to every selected row of a table. Each computed declares which columns it `needs` and a `compute(row)` function that produces the value. The Kysely plugin rewrites the query tree before SQL emit so the listed columns are fetched whenever that table is selected:
 
 ```ts
 const dbX = db.$extends({
@@ -200,7 +200,7 @@ const rows = await dbX.selectFrom('posts').selectAll().execute()
 //    rows[0].excerpt: string  — typed, computed from body
 ```
 
-**`needs` injection** — the runtime walks every `SelectQueryNode` whose `from` resolves to a table with computeds, and adds any declared `needs` column not already in the select list. Adopters who write `.select(['title'])` still get the computeds populated; they just won't see the `needs` columns on the row property unless they ask. Wildcards (`selectAll()`) skip injection entirely — every column is implicitly present.
+**`needs` injection** — the plugin walks every `SelectQueryNode` whose `from` resolves to a table with computeds, and adds any declared `needs` column not already in the select list. Adopters who write `.select(['title'])` still get the computeds populated. The injected columns DO land on the runtime row object (they were fetched, after all) — the row's TypeScript shape only widens with the computed property itself, but a property-existence check at runtime would still find the needs columns. Wildcards (`selectAll()`) skip injection entirely — every column is implicitly present.
 
 **`compute()` semantics**
 

--- a/packages/db/__tests__/unit/result-extensions.test.ts
+++ b/packages/db/__tests__/unit/result-extensions.test.ts
@@ -109,7 +109,7 @@ describe('ResultExtensionPlugin — transformQuery (needs-injection)', () => {
 
     const out = plugin.transformQuery({ node, queryId: fakeQueryId('q2') })
     // No additional selections — wildcard already covers everything.
-    expect((out as typeof node).selections).toHaveLength(1)
+    expect((out as { selections: ReadonlyArray<SelectionNode> }).selections).toHaveLength(1)
   })
 
   it('does not duplicate columns already present in the SELECT', () => {
@@ -236,6 +236,36 @@ describe('createDbClient + $extends({ result }) — end-to-end', () => {
     }
     expect(row.url).toBe('/p/3')
     expect(row.shouty).toBe('Hi!')
+    await dbX.destroy()
+  })
+
+  it('computeds are order-independent — each receives the pristine row, never a sibling output', async () => {
+    // If compute() were passed the in-flight `next` row, `second`
+    // could read `first`'s output via row-as-record. The contract is
+    // that each compute reads only the fetched columns; this test
+    // pins it by asserting `second` does NOT see `first` even when
+    // declared after it in the same bag.
+    const dialect = dialectReturning([{ id: 5, slug: 'q', title: 'T' }])
+    const db = createDbClient({ schema: { posts }, dialect })
+    const dbX = db.$extends({
+      result: {
+        posts: {
+          first: { needs: { id: true }, compute: () => 'FIRST' },
+          second: {
+            needs: { id: true },
+            compute: (r) => (r as Record<string, unknown>).first,
+          },
+        },
+      },
+    })
+    const row = (await dbX.selectFrom('posts').selectAll().executeTakeFirst()) as {
+      first: string
+      second: unknown
+    }
+    expect(row.first).toBe('FIRST')
+    // `second` got the pristine row — no `first` field on it — so
+    // reading row.first inside compute returns undefined.
+    expect(row.second).toBeUndefined()
     await dbX.destroy()
   })
 

--- a/packages/db/src/extend/apply.ts
+++ b/packages/db/src/extend/apply.ts
@@ -65,7 +65,13 @@ export function applyExtensions<DB, E extends ExtensionDefinition<DB>>(
 
   proxy = new Proxy(baseClient, {
     get(target, prop) {
-      if (typeof prop === 'string' && prop in modelBag) return modelBag[prop]
+      // Own-property check — `prop in modelBag` would also match
+      // inherited keys like `toString` / `hasOwnProperty` from
+      // Object.prototype, intercepting properties we never asked to
+      // own and breaking the underlying client's own equivalents.
+      if (typeof prop === 'string' && Object.prototype.hasOwnProperty.call(modelBag, prop)) {
+        return modelBag[prop]
+      }
       // Fall through. Bound methods on the underlying KickDbClient
       // (selectFrom, transaction, etc.) keep their original `this`
       // since `wrap()` already bound them to kysely at create time.

--- a/packages/db/src/extend/result-plugin.ts
+++ b/packages/db/src/extend/result-plugin.ts
@@ -14,9 +14,11 @@
 //      untouched.
 //
 // The two halves share state via a per-queryId Map so transformResult
-// only fires for queries this plugin marked in transformQuery — joined
-// or aliased selects (which we can't reliably attribute to a single
-// table) pass through both halves untouched.
+// only fires for queries this plugin marked in transformQuery — joins,
+// sub-selects, multi-table FROMs, and other shapes we can't reliably
+// attribute to a single table pass through both halves untouched.
+// Aliased single-table selects (`.from('posts as p')`) ARE supported —
+// the alias unwrap walks through to the underlying TableNode.
 
 import {
   ColumnNode,
@@ -85,10 +87,15 @@ export class ResultExtensionPlugin implements KyselyPlugin {
 
     const rows = args.result.rows.map((row) => {
       if (row === null || row === undefined) return row
-      const next: Record<string, unknown> = { ...(row as Record<string, unknown>) }
+      const base = row as Record<string, unknown>
+      const next: Record<string, unknown> = { ...base }
+      // Pass `base` (the pristine row, not `next`) into compute so
+      // computeds can't read each other's outputs by accident — order
+      // independence keeps the contract simple. Cross-computed
+      // dependencies are an explicit non-feature.
       for (const [key, ext] of computeds) {
         try {
-          next[key] = ext.compute(next as UnknownRow)
+          next[key] = ext.compute(base as UnknownRow)
         } catch {
           // A throwing compute shouldn't poison the entire row set;
           // surface as undefined so the caller still gets the

--- a/packages/db/src/extend/types.ts
+++ b/packages/db/src/extend/types.ts
@@ -23,11 +23,14 @@
 //   const rows = await dbX.selectFrom('posts').selectAll().execute()
 //   rows[0].url  // typed `string`, computed from id + slug
 //
-// `needs` declares which columns the compute reads. The runtime
-// auto-injects them into the SELECT list at compile time so adopters
-// who write `.select(['title'])` still get every needs-column on the
-// row (the computed property fires regardless of which subset of
-// columns the caller actually selected).
+// `needs` declares which columns the compute reads. The Kysely plugin
+// rewrites the query tree before SQL emit to add any declared `needs`
+// column not already in the SELECT list — adopters who write
+// `.select(['title'])` still get every needs-column fetched, so the
+// computed property fires regardless of which subset of columns the
+// caller selected. (The TypeScript row shape only widens with the
+// computed property itself; the injected needs columns aren't in the
+// declared shape unless the adopter selected them explicitly.)
 
 import type { KickDbClient } from '../client/types'
 
@@ -73,16 +76,27 @@ export interface ExtensionDefinition<DB> {
  * Fold result extensions into the DB row shape. For each table that
  * has computeds, every row gains the computed properties typed by the
  * compute function's return type.
+ *
+ * Implementation note: `compute(row: Row)` is contravariant in `Row`,
+ * so the obvious-looking `R[T] extends Record<string, ResultExtension<unknown>>`
+ * check fails — `ResultExtension<Row>` doesn't extend
+ * `ResultExtension<unknown>` under strictFunctionTypes. We use
+ * `(row: never)` as the variance-neutral position: every adopter
+ * compute extends `(row: never) => unknown`, so the check passes
+ * uniformly.
  */
 export type DBWithResults<DB, R> = {
-  [T in keyof DB]: T extends keyof R
-    ? R[T] extends Record<string, ResultExtension<unknown>>
-      ? DB[T] & {
-          [K in keyof R[T]]: R[T][K] extends { compute: (row: never) => infer Out } ? Out : unknown
-        }
-      : DB[T]
-    : DB[T]
+  [T in keyof DB]: T extends keyof R ? DB[T] & ComputedFields<R[T]> : DB[T]
 }
+
+/** Map a computed-bag to a record of computed-field name → return type. */
+type ComputedFields<Bag> =
+  Bag extends Record<string, { compute: (row: never) => unknown }>
+    ? {
+        [K in keyof Bag]: Bag[K] extends { compute: (row: never) => infer Out } ? Out : unknown
+      }
+    : // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+      {}
 
 /**
  * Result type of `db.$extends(...)` — the client typed against the


### PR DESCRIPTION
## Summary

Six Copilot review fixes on T17 result computeds + a type-correctness fix uncovered while addressing them.

## Surface fixes (Copilot review)

**`packages/db/src/extend/result-plugin.ts`**
- Header comment claimed "joined or aliased selects pass through" — code actually unwraps AliasNode and supports single-table aliased FROMs. Reworded to match.
- `compute()` now receives `base` (the pristine row snapshot) instead of `next` (the in-flight row). Computeds are now order-independent — a sibling computed declared earlier can no longer be read by a later compute. Cross-computed dependencies are an explicit non-feature; new test pins it.

**`packages/db/src/extend/apply.ts`**
- Proxy `get` trap switched from `prop in modelBag` to `Object.prototype.hasOwnProperty.call(modelBag, prop)`. The `in` operator hits inherited keys (`toString`, `hasOwnProperty`, etc.) on `Object.prototype`, intercepting those calls on the proxy and returning the modelBag's prototype function instead of the underlying client's value.

**`packages/db/src/extend/types.ts` + `docs/guide/db-extensions.md`**
- "compile time" claim corrected to "runtime via the Kysely plugin's transformQuery".
- "won't see needs columns on the row" replaced with a precise note: needs columns ARE on the runtime row object (they were fetched). The TypeScript shape only widens with the computed property itself — property-existence checks at runtime would still find them.

## Type-correctness fix (uncovered while testing the above)

`DBWithResults<DB, R>` was checking `R[T] extends Record<string, ResultExtension<unknown>>` to decide whether to fold computeds into the row. But `compute(row: Row)` is contravariant in `Row` under `strictFunctionTypes`, so `ResultExtension<Row>` does NOT extend `ResultExtension<unknown>` (would require `unknown extends Row`).

The result: when adopters wrote `db.$extends({ result: { posts: { url: ... } } })`, the row type stayed `{ id, slug, title }` — the computed `url` never landed in TS. Casts to `{ url: string }` failed with "missing property url".

Fix: factor out a `ComputedFields<Bag>` helper that uses `(row: never)` as the variance-neutral position. Every adopter's `compute(row: SomeRow)` is structurally a subtype of `(row: never) => unknown` because `never` is the bottom type, so the check passes uniformly. Comment in the file documents the variance dance for future readers.

## Test plan

- [x] db package: 238 tests pass (was 237; +1 order-independence regression test pinning the `base`-not-`next` contract)
- [x] `tsc --noEmit` clean across the workspace
- [x] Pre-commit hook (build + tests + format + kick-lint) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)