### PR TITLE
ci: trim test/build matrix to Node 24 + fix testing typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,18 +81,14 @@ jobs:
       - run: pnpm -r --filter='./packages/*' run typecheck
 
   test:
-    name: Test (Node ${{ matrix.node-version }})
+    name: Test (Node 24)
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
         env:
@@ -107,25 +103,20 @@ jobs:
       - run: pnpm test
 
   build:
-    name: Build (Node ${{ matrix.node-version }})
+    name: Build (Node 24)
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       # Cache the built dist/ trees so the smoke-test jobs below can
-      # reuse them without rebuilding from scratch on Node 24.
-      - if: matrix.node-version == 24
-        uses: actions/upload-artifact@v4
+      # reuse them without rebuilding from scratch.
+      - uses: actions/upload-artifact@v4
         with:
           name: built-packages
           path: packages/*/dist

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -238,7 +238,7 @@ export async function runContributor<
   K extends string,
   D extends Record<string, any> = Record<string, never>,
 >(
-  decorator: ContextDecorator<K, D, ExecutionContext>,
+  decorator: ContextDecorator<K, D>,
   options: RunContributorOptions = {},
 ): Promise<RunContributorResult<K>> {
   const meta = new Map<string, unknown>(Object.entries(options.initial ?? {}))


### PR DESCRIPTION
## Why

CI was running `test` and `build` across `{Node 20, 22, 24}` — six runner-slots per push for almost no signal. Node 20 and 22 are both LTS, and the framework's surface (Express 5, Vite 8, oxc) behaves identically across those targets. Trim the matrix to a single Node 24 job each and reclaim the quota.

Side-fix: a TS2344 in `packages/testing` was failing the `Typecheck` job —

```
packages/testing typecheck: src/index.ts(241,37):
error TS2344: Type 'ExecutionContext' does not satisfy the constraint 'Record<string, unknown>'.
```

`runContributor` was passing `ExecutionContext` into the **third** generic of `ContextDecorator<K, D, P, Ctx>`, but slot 3 is `P extends Record<string, unknown>` (params). The helper doesn't take params, so the cleanest fix is to drop the explicit generic and let the defaults flow through (`P = Record<string, never>`, `Ctx = ExecutionContext`).

## What

- `.github/workflows/ci.yml` — collapse the `test` and `build` matrix entries from `[20, 22, 24]` to a single Node 24 job each. Smoke jobs and the artifact upload step are unchanged.
- `packages/testing/src/index.ts:241` — drop the wrong `ExecutionContext` generic from `ContextDecorator<K, D, ExecutionContext>` → `ContextDecorator<K, D>`.

## What this is **not**

- **Not** a runtime-support change. `engines.node` stays at `>=20.0` across packages — adopters on Node 20/22 still install and work. We've narrowed what we _verify_, not what we _ship_.

## Test plan

- [x] `pnpm --filter @forinda/kickjs-testing typecheck` clean
- [x] `pnpm --filter @forinda/kickjs-testing test --run` — 41/41 passing
- [x] `pnpm format:check` clean
- [ ] CI green on this PR (single Node 24 test + build + the existing single-version typecheck/format/lint jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
