### PR TITLE
docs(db): tighten needs-injection wording — top-level + single-table only

### DIFF
--- a/docs/guide/db-extensions.md
+++ b/docs/guide/db-extensions.md
@@ -200,7 +200,7 @@ const rows = await dbX.selectFrom('posts').selectAll().execute()
 //    rows[0].excerpt: string  — typed, computed from body
 ```
 
-**`needs` injection** — the plugin walks every `SelectQueryNode` whose `from` resolves to a table with computeds, and adds any declared `needs` column not already in the select list. Adopters who write `.select(['title'])` still get the computeds populated. The injected columns DO land on the runtime row object (they were fetched, after all) — the row's TypeScript shape only widens with the computed property itself, but a property-existence check at runtime would still find the needs columns. Wildcards (`selectAll()`) skip injection entirely — every column is implicitly present.
+**`needs` injection** — the plugin only rewrites the **top-level** `SelectQueryNode`, and only when its `from` resolves to a single table with computeds. In that case it adds any declared `needs` column not already in the select list. Adopters who write `.select(['title'])` still get the computeds populated. Joins, sub-selects, and multi-table `FROM` clauses are skipped entirely — same with nested `SelectQueryNode`s inside `with` / `union` / scalar sub-selects. The injected columns DO land on the runtime row object (they were fetched, after all) — the row's TypeScript shape only widens with the computed property itself, but a property-existence check at runtime would still find the needs columns. Wildcards (`selectAll()`) skip injection entirely — every column is implicitly present.
 
 **`compute()` semantics**
 


### PR DESCRIPTION
## Summary

Doc-only fix in response to Copilot review on PR #152. The "needs injection" paragraph in `docs/guide/db-extensions.md` could be misread as covering nested / sub-select `SelectQueryNode`s. Behaviour unchanged.

## What the implementation actually does

`ResultExtensionPlugin.transformQuery()` checks the **root** query node only. `singleTableTarget(node)` returns the table name when:
- The query is a `SelectQueryNode`
- `from.froms` has exactly one entry
- That entry is a `TableNode` (or `AliasNode` wrapping one)

Otherwise the plugin returns the node untouched. Joins, sub-selects, multi-table FROMs, and nested `SelectQueryNode`s inside `WITH` / `UNION` / scalar sub-selects all pass through.

## Doc rewording

- "the plugin walks every `SelectQueryNode` whose `from` resolves to a table with computeds" → "the plugin only rewrites the **top-level** `SelectQueryNode`, and only when its `from` resolves to a single table with computeds".
- Added: "Nested `SelectQueryNode`s inside `WITH` / `UNION` / scalar sub-selects pass through untouched."

🤖 Generated with [Claude Code](https://claude.com/claude-code)