### PR TITLE
feat(db): MySQL relational compiler (M4.A.3) — all three dialects shipping

### DIFF
--- a/.changeset/db-mysql-compiler.md
+++ b/.changeset/db-mysql-compiler.md
@@ -1,0 +1,27 @@
+---
+'@forinda/kickjs-db': minor
+---
+
+`db.query.X.findMany({ with })` now works on MySQL 8.0+. M4.A.3 from `docs/db/m4-plan.md` — closes the "PG only" caveat that started in v5.3 and shrank with M4.A.2 (SQLite). All three dialects now ship real compilers; the `RelationalQueryNotSupportedError` throw-stub is retired.
+
+```ts
+const db = createDbClient({ schema, dialect: mysqlDialect({ pool }) })
+
+const rows = await db.query.users.findMany({
+  with: { posts: { with: { comments: true } } },
+  where: (_u, eb) => eb('isActive', '=', true),
+  limit: 20,
+})
+```
+
+The compiler emits `cast(coalesce(json_arrayagg(json_object(...)), '[]') as json)` for `many` (returns `[]` over zero rows, never `null`) and `JSON_OBJECT(...)` with `LIMIT 1` for `one` (returns `null` over zero rows). Same row-shape contract as PG and SQLite.
+
+**MySQL 8.0+ required.** `JSON_ARRAYAGG` shipped in 8.0; earlier versions don't have it. The version assertion lands at the adapter layer (`mysqlAdapter()` from `@forinda/kickjs-db-mysql` — M4.A.5) on first connection so adopters get a clear error before any query reaches the compiler. v1 spec R-1.
+
+**`createDbClient` auto-attaches `ParseJSONResultsPlugin` for MySQL** (alongside SQLite). MySQL drivers return JSON columns as TEXT — without the plugin, nested `with` results would land as JSON-encoded strings.
+
+**`pickCompiler('mysql')`** now returns the real implementation. The throw-stub is gone; all three dialects are first-class.
+
+**Adopter migration:** none for `db.query.X.findMany`-based usage. Adopters who previously caught `RelationalQueryNotSupportedError` for a MySQL fallback can remove that branch — the compiler now succeeds.
+
+Spec: `docs/db/spec-relational-query-other-dialects.md` §3.2. Tests: 13 new MySQL snapshot fixtures mirroring the PG + SQLite suites + 2 new builder integration tests asserting the MySQL path via `kysely/helpers/mysql`. Suite at 341 tests (was 327; +14).

--- a/packages/db/__tests__/unit/query-builder.test.ts
+++ b/packages/db/__tests__/unit/query-builder.test.ts
@@ -12,18 +12,18 @@
  *      sub-namespaces on first access.
  *   3. `findFirst` / `findUnique` clamp to a single row and `null`
  *      on empty result.
- *   4. SQLite emits dialect-specific SQL (json_group_array, not
- *      json_agg) — confirms the dialect picker selected the
- *      SQLite compiler.
- *   5. MySQL still throws `RelationalQueryNotSupportedError` on
- *      first `findMany` call until M4.A.3 ships the compiler.
+ *   4. Each dialect emits its own SQL primitives — PG's
+ *      `json_agg` + `row_to_json`, SQLite's `json_group_array` +
+ *      `json_object`, MySQL's `json_arrayagg` + `json_object`.
+ *      Confirms the picker selected the right compiler per
+ *      dialect tag.
  *
  * Note: by stubbing `executeQuery`, these tests do NOT exercise
  * the `ParseJSONResultsPlugin` chain that `createDbClient`
- * auto-attaches for SQLite. End-to-end JSON-string-to-object
- * round-trip lands in `packages/db-sqlite/__tests__/integration/`
- * (M4.A.5), where a real `better-sqlite3` driver returns the
- * actual JSON-encoded TEXT for the plugin to parse.
+ * auto-attaches for SQLite + MySQL. End-to-end JSON-string-to-
+ * object round-trip lands in the real-driver integration suites
+ * shipping with `@forinda/kickjs-db-sqlite` /
+ * `@forinda/kickjs-db-mysql` (M4.A.5).
  */
 
 import { describe, expect, it, vi } from 'vitest'
@@ -41,15 +41,7 @@ import {
   SqliteQueryCompiler,
   type Dialect as KyselyDialect,
 } from 'kysely'
-import {
-  createDbClient,
-  RelationalQueryNotSupportedError,
-  relations,
-  serial,
-  table,
-  uuid,
-  varchar,
-} from '../../src/index'
+import { createDbClient, relations, serial, table, uuid, varchar } from '../../src/index'
 
 const users = table('users', {
   id: uuid().primaryKey().defaultRandom(),
@@ -202,9 +194,26 @@ describe('createDbClient → db.query namespace (SQLite — M4.A.2)', () => {
   })
 })
 
-describe('createDbClient → db.query namespace (unsupported dialects)', () => {
-  it('MySQL throws RelationalQueryNotSupportedError on findMany', async () => {
+describe('createDbClient → db.query namespace (MySQL — M4.A.3)', () => {
+  it('MySQL findMany compiles via kysely/helpers/mysql', async () => {
     const db = createDbClient({ schema, dialect: makeMysqlDialect() })
-    await expect(db.query.users.findMany()).rejects.toThrow(RelationalQueryNotSupportedError)
+    const { calls } = patchExecute(db, [{ id: '1', email: 'a@b.com' }])
+    const result = await db.query.users.findMany({ with: { posts: true } })
+    expect(result).toEqual([{ id: '1', email: 'a@b.com' }])
+    // MySQL uses json_arrayagg + json_object + cast(... as json) —
+    // different from PG's json_agg + row_to_json AND from SQLite's
+    // json_group_array. Confirms the dialect picker selected the
+    // MySQL compiler.
+    expect(calls[0]?.sql).toContain('json_arrayagg')
+    expect(calls[0]?.sql).toContain('json_object')
+    expect(calls[0]?.sql).not.toContain('json_agg')
+    expect(calls[0]?.sql).not.toContain('json_group_array')
+  })
+
+  it('MySQL findFirst clamps via LIMIT 1', async () => {
+    const db = createDbClient({ schema, dialect: makeMysqlDialect() })
+    const { calls } = patchExecute(db, [])
+    await db.query.users.findFirst()
+    expect(calls[0]?.sql).toContain('limit ?')
   })
 })

--- a/packages/db/__tests__/unit/query-compile-mysql.test.ts
+++ b/packages/db/__tests__/unit/query-compile-mysql.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Snapshot SQL tests for the MySQL relational-query compiler.
+ *
+ * Mirror of `query-compile-sqlite.test.ts` but with MySQL-flavored
+ * SQL — `json_arrayagg` + `json_object` wrapped in
+ * `cast(... as json)`, backtick identifiers, no LATERAL.
+ *
+ * Spec: docs/db/spec-relational-query-other-dialects.md §3.2.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { DummyDriver, Kysely, MysqlAdapter, MysqlIntrospector, MysqlQueryCompiler } from 'kysely'
+import { compileMysql } from '../../src/query/compile-mysql'
+import {
+  RelationalQueryDepthError,
+  RelationalQueryUnknownRelationError,
+} from '../../src/query/errors'
+import type { ResolvedRelations } from '../../src/query/relations'
+import type { TableSnapshot } from '../../src/snapshot/types'
+
+interface FixtureDB {
+  users: { id: string; email: string; isActive: boolean; createdAt: Date }
+  posts: { id: string; authorId: string; title: string; publishedAt: Date | null }
+  comments: { id: string; postId: string; body: string }
+  categories: { id: string; parentId: string | null; name: string }
+}
+
+function makeDb(): Kysely<FixtureDB> {
+  return new Kysely<FixtureDB>({
+    dialect: {
+      createAdapter: () => new MysqlAdapter(),
+      createDriver: () => new DummyDriver(),
+      createIntrospector: (db) => new MysqlIntrospector(db),
+      createQueryCompiler: () => new MysqlQueryCompiler(),
+    },
+  })
+}
+
+function col(): TableSnapshot['columns'][string] {
+  return { name: '', type: 'text', nullable: true, default: null, primaryKey: false }
+}
+const TABLES: Record<string, TableSnapshot> = {
+  users: {
+    name: 'users',
+    columns: { id: col(), email: col(), isActive: col(), createdAt: col() },
+    indexes: [],
+    foreignKeys: [],
+    checks: [],
+  },
+  posts: {
+    name: 'posts',
+    columns: { id: col(), authorId: col(), title: col(), publishedAt: col() },
+    indexes: [],
+    foreignKeys: [],
+    checks: [],
+  },
+  comments: {
+    name: 'comments',
+    columns: { id: col(), postId: col(), body: col() },
+    indexes: [],
+    foreignKeys: [],
+    checks: [],
+  },
+  categories: {
+    name: 'categories',
+    columns: { id: col(), parentId: col(), name: col() },
+    indexes: [],
+    foreignKeys: [],
+    checks: [],
+  },
+}
+
+const RELATIONS: ResolvedRelations = {
+  users: {
+    posts: {
+      kind: 'many',
+      target: 'posts',
+      sourceColumns: ['id'],
+      targetColumns: ['authorId'],
+    },
+  },
+  posts: {
+    author: {
+      kind: 'one',
+      target: 'users',
+      sourceColumns: ['authorId'],
+      targetColumns: ['id'],
+    },
+    comments: {
+      kind: 'many',
+      target: 'comments',
+      sourceColumns: ['id'],
+      targetColumns: ['postId'],
+    },
+  },
+  comments: {
+    post: {
+      kind: 'one',
+      target: 'posts',
+      sourceColumns: ['postId'],
+      targetColumns: ['id'],
+    },
+  },
+  categories: {
+    parent: {
+      kind: 'one',
+      target: 'categories',
+      sourceColumns: ['parentId'],
+      targetColumns: ['id'],
+    },
+    children: {
+      kind: 'many',
+      target: 'categories',
+      sourceColumns: ['id'],
+      targetColumns: ['parentId'],
+    },
+  },
+}
+
+describe('compileMysql — happy path', () => {
+  it('bare findMany emits a flat selectAll with depth-0 alias', () => {
+    const db = makeDb()
+    const { sql, parameters } = compileMysql(db, 'users', {}, RELATIONS, TABLES)
+    expect(sql).toBe('select * from `users` as `users_0`')
+    expect(parameters).toEqual([])
+  })
+
+  it('1-deep many uses json_arrayagg + json_object + cast(... as json)', () => {
+    const db = makeDb()
+    const { sql } = compileMysql(db, 'users', { with: { posts: true } }, RELATIONS, TABLES)
+    // MySQL primitives — must NOT contain PG's json_agg or
+    // SQLite's json_group_array.
+    expect(sql).toContain('json_arrayagg')
+    expect(sql).toContain('json_object')
+    expect(sql).toContain('as json')
+    expect(sql).not.toContain('json_agg')
+    expect(sql).not.toContain('json_group_array')
+    // Correlated subquery on aliased tables (backtick-quoted).
+    expect(sql).toContain('`posts_1`.`authorId` = `users_0`.`id`')
+    expect(sql).toContain('as `posts`')
+  })
+
+  it('1-deep one — comments { with: { post: true } } uses json_object + LIMIT 1', () => {
+    const db = makeDb()
+    const { sql } = compileMysql(db, 'comments', { with: { post: true } }, RELATIONS, TABLES)
+    expect(sql).toContain('json_object')
+    expect(sql).toContain('`posts_1`.`id` = `comments_0`.`postId`')
+    expect(sql).toContain('limit ?')
+  })
+
+  it('2-deep many → many — users → posts → comments', () => {
+    const db = makeDb()
+    const { sql } = compileMysql(
+      db,
+      'users',
+      { with: { posts: { with: { comments: true } } } },
+      RELATIONS,
+      TABLES,
+    )
+    const matches = sql.match(/json_arrayagg/g) ?? []
+    expect(matches.length).toBe(2)
+    expect(sql).toContain('`comments_2`.`postId` = `posts_1`.`id`')
+    expect(sql).toContain('`posts_1`.`authorId` = `users_0`.`id`')
+  })
+
+  it('self-reference — depth-suffixed aliases per level', () => {
+    const db = makeDb()
+    const { sql } = compileMysql(
+      db,
+      'categories',
+      { with: { children: { with: { children: true } } } },
+      RELATIONS,
+      TABLES,
+    )
+    expect(sql).toContain('from `categories` as `categories_0`')
+    expect(sql).toContain('from `categories` as `categories_1`')
+    expect(sql).toContain('from `categories` as `categories_2`')
+    expect(sql).toContain('`categories_1`.`parentId` = `categories_0`.`id`')
+    expect(sql).toContain('`categories_2`.`parentId` = `categories_1`.`id`')
+  })
+
+  it('per-relation where parametrizes correctly', () => {
+    const db = makeDb()
+    const since = new Date('2026-01-01T00:00:00.000Z')
+    const { sql, parameters } = compileMysql(
+      db,
+      'users',
+      {
+        with: {
+          posts: {
+            where: (_p, eb) => eb('publishedAt', '>=', since),
+          },
+        },
+      },
+      RELATIONS,
+      TABLES,
+    )
+    expect(sql).toContain('`publishedAt` >= ?')
+    expect(parameters).toEqual([since])
+  })
+
+  it('per-relation limit clamps the inner sub-select', () => {
+    const db = makeDb()
+    const { sql, parameters } = compileMysql(
+      db,
+      'users',
+      { with: { posts: { limit: 5 } } },
+      RELATIONS,
+      TABLES,
+    )
+    expect(sql).toContain('limit ?')
+    expect(parameters).toEqual([5])
+  })
+
+  it('outer where + orderBy + limit + offset all flow through', () => {
+    const db = makeDb()
+    const { sql, parameters } = compileMysql(
+      db,
+      'users',
+      {
+        where: (_u, eb) => eb('isActive', '=', true),
+        orderBy: (_u, eb) => eb.ref('createdAt'),
+        limit: 20,
+        offset: 5,
+      },
+      RELATIONS,
+      TABLES,
+    )
+    expect(sql).toContain('where `isActive` = ?')
+    expect(sql).toContain('order by `createdAt`')
+    expect(sql).toContain('limit ?')
+    expect(sql).toContain('offset ?')
+    expect(parameters).toEqual([true, 20, 5])
+  })
+
+  it('mode=first adds LIMIT 1 to the outer query', () => {
+    const db = makeDb()
+    const { sql, parameters } = compileMysql(db, 'users', {}, RELATIONS, TABLES, 'first')
+    expect(sql).toBe('select * from `users` as `users_0` limit ?')
+    expect(parameters).toEqual([1])
+  })
+
+  it('mode=unique adds LIMIT 1', () => {
+    const db = makeDb()
+    const { sql, parameters } = compileMysql(db, 'users', {}, RELATIONS, TABLES, 'unique')
+    expect(sql).toBe('select * from `users` as `users_0` limit ?')
+    expect(parameters).toEqual([1])
+  })
+
+  it('explicit limit overrides the implicit `first` LIMIT 1', () => {
+    const db = makeDb()
+    const { sql, parameters } = compileMysql(db, 'users', { limit: 10 }, RELATIONS, TABLES, 'first')
+    expect(sql).toContain('limit ?')
+    expect(parameters).toEqual([10])
+  })
+})
+
+describe('compileMysql — error paths', () => {
+  it('unknown relation throws RelationalQueryUnknownRelationError', () => {
+    const db = makeDb()
+    expect(() =>
+      compileMysql(db, 'users', { with: { nonsense: true } as never }, RELATIONS, TABLES),
+    ).toThrow(RelationalQueryUnknownRelationError)
+  })
+
+  it('exceeding maxDepth throws RelationalQueryDepthError', () => {
+    const db = makeDb()
+    expect(() =>
+      compileMysql(
+        db,
+        'categories',
+        {
+          maxDepth: 1,
+          with: { children: { with: { children: true } } },
+        },
+        RELATIONS,
+        TABLES,
+      ),
+    ).toThrow(RelationalQueryDepthError)
+  })
+})

--- a/packages/db/src/client/create.ts
+++ b/packages/db/src/client/create.ts
@@ -61,18 +61,16 @@ export function createDbClient<TSchema, DB = SchemaToTypes<TSchema>>(
   // compiler (below) and to decide whether the JSON-results plugin
   // ships in the Kysely plugin chain.
   //
-  // SQLite drivers return JSON columns as TEXT, so the
-  // kysely/helpers/sqlite jsonArrayFrom / jsonObjectFrom won't
+  // SQLite + MySQL drivers return JSON columns as TEXT, so the
+  // kysely/helpers/<dialect> jsonArrayFrom / jsonObjectFrom won't
   // round-trip without ParseJSONResultsPlugin. PG decodes JSON
-  // natively. MySQL needs the same plugin in M4.A.3 — gating SQLite-
-  // only here keeps the plugin chain free of unused work for MySQL
-  // adopters until that compiler ships.
+  // natively — skip the plugin there to keep the chain minimal.
   // Spec: docs/db/spec-relational-query-other-dialects.md §5.
   const dialectTag = detectDialect(opts.dialect)
 
   const plugins: KyselyPlugin[] = []
   if (codecPlugin) plugins.push(codecPlugin)
-  if (dialectTag === 'sqlite') {
+  if (dialectTag === 'sqlite' || dialectTag === 'mysql') {
     plugins.push(new ParseJSONResultsPlugin())
   }
 

--- a/packages/db/src/query/compile-mysql.ts
+++ b/packages/db/src/query/compile-mysql.ts
@@ -1,0 +1,50 @@
+/**
+ * MySQL compiler for `db.query.X.findMany({ with })`.
+ *
+ * Strategy locked in `docs/db/spec-relational-query-other-dialects.md`
+ * §3.2: each `many` relation becomes a Kysely `jsonArrayFrom(...)`
+ * select expression that compiles to
+ * `cast(coalesce(json_arrayagg(json_object(...)), '[]') as json)`.
+ * Each `one` becomes `jsonObjectFrom(...)`, compiling to a
+ * `JSON_OBJECT(...)` call with `LIMIT 1`. The traversal logic is
+ * shared with the PG + SQLite compilers via `runCompile`.
+ *
+ * Result-decoding: MySQL drivers return JSON columns as TEXT (or
+ * Buffers for older mysql2 configs); `createDbClient` auto-attaches
+ * `ParseJSONResultsPlugin` for the MySQL dialect so the nested JSON
+ * round-trips back to JS objects before the codec / row-handler
+ * chain runs.
+ *
+ * MySQL minimum version: **8.0+**. `JSON_ARRAYAGG` shipped in 8.0;
+ * earlier versions don't have it. The version check fires at the
+ * adapter layer (`mysqlAdapter()` — M4.A.5) on first connection so
+ * adopters get a clear error before any query reaches this
+ * compiler. Spec R-1.
+ */
+
+import { type Kysely, type CompiledQuery } from 'kysely'
+import { jsonArrayFrom, jsonObjectFrom } from 'kysely/helpers/mysql'
+import {
+  runCompile,
+  type CompileMode,
+  type CompileOptions,
+  type JsonHelpers,
+} from './compile-shared'
+import type { ResolvedRelations } from './relations'
+import type { TableSnapshot } from '../snapshot/types'
+
+const MYSQL_HELPERS: JsonHelpers = {
+  jsonArrayFrom: jsonArrayFrom as unknown as JsonHelpers['jsonArrayFrom'],
+  jsonObjectFrom: jsonObjectFrom as unknown as JsonHelpers['jsonObjectFrom'],
+}
+
+export function compileMysql<DB>(
+  db: Kysely<DB>,
+  table: string,
+  options: CompileOptions,
+  relations: ResolvedRelations,
+  tables: Record<string, TableSnapshot>,
+  mode: CompileMode = 'many',
+): CompiledQuery {
+  return runCompile(db, table, options, relations, tables, mode, MYSQL_HELPERS)
+}

--- a/packages/db/src/query/compilers.ts
+++ b/packages/db/src/query/compilers.ts
@@ -1,10 +1,12 @@
 /**
  * Dispatch helper that selects the right relational-query compiler
- * for the runtime dialect detected by `createDbClient`.
+ * for the runtime dialect detected by `createDbClient`. After M4.A.3
+ * all three dialects ship real compilers — the throw-stub is
+ * retired.
  *
  *   - PG     → `compilePg`     (kysely/helpers/postgres)
- *   - SQLite → `compileSqlite` (kysely/helpers/sqlite, M4.A.2)
- *   - MySQL  → throw-stub      (compileMysql lands in M4.A.3)
+ *   - SQLite → `compileSqlite` (kysely/helpers/sqlite)
+ *   - MySQL  → `compileMysql`  (kysely/helpers/mysql)
  *
  * Spec: docs/db/spec-relational-query.md §4.3 +
  * docs/db/spec-relational-query-other-dialects.md §4.
@@ -12,19 +14,8 @@
 
 import { compilePg } from './compile-pg'
 import { compileSqlite } from './compile-sqlite'
-import { RelationalQueryNotSupportedError } from './errors'
+import { compileMysql } from './compile-mysql'
 import type { CompileFn } from './builder'
-
-/**
- * Throw-stub still used by the MySQL dialect until M4.A.3 fills it
- * in. Same signature as `compilePg` / `compileSqlite` so the picker
- * is a one-line lookup.
- */
-const compileNotSupported =
-  (dialect: string): CompileFn =>
-  () => {
-    throw new RelationalQueryNotSupportedError(dialect)
-  }
 
 /**
  * Pick a compiler by dialect tag. Used by `createDbClient` after it
@@ -37,6 +28,6 @@ export function pickCompiler(dialect: 'postgres' | 'sqlite' | 'mysql'): CompileF
     case 'sqlite':
       return compileSqlite as CompileFn
     case 'mysql':
-      return compileNotSupported('mysql')
+      return compileMysql as CompileFn
   }
 }


### PR DESCRIPTION
## Summary

Closes M4.A.3 — MySQL relational compiler. After this lands, `db.query.X.findMany({ with })` works on **PG, SQLite, and MySQL**. The `RelationalQueryNotSupportedError` throw-stub is retired.

## What changed

```ts
const db = createDbClient({ schema, dialect: mysqlDialect({ pool }) })

const rows = await db.query.users.findMany({
  with: { posts: { with: { comments: true } } },
  where: (_u, eb) => eb('isActive', '=', true),
  limit: 20,
})
```

Compiled SQL uses MySQL 8's `cast(coalesce(json_arrayagg(json_object(...)), '[]') as json)` for `many` and `JSON_OBJECT(...)` with `LIMIT 1` for `one`. Same row-shape contract as PG and SQLite — `many` empty-set is `[]`, `one` empty-row is `null`.

## Architecture

`compile-mysql.ts` is a ~30-line wrapper around the shared `runCompile()` (extracted in M4.A.2). All three dialects now follow the same pattern: import the right Kysely helper, register with the dialect picker, done.

`pickCompiler('mysql')` flipped from throw-stub to real impl. The `compileNotSupported` helper is gone — all three dialects are first-class.

`createDbClient` auto-attaches `ParseJSONResultsPlugin` for MySQL (alongside SQLite). MySQL drivers return JSON columns as TEXT — without the plugin, nested `with` results would land as JSON-encoded strings.

## MySQL 8.0+ required

`JSON_ARRAYAGG` shipped in 8.0; earlier versions don't have it. The version assertion lives at the **adapter** layer (`mysqlAdapter()` from `@forinda/kickjs-db-mysql` — M4.A.5), not the compiler. Adopters get a clear error at first connection rather than a cryptic "unknown function" mid-query.

## Per-dialect SQL identity

| Dialect | `many` aggregation | `one` shape | Identifiers |
| ------- | ------------------- | --------------- | ----------- |
| PG      | `coalesce((select json_agg(agg) ...), '[]')` | `(select to_json(obj) ...)` | `"col"` |
| SQLite  | `coalesce(json_group_array(json_object(...)), '[]')` | `json_object(...)` | `"col"` |
| MySQL   | `cast(coalesce(json_arrayagg(json_object(...)), '[]') as json)` | `JSON_OBJECT(...)` | `` `col` `` |

Adopter-facing API is identical.

## Suite

| Package | Files | Tests | Δ |
|---|---|---|---|
| `@forinda/kickjs-db` | 55 | **341** | +14 (13 MySQL fixtures + 2 builder tests, −1 throws assertion) |
| `@forinda/kickjs-db-pg` | 4 | 23 | unchanged |
| `@forinda/kickjs-cli` | 24 | 231 | unchanged |

Build clean. Typecheck clean.

## Test plan

- [x] `pnpm test` green across affected packages.
- [x] `pnpm typecheck` clean.
- [x] `pnpm format:check` clean.
- [x] All 16 PG + 13 SQLite snapshot fixtures still pass — shared traversal correctness unchanged.
- [x] 13 new MySQL fixtures cover the same topology matrix.
- [x] PG / SQLite / MySQL emit distinguishable SQL primitives (asserted in the builder tests).
- [ ] Real-MySQL Testcontainers integration test in `packages/db-mysql/__tests__/integration/` — deferred to M4.A.5 when the peer package lands.

## What this unlocks

After this merges, M4.A is complete on the compiler side. Adopters using Kysely's built-in `MysqlDialect` directly can already use `db.query.X` on MySQL 8+. M4.A.5 ships the `@forinda/kickjs-db-sqlite` + `@forinda/kickjs-db-mysql` peer adapter packages with real-driver integration tests + the version assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
