### PR TITLE
docs(db) + fix(db): Copilot review fixes from PR #155 + PR #156

### DIFF
--- a/docs/guide/db-extensions.md
+++ b/docs/guide/db-extensions.md
@@ -200,7 +200,7 @@ const rows = await dbX.selectFrom('posts').selectAll().execute()
 //    rows[0].excerpt: string  — typed, computed from body
 ```
 
-**`needs` injection** — the plugin only rewrites the **top-level** `SelectQueryNode`, and only when its `from` resolves to a single table with computeds. In that case it adds any declared `needs` column not already in the select list. Adopters who write `.select(['title'])` still get the computeds populated. Joins, sub-selects, and multi-table `FROM` clauses are skipped entirely — same with nested `SelectQueryNode`s inside `with` / `union` / scalar sub-selects. The injected columns DO land on the runtime row object (they were fetched, after all) — the row's TypeScript shape only widens with the computed property itself, but a property-existence check at runtime would still find the needs columns. Wildcards (`selectAll()`) skip injection entirely — every column is implicitly present.
+**`needs` injection** — the plugin only rewrites the **top-level** `SelectQueryNode`, and only when its `from` resolves to a single table with computeds. In that case it adds any declared `needs` column not already in the select list. Adopters who write `.select(['title'])` still get the computeds populated. Joins, sub-selects, and multi-table `FROM` clauses are skipped entirely — as are nested `SelectQueryNode`s inside `WITH` / `UNION` / scalar sub-selects. The injected columns DO land on the runtime row object (they were fetched, after all) — the row's TypeScript shape only widens with the computed property itself, but a property-existence check at runtime would still find the needs columns. Wildcards (`selectAll()`) skip injection entirely — every column is implicitly present.
 
 **`compute()` semantics**
 

--- a/packages/db/__tests__/unit/pg-enum-pipeline.test.ts
+++ b/packages/db/__tests__/unit/pg-enum-pipeline.test.ts
@@ -187,5 +187,33 @@ describe('pgEnum snapshot + diff + emit pipeline', () => {
       const reversed = invertChanges([change])
       expect(reversed).toEqual([change])
     })
+
+    it('emit/pg sanitises newlines + control bytes in enum names + values', () => {
+      // Pathological input — an adopter passing pgEnum('foo\nDROP TABLE x;', ...)
+      // shouldn't be able to escape the SQL comment by stuffing newlines
+      // into the comment text.
+      const sql = emitPg([
+        {
+          kind: 'removeEnumValue',
+          enum: 'foo\nDROP TABLE evil',
+          removed: ['bad\nrm -rf', 'safe', '\x07bell'],
+        },
+      ])
+      // No raw newline survives inside the rendered text — every
+      // non-empty rendered line still starts with `--`. Without
+      // sanitisation the newline injection would terminate the
+      // comment early, producing an executable line.
+      const lines = sql.split('\n').filter((l) => l.trim() !== '')
+      for (const line of lines) {
+        expect(line.startsWith('--')).toBe(true)
+      }
+      // Newlines in user-supplied text collapse to a single space.
+      expect(sql).not.toMatch(/foo\nDROP/)
+      expect(sql).not.toMatch(/bad\nrm/)
+      // C0 control bytes (other than tab / newline) become \x<hh>.
+      // BEL is \x07 — the chosen sanitisation makes the migration
+      // file printable ASCII-clean.
+      expect(sql).toMatch(/\\x07bell/)
+    })
   })
 })

--- a/packages/db/src/diff/types.ts
+++ b/packages/db/src/diff/types.ts
@@ -85,9 +85,11 @@ export interface DropEnum {
 
 /**
  * PG ALTER TYPE … ADD VALUE — non-destructive value addition.
- * Removed values + reorderings can't round-trip without dropping
- * dependent columns; the diff engine surfaces them as a separate
- * `RemoveEnumValue` advisory below.
+ * Removed values can't round-trip without dropping dependent columns;
+ * the diff engine surfaces them via the separate `RemoveEnumValue`
+ * advisory below. Pure reorderings (same value set, different order)
+ * currently produce no diff at all — PG honours the canonical sort
+ * order at storage time, so user-visible behaviour is unchanged.
  */
 export interface AddEnumValue {
   kind: 'addEnumValue'

--- a/packages/db/src/emit/pg.ts
+++ b/packages/db/src/emit/pg.ts
@@ -56,21 +56,75 @@ function emitChange(change: Change): string {
  * SQL output.
  */
 function emitRemoveEnumValueAdvisory(name: string, removed: readonly string[]): string {
-  const valuesList = removed.map((v) => quoteLiteral(v)).join(', ')
+  const safeName = sanitizeForLineComment(quoteIdent(name))
+  const valuesList = removed.map((v) => sanitizeForLineComment(quoteLiteral(v))).join(', ')
   return [
-    `-- WARNING: enum ${quoteIdent(name)} dropped value(s): ${valuesList}.`,
+    `-- WARNING: enum ${safeName} dropped value(s): ${valuesList}.`,
     `-- PostgreSQL has no ALTER TYPE ... DROP VALUE. To round-trip this`,
     `-- removal you must:`,
-    `--   1. Drop or migrate every column whose type is ${quoteIdent(name)} (or any`,
+    `--   1. Drop or migrate every column whose type is ${safeName} (or any`,
     `--      composite that references it).`,
-    `--   2. DROP TYPE ${quoteIdent(name)};`,
-    `--   3. CREATE TYPE ${quoteIdent(name)} AS ENUM (...) with the new value list.`,
+    `--   2. DROP TYPE ${safeName};`,
+    `--   3. CREATE TYPE ${safeName} AS ENUM (...) with the new value list.`,
     `--   4. Recreate the columns + restore data, mapping any rows that held`,
     `--      one of the dropped value(s) to a still-valid replacement first.`,
     `-- This migration emits no SQL for this change — write the steps above`,
     `-- by hand if the removal is intentional, or restore the value(s) in`,
     `-- the schema definition to silence this warning.`,
   ].join('\n')
+}
+
+/**
+ * Make a value safe to interpolate into a single-line `--` SQL
+ * comment. Identifiers and quoted literals normally don't carry
+ * line breaks, but the user-supplied portion (enum name + values)
+ * can contain anything an adopter passes to `pgEnum()`. A literal
+ * `\n` would terminate the comment early and turn the rest of the
+ * line into executable SQL.
+ *
+ * - `\r\n`, `\r`, `\n`, `U+2028`, `U+2029` collapse to a single space
+ *   so the rest of the comment stays on one line.
+ * - C0 / C1 control bytes (other than tab) become `\x<hh>` so the
+ *   migration file remains a plain ASCII-safe text.
+ */
+function sanitizeForLineComment(value: string): string {
+  // Walk code units rather than regex character classes \u2014 control-char
+  // regex literals trip `no-control-regex` lints and confuse some
+  // editor analysers with "unreachable" warnings on the second
+  // replace. Code-unit iteration is unambiguous: for every char we
+  // either pass it through, collapse a line-break to a space, or
+  // escape a control byte into `\x<hh>`.
+  let out = ''
+  let prevWasLineBreak = false
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i)
+    // Line-break code points \u2192 collapse runs to a single space.
+    // Includes \r (0x0D), \n (0x0A), U+2028 (LINE SEPARATOR),
+    // U+2029 (PARAGRAPH SEPARATOR).
+    const isLineBreak = code === 0x0a || code === 0x0d || code === 0x2028 || code === 0x2029
+    if (isLineBreak) {
+      if (!prevWasLineBreak) out += ' '
+      prevWasLineBreak = true
+      continue
+    }
+    prevWasLineBreak = false
+    // Tab (0x09) passes through \u2014 visually fine inside a `--` comment.
+    // Other C0 control bytes (0x00-0x08, 0x0B, 0x0C, 0x0E-0x1F) and
+    // DEL (0x7F) escape to `\x<hh>` so the migration file stays
+    // printable ASCII clean.
+    const isControl =
+      (code >= 0x00 && code <= 0x08) ||
+      code === 0x0b ||
+      code === 0x0c ||
+      (code >= 0x0e && code <= 0x1f) ||
+      code === 0x7f
+    if (isControl) {
+      out += `\\x${code.toString(16).padStart(2, '0')}`
+      continue
+    }
+    out += value[i]
+  }
+  return out
 }
 
 function emitAddColumn(table: string, c: ColumnSnapshot): string {

--- a/packages/db/src/emit/pg.ts
+++ b/packages/db/src/emit/pg.ts
@@ -82,10 +82,19 @@ function emitRemoveEnumValueAdvisory(name: string, removed: readonly string[]): 
  * `\n` would terminate the comment early and turn the rest of the
  * line into executable SQL.
  *
- * - `\r\n`, `\r`, `\n`, `U+2028`, `U+2029` collapse to a single space
- *   so the rest of the comment stays on one line.
- * - C0 / C1 control bytes (other than tab) become `\x<hh>` so the
- *   migration file remains a plain ASCII-safe text.
+ * Scope of the sanitiser:
+ * - Line-break code points (`\r`, `\n`, `U+2028`, `U+2029`) collapse
+ *   runs to a single space so the comment stays on one line.
+ * - C0 control bytes excluding tab (0x00-0x08, 0x0B, 0x0C, 0x0E-0x1F)
+ *   plus DEL (0x7F) escape to `\x<hh>`.
+ * - Tab (0x09) passes through — visually fine inside a `--` comment.
+ *
+ * Out of scope on purpose: C1 controls (U+0080-U+009F) and other
+ * non-ASCII characters pass through unchanged. Adopters do legitimately
+ * pass UTF-8 enum names + values (`'café'`, `'naïve'`); aggressively
+ * escaping them would degrade the migration file's readability without
+ * adding security — only line terminators can break out of a `--`
+ * comment, and those are handled above.
  */
 function sanitizeForLineComment(value: string): string {
   // Walk code units rather than regex character classes \u2014 control-char


### PR DESCRIPTION
## Summary

Combined fixes for Copilot review nits on two recently-merged PRs.

### PR #155 (T17 result-computeds doc)
- "— same with nested …" → "— as are nested …" for clearer English flow.
- `with` / `union` (lowercase — ambiguous between SQL keyword and Kysely's `.with()` / `.union()` methods) → `WITH` / `UNION` so the doc unambiguously refers to the SQL constructs that produce nested `SelectQueryNode`s.

### PR #156 (removed-enum-value handling)

**`emit/pg.ts` — SQL injection guard on the `--` comment block.** An adopter passing `pgEnum('foo\nDROP TABLE x', ...)` previously had their newline interpolated verbatim into the warning comment, terminating the `--` early and turning the rest into an executable line. Now the user-supplied portions go through `sanitizeForLineComment(value)`:

- Line-break code points (`\r`, `\n`, U+2028, U+2029) collapse to a single space — runs collapse together.
- C0 control bytes other than tab (0x00-0x08, 0x0B, 0x0C, 0x0E-0x1F, 0x7F) escape to `\x<hh>` hex literals.
- Tab passes through (visually fine inside a `--` comment).

Implemented as an explicit code-unit loop rather than a regex character class so editor analysers don't flag `no-control-regex` / "unreachable code" warnings on the unusual range syntax.

**`diff/types.ts` — `AddEnumValue` docstring** no longer claims pure reorderings are surfaced. They produce no diff at all (PG canonicalises order at storage time, user-visible behaviour unchanged). Only removals get the `RemoveEnumValue` advisory.

## Test plan

- [x] +1 sanitiser test covering newline injection (`foo\nDROP TABLE`) + control-byte escape (`\x07` → `\x07` hex literal). Asserts every rendered line still starts with `--` regardless of input.
- [x] 14 pg-enum-pipeline tests pass (was 13).
- [x] 245/245 db tests pass overall.
- [x] `tsc --noEmit` clean.
- [x] Pre-commit hook (build + tests + format + kick-lint) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)