### PR TITLE
feat(kickjs): tighten RequestContext data getters with DeepReadonly

### DIFF
--- a/.changeset/readonly-request-context.md
+++ b/.changeset/readonly-request-context.md
@@ -6,7 +6,8 @@
 are now typed `DeepReadonly<T>` (or `Readonly<T>` for headers,
 `ReadonlyArray<...>` for files). This is a **type-only** change — no
 runtime difference, no `Object.freeze`, no perf cost — but adopter code
-that mutates these in place will start failing at compile time:
+that mutates these in place will start failing at compile time, **once
+`ctx` is properly typed**:
 
 ```ts
 // Before — silently accepted, even when bypassing Zod validation
@@ -24,6 +25,17 @@ This matches the framework's existing rule — _writes flow through
 `ctx.set(key, value)` or a Context Contributor's return value, not by
 mutating the request bag in place_ — and now the type system enforces
 it.
+
+::: tip Protection only kicks in for typed contexts
+The default generic for `RequestContext` is `any`, and `DeepReadonly<any>`
+collapses to `any`. Adopters who write `ctx: RequestContext` get no
+protection (and no breakage). Adopters who write
+`ctx: Ctx<KickRoutes.UserController['create']>` (or pass explicit
+generics like `RequestContext<CreateUserBody>`) get the readonly
+locks the changeset describes. The CLI scaffolders (`kick g scaffold`,
+`kick g controller`) already emit `Ctx<KickRoutes…>` by default, so
+freshly generated controllers see the protection automatically.
+:::
 
 ### Migration
 

--- a/.changeset/readonly-request-context.md
+++ b/.changeset/readonly-request-context.md
@@ -12,12 +12,12 @@ that mutates these in place will start failing at compile time:
 // Before — silently accepted, even when bypassing Zod validation
 ctx.body.injectedField = 'computed'
 ctx.headers.authorization = 'fake'
-ctx.files.push(extra)
+ctx.files!.push(extra)
 
 // After — tsc errors
 //   "Cannot assign to 'injectedField' because it is a read-only property."
 //   "Cannot assign to 'authorization' because it is a read-only property."
-//   "Property 'push' does not exist on type 'readonly ..."
+//   "Property 'push' does not exist on type 'readonly any[]'."
 ```
 
 This matches the framework's existing rule — _writes flow through

--- a/.changeset/readonly-request-context.md
+++ b/.changeset/readonly-request-context.md
@@ -1,0 +1,54 @@
+---
+'@forinda/kickjs': minor
+---
+
+`RequestContext.body`, `params`, `query`, `headers`, `file`, and `files`
+are now typed `DeepReadonly<T>` (or `Readonly<T>` for headers,
+`ReadonlyArray<...>` for files). This is a **type-only** change — no
+runtime difference, no `Object.freeze`, no perf cost — but adopter code
+that mutates these in place will start failing at compile time:
+
+```ts
+// Before — silently accepted, even when bypassing Zod validation
+ctx.body.injectedField = 'computed'
+ctx.headers.authorization = 'fake'
+ctx.files.push(extra)
+
+// After — tsc errors
+//   "Cannot assign to 'injectedField' because it is a read-only property."
+//   "Cannot assign to 'authorization' because it is a read-only property."
+//   "Property 'push' does not exist on type 'readonly ..."
+```
+
+This matches the framework's existing rule — _writes flow through
+`ctx.set(key, value)` or a Context Contributor's return value, not by
+mutating the request bag in place_ — and now the type system enforces
+it.
+
+### Migration
+
+Most usages already comply. If you mutate one of these surfaces
+intentionally, two escape hatches:
+
+1. **Compute and stash** (preferred):
+   ```ts
+   const enriched = { ...ctx.body, computed: f(ctx.body) }
+   ctx.set('enrichedBody', enriched)
+   ```
+2. **Drop down to the raw Express handle**:
+   ```ts
+   ;(ctx.req.body as any).injectedField = 'computed'
+   ```
+
+The escape hatches stay supported. The default just stops surprising
+adopters who validated a payload with Zod, then watched a downstream
+middleware silently mutate it.
+
+`ctx.session`, `ctx.user`, `ctx.cookies`, and `ctx.requestId` are
+unchanged — those have legitimate write-side flows (auth strategies,
+session stores, etc.) and wrapping them in `Readonly` would create
+real friction.
+
+A new `DeepReadonly<T>` type alias is exported from
+`@forinda/kickjs` for adopters who want to apply the same lock to
+their own typed payloads.

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -1,3 +1,4 @@
+/// <reference types="multer" />
 import type { Request, Response, NextFunction } from 'express'
 import { type ContextMeta, type ExecutionContext, type MetaValue } from '../core/execution-context'
 import { requestStore } from './request-store'
@@ -25,8 +26,7 @@ import {
  * distributes conditional types over `any`), so adopters who haven't
  * typed their `Ctx` get no protection but no breakage either.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type DeepReadonly<T> = T extends (...args: any[]) => any
+export type DeepReadonly<T> = T extends (...args: never[]) => unknown
   ? T
   : T extends Date | RegExp
     ? T
@@ -241,25 +241,30 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
 
   /**
    * Single uploaded file (requires `@FileUpload({ mode: 'single' })`).
-   * Read-only — file metadata is set by the upload middleware and
-   * shouldn't be mutated downstream.
+   * Returned as `DeepReadonly<Express.Multer.File>` — file metadata is
+   * set by the upload middleware and shouldn't be mutated downstream.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  get file(): DeepReadonly<any> | undefined {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (this.req as any).file
+  get file(): DeepReadonly<Express.Multer.File> | undefined {
+    return this.req.file
   }
 
   /**
    * Array of uploaded files (requires `@FileUpload({ mode: 'array' })`).
-   * Returns a `ReadonlyArray` — `push`/`pop`/index assignment all error
-   * at compile time. Use the underlying `ctx.req.files` if you need to
-   * splice the list in place (rare).
+   * Returns a `ReadonlyArray<DeepReadonly<Express.Multer.File>>` — both
+   * the list (`push`/`pop`) and each file's fields (`size`, `originalname`,
+   * etc.) are locked. Use `ctx.req.files` if you genuinely need the
+   * mutable Express handle.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  get files(): ReadonlyArray<DeepReadonly<any>> | undefined {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (this.req as any).files
+  get files(): ReadonlyArray<DeepReadonly<Express.Multer.File>> | undefined {
+    // multer's `Request['files']` is a union — array (mode: 'array' /
+    // 'any') or `{ [fieldname]: File[] }` (mode: 'fields'). The
+    // `@FileUpload({ mode: 'array' })` decorator only sets the array
+    // shape, but `Request['files']` is the broad union. Narrow back to
+    // `File[]` here for the common-case getter; adopters using
+    // `mode: 'fields'` can read `ctx.req.files` directly for the
+    // dictionary shape.
+    const f = this.req.files
+    return Array.isArray(f) ? f : undefined
   }
 
   // ── Metadata Store ──────────────────────────────────────────────────

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -9,16 +9,21 @@ import {
 } from './query'
 
 /**
- * Recursively marks every property of `T` as `readonly`. Pass-through for
- * `Function`, `Date`, `Map`, `Set`, and `RegExp` since deeply rewriting
- * their internals would break their public API. Used to lock typed
- * request data (`body`, `params`, `query`) so adopters can't mutate
- * Zod-validated payloads in place — the contract is "compute new values,
- * stash via `ctx.set`", not "edit the request bag".
+ * Recursively marks every property of `T` as `readonly`. Preserves
+ * `Function`, `Date`, and `RegExp` unchanged, and converts `Map` / `Set`
+ * to `ReadonlyMap` / `ReadonlySet` so their mutating methods (`set`,
+ * `delete`, `add`, `clear`) are removed from the public surface.
+ * Tuples keep their positional element types — only their per-element
+ * mutability is locked.
  *
- * Type-only. No runtime cost. `DeepReadonly<any>` is `any` (TS distributes
- * conditional types over `any`), so adopters who haven't typed their
- * `Ctx` get no protection but no breakage either.
+ * Used to seal typed request data (`body`, `params`, `query`) so
+ * adopters can't mutate Zod-validated payloads in place — the contract
+ * is "compute new values, stash via `ctx.set`", not "edit the request
+ * bag".
+ *
+ * Type-only. No runtime cost. `DeepReadonly<any>` is `any` (TS
+ * distributes conditional types over `any`), so adopters who haven't
+ * typed their `Ctx` get no protection but no breakage either.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type DeepReadonly<T> = T extends (...args: any[]) => any
@@ -29,8 +34,15 @@ export type DeepReadonly<T> = T extends (...args: any[]) => any
       ? ReadonlyMap<DeepReadonly<K>, DeepReadonly<V>>
       : T extends Set<infer V>
         ? ReadonlySet<DeepReadonly<V>>
-        : T extends ReadonlyArray<infer U>
-          ? ReadonlyArray<DeepReadonly<U>>
+        : T extends readonly (infer U)[]
+          ? // Distinguish a regular array from a tuple. A regular `T[]` widens
+            // its `length` to `number`; a tuple's `length` is a literal
+            // (e.g. `2`). The literal branch maps over `keyof T` so each
+            // positional slot keeps its own type — `DeepReadonly<[1, 2]>` →
+            // `readonly [1, 2]`, not `readonly (1 | 2)[]`.
+            number extends T['length']
+            ? ReadonlyArray<DeepReadonly<U>>
+            : { readonly [K in keyof T]: DeepReadonly<T[K]> }
           : T extends object
             ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
             : T

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -9,6 +9,33 @@ import {
 } from './query'
 
 /**
+ * Recursively marks every property of `T` as `readonly`. Pass-through for
+ * `Function`, `Date`, `Map`, `Set`, and `RegExp` since deeply rewriting
+ * their internals would break their public API. Used to lock typed
+ * request data (`body`, `params`, `query`) so adopters can't mutate
+ * Zod-validated payloads in place — the contract is "compute new values,
+ * stash via `ctx.set`", not "edit the request bag".
+ *
+ * Type-only. No runtime cost. `DeepReadonly<any>` is `any` (TS distributes
+ * conditional types over `any`), so adopters who haven't typed their
+ * `Ctx` get no protection but no breakage either.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type DeepReadonly<T> = T extends (...args: any[]) => any
+  ? T
+  : T extends Date | RegExp
+    ? T
+    : T extends Map<infer K, infer V>
+      ? ReadonlyMap<DeepReadonly<K>, DeepReadonly<V>>
+      : T extends Set<infer V>
+        ? ReadonlySet<DeepReadonly<V>>
+        : T extends ReadonlyArray<infer U>
+          ? ReadonlyArray<DeepReadonly<U>>
+          : T extends object
+            ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+            : T
+
+/**
  * Re-export the augmentable {@link ContextMeta} registry from core/.
  * Declared in `core/execution-context.ts` so non-HTTP transports
  * (WS/queue/cron, V2) share one declaration site. Apps still augment
@@ -84,19 +111,29 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
 
   // ── Request Data ────────────────────────────────────────────────────
 
-  get body(): TBody {
-    return this.req.body as TBody
+  /**
+   * Parsed request body. Returned as `DeepReadonly<TBody>` so adopters
+   * can't mutate Zod-validated payloads in place — compute new values
+   * and stash them via `ctx.set('key', value)` or a Context Contributor
+   * instead. Reach for `ctx.req.body` if you genuinely need the raw,
+   * mutable Express handle (rare).
+   */
+  get body(): DeepReadonly<TBody> {
+    return this.req.body as DeepReadonly<TBody>
   }
 
-  get params(): TParams {
-    return this.req.params as TParams
+  /** Path parameters parsed from the route — read-only, see {@link body}. */
+  get params(): DeepReadonly<TParams> {
+    return this.req.params as DeepReadonly<TParams>
   }
 
-  get query(): TQuery {
-    return this.req.query as TQuery
+  /** Parsed query string — read-only, see {@link body}. */
+  get query(): DeepReadonly<TQuery> {
+    return this.req.query as DeepReadonly<TQuery>
   }
 
-  get headers() {
+  /** Inbound HTTP headers — read-only, see {@link body}. */
+  get headers(): Readonly<Request['headers']> {
     return this.req.headers
   }
 
@@ -190,13 +227,26 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
 
   // ── File Uploads ────────────────────────────────────────────────────
 
-  /** Single uploaded file (requires @FileUpload({ mode: 'single' })) */
-  get file(): any {
+  /**
+   * Single uploaded file (requires `@FileUpload({ mode: 'single' })`).
+   * Read-only — file metadata is set by the upload middleware and
+   * shouldn't be mutated downstream.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get file(): DeepReadonly<any> | undefined {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (this.req as any).file
   }
 
-  /** Array of uploaded files (requires @FileUpload({ mode: 'array' })) */
-  get files(): any[] | undefined {
+  /**
+   * Array of uploaded files (requires `@FileUpload({ mode: 'array' })`).
+   * Returns a `ReadonlyArray` — `push`/`pop`/index assignment all error
+   * at compile time. Use the underlying `ctx.req.files` if you need to
+   * splice the list in place (rare).
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get files(): ReadonlyArray<DeepReadonly<any>> | undefined {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (this.req as any).files
   }
 

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -16,12 +16,7 @@ export { bootstrap } from './http/bootstrap'
 // Cluster
 export { isClusterPrimary, type ClusterOptions } from './http/cluster'
 
-export {
-  RequestContext,
-  type Ctx,
-  type RouteShape,
-  type DeepReadonly,
-} from './http/context'
+export { RequestContext, type Ctx, type RouteShape, type DeepReadonly } from './http/context'
 export { defineHttpContextDecorator } from './http/define-http-context-decorator'
 
 export { buildRoutes } from './http/router-builder'

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -16,7 +16,12 @@ export { bootstrap } from './http/bootstrap'
 // Cluster
 export { isClusterPrimary, type ClusterOptions } from './http/cluster'
 
-export { RequestContext, type Ctx, type RouteShape } from './http/context'
+export {
+  RequestContext,
+  type Ctx,
+  type RouteShape,
+  type DeepReadonly,
+} from './http/context'
 export { defineHttpContextDecorator } from './http/define-http-context-decorator'
 
 export { buildRoutes } from './http/router-builder'


### PR DESCRIPTION
## Why

The framework already documents the rule: _writes to per-request state
flow through `ctx.set(key, value)` or a Context Contributor's return
value, not by mutating the request bag in place_. But nothing was
enforcing it. Adopters could quietly do:

```ts
@Post('/users')
create(ctx: Ctx<KickRoutes.UserController['create']>) {
  ctx.body.tenantId = currentTenant() // silently bypasses Zod
  ctx.headers['x-internal'] = 'derived'
  ctx.files.push(extraFile)
  await this.svc.save(ctx.body)        // saves the mutated thing
}
```

…and the type system happily accepts it. The Zod-validated payload
becomes whatever the controller wanted, the audit trail says one thing
and the persisted row says another, and the contract the framework
teaches in `dependency-injection.md` is fiction in practice.

This PR makes the contract enforced at compile time.

## What

`RequestContext.body`, `params`, `query`, `headers`, `file`, and `files`
now return `DeepReadonly<T>` / `Readonly<T>` / `ReadonlyArray<...>`.
Type-only — runtime is byte-for-byte identical, no `Object.freeze`, no
perf cost, no Express-incompatibility.

| Property | Before | After |
|---|---|---|
| `body` | `TBody` | `DeepReadonly<TBody>` |
| `params` | `TParams` | `DeepReadonly<TParams>` |
| `query` | `TQuery` | `DeepReadonly<TQuery>` |
| `headers` | `Request['headers']` | `Readonly<Request['headers']>` |
| `file` | `any` | `DeepReadonly<any> \| undefined` |
| `files` | `any[] \| undefined` | `ReadonlyArray<DeepReadonly<any>> \| undefined` |

`session`, `user`, `cookies`, and `requestId` stay mutable — those have
legitimate write-side flows (auth strategies, session stores) and
locking them creates real friction without payoff.

A new public `DeepReadonly<T>` type alias is exported from
`@forinda/kickjs` so adopters can apply the same lock to their own
typed payloads.

## What this is **not**

- **Not** a runtime change. No `Object.freeze`. The Express ecosystem
  (validate middleware that does `req.body = parsed.data`, multer that
  populates `req.files`, body-parser, etc.) all keeps working —
  middleware writes via `req.*`, never via `ctx.*`.
- **Not** a deep-mutation guarantee for `ctx.body = …`. That was already
  impossible — `body` is a getter without a setter, so direct
  reassignment was always a tsc error. The new types catch the **inner**
  mutation (`ctx.body.x = …`), which used to slip through.

## Migration

Most usages already comply. Two escape hatches for the rare case where
mutation was intentional:

1. **Compute and stash** (preferred — matches the existing rule):
   ```ts
   const enriched = { ...ctx.body, computed: f(ctx.body) }
   ctx.set('enrichedBody', enriched)
   ```
2. **Drop down to the raw Express handle**:
   ```ts
   ;(ctx.req.body as any).injectedField = 'computed'
   ```

## Test plan

- [x] `pnpm --filter @forinda/kickjs test` — 364/364 passing (no
  runtime regressions; type-only change)
- [x] `pnpm -r --filter='./packages/*' run typecheck` — every workspace
  package passes after rebuild (no internal code mutates body/query/
  params via ctx; all framework writes flow via `req.*`)
- [x] `pnpm format:check` clean
- [ ] CI green
