### PR TITLE
feat(vite): __KICKJS_DEVTOOLS__ build-time flag for devtools tree-shaking (M2.E)

### DIFF
--- a/docs/guide/devtools.md
+++ b/docs/guide/devtools.md
@@ -20,6 +20,48 @@ bootstrap({
 
 DevTools endpoints are now available at `/_debug/*`.
 
+### Stripping DevTools from production bundles
+
+The runtime `enabled` flag above keeps the DevTools adapter inert in prod, but the import of `@forinda/kickjs-devtools` is still in the bundle — code, dependencies, and all. To drop the package entirely from the production output, gate the import behind the `__KICKJS_DEVTOOLS__` build-time flag injected by `@forinda/kickjs-vite`:
+
+```ts
+/// <reference types="@forinda/kickjs-vite/globals" />
+import { bootstrap } from '@forinda/kickjs'
+
+const adapters = [/* prod adapters… */]
+
+if (__KICKJS_DEVTOOLS__) {
+  const { DevToolsAdapter } = await import('@forinda/kickjs-devtools')
+  adapters.push(DevToolsAdapter({ basePath: '/_debug' }))
+}
+
+bootstrap({ modules: [UserModule, ProductModule], adapters })
+```
+
+Vite/Rollup substitutes `__KICKJS_DEVTOOLS__` with `true` (during `vite dev`) or `false` (during `vite build`) and tree-shakes the unreachable branch — including the dynamic `import('@forinda/kickjs-devtools')` chunk — out of the prod bundle entirely.
+
+The `kickjsVitePlugin()` registers the flag by default. Override per build via the env var `KICKJS_DEVTOOLS=0|1` or per project via plugin options:
+
+```ts
+// vite.config.ts
+import { kickjsVitePlugin } from '@forinda/kickjs-vite'
+
+export default defineConfig({
+  plugins: [
+    kickjsVitePlugin({
+      // Force-disable for a "no-devtools" build profile
+      devtools: { enabled: false },
+      // Or rename the global to avoid collisions:
+      // devtools: { flagName: '__APP_DEVTOOLS__' },
+      // Or skip the plugin entirely:
+      // devtools: false,
+    }),
+  ],
+})
+```
+
+Resolution order: explicit `enabled` option → `KICKJS_DEVTOOLS=0|1|true|false` env → Vite `command` (`'serve'` → `true`, `'build'` → `false`).
+
 ## Endpoints
 
 ### `GET /_debug/routes`

--- a/packages/vite/__tests__/devtools-flag-plugin.test.ts
+++ b/packages/vite/__tests__/devtools-flag-plugin.test.ts
@@ -1,0 +1,169 @@
+// Coverage for the build-time DevTools flag plugin. Tests exercise:
+//   - Default value resolution (dev=true, build=false)
+//   - Explicit `enabled` override wins over env
+//   - `KICKJS_DEVTOOLS=0|1|true|false` env override wins over command
+//   - Custom flagName lands at the right key
+//   - The plugin is registered in `kickjsVitePlugin()` by default,
+//     and skipped when `devtools: false` is passed.
+
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import type { Plugin } from 'vite'
+
+import {
+  devtoolsFlagPlugin,
+  resolveDevtoolsFlag,
+  kickjsVitePlugin,
+} from '../src/index'
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+interface ConfigEnvLike {
+  command: 'serve' | 'build'
+  mode: string
+}
+
+function callConfig(plugin: Plugin, env: ConfigEnvLike): { define?: Record<string, string> } {
+  const hook = plugin.config
+  if (typeof hook !== 'function') return {}
+  const result = (hook as unknown as (
+    cfg: Record<string, unknown>,
+    env: ConfigEnvLike,
+  ) => { define?: Record<string, string> })({}, env)
+  return result ?? {}
+}
+
+const findPlugin = (plugins: Plugin[], name: string): Plugin | undefined =>
+  plugins.find((p) => p.name === name)
+
+// ── resolveDevtoolsFlag ───────────────────────────────────────────────
+
+describe('resolveDevtoolsFlag', () => {
+  const originalEnv = process.env.KICKJS_DEVTOOLS
+  const originalNodeEnv = process.env.NODE_ENV
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.KICKJS_DEVTOOLS
+    else process.env.KICKJS_DEVTOOLS = originalEnv
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV
+    else process.env.NODE_ENV = originalNodeEnv
+  })
+
+  it('explicit `enabled: true` wins over everything', () => {
+    process.env.KICKJS_DEVTOOLS = '0'
+    expect(resolveDevtoolsFlag({ enabled: true }, { command: 'build', mode: 'production' })).toBe(
+      true,
+    )
+  })
+
+  it('explicit `enabled: false` wins over everything', () => {
+    process.env.KICKJS_DEVTOOLS = '1'
+    expect(
+      resolveDevtoolsFlag({ enabled: false }, { command: 'serve', mode: 'development' }),
+    ).toBe(false)
+  })
+
+  it('KICKJS_DEVTOOLS=1 wins over command=build', () => {
+    process.env.KICKJS_DEVTOOLS = '1'
+    expect(resolveDevtoolsFlag({}, { command: 'build', mode: 'production' })).toBe(true)
+  })
+
+  it('KICKJS_DEVTOOLS=true also enables', () => {
+    process.env.KICKJS_DEVTOOLS = 'true'
+    expect(resolveDevtoolsFlag({}, { command: 'build', mode: 'production' })).toBe(true)
+  })
+
+  it('KICKJS_DEVTOOLS=0 wins over command=serve', () => {
+    process.env.KICKJS_DEVTOOLS = '0'
+    expect(resolveDevtoolsFlag({}, { command: 'serve', mode: 'development' })).toBe(false)
+  })
+
+  it('KICKJS_DEVTOOLS=false also disables', () => {
+    process.env.KICKJS_DEVTOOLS = 'false'
+    expect(resolveDevtoolsFlag({}, { command: 'serve', mode: 'development' })).toBe(false)
+  })
+
+  it('command=serve → true (no env override)', () => {
+    delete process.env.KICKJS_DEVTOOLS
+    expect(resolveDevtoolsFlag({}, { command: 'serve', mode: 'development' })).toBe(true)
+  })
+
+  it('command=build → false (no env override)', () => {
+    delete process.env.KICKJS_DEVTOOLS
+    expect(resolveDevtoolsFlag({}, { command: 'build', mode: 'production' })).toBe(false)
+  })
+
+  it('falls back to NODE_ENV when no env arg is given (test runner / standalone callers)', () => {
+    delete process.env.KICKJS_DEVTOOLS
+    process.env.NODE_ENV = 'production'
+    expect(resolveDevtoolsFlag()).toBe(false)
+    process.env.NODE_ENV = 'development'
+    expect(resolveDevtoolsFlag()).toBe(true)
+  })
+})
+
+// ── devtoolsFlagPlugin direct ─────────────────────────────────────────
+
+describe('devtoolsFlagPlugin', () => {
+  beforeEach(() => {
+    delete process.env.KICKJS_DEVTOOLS
+  })
+
+  it('registers __KICKJS_DEVTOOLS__ as JSON-encoded literal in serve', () => {
+    const result = callConfig(devtoolsFlagPlugin(), { command: 'serve', mode: 'development' })
+    expect(result.define).toEqual({ __KICKJS_DEVTOOLS__: 'true' })
+  })
+
+  it('registers false in build mode', () => {
+    const result = callConfig(devtoolsFlagPlugin(), { command: 'build', mode: 'production' })
+    expect(result.define).toEqual({ __KICKJS_DEVTOOLS__: 'false' })
+  })
+
+  it('honors a custom flagName', () => {
+    const result = callConfig(devtoolsFlagPlugin({ flagName: '__APP_DEVTOOLS__' }), {
+      command: 'serve',
+      mode: 'development',
+    })
+    expect(result.define).toEqual({ __APP_DEVTOOLS__: 'true' })
+  })
+
+  it('explicit enabled overrides command', () => {
+    const result = callConfig(devtoolsFlagPlugin({ enabled: false }), {
+      command: 'serve',
+      mode: 'development',
+    })
+    expect(result.define).toEqual({ __KICKJS_DEVTOOLS__: 'false' })
+  })
+
+  it('plugin name is stable for inspection / overrides', () => {
+    expect(devtoolsFlagPlugin().name).toBe('kickjs:devtools-flag')
+  })
+})
+
+// ── Wiring into kickjsVitePlugin ──────────────────────────────────────
+
+describe('kickjsVitePlugin — devtools flag wiring', () => {
+  it('registers the devtools-flag plugin by default', () => {
+    const plugins = kickjsVitePlugin()
+    expect(findPlugin(plugins, 'kickjs:devtools-flag')).toBeDefined()
+  })
+
+  it('skips the plugin when devtools: false is passed', () => {
+    const plugins = kickjsVitePlugin({ devtools: false })
+    expect(findPlugin(plugins, 'kickjs:devtools-flag')).toBeUndefined()
+  })
+
+  it('forwards explicit enabled option through to the registered plugin', () => {
+    const plugins = kickjsVitePlugin({ devtools: { enabled: false } })
+    const plugin = findPlugin(plugins, 'kickjs:devtools-flag')
+    expect(plugin).toBeDefined()
+    const result = callConfig(plugin!, { command: 'serve', mode: 'development' })
+    expect(result.define).toEqual({ __KICKJS_DEVTOOLS__: 'false' })
+  })
+
+  it('forwards custom flagName through to the registered plugin', () => {
+    const plugins = kickjsVitePlugin({ devtools: { flagName: '__MY_FLAG__' } })
+    const plugin = findPlugin(plugins, 'kickjs:devtools-flag')
+    const result = callConfig(plugin!, { command: 'build', mode: 'production' })
+    expect(result.define).toEqual({ __MY_FLAG__: 'false' })
+  })
+})

--- a/packages/vite/__tests__/vite-plugin.test.ts
+++ b/packages/vite/__tests__/vite-plugin.test.ts
@@ -79,20 +79,27 @@ describe('kickjsVitePlugin()', () => {
     expect(names).toContain('kickjs:hmr')
     expect(names).toContain('kickjs:virtual-modules')
     expect(names).toContain('kickjs:dev-server')
+    expect(names).toContain('kickjs:devtools-flag')
   })
 
-  it('returns exactly 6 sub-plugins', () => {
-    expect(plugins).toHaveLength(6)
+  it('returns exactly 7 sub-plugins (default config registers the devtools flag)', () => {
+    expect(plugins).toHaveLength(7)
   })
 
   it('accepts a custom entry option', () => {
     const custom = kickjsVitePlugin({ entry: 'app/server.ts' })
-    expect(custom).toHaveLength(6)
+    expect(custom).toHaveLength(7)
   })
 
   it('accepts empty options', () => {
     const noArgs = kickjsVitePlugin({})
-    expect(noArgs).toHaveLength(6)
+    expect(noArgs).toHaveLength(7)
+  })
+
+  it('drops the devtools flag plugin when devtools: false', () => {
+    const stripped = kickjsVitePlugin({ devtools: false })
+    expect(stripped).toHaveLength(6)
+    expect(stripped.map((p) => p.name)).not.toContain('kickjs:devtools-flag')
   })
 })
 

--- a/packages/vite/globals.d.ts
+++ b/packages/vite/globals.d.ts
@@ -1,0 +1,29 @@
+// Ambient declaration for the build-time DevTools flag injected by
+// `devtoolsFlagPlugin()` (default: `__KICKJS_DEVTOOLS__`).
+//
+// Adopters add a triple-slash directive in their entry file or
+// reference this package from their tsconfig "types" so the global
+// resolves at type-check time:
+//
+//   /// <reference types="@forinda/kickjs-vite/globals" />
+//
+//   if (__KICKJS_DEVTOOLS__) {
+//     const { DevToolsAdapter } = await import('@forinda/kickjs-devtools')
+//     adapters.push(DevToolsAdapter())
+//   }
+//
+// The bundler substitutes `__KICKJS_DEVTOOLS__` with `true` / `false`
+// at build time; Vite/Rollup tree-shakes the unreachable branch +
+// the dynamic `import()` chunk along with it.
+
+declare global {
+  /**
+   * Build-time flag — `true` during `vite dev` and tests, `false`
+   * during `vite build` (production). Override per-build via
+   * `devtoolsFlagPlugin({ enabled })` or the `KICKJS_DEVTOOLS` env
+   * var.
+   */
+  const __KICKJS_DEVTOOLS__: boolean
+}
+
+export {}

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -36,10 +36,14 @@
     ".": {
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.mts"
+    },
+    "./globals": {
+      "types": "./globals.d.ts"
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "globals.d.ts"
   ],
   "scripts": {
     "build": "wireit",

--- a/packages/vite/src/devtools-flag-plugin.ts
+++ b/packages/vite/src/devtools-flag-plugin.ts
@@ -1,0 +1,78 @@
+// `devtoolsFlagPlugin()` — exposes `__KICKJS_DEVTOOLS__` as a build-time
+// constant adopters guard their devtools imports behind. Vite/Rollup's
+// existing dead-code-elimination strips the gated branch from production
+// bundles entirely (including any dynamic `import('@forinda/kickjs-devtools')`
+// inside the gate), giving "devtools-in-dev, zero overhead in prod"
+// without a babel pass.
+//
+// Adopter usage:
+//
+//   const adapters = [/* prod adapters… */]
+//   if (__KICKJS_DEVTOOLS__) {
+//     const { DevToolsAdapter } = await import('@forinda/kickjs-devtools')
+//     adapters.push(DevToolsAdapter({ basePath: '/_debug' }))
+//   }
+//
+//   bootstrap({ adapters, modules: [...] })
+//
+// Resolution order for the flag's value:
+//   1. explicit `enabled` option on the plugin → wins
+//   2. `KICKJS_DEVTOOLS=0|1` env var → operator-side override
+//   3. Vite `command` — `'serve'` (dev) → true, `'build'` → false.
+//      `command` is cleaner than NODE_ENV: Vite passes it explicitly
+//      to plugins regardless of how the user set their environment.
+//
+// The plugin returns a Vite `config` hook that adds the literal under
+// `define`. Vite's `define` is a verbatim-substitution map; stringifying
+// with JSON.stringify keeps the value a true / false token (no quotes
+// would break the parser).
+
+import type { ConfigEnv, Plugin } from 'vite'
+
+export interface DevtoolsFlagOptions {
+  /**
+   * Force the flag value. When set, environment-based detection is
+   * bypassed entirely. Useful for explicit feature gates per build
+   * profile.
+   *
+   * @default `vite command === 'serve'` (true in dev, false in build)
+   */
+  enabled?: boolean
+  /**
+   * Override the global name. Default `__KICKJS_DEVTOOLS__`.
+   * Useful for adopters who want a project-specific flag name to
+   * avoid colliding with another tooling's own globals.
+   */
+  flagName?: string
+}
+
+/**
+ * Resolve the build-time devtools flag. Exposed for unit tests +
+ * adopters who want to compute the same answer the plugin would.
+ */
+export function resolveDevtoolsFlag(opts: DevtoolsFlagOptions = {}, env?: ConfigEnv): boolean {
+  if (typeof opts.enabled === 'boolean') return opts.enabled
+  const envOverride = process.env.KICKJS_DEVTOOLS
+  if (envOverride === '1' || envOverride === 'true') return true
+  if (envOverride === '0' || envOverride === 'false') return false
+  // env may be undefined when callers compute the flag outside a
+  // Vite plugin invocation (tests). Fall back to NODE_ENV as a last
+  // resort so the resolver still gives a sensible answer.
+  if (env) return env.command === 'serve'
+  return process.env.NODE_ENV !== 'production'
+}
+
+export function devtoolsFlagPlugin(opts: DevtoolsFlagOptions = {}): Plugin {
+  const flagName = opts.flagName ?? '__KICKJS_DEVTOOLS__'
+  return {
+    name: 'kickjs:devtools-flag',
+    config(_userConfig, env) {
+      const enabled = resolveDevtoolsFlag(opts, env)
+      return {
+        define: {
+          [flagName]: JSON.stringify(enabled),
+        },
+      }
+    },
+  }
+}

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -74,6 +74,7 @@ import { kickjsVirtualModulesPlugin } from './virtual-modules'
 import { kickjsDevServerPlugin } from './dev-server'
 import { kickjsModuleDiscoveryPlugin } from './module-discovery'
 import { kickjsHmrPlugin } from './hmr-plugin'
+import { devtoolsFlagPlugin } from './devtools-flag-plugin'
 
 /**
  * Create the KickJS Vite plugin array.
@@ -122,7 +123,7 @@ export function kickjsVitePlugin(options: KickJSPluginOptions = {}): Plugin[] {
     },
   }
 
-  return [
+  const plugins: Plugin[] = [
     rootResolver,
     kickjsCorePlugin(ctx),
     kickjsModuleDiscoveryPlugin(ctx),
@@ -130,6 +131,13 @@ export function kickjsVitePlugin(options: KickJSPluginOptions = {}): Plugin[] {
     kickjsVirtualModulesPlugin(ctx),
     kickjsDevServerPlugin(ctx),
   ]
+  // Register the devtools flag plugin by default. Adopters who don't
+  // gate their devtools imports get a harmless no-op; adopters who do
+  // get tree-shaking for free. Pass `devtools: false` to skip.
+  if (options.devtools !== false) {
+    plugins.push(devtoolsFlagPlugin(options.devtools ?? {}))
+  }
+  return plugins
 }
 
 // Re-export types for consumers
@@ -138,7 +146,13 @@ export type {
   PluginContext,
   HmrOptions,
   HmrInvalidationContext,
+  DevtoolsOptions,
 } from './types'
 
 // Standalone plugins users can compose alongside `kickjsVitePlugin()`
 export { envWatchPlugin } from './env-watch-plugin'
+export {
+  devtoolsFlagPlugin,
+  resolveDevtoolsFlag,
+  type DevtoolsFlagOptions,
+} from './devtools-flag-plugin'

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -39,6 +39,36 @@ export interface KickJSPluginOptions {
 
   /** HMR logger / behaviour overrides (see {@link HmrOptions}). */
   hmr?: HmrOptions
+
+  /**
+   * DevTools build-time flag knob. The plugin exposes
+   * `__KICKJS_DEVTOOLS__` as a global constant adopters can guard
+   * imports of `@forinda/kickjs-devtools` behind so the entire
+   * adapter (and its dynamic-import chunk) drops out of production
+   * bundles via Vite's existing tree-shaking. Default value: `true`
+   * during `vite dev`, `false` during `vite build`.
+   *
+   * Pass `{ enabled: false }` to force-disable in any mode (useful
+   * for shipping a "no devtools" build profile alongside the dev
+   * server). Pass `{ flagName: '__APP_DEVTOOLS__' }` to rename the
+   * global if it collides with another tool. Pass `false` to skip
+   * registering the plugin entirely (no `define` entry written).
+   *
+   * @default `{}` — flag is registered with environment-based defaults
+   */
+  devtools?: DevtoolsOptions | false
+}
+
+/**
+ * DevTools-flag plugin options. Mirrors the structure of
+ * `DevtoolsFlagOptions` from `./devtools-flag-plugin` so the public
+ * type stays close to the runtime contract.
+ */
+export interface DevtoolsOptions {
+  /** Force the flag value, bypassing dev-vs-build detection. */
+  enabled?: boolean
+  /** Override the global name. Default `__KICKJS_DEVTOOLS__`. */
+  flagName?: string
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes M2.E with the simpler-than-Babel approach: `kickjsVitePlugin()` registers a `__KICKJS_DEVTOOLS__` global via Vite's `define`. Adopters guard their devtools imports behind it; Vite/Rollup's existing dead-code-elimination drops the gated branch — including the dynamic `import('@forinda/kickjs-devtools')` chunk — from production bundles.

**Zero new build deps, predictable behaviour, adopter-controlled.** The Babel auto-strip approach the original plan task 15 sketched would have added ~2MB of dependencies and silently broken naive code with dangling references; the flag pattern is explicit and lets adopters opt in per-call site.

## Adopter pattern

```ts
/// <reference types="@forinda/kickjs-vite/globals" />
import { bootstrap } from '@forinda/kickjs'

const adapters = [/* prod adapters… */]

if (__KICKJS_DEVTOOLS__) {
  const { DevToolsAdapter } = await import('@forinda/kickjs-devtools')
  adapters.push(DevToolsAdapter({ basePath: '/_debug' }))
}

bootstrap({ modules: [UserModule, ProductModule], adapters })
```

## Resolution order

1. explicit `kickjsVitePlugin({ devtools: { enabled } })` option → wins
2. `KICKJS_DEVTOOLS=0|1|true|false` env var → operator-side override
3. Vite `command` — `'serve'` → `true`, `'build'` → `false`
4. `NODE_ENV` fallback when called outside a Vite plugin invocation (tests)

## Public surface

- `devtoolsFlagPlugin(opts?)` — standalone Vite plugin emitting the `define` entry. Stable name `kickjs:devtools-flag`.
- `resolveDevtoolsFlag(opts?, env?)` — pure resolver, exposed for tests + adopters.
- `DevtoolsFlagOptions` / `DevtoolsOptions` — option types.
- `globals.d.ts` ambient declaration shipped at package root for typing the flag globally.

`kickjsVitePlugin()` registers the flag plugin by default. Pass `devtools: false` to skip; `{ enabled: ... }` / `{ flagName: ... }` to override.

## Test plan

- [x] vite package: 66 tests pass (was 51; +18 new flag-plugin tests, +1 wiring test, +regenerated existing length assertions)
- [x] `tsc --noEmit` clean
- [x] Pre-commit hook (build + tests + format + kick-lint) clean

## Docs

`docs/guide/devtools.md` gains a "Stripping DevTools from production bundles" section walking through the gate pattern, plugin overrides, env override, and resolution order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)