### PR TITLE
docs: clarify request-scope auto-mount; route reads through getRequestValue

### DIFF
--- a/docs/guide/dependency-injection.md
+++ b/docs/guide/dependency-injection.md
@@ -230,7 +230,15 @@ Under the hood this uses Node's `AsyncLocalStorage`, so it works correctly even 
 
 ### Setup
 
-Mount `requestScopeMiddleware()` early in your middleware pipeline (before route handlers):
+Nothing — request-scoped DI works out of the box. `bootstrap()` opens an
+`AsyncLocalStorage` frame around every request automatically, so
+`Scope.REQUEST` services resolve correctly without any manual wiring.
+
+If you need to control _where_ the frame opens (for example, to keep a
+tracing wrapper outside it so spans see the raw request), include
+`requestScopeMiddleware()` in your `middleware` list explicitly. KickJS
+detects an explicit mount and skips the default placement, so you never
+end up with a doubled frame:
 
 ```typescript
 import { bootstrap, requestScopeMiddleware } from '@forinda/kickjs'
@@ -240,7 +248,8 @@ bootstrap({
     /* ... */
   ],
   middleware: [
-    requestScopeMiddleware(), // enables REQUEST-scoped DI
+    tracing(),
+    requestScopeMiddleware(), // mount here instead of the default position
     // ... other middleware
   ],
 })
@@ -249,13 +258,12 @@ bootstrap({
 ### Declaring a Request-Scoped Service
 
 ```typescript
-import { Service, Scope, Autowired } from '@forinda/kickjs'
-import { getRequestStore } from '@forinda/kickjs'
+import { Service, Scope, Autowired, getRequestValue } from '@forinda/kickjs'
 
 @Service({ scope: Scope.REQUEST })
 class TenantContext {
   get tenantId(): string {
-    return getRequestStore().values.get('tenantId')
+    return getRequestValue<string>('tenantId') ?? ''
   }
 }
 
@@ -300,23 +308,62 @@ class OrderController {
 
 ### Pre-Registered Request Values
 
-Middleware can store values in the request store before controllers run. Use `getRequestStore().values.set()` to make data available for injection:
+Need a value computed once per request and visible to every downstream
+handler and request-scoped service? Use a [Context Contributor](context-decorators.md) — a typed,
+ordered, declarative way to populate the request frame before the
+handler runs:
 
 ```typescript
-import { getRequestStore } from '@forinda/kickjs'
+import { defineContextDecorator } from '@forinda/kickjs'
 
-// In auth middleware
-function authMiddleware() {
-  return async (req, res, next) => {
-    const user = await verifyToken(req.headers.authorization)
-    getRequestStore().values.set('currentUser', user)
-    getRequestStore().values.set('tenantId', user.tenantId)
-    next()
+const LoadCurrentUser = defineContextDecorator({
+  key: 'currentUser',
+  resolve: async (ctx) => verifyToken(ctx.req.headers.authorization),
+})
+
+const LoadTenantId = defineContextDecorator({
+  key: 'tenantId',
+  dependsOn: ['currentUser'],
+  resolve: (ctx) => ctx.get('currentUser')!.tenantId,
+})
+
+@Controller()
+class DashboardController {
+  @LoadCurrentUser
+  @LoadTenantId
+  @Get('/me')
+  show(ctx: RequestContext) {
+    return ctx.json({
+      user: ctx.get('currentUser'),
+      tenant: ctx.get('tenantId'),
+    })
   }
 }
 ```
 
-These values can then be read inside any request-scoped service via `getRequestStore().values.get()`.
+Inside any `Scope.REQUEST` service, read the same value with
+`getRequestValue<T>(key)`:
+
+```typescript
+import { Service, Scope, getRequestValue } from '@forinda/kickjs'
+
+@Service({ scope: Scope.REQUEST })
+class CurrentUserService {
+  get tenantId(): string | null {
+    return getRequestValue<string>('tenantId') ?? null
+  }
+}
+```
+
+`getRequestValue()` returns `undefined` outside a request frame
+(background jobs, startup, tests without a request) — null-tolerant by
+design so service code that runs in both request and non-request paths
+doesn't throw.
+
+For ad-hoc writes from inside a handler, use `ctx.set('key', value)`.
+A controller-side write is appropriate when the value depends on
+already-running handler logic; for everything else, prefer a contributor
+so the dependency graph is explicit and order is enforced.
 
 ### Scope Compatibility Rules
 

--- a/docs/guide/dependency-injection.md
+++ b/docs/guide/dependency-injection.md
@@ -257,13 +257,27 @@ bootstrap({
 
 ### Declaring a Request-Scoped Service
 
+`getRequestValue(key)` is keyed off the augmentable `ContextMeta`
+registry — augment it once at module level and every read from that
+key gets the right type without `as` casts:
+
+```typescript
+declare module '@forinda/kickjs' {
+  interface ContextMeta {
+    tenantId: string
+    currentUser: { id: string; email: string; tenantId: string }
+  }
+}
+```
+
 ```typescript
 import { Service, Scope, Autowired, getRequestValue } from '@forinda/kickjs'
 
 @Service({ scope: Scope.REQUEST })
 class TenantContext {
   get tenantId(): string {
-    return getRequestValue<string>('tenantId') ?? ''
+    // typed as `string | undefined` thanks to the ContextMeta augmentation
+    return getRequestValue('tenantId') ?? ''
   }
 }
 
@@ -313,15 +327,21 @@ handler and request-scoped service? Use a [Context Contributor](context-decorato
 ordered, declarative way to populate the request frame before the
 handler runs:
 
-```typescript
-import { defineContextDecorator } from '@forinda/kickjs'
+Because these contributors touch `ctx.req.headers`, use
+`defineHttpContextDecorator` — the HTTP-typed wrapper that binds `ctx`
+to `RequestContext` so `ctx.req` is available and typed. Use plain
+`defineContextDecorator` only for transport-agnostic contributors that
+read `ctx.get(...)` and nothing else:
 
-const LoadCurrentUser = defineContextDecorator({
+```typescript
+import { defineHttpContextDecorator } from '@forinda/kickjs'
+
+const LoadCurrentUser = defineHttpContextDecorator({
   key: 'currentUser',
   resolve: async (ctx) => verifyToken(ctx.req.headers.authorization),
 })
 
-const LoadTenantId = defineContextDecorator({
+const LoadTenantId = defineHttpContextDecorator({
   key: 'tenantId',
   dependsOn: ['currentUser'],
   resolve: (ctx) => ctx.get('currentUser')!.tenantId,
@@ -342,7 +362,9 @@ class DashboardController {
 ```
 
 Inside any `Scope.REQUEST` service, read the same value with
-`getRequestValue<T>(key)`:
+`getRequestValue(key)`. The return type comes from the `ContextMeta`
+augmentation above — there is no value-type generic, so don't write
+`getRequestValue<string>(...)`:
 
 ```typescript
 import { Service, Scope, getRequestValue } from '@forinda/kickjs'
@@ -350,15 +372,18 @@ import { Service, Scope, getRequestValue } from '@forinda/kickjs'
 @Service({ scope: Scope.REQUEST })
 class CurrentUserService {
   get tenantId(): string | null {
-    return getRequestValue<string>('tenantId') ?? null
+    // typed via ContextMeta['tenantId'] — `string | undefined`
+    return getRequestValue('tenantId') ?? null
   }
 }
 ```
 
-`getRequestValue()` returns `undefined` outside a request frame
-(background jobs, startup, tests without a request) — null-tolerant by
-design so service code that runs in both request and non-request paths
-doesn't throw.
+`getRequestValue()` returns `MetaValue<K> | undefined` — typed via
+`ContextMeta[K]` when augmented, falling back to `unknown` when the
+key isn't registered. It also returns `undefined` outside a request
+frame (background jobs, startup, tests without a request), which is
+intentional: service code that runs in both request and non-request
+paths doesn't throw.
 
 For ad-hoc writes from inside a handler, use `ctx.set('key', value)`.
 A controller-side write is appropriate when the value depends on

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -312,9 +312,9 @@ The `traceContext()` middleware implements [W3C Trace Context](https://www.w3.or
 ### Setup
 
 `traceContext()` writes into the request's `AsyncLocalStorage` frame, so
-it has to run inside one. KickJS opens that frame automatically before
-any user middleware, so just dropping `traceContext()` into your list
-works:
+it has to run inside one. **By default** (`contextStore: 'auto'`),
+KickJS opens that frame automatically before any user middleware, so
+dropping `traceContext()` into your list just works:
 
 ```ts
 import express from 'express'
@@ -334,6 +334,11 @@ If you need to control the frame's position explicitly — e.g., to keep
 an outer wrapper above it — mount `requestScopeMiddleware()` yourself
 and place `traceContext()` after it. KickJS detects the explicit mount
 and skips its default placement.
+
+If you opted out of auto-mount with `contextStore: 'manual'`,
+`traceContext()` will silently no-op (there's no frame to write
+into) — make sure `requestScopeMiddleware()` (or your own ALS wrapper)
+runs before it.
 
 ### How it works
 
@@ -357,14 +362,34 @@ traceContext({ propagateResponse: true })
 ### Accessing the trace ID in application code
 
 Inside a controller or service, read the trace values via the typed
-helper:
+helper. `getRequestValue` is keyed off the augmentable `ContextMeta`
+registry — augment it once for the trace fields and every read returns
+the right type:
+
+```ts
+declare module '@forinda/kickjs' {
+  interface ContextMeta {
+    traceId: string
+    spanId: string
+    parentSpanId: string
+    traceFlags: number
+    traceVersion: string
+  }
+}
+```
 
 ```ts
 import { getRequestValue } from '@forinda/kickjs'
 
-const traceId = getRequestValue<string>('traceId')
-const spanId = getRequestValue<string>('spanId')
+const traceId = getRequestValue('traceId') // string | undefined
+const spanId = getRequestValue('spanId') // string | undefined
 ```
+
+Without the augmentation, the return type falls back to
+`unknown | undefined`. Don't reach for a value-type generic
+(`getRequestValue<string>('traceId')`) — that generic slot is the
+**key** type, not the value type, and passing `<string>` widens the
+key and hides the typed lookup.
 
 `getRequestValue()` returns `undefined` outside a request frame —
 null-tolerant by design so the same code can run in both request and

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -356,22 +356,26 @@ traceContext({ propagateResponse: true })
 
 ### Accessing the trace ID in application code
 
-Inside a controller or service you can read the trace values from the request store:
+Inside a controller or service, read the trace values via the typed
+helper:
 
 ```ts
-import { requestStore } from '@forinda/kickjs'
+import { getRequestValue } from '@forinda/kickjs'
 
-const store = requestStore.getStore()
-const traceId = store?.values.get('traceId')
-const spanId = store?.values.get('spanId')
+const traceId = getRequestValue<string>('traceId')
+const spanId = getRequestValue<string>('spanId')
 ```
 
-Or directly from the request object:
+`getRequestValue()` returns `undefined` outside a request frame —
+null-tolerant by design so the same code can run in both request and
+background paths.
+
+Or directly from the request object inside a handler:
 
 ```ts
 @Get('/health')
 async health(ctx: RequestContext) {
-  const traceId = (ctx.req as any).traceId
+  const traceId = (ctx.req as Request & { traceId?: string }).traceId
   ctx.json({ status: 'ok', traceId })
 }
 ```

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -311,22 +311,29 @@ The `traceContext()` middleware implements [W3C Trace Context](https://www.w3.or
 
 ### Setup
 
-`traceContext()` must be mounted **after** `requestScopeMiddleware()` because it stores values in the request's `AsyncLocalStorage` store.
+`traceContext()` writes into the request's `AsyncLocalStorage` frame, so
+it has to run inside one. KickJS opens that frame automatically before
+any user middleware, so just dropping `traceContext()` into your list
+works:
 
 ```ts
 import express from 'express'
-import { bootstrap, requestScopeMiddleware, traceContext, requestLogger } from '@forinda/kickjs'
+import { bootstrap, traceContext, requestLogger } from '@forinda/kickjs'
 
 bootstrap({
   modules,
   middleware: [
-    requestScopeMiddleware(),
     traceContext(), // extracts or generates traceId
     requestLogger(), // logger automatically includes traceId
     express.json(),
   ],
 })
 ```
+
+If you need to control the frame's position explicitly — e.g., to keep
+an outer wrapper above it — mount `requestScopeMiddleware()` yourself
+and place `traceContext()` after it. KickJS detects the explicit mount
+and skips its default placement.
 
 ### How it works
 


### PR DESCRIPTION
## Why

Two stale doc patterns that were misleading adopters:

### 1. "Mount `requestScopeMiddleware()` manually"

`docs/guide/dependency-injection.md` and `docs/guide/middleware.md`
both told adopters to wire `requestScopeMiddleware()` into their
middleware list. That hasn't been required since `Application` started
auto-mounting the AsyncLocalStorage frame under the default
`contextStore: 'auto'` setting — a fresh `bootstrap()` already opens
the frame around every request, so `Scope.REQUEST` services and
`traceContext()` work with **zero wiring**.

The manual mount is now documented as an explicit opt-in for the
narrow case where an outer wrapper has to live above the frame (e.g.,
a tracing wrapper that needs to see the raw request). Application
detects an explicit mount via the symbol marker and skips its default
placement, so adopters never end up with a doubled frame.

### 2. Internal store APIs leaking into adopter code

The same pages were steering adopters at the raw bag surface:

```ts
// before — internal Map API, no type, no null-tolerance
const store = requestStore.getStore()
const traceId = store?.values.get('traceId')
getRequestStore().values.set('currentUser', user)
```

That violates the "writes flow through `ctx.set` or a Context
Contributor; reads use `getRequestValue<T>(key)`" rule the framework
already encodes (no `setRequestValue` is exported). Replaced with the
typed surface in three spots:

- **Reads from a service** → `getRequestValue<string>('traceId')` /
  `getRequestValue<User>('currentUser')`. Returns `T | undefined`,
  null-tolerant so the same code runs in request and background paths.
- **Writes from middleware/auth** → a Context Contributor
  (`defineContextDecorator({ key, resolve })`). Dependencies are
  declared, order is enforced at startup, and the contributor's return
  value lands in the bag via the runner's `ctx.set(reg.key, value)`.

## What

| File | Change |
|---|---|
| `docs/guide/dependency-injection.md` | "Setup" → describes auto-mount; manual mount shown as opt-in. "Pre-Registered Request Values" rewritten around `defineContextDecorator` + `getRequestValue` instead of `getRequestStore().values.set/get`. |
| `docs/guide/middleware.md` | trace-context "Setup" drops the redundant `requestScopeMiddleware()` from the example. "Accessing the trace ID" replaces `requestStore.getStore()?.values.get('traceId')` with `getRequestValue<string>('traceId')`. |

Versioned snapshots (`docs/versions/5.x.x/`) are intentionally
unchanged — those are point-in-time release archives.

## Sweep

Audited every other user-facing surface (other guide pages, the
`docs/db/` book, `examples/`, `tutorials/`, `articles/`, CLI scaffold
templates) for direct `requestStore.getStore()` / `.values.set` /
`.values.get` access. Nothing else leaks: remaining matches are either
historical changelog entries or sentences that document the rule
itself with the typed helpers (`getRequestValue`,
`getRequestStore()` — the typed full-record helper, not the raw
ALS handle).

Framework internals (`packages/kickjs/src/{core,http}/...`)
legitimately write the store — those are the framework's job and
aren't user-facing leaks.

## Test plan

- [x] `pnpm format:check` clean
- [x] No remaining `getRequestStore().values.set/get` or
  `requestStore.getStore()?.values.set/get` in any doc, example,
  tutorial, article, or CLI template
- [ ] CI green
- [ ] `pnpm docs:dev` renders both pages without anchor breakage
