### PR TITLE
feat(db): detect + warn on removed pgEnum values (M2 punch list)

### DIFF
--- a/packages/db/__tests__/unit/pg-enum-pipeline.test.ts
+++ b/packages/db/__tests__/unit/pg-enum-pipeline.test.ts
@@ -4,7 +4,7 @@ import { table, uuid, varchar } from '../../src/index'
 import { pgEnum } from '../../src/dsl/columns/pg'
 import { extractSnapshot } from '../../src/snapshot/extract'
 import { diff } from '../../src/diff/engine'
-import { invertChanges } from '../../src/diff/invert'
+import { hasAmbiguousReverse, invertChanges } from '../../src/diff/invert'
 import { emitPg } from '../../src/emit/pg'
 
 describe('pgEnum snapshot + diff + emit pipeline', () => {
@@ -102,5 +102,90 @@ describe('pgEnum snapshot + diff + emit pipeline', () => {
     // Forward starts with createEnum then createTable; reverse should
     // start with dropTable (or its dependents) and end with dropEnum.
     expect(reverse[reverse.length - 1].kind).toBe('dropEnum')
+  })
+
+  describe('removed enum value handling', () => {
+    it('diff emits a removeEnumValue advisory when values disappear from a kept enum', () => {
+      const before = pgEnum('status', 'alpha', 'beta', 'released')
+      const after = pgEnum('status', 'alpha', 'released')
+      const prev = extractSnapshot({ status: before }, 'postgres')
+      const next = extractSnapshot({ status: after }, 'postgres')
+      const changes = diff(prev, next)
+      expect(changes).toHaveLength(1)
+      expect(changes[0]).toMatchObject({
+        kind: 'removeEnumValue',
+        enum: 'status',
+        removed: ['beta'],
+      })
+    })
+
+    it('diff records multiple removed values in their original declaration order', () => {
+      const before = pgEnum('phase', 'draft', 'review', 'staged', 'released', 'archived')
+      const after = pgEnum('phase', 'draft', 'released')
+      const prev = extractSnapshot({ phase: before }, 'postgres')
+      const next = extractSnapshot({ phase: after }, 'postgres')
+      const changes = diff(prev, next)
+      const removeChange = changes.find((c) => c.kind === 'removeEnumValue')
+      expect(removeChange).toBeDefined()
+      // Order matches the prev snapshot's value list, not the operator's
+      // (potentially ad-hoc) reasoning order.
+      expect((removeChange as { removed: readonly string[] }).removed).toEqual([
+        'review',
+        'staged',
+        'archived',
+      ])
+    })
+
+    it('diff combines additions and removals into separate changes', () => {
+      const before = pgEnum('phase', 'draft', 'staged')
+      const after = pgEnum('phase', 'draft', 'released')
+      const prev = extractSnapshot({ phase: before }, 'postgres')
+      const next = extractSnapshot({ phase: after }, 'postgres')
+      const changes = diff(prev, next)
+      const kinds = changes.map((c) => c.kind)
+      expect(kinds).toContain('addEnumValue')
+      expect(kinds).toContain('removeEnumValue')
+      expect(changes.find((c) => c.kind === 'addEnumValue')).toMatchObject({
+        value: 'released',
+      })
+      expect(changes.find((c) => c.kind === 'removeEnumValue')).toMatchObject({
+        removed: ['staged'],
+      })
+    })
+
+    it('emit/pg renders the advisory comment block (no SQL DDL)', () => {
+      const sql = emitPg([
+        { kind: 'removeEnumValue', enum: 'status', removed: ['beta', 'archived'] },
+      ])
+      expect(sql).toMatch(/-- WARNING: enum "status" dropped value\(s\): 'beta', 'archived'\./)
+      expect(sql).toMatch(/PostgreSQL has no ALTER TYPE \.\.\. DROP VALUE/)
+      expect(sql).toMatch(/DROP TYPE "status"/)
+      expect(sql).toMatch(/CREATE TYPE "status" AS ENUM/)
+      // No actual DDL — every rendered line is a SQL comment.
+      const nonComment = sql
+        .split('\n')
+        .filter((line) => line.trim() !== '')
+        .find((line) => !line.startsWith('--'))
+      expect(nonComment).toBeUndefined()
+    })
+
+    it('removeEnumValue is flagged as ambiguous-reverse so the down draft warns', () => {
+      const before = pgEnum('status', 'a', 'b')
+      const after = pgEnum('status', 'a')
+      const prev = extractSnapshot({ status: before }, 'postgres')
+      const next = extractSnapshot({ status: after }, 'postgres')
+      const forward = diff(prev, next)
+      expect(hasAmbiguousReverse(forward)).toBe(true)
+    })
+
+    it('invertChanges carries the advisory verbatim (symmetric advisory)', () => {
+      const change = {
+        kind: 'removeEnumValue' as const,
+        enum: 'status',
+        removed: ['beta'],
+      }
+      const reversed = invertChanges([change])
+      expect(reversed).toEqual([change])
+    })
   })
 })

--- a/packages/db/src/diff/engine.ts
+++ b/packages/db/src/diff/engine.ts
@@ -64,15 +64,17 @@ function diffEnumsCreatePhase(prev: SchemaSnapshot, next: SchemaSnapshot, change
   }
 
   // ALTER TYPE ADD VALUE for non-destructive value additions on
-  // existing enums. Removed / reordered values are NOT round-trippable
-  // without dropping every column that references the type — those
-  // surface as a no-op + a comment in emit so the adopter writes a
-  // manual migration.
+  // existing enums. Removed values are NOT round-trippable without
+  // dropping every column that references the type — those surface
+  // as a `removeEnumValue` advisory the emitter turns into a SQL
+  // comment with explicit operator guidance.
   for (const [name, e] of Object.entries(nextEnums)) {
     const prior = prevEnums[name]
     if (!prior) continue
     const priorValues = new Set(prior.values)
+    const nextValues = new Set(e.values)
     const nextValueList = e.values
+
     let lastInsertedAt = -1
     for (let i = 0; i < nextValueList.length; i++) {
       const value = nextValueList[i]
@@ -91,6 +93,14 @@ function diffEnumsCreatePhase(prev: SchemaSnapshot, next: SchemaSnapshot, change
         ...(beforeIsExisting ? { before } : {}),
       })
       void lastInsertedAt
+    }
+
+    // Removed values — collect in declaration order from the prior
+    // snapshot so the emitter list matches the order the operator
+    // originally wrote.
+    const removed = prior.values.filter((v) => !nextValues.has(v))
+    if (removed.length > 0) {
+      changes.push({ kind: 'removeEnumValue', enum: name, removed })
     }
   }
 }

--- a/packages/db/src/diff/invert.ts
+++ b/packages/db/src/diff/invert.ts
@@ -68,6 +68,13 @@ function invert(change: Change): Change {
       // forward change verbatim; the operator gets a draft + a clear
       // signal that the down won't auto-revert.
       return change
+    case 'removeEnumValue':
+      // The forward direction of a value removal is itself an
+      // advisory + manual operation; the reverse is symmetric. Carry
+      // the change verbatim so the down draft surfaces the same
+      // SQL-comment guidance, with `removed` listing the values that
+      // would need to be re-added.
+      return change
   }
 }
 
@@ -84,6 +91,11 @@ const AMBIGUOUS_REVERSE_KINDS = new Set<Change['kind']>([
   // supported without recreating the type. The down draft surfaces
   // the forward statement so the operator manually rewrites it.
   'addEnumValue',
+  // Removed values can't auto-reverse for the symmetric reason: the
+  // value(s) that disappeared from the schema may have been held by
+  // existing rows whose state is already gone. Down draft preserves
+  // the advisory comment.
+  'removeEnumValue',
 ])
 
 export function hasAmbiguousReverse(forward: ChangeSet): boolean {

--- a/packages/db/src/diff/types.ts
+++ b/packages/db/src/diff/types.ts
@@ -86,8 +86,8 @@ export interface DropEnum {
 /**
  * PG ALTER TYPE … ADD VALUE — non-destructive value addition.
  * Removed values + reorderings can't round-trip without dropping
- * dependent columns; the diff engine surfaces them as a NoOp + a
- * comment inside emit so the adopter writes a manual migration.
+ * dependent columns; the diff engine surfaces them as a separate
+ * `RemoveEnumValue` advisory below.
  */
 export interface AddEnumValue {
   kind: 'addEnumValue'
@@ -95,6 +95,26 @@ export interface AddEnumValue {
   value: string
   /** When set, emit `ALTER TYPE … ADD VALUE 'x' BEFORE 'y'`. */
   before?: string
+}
+
+/**
+ * Advisory-only change kind raised when an enum keeps the same name
+ * but loses one or more values across the diff. PostgreSQL has no
+ * `ALTER TYPE … DROP VALUE` — round-tripping requires dropping every
+ * column that uses the type, dropping the type, recreating with the
+ * new value list, then recreating the columns and restoring data.
+ *
+ * The diff engine records the removed values; the emitter renders a
+ * multi-line SQL comment with explicit guidance instead of a no-op
+ * silently swallowed by the migration runner. Operators choosing to
+ * proceed write the multi-step migration by hand.
+ */
+export interface RemoveEnumValue {
+  kind: 'removeEnumValue'
+  /** Enum type name. */
+  enum: string
+  /** Values present in the previous snapshot but not in the next. */
+  removed: readonly string[]
 }
 
 export type Change =
@@ -112,5 +132,6 @@ export type Change =
   | CreateEnum
   | DropEnum
   | AddEnumValue
+  | RemoveEnumValue
 
 export type ChangeSet = Change[]

--- a/packages/db/src/emit/pg.ts
+++ b/packages/db/src/emit/pg.ts
@@ -40,7 +40,37 @@ function emitChange(change: Change): string {
       const before = change.before ? ` BEFORE ${quoteLiteral(change.before)}` : ''
       return `ALTER TYPE ${quoteIdent(change.enum)} ADD VALUE ${quoteLiteral(change.value)}${before};`
     }
+    case 'removeEnumValue':
+      return emitRemoveEnumValueAdvisory(change.enum, change.removed)
   }
+}
+
+/**
+ * PostgreSQL has no `ALTER TYPE … DROP VALUE` — emitting silently
+ * here would drop these values from the schema's intent without
+ * reflecting in the database. Instead we render a multi-line SQL
+ * comment with the manual migration steps the operator must take.
+ *
+ * The migration file still applies cleanly; the comment block makes
+ * the missing operation visible in code review and in the generated
+ * SQL output.
+ */
+function emitRemoveEnumValueAdvisory(name: string, removed: readonly string[]): string {
+  const valuesList = removed.map((v) => quoteLiteral(v)).join(', ')
+  return [
+    `-- WARNING: enum ${quoteIdent(name)} dropped value(s): ${valuesList}.`,
+    `-- PostgreSQL has no ALTER TYPE ... DROP VALUE. To round-trip this`,
+    `-- removal you must:`,
+    `--   1. Drop or migrate every column whose type is ${quoteIdent(name)} (or any`,
+    `--      composite that references it).`,
+    `--   2. DROP TYPE ${quoteIdent(name)};`,
+    `--   3. CREATE TYPE ${quoteIdent(name)} AS ENUM (...) with the new value list.`,
+    `--   4. Recreate the columns + restore data, mapping any rows that held`,
+    `--      one of the dropped value(s) to a still-valid replacement first.`,
+    `-- This migration emits no SQL for this change — write the steps above`,
+    `-- by hand if the removal is intentional, or restore the value(s) in`,
+    `-- the schema definition to silence this warning.`,
+  ].join('\n')
 }
 
 function emitAddColumn(table: string, c: ColumnSnapshot): string {


### PR DESCRIPTION
## Summary

Closes the M2 "removed-enum-value handling" punch-list item. Previously the diff engine silently dropped enum-value removals on the floor — schema intent diverged from the database without any signal in the migration output. Now they surface as a `removeEnumValue` advisory the emitter renders as an explicit SQL comment block with the manual migration steps.

## Why advisory-only

PostgreSQL has no `ALTER TYPE … DROP VALUE`. Removing a value requires:

1. Drop or migrate every column whose type is the enum (or any composite that references it)
2. `DROP TYPE`
3. `CREATE TYPE` with the new value list
4. Recreate the columns + restore data, mapping any rows that held the dropped value(s) to a still-valid replacement first

There's no one-statement automatic path. Operators choosing to proceed write that migration by hand. The advisory comment in the generated SQL makes the missing operation visible at code-review time and in the file the operator opens. Restoring the value(s) in the schema definition silences the advisory — useful for accidental removals.

## New surface

- `RemoveEnumValue` `Change` kind in `diff/types.ts` — `{ enum: string, removed: readonly string[] }`. Listed values come from the prev snapshot in declaration order.
- `diff` engine adds the change in `diffEnumsCreatePhase` after walking the kept-enum value sets. Mixing additions + removals on the same enum produces both `addEnumValue` + `removeEnumValue` outputs.
- `emit/pg` renders a multi-line `-- WARNING: …` comment block listing the removed values + the four-step recipe + the silence-the-warning hint. No DDL emitted for this kind.
- `invert.ts` mirrors the kind verbatim (down draft preserves the same advisory). `hasAmbiguousReverse()` returns true so the down migration is correctly flagged for operator review.

## Test plan

- [x] +6 new test cases — single-value removal, multi-value removal preserves prev-snapshot order, mixed add+remove emits both kinds, emit/pg comment-block contents (warning header + no-DDL guarantee), `hasAmbiguousReverse` flips true, invert round-trips the advisory.
- [x] 244/244 db tests pass (was 238; +6).
- [x] `tsc --noEmit` clean.
- [x] Pre-commit hook (build + tests + format + kick-lint) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)