### PR TITLE
feat(db-sqlite,db-mysql): peer adapter packages (M4.A.5) — closes M4.A

### DIFF
--- a/.changeset/db-sqlite-mysql-peer-packages.md
+++ b/.changeset/db-sqlite-mysql-peer-packages.md
@@ -1,0 +1,61 @@
+---
+'@forinda/kickjs-db-sqlite': minor
+'@forinda/kickjs-db-mysql': minor
+'@forinda/kickjs-db': patch
+'@forinda/kickjs-db-pg': patch
+---
+
+Two new peer adapter packages closing M4.A.5 from `docs/db/m4-plan.md`.
+
+## `@forinda/kickjs-db-sqlite` (initial release: 0.1.0)
+
+better-sqlite3 adapter for `@forinda/kickjs-db`. Mirrors the `@forinda/kickjs-db-pg` template:
+
+- **`sqliteDialect({ database })`** — wraps Kysely's `SqliteDialect`. Pair with `createDbClient({ schema, dialect })`.
+- **`sqliteAdapter({ database })`** — implements `MigrationAdapter` for the kickjs migration runner (`kick db migrate latest`, `kickDbAdapter` boot-time apply). Handles `kick_migrations` / `kick_migrations_lock` table creation, lock acquisition, applying SQL in / out of a transaction.
+- **Pairs with the SQLite relational compiler** that landed in `@forinda/kickjs-db@5.4.0` (M4.A.2). `db.query.X.findMany({ with })` round-trips correctly via the auto-attached `ParseJSONResultsPlugin`.
+- **Drift detection (`introspect()`)** is a follow-up — throws `KICK_DB_INTROSPECT_NOT_SUPPORTED` for now. Set `driftCheck: 'off'` until the `sqlite_master` + `pragma` walk lands.
+
+```ts
+import Database from 'better-sqlite3'
+import { createDbClient } from '@forinda/kickjs-db'
+import { sqliteAdapter, sqliteDialect } from '@forinda/kickjs-db-sqlite'
+
+const database = new Database('app.db')
+const db = createDbClient({ schema, dialect: sqliteDialect({ database }) })
+const migrationAdapter = sqliteAdapter({ database })
+```
+
+## `@forinda/kickjs-db-mysql` (initial release: 0.1.0)
+
+mysql2 adapter for `@forinda/kickjs-db`. **MySQL 8.0+ required** (the relational layer compiles to `JSON_ARRAYAGG`, which shipped in 8.0).
+
+- **`mysqlDialect({ pool })`** — wraps Kysely's `MysqlDialect`.
+- **`mysqlAdapter({ pool })`** — implements `MigrationAdapter`. Asserts the MySQL version on first connection (lazy — no I/O at construction time). Throws `KickDbError(KICK_DB_RELATIONAL_NOT_SUPPORTED)` on MySQL 5.x / unparseable version strings, with the detected version in the error message.
+- **MariaDB 10.x+** is treated as supported (its `JSON_ARRAYAGG` shipped in 10.5).
+- **`parseMysqlMajorVersion(version)`** — exposed for adopters who want to run the same check in their own boot logic.
+- **Drift detection** is a follow-up — same `KICK_DB_INTROSPECT_NOT_SUPPORTED` story as the SQLite adapter; the `information_schema` walk lands later.
+
+```ts
+import { createPool } from 'mysql2/promise'
+import { createDbClient } from '@forinda/kickjs-db'
+import { mysqlAdapter, mysqlDialect } from '@forinda/kickjs-db-mysql'
+
+const pool = createPool({ host, user, password, database })
+const db = createDbClient({ schema, dialect: mysqlDialect({ pool }) })
+const migrationAdapter = mysqlAdapter({ pool })
+```
+
+## `@forinda/kickjs-db` + `@forinda/kickjs-db-pg` (patch — keyword sweep)
+
+Patch bumps for a metadata-only sweep across the db-family packages. Every package in `@forinda/kickjs-*` now declares the consistent keyword set: `kickjs` (for plain-text npm search), `@forinda/kickjs` (the framework), the package's own name, and the related-package siblings — so adopters discover SQLite + MySQL alongside the PG adapter on npmjs.com. No code changes; no API surface changes.
+
+## What's tested
+
+- `@forinda/kickjs-db-sqlite`: 10 real-driver integration tests using in-memory `better-sqlite3` — relational query round-trip (2-deep nested `with`, empty inner sets, `findFirst`/`findUnique`, per-relation filters, JSON parse plugin auto-attach) + migration adapter contract (table creation, applied-row lifecycle, lock acquisition, introspect-throws).
+- `@forinda/kickjs-db-mysql`: 11 unit tests covering the version-string parser + the version-assertion gate (MySQL 8 / MariaDB 10 pass, MySQL 5.7 / unparseable throw, version check is cached after first success). Real-driver Testcontainers integration test ships in a follow-up to keep CI cheap.
+
+## What's deferred
+
+- Real-driver Testcontainers MySQL integration test — dropped to a follow-up so this PR stays cheap to run on every push.
+- `introspect()` for both dialects — the migration runner's drift check refuses without it; adopters set `driftCheck: 'off'` until follow-up impls land.

--- a/.changeset/db-sqlite-mysql-peer-packages.md
+++ b/.changeset/db-sqlite-mysql-peer-packages.md
@@ -28,12 +28,13 @@ const migrationAdapter = sqliteAdapter({ database })
 
 ## `@forinda/kickjs-db-mysql` (initial release: 0.1.0)
 
-mysql2 adapter for `@forinda/kickjs-db`. **MySQL 8.0+ required** (the relational layer compiles to `JSON_ARRAYAGG`, which shipped in 8.0).
+mysql2 adapter for `@forinda/kickjs-db`. **MySQL 8.0+ / MariaDB 10.5+ required** (the relational layer compiles to `JSON_ARRAYAGG`, which shipped in MySQL 8.0 and MariaDB 10.5).
 
 - **`mysqlDialect({ pool })`** — wraps Kysely's `MysqlDialect`.
-- **`mysqlAdapter({ pool })`** — implements `MigrationAdapter`. Asserts the MySQL version on first connection (lazy — no I/O at construction time). Throws `KickDbError(KICK_DB_RELATIONAL_NOT_SUPPORTED)` on MySQL 5.x / unparseable version strings, with the detected version in the error message.
-- **MariaDB 10.x+** is treated as supported (its `JSON_ARRAYAGG` shipped in 10.5).
-- **`parseMysqlMajorVersion(version)`** — exposed for adopters who want to run the same check in their own boot logic.
+- **`mysqlAdapter({ pool })`** — implements `MigrationAdapter`. Asserts the version on first connection (lazy — no I/O at construction time). Throws `KickDbError(KICK_DB_RELATIONAL_NOT_SUPPORTED)` on MySQL 5.x / MariaDB 10.0–10.4 / unparseable version strings, with the detected version in the error message.
+- **Per-flavor version floor** — MySQL needs major `>= 8`; MariaDB needs `>= 10.5`. The adapter detects the flavor from the version string and applies the right floor.
+- **Multi-statement splitter** — mysql2's default `Pool.query()` rejects multi-statement SQL unless `multipleStatements: true` is set. The adapter splits SQL blobs at top-level `;` boundaries (respecting string literals + `--` and C-style block comments) so kickjs-generated migrations apply out of the box.
+- **`parseMysqlVersion(version)`** + **`parseMysqlMajorVersion(version)`** + **`splitMysqlStatements(sql)`** — all exposed for adopters who want the same checks / splitter in their own boot logic.
 - **Drift detection** is a follow-up — same `KICK_DB_INTROSPECT_NOT_SUPPORTED` story as the SQLite adapter; the `information_schema` walk lands later.
 
 ```ts

--- a/packages/db-mysql/LICENSE
+++ b/packages/db-mysql/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Felix Orinda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/db-mysql/README.md
+++ b/packages/db-mysql/README.md
@@ -34,17 +34,25 @@ export const migrationAdapter = mysqlAdapter({ pool })
 
 `createDbClient` auto-attaches Kysely's `ParseJSONResultsPlugin` for the MySQL dialect — `db.query.X.findMany({ with })` round-trips nested rows as parsed JS objects rather than JSON-encoded TEXT.
 
-## MySQL 8.0+ required
+## MySQL 8.0+ / MariaDB 10.5+ required
 
-The relational query layer compiles to `JSON_ARRAYAGG`, which shipped in MySQL 8.0. `mysqlAdapter()` checks the version on first connection (lazily — no I/O at construction time). MySQL 5.x or unparseable versions throw `KickDbError` with code `KICK_DB_RELATIONAL_NOT_SUPPORTED` so adopters get a clear error before any query reaches the compiler.
+The relational query layer compiles to `JSON_ARRAYAGG`, which shipped in MySQL 8.0 and MariaDB 10.5. `mysqlAdapter()` checks the version on first connection (lazily — no I/O at construction time). Older versions and unparseable strings throw `KickDbError` with code `KICK_DB_RELATIONAL_NOT_SUPPORTED` so adopters get a clear error before any query reaches the compiler.
 
-MariaDB 10.x is treated as supported (its `JSON_ARRAYAGG` shipped in 10.5).
+The version parser (`parseMysqlVersion`) detects MariaDB via the version string and applies the correct floor per flavor:
+
+- **MySQL** — major `>= 8`.
+- **MariaDB** — `>= 10.5` (10.0 – 10.4 throw; 10.5+ and 11.x pass).
+
+## Multi-statement migrations
+
+mysql2's default `Pool.query()` rejects multi-statement SQL unless the driver is configured with `multipleStatements: true`. The adapter splits SQL blobs at top-level `;` boundaries (respecting string literals and `--` / C-style block comments) so kickjs-generated migrations apply against default mysql2 settings. Adopters with `multipleStatements: true` on their pool pay no extra cost — the splitter is cheap on small DDL blobs.
 
 ## What ships
 
 - **`mysqlDialect({ pool })`** — wraps Kysely's `MysqlDialect`.
-- **`mysqlAdapter({ pool })`** — implements `MigrationAdapter` for `@forinda/kickjs-db`'s migration runner (`kick db migrate` + `kickDbAdapter` boot-time apply). Handles `kick_migrations` / `kick_migrations_lock` table creation, lock acquisition, applying SQL in / out of a transaction, plus the version assertion.
-- **`parseMysqlMajorVersion(version)`** — exposed for adopters who want to run the same check in their own boot logic.
+- **`mysqlAdapter({ pool })`** — implements `MigrationAdapter` for `@forinda/kickjs-db`'s migration runner (`kick db migrate` + `kickDbAdapter` boot-time apply). Handles `kick_migrations` / `kick_migrations_lock` table creation, lock acquisition, applying SQL in / out of a transaction, plus the version assertion and multi-statement splitting.
+- **`parseMysqlVersion(version)`** + **`parseMysqlMajorVersion(version)`** — exposed for adopters who want to run the same check in their own boot logic. The full parser returns `{ flavor, major, minor }` so adopters can branch on MariaDB vs MySQL; the major-only shim is kept for back-compat.
+- **`splitMysqlStatements(sql)`** — exposed for adopters who want to run the same multi-statement splitter outside the adapter (custom migration tooling, etc.).
 - **Drift detection (`introspect()`) is not yet implemented in v1** — it throws `KickDbError` with code `KICK_DB_INTROSPECT_NOT_SUPPORTED`. Set `driftCheck: 'off'` on the migration runner until a follow-up adds the `information_schema` walk.
 
 ## License

--- a/packages/db-mysql/README.md
+++ b/packages/db-mysql/README.md
@@ -1,0 +1,52 @@
+# @forinda/kickjs-db-mysql
+
+> mysql2 adapter for `@forinda/kickjs-db` — `MigrationAdapter` + Kysely `MysqlDialect`. **MySQL 8.0+ required.**
+
+Ships the bridge between `@forinda/kickjs-db`'s migration runner / relational query layer and a MySQL 8.0+ database via [`mysql2`](https://github.com/sidorares/node-mysql2) (or any structurally compatible pool).
+
+## Install
+
+```bash
+pnpm add @forinda/kickjs-db @forinda/kickjs-db-mysql mysql2
+```
+
+## Quick start
+
+```ts
+import { createPool } from 'mysql2/promise'
+import { createDbClient } from '@forinda/kickjs-db'
+import { mysqlAdapter, mysqlDialect } from '@forinda/kickjs-db-mysql'
+
+const pool = createPool({
+  host: '127.0.0.1',
+  user: 'root',
+  password: '...',
+  database: 'app',
+})
+
+export const db = createDbClient({
+  schema, // your declared schema
+  dialect: mysqlDialect({ pool }),
+})
+
+export const migrationAdapter = mysqlAdapter({ pool })
+```
+
+`createDbClient` auto-attaches Kysely's `ParseJSONResultsPlugin` for the MySQL dialect — `db.query.X.findMany({ with })` round-trips nested rows as parsed JS objects rather than JSON-encoded TEXT.
+
+## MySQL 8.0+ required
+
+The relational query layer compiles to `JSON_ARRAYAGG`, which shipped in MySQL 8.0. `mysqlAdapter()` checks the version on first connection (lazily — no I/O at construction time). MySQL 5.x or unparseable versions throw `KickDbError` with code `KICK_DB_RELATIONAL_NOT_SUPPORTED` so adopters get a clear error before any query reaches the compiler.
+
+MariaDB 10.x is treated as supported (its `JSON_ARRAYAGG` shipped in 10.5).
+
+## What ships
+
+- **`mysqlDialect({ pool })`** — wraps Kysely's `MysqlDialect`.
+- **`mysqlAdapter({ pool })`** — implements `MigrationAdapter` for `@forinda/kickjs-db`'s migration runner (`kick db migrate` + `kickDbAdapter` boot-time apply). Handles `kick_migrations` / `kick_migrations_lock` table creation, lock acquisition, applying SQL in / out of a transaction, plus the version assertion.
+- **`parseMysqlMajorVersion(version)`** — exposed for adopters who want to run the same check in their own boot logic.
+- **Drift detection (`introspect()`) is not yet implemented in v1** — it throws `KickDbError` with code `KICK_DB_INTROSPECT_NOT_SUPPORTED`. Set `driftCheck: 'off'` on the migration runner until a follow-up adds the `information_schema` walk.
+
+## License
+
+MIT © Felix Orinda

--- a/packages/db-mysql/__tests__/unit/version-check.test.ts
+++ b/packages/db-mysql/__tests__/unit/version-check.test.ts
@@ -1,106 +1,248 @@
 /**
- * Unit coverage for the MySQL 8.0+ version assertion + the version
- * string parser. The full real-driver integration test using
- * Testcontainers MySQL lands in a follow-up — kicking the larger
- * Docker-image dependency to a separate PR keeps this package's
- * suite cheap to run on every commit.
+ * Unit coverage for the MySQL adapter:
+ *   - version-string parser (MySQL + MariaDB shapes)
+ *   - version-assertion gate (8.0+ for MySQL, 10.5+ for MariaDB)
+ *   - multi-statement SQL splitter
+ *   - mock-pool query-call observation (caching, statement runs)
+ *
+ * Real-driver Testcontainers MySQL integration test ships in a
+ * follow-up — kicking the larger Docker-image dependency to a
+ * separate PR keeps this suite cheap to run on every commit.
  *
  * Spec: docs/db/spec-relational-query-other-dialects.md §7 R-1.
  */
 
 import { describe, expect, it } from 'vitest'
-import { mysqlAdapter, parseMysqlMajorVersion, type MysqlPoolLike } from '../../src'
+import {
+  mysqlAdapter,
+  parseMysqlMajorVersion,
+  parseMysqlVersion,
+  splitMysqlStatements,
+  type MysqlConnectionLike,
+  type MysqlPoolLike,
+} from '../../src'
 
-describe('parseMysqlMajorVersion', () => {
-  it('parses standard 8.x.y shapes', () => {
-    expect(parseMysqlMajorVersion('8.0.34')).toBe(8)
-    expect(parseMysqlMajorVersion('8.4.0')).toBe(8)
-    expect(parseMysqlMajorVersion('8.0.34-log')).toBe(8)
+describe('parseMysqlVersion', () => {
+  it('parses standard MySQL 8.x.y shapes as flavor=mysql', () => {
+    expect(parseMysqlVersion('8.0.34')).toEqual({ flavor: 'mysql', major: 8, minor: 0 })
+    expect(parseMysqlVersion('8.4.0')).toEqual({ flavor: 'mysql', major: 8, minor: 4 })
+    expect(parseMysqlVersion('8.0.34-log')).toEqual({ flavor: 'mysql', major: 8, minor: 0 })
   })
 
-  it('parses 5.x as 5', () => {
-    expect(parseMysqlMajorVersion('5.7.42')).toBe(5)
-    expect(parseMysqlMajorVersion('5.7.42-log')).toBe(5)
+  it('parses MySQL 5.x as flavor=mysql', () => {
+    expect(parseMysqlVersion('5.7.42')).toEqual({ flavor: 'mysql', major: 5, minor: 7 })
+    expect(parseMysqlVersion('5.7.42-log')).toEqual({ flavor: 'mysql', major: 5, minor: 7 })
   })
 
-  it('parses MariaDB 10.x as 10 (above the 8 floor)', () => {
-    expect(parseMysqlMajorVersion('10.6.11-MariaDB-1:10.6.11+maria~ubu2004')).toBe(10)
-    expect(parseMysqlMajorVersion('10.5.21-MariaDB-log')).toBe(10)
+  it('detects MariaDB and parses major + minor', () => {
+    expect(parseMysqlVersion('10.6.11-MariaDB-1:10.6.11+maria~ubu2004')).toEqual({
+      flavor: 'mariadb',
+      major: 10,
+      minor: 6,
+    })
+    expect(parseMysqlVersion('10.5.21-MariaDB-log')).toEqual({
+      flavor: 'mariadb',
+      major: 10,
+      minor: 5,
+    })
+    expect(parseMysqlVersion('10.4.32-MariaDB')).toEqual({
+      flavor: 'mariadb',
+      major: 10,
+      minor: 4,
+    })
   })
 
   it('returns null on garbage input', () => {
-    expect(parseMysqlMajorVersion('')).toBeNull()
-    expect(parseMysqlMajorVersion('x.y.z')).toBeNull()
-    expect(parseMysqlMajorVersion('not-a-version')).toBeNull()
+    expect(parseMysqlVersion('')).toBeNull()
+    expect(parseMysqlVersion('x.y.z')).toBeNull()
+    expect(parseMysqlVersion('not-a-version')).toBeNull()
+    expect(parseMysqlVersion('8')).toBeNull() // missing minor
   })
 
   it('handles leading whitespace', () => {
-    expect(parseMysqlMajorVersion('  8.0.34')).toBe(8)
+    expect(parseMysqlVersion('  8.0.34')).toEqual({ flavor: 'mysql', major: 8, minor: 0 })
+  })
+})
+
+describe('parseMysqlMajorVersion (back-compat shim)', () => {
+  it('still returns the major number for MySQL', () => {
+    expect(parseMysqlMajorVersion('8.0.34')).toBe(8)
+  })
+  it('still returns 10 for MariaDB 10.x', () => {
+    expect(parseMysqlMajorVersion('10.6.11-MariaDB')).toBe(10)
+  })
+  it('returns null on garbage', () => {
+    expect(parseMysqlMajorVersion('xyz')).toBeNull()
   })
 })
 
 /**
- * Build a minimal mock pool that returns a canned VERSION() result
- * + asserts no other queries run before the version check passes.
+ * Build a mock pool that records ALL queries (including
+ * `SELECT VERSION()`) into a single observable array. Returns the
+ * canned version string for any VERSION() probe.
  */
-function makeMockPool(version: string, otherQueries: string[] = []): MysqlPoolLike {
-  let versionAsked = false
+function makeMockPool(version: string): { pool: MysqlPoolLike; queries: string[] } {
   const queries: string[] = []
-  return {
+  const pool: MysqlPoolLike = {
     async query(sql: string) {
       queries.push(sql)
-      if (/^SELECT VERSION/i.test(sql)) {
-        versionAsked = true
-        return [[{ version }] as never[], []]
+      if (/SELECT\s+VERSION\(\)/i.test(sql)) {
+        return [[{ version }] as never, []]
       }
-      // Track non-version queries; tests assert the version assertion
-      // gates them.
-      otherQueries.push(sql)
-      void versionAsked
-      return [[] as never[], []]
+      return [{ affectedRows: 0 } as never, []]
     },
-    async getConnection() {
+    async getConnection(): Promise<MysqlConnectionLike> {
       throw new Error('not used in version-check tests')
     },
   }
+  return { pool, queries }
 }
 
 describe('mysqlAdapter — version assertion gate', () => {
   it('passes through on MySQL 8.0+', async () => {
-    const adapter = mysqlAdapter({ pool: makeMockPool('8.0.34') })
+    const { pool } = makeMockPool('8.0.34')
+    const adapter = mysqlAdapter({ pool })
     await expect(adapter.ensureMigrationTables()).resolves.toBeUndefined()
   })
 
-  it('passes through on MariaDB 10.x', async () => {
-    const adapter = mysqlAdapter({ pool: makeMockPool('10.6.11-MariaDB-log') })
+  it('passes through on MariaDB 10.5+', async () => {
+    const { pool } = makeMockPool('10.6.11-MariaDB-log')
+    const adapter = mysqlAdapter({ pool })
     await expect(adapter.ensureMigrationTables()).resolves.toBeUndefined()
   })
 
-  it('throws KickDbError on MySQL 5.7', async () => {
-    const adapter = mysqlAdapter({ pool: makeMockPool('5.7.42-log') })
+  it('throws on MySQL 5.7', async () => {
+    const { pool } = makeMockPool('5.7.42-log')
+    const adapter = mysqlAdapter({ pool })
     await expect(adapter.ensureMigrationTables()).rejects.toThrow(/MySQL 8\.0\+ required/)
   })
 
-  it('throws KickDbError on unparseable version string', async () => {
-    const adapter = mysqlAdapter({ pool: makeMockPool('not-a-version') })
-    await expect(adapter.ensureMigrationTables()).rejects.toThrow(/MySQL 8\.0\+ required/)
+  it('throws on MariaDB 10.4 (below the 10.5 floor)', async () => {
+    const { pool } = makeMockPool('10.4.32-MariaDB')
+    const adapter = mysqlAdapter({ pool })
+    await expect(adapter.ensureMigrationTables()).rejects.toThrow(/MariaDB 10\.5\+ required/)
   })
 
-  it('caches the version check after first success', async () => {
-    const queries: string[] = []
-    const adapter = mysqlAdapter({ pool: makeMockPool('8.0.34', queries) })
+  it('throws on MariaDB 10.0', async () => {
+    const { pool } = makeMockPool('10.0.38-MariaDB')
+    const adapter = mysqlAdapter({ pool })
+    await expect(adapter.ensureMigrationTables()).rejects.toThrow(/MariaDB 10\.5\+ required/)
+  })
+
+  it('passes on MariaDB 11.x (major above the floor)', async () => {
+    const { pool } = makeMockPool('11.0.2-MariaDB')
+    const adapter = mysqlAdapter({ pool })
+    await expect(adapter.ensureMigrationTables()).resolves.toBeUndefined()
+  })
+
+  it('throws on unparseable version string', async () => {
+    const { pool } = makeMockPool('not-a-version')
+    const adapter = mysqlAdapter({ pool })
+    await expect(adapter.ensureMigrationTables()).rejects.toThrow(/unparseable version/)
+  })
+
+  it('caches the version check after first success — VERSION() runs exactly once', async () => {
+    const { pool, queries } = makeMockPool('8.0.34')
+    const adapter = mysqlAdapter({ pool })
     await adapter.ensureMigrationTables()
     await adapter.ensureMigrationTables()
-    // Second call should not re-run SELECT VERSION().
-    const versionQueries = queries.filter((q) => /VERSION/i.test(q))
-    expect(versionQueries.length).toBe(0) // VERSION() goes to a different pile in the mock
-    // The other queries pile collected the DDL — first call ran 2,
-    // second call ran 2 more = 4 DDL invocations total.
-    expect(queries.length).toBe(4)
+    const versionQueries = queries.filter((q) => /SELECT\s+VERSION\(\)/i.test(q))
+    expect(versionQueries.length).toBe(1)
+  })
+})
+
+describe('splitMysqlStatements', () => {
+  it('splits a simple two-statement DDL block', () => {
+    const sql = `CREATE TABLE foo (id int);\nINSERT INTO foo VALUES (1);`
+    expect(splitMysqlStatements(sql)).toEqual([
+      'CREATE TABLE foo (id int)',
+      'INSERT INTO foo VALUES (1)',
+    ])
+  })
+
+  it('returns a single statement when no semicolon present', () => {
+    expect(splitMysqlStatements('SELECT 1')).toEqual(['SELECT 1'])
+  })
+
+  it('treats trailing semicolon as terminator, not empty statement', () => {
+    expect(splitMysqlStatements('SELECT 1;')).toEqual(['SELECT 1'])
+  })
+
+  it('ignores semicolons inside single-quote string literals', () => {
+    const sql = `INSERT INTO t VALUES ('a;b'); INSERT INTO t VALUES ('c');`
+    expect(splitMysqlStatements(sql)).toEqual([
+      `INSERT INTO t VALUES ('a;b')`,
+      `INSERT INTO t VALUES ('c')`,
+    ])
+  })
+
+  it('ignores semicolons inside double-quote string literals', () => {
+    const sql = `INSERT INTO t VALUES ("a;b"); INSERT INTO t VALUES ("c");`
+    expect(splitMysqlStatements(sql)).toEqual([
+      `INSERT INTO t VALUES ("a;b")`,
+      `INSERT INTO t VALUES ("c")`,
+    ])
+  })
+
+  it('ignores semicolons inside backtick identifiers', () => {
+    const sql = 'SELECT `weird;name` FROM t; SELECT 1;'
+    expect(splitMysqlStatements(sql)).toEqual(['SELECT `weird;name` FROM t', 'SELECT 1'])
+  })
+
+  it('ignores semicolons inside `--` line comments', () => {
+    const sql = `SELECT 1 -- not; a separator\n; SELECT 2;`
+    const out = splitMysqlStatements(sql)
+    expect(out).toHaveLength(2)
+    expect(out[0]).toContain('SELECT 1')
+    expect(out[1]).toBe('SELECT 2')
+  })
+
+  it('ignores semicolons inside `/* */` block comments', () => {
+    const sql = `SELECT 1 /* not; a; separator */; SELECT 2;`
+    expect(splitMysqlStatements(sql)).toEqual(['SELECT 1 /* not; a; separator */', 'SELECT 2'])
+  })
+
+  it('handles escaped quotes inside string literals', () => {
+    const sql = `INSERT INTO t VALUES ('it\\'s; fine'); SELECT 1;`
+    const out = splitMysqlStatements(sql)
+    expect(out).toHaveLength(2)
+    expect(out[0]).toContain("it\\'s; fine")
+    expect(out[1]).toBe('SELECT 1')
+  })
+})
+
+describe('mysqlAdapter — multi-statement DDL via splitter', () => {
+  it('ensureMigrationTables splits the multi-statement DDL into separate query() calls', async () => {
+    const { pool, queries } = makeMockPool('8.0.34')
+    const adapter = mysqlAdapter({ pool })
+    await adapter.ensureMigrationTables()
+
+    const ddlQueries = queries.filter((q) => !/SELECT\s+VERSION\(\)/i.test(q))
+
+    // No DDL statement should still contain a top-level `;` —
+    // default mysql2 settings reject multi-statement queries, so
+    // every entry in ddlQueries must be a single statement.
+    for (const q of ddlQueries) {
+      expect(q.endsWith(';')).toBe(false)
+    }
+    // migrationsTableDdl + lockTableDdl together emit > 1
+    // top-level statements; the splitter must pull them apart.
+    expect(ddlQueries.length).toBeGreaterThan(2)
+  })
+
+  it('applySqlNoTx splits a multi-statement migration', async () => {
+    const { pool, queries } = makeMockPool('8.0.34')
+    const adapter = mysqlAdapter({ pool })
+    await adapter.ensureMigrationTables()
+    queries.length = 0
+
+    await adapter.applySqlNoTx(`CREATE TABLE x (id int);\nINSERT INTO x VALUES (1);`)
+    expect(queries).toEqual(['CREATE TABLE x (id int)', 'INSERT INTO x VALUES (1)'])
   })
 
   it('introspect throws — drift detection lands in a follow-up', async () => {
-    const adapter = mysqlAdapter({ pool: makeMockPool('8.0.34') })
+    const { pool } = makeMockPool('8.0.34')
+    const adapter = mysqlAdapter({ pool })
     await expect(adapter.introspect()).rejects.toThrow(/not supported in v1/)
   })
 })

--- a/packages/db-mysql/__tests__/unit/version-check.test.ts
+++ b/packages/db-mysql/__tests__/unit/version-check.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit coverage for the MySQL 8.0+ version assertion + the version
+ * string parser. The full real-driver integration test using
+ * Testcontainers MySQL lands in a follow-up — kicking the larger
+ * Docker-image dependency to a separate PR keeps this package's
+ * suite cheap to run on every commit.
+ *
+ * Spec: docs/db/spec-relational-query-other-dialects.md §7 R-1.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { mysqlAdapter, parseMysqlMajorVersion, type MysqlPoolLike } from '../../src'
+
+describe('parseMysqlMajorVersion', () => {
+  it('parses standard 8.x.y shapes', () => {
+    expect(parseMysqlMajorVersion('8.0.34')).toBe(8)
+    expect(parseMysqlMajorVersion('8.4.0')).toBe(8)
+    expect(parseMysqlMajorVersion('8.0.34-log')).toBe(8)
+  })
+
+  it('parses 5.x as 5', () => {
+    expect(parseMysqlMajorVersion('5.7.42')).toBe(5)
+    expect(parseMysqlMajorVersion('5.7.42-log')).toBe(5)
+  })
+
+  it('parses MariaDB 10.x as 10 (above the 8 floor)', () => {
+    expect(parseMysqlMajorVersion('10.6.11-MariaDB-1:10.6.11+maria~ubu2004')).toBe(10)
+    expect(parseMysqlMajorVersion('10.5.21-MariaDB-log')).toBe(10)
+  })
+
+  it('returns null on garbage input', () => {
+    expect(parseMysqlMajorVersion('')).toBeNull()
+    expect(parseMysqlMajorVersion('x.y.z')).toBeNull()
+    expect(parseMysqlMajorVersion('not-a-version')).toBeNull()
+  })
+
+  it('handles leading whitespace', () => {
+    expect(parseMysqlMajorVersion('  8.0.34')).toBe(8)
+  })
+})
+
+/**
+ * Build a minimal mock pool that returns a canned VERSION() result
+ * + asserts no other queries run before the version check passes.
+ */
+function makeMockPool(version: string, otherQueries: string[] = []): MysqlPoolLike {
+  let versionAsked = false
+  const queries: string[] = []
+  return {
+    async query(sql: string) {
+      queries.push(sql)
+      if (/^SELECT VERSION/i.test(sql)) {
+        versionAsked = true
+        return [[{ version }] as never[], []]
+      }
+      // Track non-version queries; tests assert the version assertion
+      // gates them.
+      otherQueries.push(sql)
+      void versionAsked
+      return [[] as never[], []]
+    },
+    async getConnection() {
+      throw new Error('not used in version-check tests')
+    },
+  }
+}
+
+describe('mysqlAdapter — version assertion gate', () => {
+  it('passes through on MySQL 8.0+', async () => {
+    const adapter = mysqlAdapter({ pool: makeMockPool('8.0.34') })
+    await expect(adapter.ensureMigrationTables()).resolves.toBeUndefined()
+  })
+
+  it('passes through on MariaDB 10.x', async () => {
+    const adapter = mysqlAdapter({ pool: makeMockPool('10.6.11-MariaDB-log') })
+    await expect(adapter.ensureMigrationTables()).resolves.toBeUndefined()
+  })
+
+  it('throws KickDbError on MySQL 5.7', async () => {
+    const adapter = mysqlAdapter({ pool: makeMockPool('5.7.42-log') })
+    await expect(adapter.ensureMigrationTables()).rejects.toThrow(/MySQL 8\.0\+ required/)
+  })
+
+  it('throws KickDbError on unparseable version string', async () => {
+    const adapter = mysqlAdapter({ pool: makeMockPool('not-a-version') })
+    await expect(adapter.ensureMigrationTables()).rejects.toThrow(/MySQL 8\.0\+ required/)
+  })
+
+  it('caches the version check after first success', async () => {
+    const queries: string[] = []
+    const adapter = mysqlAdapter({ pool: makeMockPool('8.0.34', queries) })
+    await adapter.ensureMigrationTables()
+    await adapter.ensureMigrationTables()
+    // Second call should not re-run SELECT VERSION().
+    const versionQueries = queries.filter((q) => /VERSION/i.test(q))
+    expect(versionQueries.length).toBe(0) // VERSION() goes to a different pile in the mock
+    // The other queries pile collected the DDL — first call ran 2,
+    // second call ran 2 more = 4 DDL invocations total.
+    expect(queries.length).toBe(4)
+  })
+
+  it('introspect throws — drift detection lands in a follow-up', async () => {
+    const adapter = mysqlAdapter({ pool: makeMockPool('8.0.34') })
+    await expect(adapter.introspect()).rejects.toThrow(/not supported in v1/)
+  })
+})

--- a/packages/db-mysql/__tests__/unit/version-check.test.ts
+++ b/packages/db-mysql/__tests__/unit/version-check.test.ts
@@ -52,6 +52,27 @@ describe('parseMysqlVersion', () => {
     })
   })
 
+  it('strips the `5.5.5-` wire-protocol compat prefix on MariaDB', () => {
+    // MariaDB advertises `5.5.5-<real>-MariaDB...` to keep older
+    // MySQL clients happy. The leading `5.5.5-` is fake — the real
+    // server version sits immediately before `-MariaDB`.
+    expect(parseMysqlVersion('5.5.5-10.6.11-MariaDB-1:10.6.11+maria~ubu2004')).toEqual({
+      flavor: 'mariadb',
+      major: 10,
+      minor: 6,
+    })
+    expect(parseMysqlVersion('5.5.5-10.4.32-MariaDB')).toEqual({
+      flavor: 'mariadb',
+      major: 10,
+      minor: 4,
+    })
+    expect(parseMysqlVersion('5.5.5-11.0.2-MariaDB')).toEqual({
+      flavor: 'mariadb',
+      major: 11,
+      minor: 0,
+    })
+  })
+
   it('returns null on garbage input', () => {
     expect(parseMysqlVersion('')).toBeNull()
     expect(parseMysqlVersion('x.y.z')).toBeNull()
@@ -208,6 +229,45 @@ describe('splitMysqlStatements', () => {
     expect(out).toHaveLength(2)
     expect(out[0]).toContain("it\\'s; fine")
     expect(out[1]).toBe('SELECT 1')
+  })
+
+  it('handles SQL-standard doubled-quote escapes inside single-quoted strings', () => {
+    // `'it''s; fine'` is a single string literal containing `it's; fine`.
+    // The semicolon inside MUST NOT split the statement.
+    const sql = `INSERT INTO t VALUES ('it''s; fine'); SELECT 1;`
+    const out = splitMysqlStatements(sql)
+    expect(out).toEqual([`INSERT INTO t VALUES ('it''s; fine')`, 'SELECT 1'])
+  })
+
+  it('handles SQL-standard doubled-quote escapes inside double-quoted strings', () => {
+    const sql = `INSERT INTO t VALUES ("she said ""hi""; bye"); SELECT 1;`
+    const out = splitMysqlStatements(sql)
+    expect(out).toEqual([`INSERT INTO t VALUES ("she said ""hi""; bye")`, 'SELECT 1'])
+  })
+
+  it('treats consecutive `--` without trailing whitespace as operators, not a comment', () => {
+    // `5--3` is `5 - (-3)` in MySQL — `--` starts a comment only
+    // when followed by whitespace/end-of-input. The splitter must
+    // pass `5--3;` through and then split on the trailing `;`.
+    const sql = `SELECT 5--3; SELECT 1;`
+    const out = splitMysqlStatements(sql)
+    expect(out).toEqual(['SELECT 5--3', 'SELECT 1'])
+  })
+
+  it('still treats `-- ` (with trailing space) as a line comment', () => {
+    const sql = `SELECT 1 -- comment; not a separator\n; SELECT 2;`
+    const out = splitMysqlStatements(sql)
+    expect(out).toHaveLength(2)
+    expect(out[0]).toContain('SELECT 1')
+    expect(out[0]).toContain('-- comment; not a separator')
+    expect(out[1]).toBe('SELECT 2')
+  })
+
+  it('treats `--` at end-of-input as a comment introducer', () => {
+    // `--` followed by nothing is still a comment per MySQL docs.
+    // Empty-comment edge case: no `;` follows so we get one statement.
+    const sql = `SELECT 1 --`
+    expect(splitMysqlStatements(sql)).toEqual(['SELECT 1 --'])
   })
 })
 

--- a/packages/db-mysql/package.json
+++ b/packages/db-mysql/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@forinda/kickjs-db-pg",
-  "version": "6.0.0",
-  "description": "node-postgres adapter for @forinda/kickjs-db — MigrationAdapter + Kysely PostgresDialect",
+  "name": "@forinda/kickjs-db-mysql",
+  "version": "0.1.0",
+  "description": "mysql2 adapter for @forinda/kickjs-db — MigrationAdapter + Kysely MysqlDialect (MySQL 8.0+)",
   "keywords": [
     "kickjs",
-    "postgres",
-    "pg",
+    "mysql",
+    "mysql2",
     "orm",
     "migrations",
     "query-builder",
@@ -56,16 +56,14 @@
   },
   "peerDependencies": {
     "@forinda/kickjs-db": "workspace:*",
-    "pg": ">=8.11.0"
+    "mysql2": ">=3.0.0"
   },
   "devDependencies": {
     "@forinda/kickjs": "workspace:*",
     "@forinda/kickjs-db": "workspace:*",
-    "@testcontainers/postgresql": "^10.16.0",
     "@types/node": "^25.6.0",
-    "@types/pg": "^8.11.10",
     "kysely": "^0.28.16",
-    "pg": "^8.13.1",
+    "mysql2": "^3.15.3",
     "typescript": "^6.0.3"
   },
   "publishConfig": {
@@ -80,7 +78,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/forinda/kick-js.git",
-    "directory": "packages/db-pg"
+    "directory": "packages/db-mysql"
   },
   "bugs": {
     "url": "https://github.com/forinda/kick-js/issues"

--- a/packages/db-mysql/package.json
+++ b/packages/db-mysql/package.json
@@ -26,7 +26,9 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
     "build": "wireit",

--- a/packages/db-mysql/src/adapter.ts
+++ b/packages/db-mysql/src/adapter.ts
@@ -66,20 +66,50 @@ export interface ParsedMysqlVersion {
  * Parse a MySQL `SELECT VERSION()` string. Handles:
  *
  *   - MySQL: `8.0.34`, `8.4.0`, `5.7.42-log`
- *   - MariaDB: `10.6.11-MariaDB-1:10.6.11+maria~ubu2004`,
- *              `10.5.21-MariaDB-log`, `10.4.32-MariaDB`
+ *   - MariaDB plain: `10.6.11-MariaDB`, `10.5.21-MariaDB-log`,
+ *                    `10.4.32-MariaDB`
+ *   - MariaDB w/ compat prefix: `5.5.5-10.6.11-MariaDB-1:10.6.11+maria~ubu2004`
+ *     (the leading `5.5.5-` is a wire-protocol thing for older MySQL
+ *     clients; the real server version sits immediately before
+ *     `-MariaDB`)
  *
  * Returns `null` on unparseable input.
  */
 export function parseMysqlVersion(version: string): ParsedMysqlVersion | null {
   const trimmed = version.trim()
+  const isMariaDb = /MariaDB/i.test(trimmed)
+
+  if (isMariaDb) {
+    // Pull the `major.minor` that sits immediately before
+    // `-MariaDB`. This skips the `5.5.5-` compat prefix when
+    // present and grabs the real server version regardless of
+    // whether one's there.
+    const m = /(\d+)\.(\d+)(?:\.\d+)?-MariaDB/i.exec(trimmed)
+    if (m) {
+      const major = Number(m[1])
+      const minor = Number(m[2])
+      if (Number.isFinite(major) && Number.isFinite(minor)) {
+        return { flavor: 'mariadb', major, minor }
+      }
+    }
+    // Fallback for vendor strings we haven't seen — try the
+    // leading x.y. Better to surface the wrong floor than to
+    // refuse an otherwise valid MariaDB outright.
+    const fallback = /^(\d+)\.(\d+)/.exec(trimmed)
+    if (!fallback) return null
+    const major = Number(fallback[1])
+    const minor = Number(fallback[2])
+    if (!Number.isFinite(major) || !Number.isFinite(minor)) return null
+    return { flavor: 'mariadb', major, minor }
+  }
+
+  // MySQL: leading x.y from the start of the string.
   const m = /^(\d+)\.(\d+)/.exec(trimmed)
   if (!m) return null
   const major = Number(m[1])
   const minor = Number(m[2])
   if (!Number.isFinite(major) || !Number.isFinite(minor)) return null
-  const flavor: ParsedMysqlVersion['flavor'] = /MariaDB/i.test(trimmed) ? 'mariadb' : 'mysql'
-  return { flavor, major, minor }
+  return { flavor: 'mysql', major, minor }
 }
 
 /**
@@ -130,6 +160,21 @@ function checkVersionSupport(parsed: ParsedMysqlVersion | null, raw: string): st
  * lets the adapter run kickjs-emitted DDL (multi-statement, but
  * always semicolon-separated at the top level) without that flag.
  *
+ * Two MySQL-specific quirks the splitter handles:
+ *
+ *   - **`--` comments require trailing whitespace/end-of-input.**
+ *     Per MySQL docs, `--` is only a line-comment introducer when
+ *     followed by whitespace (space/tab/newline) or end-of-input —
+ *     otherwise it's two unary-minus operators (`5--3` evaluates
+ *     to `8`). Bare `--xyz` is a parse error in MySQL but kickjs
+ *     should pass it through unchanged so the driver surfaces the
+ *     real error, not silently swallow the rest of the line.
+ *   - **Doubled-quote string escapes.** MySQL accepts both
+ *     backslash-escapes (`'it\'s'`) and SQL-standard doubled-quote
+ *     escapes (`'it''s'`). The state machine peeks for the doubled
+ *     form and stays in-string. Same rule applies to `""` inside
+ *     double-quoted strings.
+ *
  * Adopter-written migrations with pathological SQL — e.g. `;` in
  * an unterminated block comment — won't split correctly.
  * Documented in the README; turn on `multipleStatements: true` on
@@ -144,9 +189,13 @@ export function splitMysqlStatements(sql: string): string[] {
   let inLineComment = false
   let inBlockComment = false
 
+  const isCommentWhitespace = (c: string) =>
+    c === ' ' || c === '\t' || c === '\n' || c === '\r' || c === '\f' || c === '\v'
+
   for (let i = 0; i < sql.length; i++) {
     const ch = sql[i]
     const next = i + 1 < sql.length ? sql[i + 1] : ''
+    const after = i + 2 < sql.length ? sql[i + 2] : ''
 
     if (inLineComment) {
       buf += ch
@@ -163,8 +212,15 @@ export function splitMysqlStatements(sql: string): string[] {
       continue
     }
     if (inSingle) {
+      // Doubled `''` is an SQL-standard escape — stay in-string.
+      if (ch === "'" && next === "'") {
+        buf += ch
+        buf += next
+        i++
+        continue
+      }
       buf += ch
-      if (ch === '\\' && next != null) {
+      if (ch === '\\' && next !== '') {
         buf += next
         i++
         continue
@@ -173,8 +229,15 @@ export function splitMysqlStatements(sql: string): string[] {
       continue
     }
     if (inDouble) {
+      // Doubled `""` is an SQL-standard escape — stay in-string.
+      if (ch === '"' && next === '"') {
+        buf += ch
+        buf += next
+        i++
+        continue
+      }
       buf += ch
-      if (ch === '\\' && next != null) {
+      if (ch === '\\' && next !== '') {
         buf += next
         i++
         continue
@@ -188,7 +251,10 @@ export function splitMysqlStatements(sql: string): string[] {
       continue
     }
 
-    if (ch === '-' && next === '-') {
+    // `--` is a comment introducer only when followed by whitespace
+    // (or end-of-input). Anything else (`5--3`, `--xyz`) is left as
+    // operator-soup and the driver decides what to do with it.
+    if (ch === '-' && next === '-' && (after === '' || isCommentWhitespace(after))) {
       buf += ch
       inLineComment = true
       continue

--- a/packages/db-mysql/src/adapter.ts
+++ b/packages/db-mysql/src/adapter.ts
@@ -13,14 +13,21 @@ import {
  * structural surface of `mysql2/promise`'s Pool. The adapter only
  * uses `query(...)` and `getConnection(...)` so any mysql2-compatible
  * driver works.
+ *
+ * Return type is `Promise<[R, unknown]>` (not `[R[], unknown]`) so
+ * mysql2's `Pool.query()` is structurally assignable: SELECT
+ * statements return `RowDataPacket[]` (so callers pass `R =
+ * MyRow[]`), INSERT / UPDATE / DELETE return `ResultSetHeader` (so
+ * callers pass `R = ResultSetHeader`). Each adapter call site picks
+ * the row shape it expects via the type parameter.
  */
 export interface MysqlConnectionLike {
-  query<R = unknown>(sql: string, params?: readonly unknown[]): Promise<[R[], unknown]>
+  query<R = unknown>(sql: string, params?: readonly unknown[]): Promise<[R, unknown]>
   release(): void
 }
 
 export interface MysqlPoolLike {
-  query<R = unknown>(sql: string, params?: readonly unknown[]): Promise<[R[], unknown]>
+  query<R = unknown>(sql: string, params?: readonly unknown[]): Promise<[R, unknown]>
   getConnection(): Promise<MysqlConnectionLike>
 }
 
@@ -34,35 +41,207 @@ export interface MysqlAdapterOptions {
 }
 
 /**
- * Minimum supported MySQL major version. JSON_ARRAYAGG shipped in
- * 8.0; earlier versions can't run kickjs-db's relational query layer.
+ * Minimum supported MySQL major + MariaDB version. `JSON_ARRAYAGG`
+ * shipped in MySQL 8.0 and MariaDB 10.5 — earlier versions can't
+ * run kickjs-db's relational query layer.
+ *
  * Spec: docs/db/spec-relational-query-other-dialects.md §7 R-1.
  */
 const MIN_MYSQL_MAJOR = 8
+const MIN_MARIADB_MAJOR = 10
+const MIN_MARIADB_MINOR = 5
 
 /**
- * Parse a MySQL version string into a major version number. MySQL's
- * `SELECT VERSION()` returns shapes like `8.0.34`, `8.4.0`,
- * `5.7.42-log`, `10.6.11-MariaDB-...`. We only care about the
- * leading integer for the floor check; MariaDB's 10.x is treated
- * as 10 (above the 8 floor).
+ * Parsed shape returned by `parseMysqlVersion`. `flavor` lets
+ * adopters distinguish MySQL from MariaDB without re-grepping the
+ * raw string.
  */
-export function parseMysqlMajorVersion(version: string): number | null {
-  const m = /^(\d+)\./.exec(version.trim())
+export interface ParsedMysqlVersion {
+  flavor: 'mysql' | 'mariadb'
+  major: number
+  minor: number
+}
+
+/**
+ * Parse a MySQL `SELECT VERSION()` string. Handles:
+ *
+ *   - MySQL: `8.0.34`, `8.4.0`, `5.7.42-log`
+ *   - MariaDB: `10.6.11-MariaDB-1:10.6.11+maria~ubu2004`,
+ *              `10.5.21-MariaDB-log`, `10.4.32-MariaDB`
+ *
+ * Returns `null` on unparseable input.
+ */
+export function parseMysqlVersion(version: string): ParsedMysqlVersion | null {
+  const trimmed = version.trim()
+  const m = /^(\d+)\.(\d+)/.exec(trimmed)
   if (!m) return null
   const major = Number(m[1])
-  return Number.isFinite(major) ? major : null
+  const minor = Number(m[2])
+  if (!Number.isFinite(major) || !Number.isFinite(minor)) return null
+  const flavor: ParsedMysqlVersion['flavor'] = /MariaDB/i.test(trimmed) ? 'mariadb' : 'mysql'
+  return { flavor, major, minor }
+}
+
+/**
+ * Back-compat shim — pre-existing API surface that returned the
+ * major version only. Kept exported so adopters depending on it
+ * keep working; new code should use `parseMysqlVersion`.
+ *
+ * @deprecated Use `parseMysqlVersion` for full version + flavor info.
+ */
+export function parseMysqlMajorVersion(version: string): number | null {
+  const parsed = parseMysqlVersion(version)
+  return parsed?.major ?? null
+}
+
+/**
+ * Returns the failure reason if the parsed version doesn't satisfy
+ * kickjs-db's floor, or `null` if it does. Pure — no I/O.
+ */
+function checkVersionSupport(parsed: ParsedMysqlVersion | null, raw: string): string | null {
+  if (parsed == null) {
+    return `unparseable version string: ${raw || '<empty>'}`
+  }
+  if (parsed.flavor === 'mariadb') {
+    if (parsed.major > MIN_MARIADB_MAJOR) return null
+    if (parsed.major < MIN_MARIADB_MAJOR) {
+      return `MariaDB ${MIN_MARIADB_MAJOR}.${MIN_MARIADB_MINOR}+ required (detected: ${raw})`
+    }
+    if (parsed.minor < MIN_MARIADB_MINOR) {
+      return `MariaDB ${MIN_MARIADB_MAJOR}.${MIN_MARIADB_MINOR}+ required (detected: ${raw})`
+    }
+    return null
+  }
+  // MySQL flavor.
+  if (parsed.major < MIN_MYSQL_MAJOR) {
+    return `MySQL ${MIN_MYSQL_MAJOR}.0+ required (detected: ${raw})`
+  }
+  return null
+}
+
+/**
+ * Split a SQL blob into individual statements at the top-level `;`
+ * boundary. Respects single-quote / double-quote / backtick string
+ * literals AND `--` line comments + C-style block comments —
+ * `;` inside any of those does not terminate a statement.
+ *
+ * mysql2's default `Pool.query()` rejects multi-statement SQL unless
+ * the driver was created with `multipleStatements: true`. Splitting
+ * lets the adapter run kickjs-emitted DDL (multi-statement, but
+ * always semicolon-separated at the top level) without that flag.
+ *
+ * Adopter-written migrations with pathological SQL — e.g. `;` in
+ * an unterminated block comment — won't split correctly.
+ * Documented in the README; turn on `multipleStatements: true` on
+ * the pool if you hit it.
+ */
+export function splitMysqlStatements(sql: string): string[] {
+  const out: string[] = []
+  let buf = ''
+  let inSingle = false
+  let inDouble = false
+  let inBacktick = false
+  let inLineComment = false
+  let inBlockComment = false
+
+  for (let i = 0; i < sql.length; i++) {
+    const ch = sql[i]
+    const next = i + 1 < sql.length ? sql[i + 1] : ''
+
+    if (inLineComment) {
+      buf += ch
+      if (ch === '\n') inLineComment = false
+      continue
+    }
+    if (inBlockComment) {
+      buf += ch
+      if (ch === '*' && next === '/') {
+        buf += next
+        i++
+        inBlockComment = false
+      }
+      continue
+    }
+    if (inSingle) {
+      buf += ch
+      if (ch === '\\' && next != null) {
+        buf += next
+        i++
+        continue
+      }
+      if (ch === "'") inSingle = false
+      continue
+    }
+    if (inDouble) {
+      buf += ch
+      if (ch === '\\' && next != null) {
+        buf += next
+        i++
+        continue
+      }
+      if (ch === '"') inDouble = false
+      continue
+    }
+    if (inBacktick) {
+      buf += ch
+      if (ch === '`') inBacktick = false
+      continue
+    }
+
+    if (ch === '-' && next === '-') {
+      buf += ch
+      inLineComment = true
+      continue
+    }
+    if (ch === '/' && next === '*') {
+      buf += ch
+      inBlockComment = true
+      continue
+    }
+    if (ch === "'") {
+      buf += ch
+      inSingle = true
+      continue
+    }
+    if (ch === '"') {
+      buf += ch
+      inDouble = true
+      continue
+    }
+    if (ch === '`') {
+      buf += ch
+      inBacktick = true
+      continue
+    }
+    if (ch === ';') {
+      const trimmed = buf.trim()
+      if (trimmed.length > 0) out.push(trimmed)
+      buf = ''
+      continue
+    }
+    buf += ch
+  }
+
+  const tail = buf.trim()
+  if (tail.length > 0) out.push(tail)
+  return out
 }
 
 /**
  * MigrationAdapter implementation backed by mysql2.
  *
- * Asserts MySQL 8.0+ on first connection (via the first
- * `ensureMigrationTables` call, lazily — no I/O at construction
- * time). Earlier versions throw `KickDbError` with code
- * `KICK_DB_RELATIONAL_NOT_SUPPORTED` carrying the detected version
- * so adopters get a clear error before any query reaches the
- * relational compiler.
+ * Asserts MySQL 8.0+ (or MariaDB 10.5+) on first connection (via
+ * the first `ensureMigrationTables` call, lazily — no I/O at
+ * construction time). Earlier versions throw `KickDbError` with
+ * code `KICK_DB_RELATIONAL_NOT_SUPPORTED` carrying the detected
+ * version so adopters get a clear error before any query reaches
+ * the relational compiler.
+ *
+ * Multi-statement support: every `query()` call splits the SQL
+ * blob at top-level semicolons and runs each statement
+ * sequentially. Works against mysql2's default settings; adopters
+ * who set `multipleStatements: true` on the pool pay no extra
+ * cost (the split is cheap on small DDL blobs).
  *
  * Lock semantics: single-row UPDATE WHERE locked_at IS NULL on
  * `kick_migrations_lock`. Only the row created by
@@ -81,18 +260,40 @@ export function mysqlAdapter(opts: MysqlAdapterOptions): MigrationAdapter {
 
   async function assertVersion() {
     if (versionVerified) return
-    const [rows] = await pool.query<{ version: string }>(`SELECT VERSION() AS \`version\``)
+    const [rows] = await pool.query<{ version: string }[]>(`SELECT VERSION() AS \`version\``)
     const versionString = rows[0]?.version ?? ''
-    const major = parseMysqlMajorVersion(versionString)
-    if (major == null || major < MIN_MYSQL_MAJOR) {
+    const parsed = parseMysqlVersion(versionString)
+    const failure = checkVersionSupport(parsed, versionString)
+    if (failure) {
       throw new KickDbError(
         'KICK_DB_RELATIONAL_NOT_SUPPORTED',
-        `MySQL ${MIN_MYSQL_MAJOR}.0+ required for the relational query layer ` +
-          `(JSON_ARRAYAGG shipped in 8.0); detected version: ${versionString || '<unknown>'}. ` +
-          `Use a layer-1/layer-2 query (selectFrom / selectAll) on older MySQL versions.`,
+        `${failure}. JSON_ARRAYAGG (required by the relational query layer) shipped in ` +
+          `MySQL 8.0 and MariaDB 10.5. Use layer-1/layer-2 queries (selectFrom / selectAll) ` +
+          `on older versions.`,
       )
     }
     versionVerified = true
+  }
+
+  /**
+   * Run a (possibly multi-statement) SQL blob via the pool,
+   * splitting at top-level `;` so default mysql2 settings work.
+   */
+  async function runStatements(sql: string): Promise<void> {
+    for (const stmt of splitMysqlStatements(sql)) {
+      await pool.query(stmt)
+    }
+  }
+
+  /**
+   * Same as `runStatements` but on a held connection (used inside
+   * `applySqlInTx` so all statements share the BEGIN / COMMIT
+   * boundary).
+   */
+  async function runStatementsOnConn(conn: MysqlConnectionLike, sql: string): Promise<void> {
+    for (const stmt of splitMysqlStatements(sql)) {
+      await conn.query(stmt)
+    }
   }
 
   return {
@@ -100,19 +301,21 @@ export function mysqlAdapter(opts: MysqlAdapterOptions): MigrationAdapter {
 
     async ensureMigrationTables() {
       await assertVersion()
-      await pool.query(migrationsTableDdl(dialect))
-      await pool.query(lockTableDdl(dialect))
+      await runStatements(migrationsTableDdl(dialect))
+      await runStatements(lockTableDdl(dialect))
     },
 
     async listApplied(): Promise<MigrationRow[]> {
-      const [rows] = await pool.query<{
-        id: string
-        name: string
-        hash: string
-        batch: number
-        applied_at: string | Date
-        direction: 'up' | 'down'
-      }>(
+      const [rows] = await pool.query<
+        Array<{
+          id: string
+          name: string
+          hash: string
+          batch: number
+          applied_at: string | Date
+          direction: 'up' | 'down'
+        }>
+      >(
         `SELECT id, name, hash, batch, applied_at, direction
          FROM \`kick_migrations\`
          ORDER BY applied_at ASC, id ASC`,
@@ -141,14 +344,12 @@ export function mysqlAdapter(opts: MysqlAdapterOptions): MigrationAdapter {
     },
 
     async acquireLock(owner: string): Promise<boolean> {
-      // mysql2's query() returns [result, fields] for UPDATE where
-      // result has affectedRows. Cast through unknown to the result.
-      const [result] = (await pool.query(
+      const [result] = await pool.query<{ affectedRows: number }>(
         `UPDATE \`kick_migrations_lock\`
          SET locked_at = CURRENT_TIMESTAMP, locked_by = ?
          WHERE id = 1 AND locked_at IS NULL`,
         [owner],
-      )) as unknown as [{ affectedRows: number }, unknown]
+      )
       return result.affectedRows === 1
     },
 
@@ -164,7 +365,7 @@ export function mysqlAdapter(opts: MysqlAdapterOptions): MigrationAdapter {
       const conn = await pool.getConnection()
       try {
         await conn.query('START TRANSACTION')
-        await conn.query(sql)
+        await runStatementsOnConn(conn, sql)
         await conn.query('COMMIT')
       } catch (err) {
         await conn.query('ROLLBACK').catch(() => {
@@ -177,7 +378,7 @@ export function mysqlAdapter(opts: MysqlAdapterOptions): MigrationAdapter {
     },
 
     async applySqlNoTx(sql: string) {
-      await pool.query(sql)
+      await runStatements(sql)
     },
 
     async introspect(): Promise<SchemaSnapshot> {

--- a/packages/db-mysql/src/adapter.ts
+++ b/packages/db-mysql/src/adapter.ts
@@ -1,0 +1,198 @@
+import {
+  KickDbError,
+  lockTableDdl,
+  migrationsTableDdl,
+  type Dialect,
+  type MigrationAdapter,
+  type MigrationRow,
+  type SchemaSnapshot,
+} from '@forinda/kickjs-db'
+
+/**
+ * mysql2-shaped pool that `mysqlAdapter` consumes. Mirrors the
+ * structural surface of `mysql2/promise`'s Pool. The adapter only
+ * uses `query(...)` and `getConnection(...)` so any mysql2-compatible
+ * driver works.
+ */
+export interface MysqlConnectionLike {
+  query<R = unknown>(sql: string, params?: readonly unknown[]): Promise<[R[], unknown]>
+  release(): void
+}
+
+export interface MysqlPoolLike {
+  query<R = unknown>(sql: string, params?: readonly unknown[]): Promise<[R[], unknown]>
+  getConnection(): Promise<MysqlConnectionLike>
+}
+
+export interface MysqlAdapterOptions {
+  /**
+   * mysql2-compatible Pool. Caller-owned — `close()` on the adapter
+   * does NOT end the pool because adopters typically share a single
+   * pool across the migration adapter and the KickDbClient.
+   */
+  pool: MysqlPoolLike
+}
+
+/**
+ * Minimum supported MySQL major version. JSON_ARRAYAGG shipped in
+ * 8.0; earlier versions can't run kickjs-db's relational query layer.
+ * Spec: docs/db/spec-relational-query-other-dialects.md §7 R-1.
+ */
+const MIN_MYSQL_MAJOR = 8
+
+/**
+ * Parse a MySQL version string into a major version number. MySQL's
+ * `SELECT VERSION()` returns shapes like `8.0.34`, `8.4.0`,
+ * `5.7.42-log`, `10.6.11-MariaDB-...`. We only care about the
+ * leading integer for the floor check; MariaDB's 10.x is treated
+ * as 10 (above the 8 floor).
+ */
+export function parseMysqlMajorVersion(version: string): number | null {
+  const m = /^(\d+)\./.exec(version.trim())
+  if (!m) return null
+  const major = Number(m[1])
+  return Number.isFinite(major) ? major : null
+}
+
+/**
+ * MigrationAdapter implementation backed by mysql2.
+ *
+ * Asserts MySQL 8.0+ on first connection (via the first
+ * `ensureMigrationTables` call, lazily — no I/O at construction
+ * time). Earlier versions throw `KickDbError` with code
+ * `KICK_DB_RELATIONAL_NOT_SUPPORTED` carrying the detected version
+ * so adopters get a clear error before any query reaches the
+ * relational compiler.
+ *
+ * Lock semantics: single-row UPDATE WHERE locked_at IS NULL on
+ * `kick_migrations_lock`. Only the row created by
+ * `ensureMigrationTables()` exists, so the UPDATE either flips
+ * `locked_at` and returns `affectedRows=1` (we won) or matches
+ * zero rows (someone else holds it).
+ *
+ * Introspection: not implemented in v1 — throws `KickDbError` with
+ * code `KICK_DB_INTROSPECT_NOT_SUPPORTED`. Drift detection lands
+ * in a follow-up that walks `information_schema`.
+ */
+export function mysqlAdapter(opts: MysqlAdapterOptions): MigrationAdapter {
+  const dialect: Dialect = 'mysql'
+  const { pool } = opts
+  let versionVerified = false
+
+  async function assertVersion() {
+    if (versionVerified) return
+    const [rows] = await pool.query<{ version: string }>(`SELECT VERSION() AS \`version\``)
+    const versionString = rows[0]?.version ?? ''
+    const major = parseMysqlMajorVersion(versionString)
+    if (major == null || major < MIN_MYSQL_MAJOR) {
+      throw new KickDbError(
+        'KICK_DB_RELATIONAL_NOT_SUPPORTED',
+        `MySQL ${MIN_MYSQL_MAJOR}.0+ required for the relational query layer ` +
+          `(JSON_ARRAYAGG shipped in 8.0); detected version: ${versionString || '<unknown>'}. ` +
+          `Use a layer-1/layer-2 query (selectFrom / selectAll) on older MySQL versions.`,
+      )
+    }
+    versionVerified = true
+  }
+
+  return {
+    dialect,
+
+    async ensureMigrationTables() {
+      await assertVersion()
+      await pool.query(migrationsTableDdl(dialect))
+      await pool.query(lockTableDdl(dialect))
+    },
+
+    async listApplied(): Promise<MigrationRow[]> {
+      const [rows] = await pool.query<{
+        id: string
+        name: string
+        hash: string
+        batch: number
+        applied_at: string | Date
+        direction: 'up' | 'down'
+      }>(
+        `SELECT id, name, hash, batch, applied_at, direction
+         FROM \`kick_migrations\`
+         ORDER BY applied_at ASC, id ASC`,
+      )
+      return rows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        hash: row.hash,
+        batch: Number(row.batch),
+        appliedAt:
+          row.applied_at instanceof Date ? row.applied_at.toISOString() : String(row.applied_at),
+        direction: row.direction,
+      }))
+    },
+
+    async recordApplied(row) {
+      await pool.query(
+        `INSERT INTO \`kick_migrations\` (id, name, hash, batch, direction)
+         VALUES (?, ?, ?, ?, ?)`,
+        [row.id, row.name, row.hash, row.batch, row.direction],
+      )
+    },
+
+    async removeApplied(id: string) {
+      await pool.query(`DELETE FROM \`kick_migrations\` WHERE id = ?`, [id])
+    },
+
+    async acquireLock(owner: string): Promise<boolean> {
+      // mysql2's query() returns [result, fields] for UPDATE where
+      // result has affectedRows. Cast through unknown to the result.
+      const [result] = (await pool.query(
+        `UPDATE \`kick_migrations_lock\`
+         SET locked_at = CURRENT_TIMESTAMP, locked_by = ?
+         WHERE id = 1 AND locked_at IS NULL`,
+        [owner],
+      )) as unknown as [{ affectedRows: number }, unknown]
+      return result.affectedRows === 1
+    },
+
+    async releaseLock() {
+      await pool.query(
+        `UPDATE \`kick_migrations_lock\`
+         SET locked_at = NULL, locked_by = NULL
+         WHERE id = 1`,
+      )
+    },
+
+    async applySqlInTx(sql: string) {
+      const conn = await pool.getConnection()
+      try {
+        await conn.query('START TRANSACTION')
+        await conn.query(sql)
+        await conn.query('COMMIT')
+      } catch (err) {
+        await conn.query('ROLLBACK').catch(() => {
+          // Swallow rollback errors; we're already throwing the original.
+        })
+        throw err
+      } finally {
+        conn.release()
+      }
+    },
+
+    async applySqlNoTx(sql: string) {
+      await pool.query(sql)
+    },
+
+    async introspect(): Promise<SchemaSnapshot> {
+      throw new KickDbError(
+        'KICK_DB_INTROSPECT_NOT_SUPPORTED',
+        'MySQL introspection is not supported in v1. ' +
+          'Drift detection requires an information_schema walk that lands in a follow-up. ' +
+          'Set `driftCheck: "off"` on the migration runner until then.',
+      )
+    },
+
+    async close() {
+      // Caller owns the pool. The adapter doesn't end() it —
+      // adopters typically share the same pool with the
+      // KickDbClient.
+    },
+  }
+}

--- a/packages/db-mysql/src/dialect.ts
+++ b/packages/db-mysql/src/dialect.ts
@@ -1,0 +1,51 @@
+// mysqlDialect — thin factory over Kysely's MysqlDialect so adopters
+// never have to reach for `import { MysqlDialect } from 'kysely'`.
+// Mirrors the `@forinda/kickjs-db-pg` template; the kysely subpackage
+// is a pinned internal dep of the framework.
+
+import { MysqlDialect, type Dialect as KyselyDialect } from 'kysely'
+
+import type { MysqlPoolLike } from './adapter'
+
+export interface MysqlDialectOptions {
+  /**
+   * mysql2-compatible pool. Both `mysql.createPool(...)` from
+   * `mysql2/promise` and `mysql2.createPool(...)` (callback API
+   * wrapped in a promise) match structurally.
+   */
+  pool: MysqlPoolLike
+}
+
+/**
+ * Construct the dialect that `createDbClient({ dialect })` consumes.
+ *
+ * **MySQL 8.0+ required.** Kickjs-db's relational query layer
+ * compiles to `JSON_ARRAYAGG`, which shipped in 8.0. Adapter-side
+ * version assertion lands at first connection from `mysqlAdapter()`;
+ * see that factory's docs.
+ *
+ * @example
+ * ```ts
+ * import { createDbClient } from '@forinda/kickjs-db'
+ * import { mysqlAdapter, mysqlDialect } from '@forinda/kickjs-db-mysql'
+ * import { createPool } from 'mysql2/promise'
+ *
+ * const pool = createPool({
+ *   host: '127.0.0.1', user: 'root', password: '...', database: 'app',
+ * })
+ *
+ * export const db = createDbClient({
+ *   schema,
+ *   dialect: mysqlDialect({ pool }),
+ * })
+ *
+ * export const migrationAdapter = mysqlAdapter({ pool })
+ * ```
+ */
+export function mysqlDialect(opts: MysqlDialectOptions): KyselyDialect {
+  // MysqlDialect's `pool` parameter is typed as `mysql2.Pool` in
+  // newer Kysely versions; casting through `unknown` keeps adopters
+  // using compatible drivers (e.g. mysql-mariadb forks) working
+  // without pulling mysql2's typings into our public surface.
+  return new MysqlDialect({ pool: opts.pool as unknown as never })
+}

--- a/packages/db-mysql/src/index.ts
+++ b/packages/db-mysql/src/index.ts
@@ -1,8 +1,11 @@
 export {
   mysqlAdapter,
   parseMysqlMajorVersion,
+  parseMysqlVersion,
+  splitMysqlStatements,
   type MysqlAdapterOptions,
   type MysqlConnectionLike,
   type MysqlPoolLike,
+  type ParsedMysqlVersion,
 } from './adapter'
 export { mysqlDialect, type MysqlDialectOptions } from './dialect'

--- a/packages/db-mysql/src/index.ts
+++ b/packages/db-mysql/src/index.ts
@@ -1,0 +1,8 @@
+export {
+  mysqlAdapter,
+  parseMysqlMajorVersion,
+  type MysqlAdapterOptions,
+  type MysqlConnectionLike,
+  type MysqlPoolLike,
+} from './adapter'
+export { mysqlDialect, type MysqlDialectOptions } from './dialect'

--- a/packages/db-mysql/tsconfig.json
+++ b/packages/db-mysql/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/db-mysql/tsconfig.test.json
+++ b/packages/db-mysql/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "baseUrl": ".",
+    "types": [],
+    "paths": {
+      "@forinda/kickjs": ["../kickjs/src/index.ts"],
+      "@forinda/kickjs/*": ["../kickjs/src/*"],
+      "@forinda/kickjs-db/pg": ["../db/src/dsl/columns/pg.ts"],
+      "@forinda/kickjs-db": ["../db/src/index.ts"],
+      "@forinda/kickjs-db/*": ["../db/src/*"],
+      "@forinda/kickjs-db-mysql": ["src/index.ts"],
+      "@forinda/kickjs-db-mysql/*": ["src/*"]
+    }
+  },
+  "include": ["src", "__tests__"]
+}

--- a/packages/db-mysql/tsdown.config.ts
+++ b/packages/db-mysql/tsdown.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsdown'
+import { createBanner, readPkg } from '../../build.utils.mjs'
+
+const pkg = readPkg(import.meta.dirname)
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm'],
+  platform: 'node',
+  minify: { compress: true, mangle: false },
+  dts: true,
+  external: ['@forinda/kickjs', '@forinda/kickjs-db', 'kysely', 'mysql2', /^node:/],
+  banner: { js: createBanner(pkg.name, pkg.version) },
+})

--- a/packages/db-mysql/vitest.config.ts
+++ b/packages/db-mysql/vitest.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from 'vitest/config'
+import swc from 'unplugin-swc'
+import path from 'node:path'
+
+export default defineConfig({
+  plugins: [
+    swc.vite({
+      jsc: {
+        parser: { syntax: 'typescript', decorators: true },
+        transform: { legacyDecorator: true, decoratorMetadata: true },
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      '@forinda/kickjs': path.resolve(__dirname, '../kickjs/src/index.ts'),
+      '@forinda/kickjs-db/pg': path.resolve(__dirname, '../db/src/dsl/columns/pg.ts'),
+      '@forinda/kickjs-db': path.resolve(__dirname, '../db/src/index.ts'),
+      '@forinda/kickjs-db-mysql': path.resolve(__dirname, 'src/index.ts'),
+    },
+  },
+  test: {
+    typecheck: { tsconfig: './tsconfig.test.json' },
+    environment: 'node',
+    include: ['__tests__/**/*.test.ts'],
+    globals: false,
+    pool: 'threads',
+    maxConcurrency: 1,
+    testTimeout: 90_000,
+  },
+})

--- a/packages/db-sqlite/LICENSE
+++ b/packages/db-sqlite/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Felix Orinda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/db-sqlite/README.md
+++ b/packages/db-sqlite/README.md
@@ -1,0 +1,40 @@
+# @forinda/kickjs-db-sqlite
+
+> better-sqlite3 adapter for `@forinda/kickjs-db` — `MigrationAdapter` + Kysely `SqliteDialect`.
+
+Ships the bridge between `@forinda/kickjs-db`'s migration runner / relational query layer and an in-process SQLite database via [`better-sqlite3`](https://github.com/WiseLibs/better-sqlite3) (or any structurally compatible handle, e.g. `bun:sqlite`).
+
+## Install
+
+```bash
+pnpm add @forinda/kickjs-db @forinda/kickjs-db-sqlite better-sqlite3
+```
+
+## Quick start
+
+```ts
+import Database from 'better-sqlite3'
+import { createDbClient } from '@forinda/kickjs-db'
+import { sqliteAdapter, sqliteDialect } from '@forinda/kickjs-db-sqlite'
+
+const database = new Database('app.db')
+
+export const db = createDbClient({
+  schema, // your declared schema
+  dialect: sqliteDialect({ database }),
+})
+
+export const migrationAdapter = sqliteAdapter({ database })
+```
+
+`createDbClient` auto-attaches Kysely's `ParseJSONResultsPlugin` for the SQLite dialect — `db.query.X.findMany({ with })` round-trips nested rows as parsed JS objects rather than JSON-encoded TEXT.
+
+## What ships
+
+- **`sqliteDialect({ database })`** — wraps Kysely's `SqliteDialect`.
+- **`sqliteAdapter({ database })`** — implements `MigrationAdapter` for `@forinda/kickjs-db`'s migration runner (`kick db migrate` + `kickDbAdapter` boot-time apply). Handles `kick_migrations` / `kick_migrations_lock` table creation, lock acquisition, applying SQL in / out of a transaction.
+- **Drift detection (`introspect()`) is not yet implemented in v1** — it throws `KickDbError` with code `KICK_DB_INTROSPECT_NOT_SUPPORTED`. Set `driftCheck: 'off'` on the migration runner until a follow-up adds the `sqlite_master` + `pragma` walk.
+
+## License
+
+MIT © Felix Orinda

--- a/packages/db-sqlite/__tests__/integration/relational-query.test.ts
+++ b/packages/db-sqlite/__tests__/integration/relational-query.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Real-driver integration test for the SQLite relational-query
+ * compiler — exercises the full path from `db.query.X.findMany({ with })`
+ * through `compileSqlite` -> kysely/helpers/sqlite's
+ * `jsonArrayFrom`/`jsonObjectFrom` -> `ParseJSONResultsPlugin` ->
+ * better-sqlite3 -> JS row tree.
+ *
+ * Spec: docs/db/spec-relational-query-other-dialects.md §3.1.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import Database from 'better-sqlite3'
+
+import {
+  createDbClient,
+  integer,
+  relations,
+  serial,
+  table,
+  varchar,
+  type KickDbClient,
+} from '@forinda/kickjs-db'
+import { sqliteAdapter, sqliteDialect } from '../../src'
+
+const users = table('users', {
+  id: serial().primaryKey(),
+  email: varchar(255).notNull().unique(),
+})
+
+const posts = table('posts', {
+  id: serial().primaryKey(),
+  authorId: integer()
+    .notNull()
+    .references(() => users.id),
+  title: varchar(255).notNull(),
+})
+
+const comments = table('comments', {
+  id: serial().primaryKey(),
+  postId: integer()
+    .notNull()
+    .references(() => posts.id),
+  body: varchar(1000).notNull(),
+})
+
+const usersRelations = relations(users, (h) => ({ posts: h.many(posts) }))
+const postsRelations = relations(posts, (h) => ({
+  author: h.one(users, { fields: [posts.authorId], references: [users.id] }),
+  comments: h.many(comments),
+}))
+const commentsRelations = relations(comments, (h) => ({
+  post: h.one(posts, { fields: [comments.postId], references: [posts.id] }),
+}))
+
+interface DB {
+  users: { id: number; email: string }
+  posts: { id: number; authorId: number; title: string }
+  comments: { id: number; postId: number; body: string }
+}
+
+declare module '@forinda/kickjs-db' {
+  interface KickDbRelationsRegister {
+    db: {
+      users: { posts: { kind: 'many'; target: 'posts' } }
+      posts: {
+        author: { kind: 'one'; target: 'users' }
+        comments: { kind: 'many'; target: 'comments' }
+      }
+      comments: { post: { kind: 'one'; target: 'posts' } }
+    }
+  }
+}
+
+let database: Database.Database
+let db: KickDbClient<DB>
+
+const seedSchemaSql = `
+  CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT NOT NULL UNIQUE
+  );
+  CREATE TABLE posts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    authorId INTEGER NOT NULL REFERENCES users(id),
+    title TEXT NOT NULL
+  );
+  CREATE TABLE comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    postId INTEGER NOT NULL REFERENCES posts(id),
+    body TEXT NOT NULL
+  );
+`
+
+beforeAll(() => {
+  database = new Database(':memory:')
+  database.exec(seedSchemaSql)
+
+  const schema = {
+    users,
+    posts,
+    comments,
+    usersRelations,
+    postsRelations,
+    commentsRelations,
+  }
+  db = createDbClient<typeof schema, DB>({
+    schema,
+    dialect: sqliteDialect({ database }),
+  })
+})
+
+afterAll(async () => {
+  await db?.destroy()
+  database?.close()
+})
+
+beforeEach(() => {
+  // Reset rows + sqlite_sequence so AUTOINCREMENT IDs restart at 1
+  // each test. Without the sequence reset, post-DELETE inserts would
+  // get IDs 3+ on a clean run, breaking the hard-coded authorId
+  // references in seed().
+  database.exec(`
+    DELETE FROM comments;
+    DELETE FROM posts;
+    DELETE FROM users;
+    DELETE FROM sqlite_sequence WHERE name IN ('users', 'posts', 'comments');
+  `)
+})
+
+async function seed() {
+  await db
+    .insertInto('users')
+    .values([{ email: 'a@b.com' }, { email: 'c@d.com' }])
+    .execute()
+  await db
+    .insertInto('posts')
+    .values([
+      { authorId: 1, title: 'first' },
+      { authorId: 1, title: 'second' },
+      { authorId: 2, title: 'third' },
+    ])
+    .execute()
+  await db
+    .insertInto('comments')
+    .values([
+      { postId: 1, body: 'c1' },
+      { postId: 1, body: 'c2' },
+      { postId: 2, body: 'c3' },
+    ])
+    .execute()
+}
+
+describe('db.query.X.findMany({ with }) — real better-sqlite3 round trip', () => {
+  it('2-deep nested findMany returns the declared shape', async () => {
+    await seed()
+    const rows = await db.query.users.findMany({
+      with: { posts: { with: { comments: true } } },
+      orderBy: (_u, eb) => eb.ref('id'),
+    })
+    expect(rows).toHaveLength(2)
+
+    const u1 = rows.find((r) => r.email === 'a@b.com')!
+    expect(u1.posts).toHaveLength(2)
+    const p1 = u1.posts.find((p) => p.title === 'first')!
+    expect(p1.comments.map((c) => c.body).toSorted()).toEqual(['c1', 'c2'])
+    const p2 = u1.posts.find((p) => p.title === 'second')!
+    expect(p2.comments.map((c) => c.body)).toEqual(['c3'])
+
+    const u2 = rows.find((r) => r.email === 'c@d.com')!
+    expect(u2.posts).toHaveLength(1)
+    // Empty inner set — must be [] not null, matching PG behavior.
+    expect(u2.posts[0].comments).toEqual([])
+  })
+
+  it('findFirst returns null on empty table', async () => {
+    const u = await db.query.users.findFirst()
+    expect(u).toBeNull()
+  })
+
+  it('findFirst clamps to one row', async () => {
+    await seed()
+    const u = await db.query.users.findFirst({ orderBy: (_u, eb) => eb.ref('id') })
+    expect(u?.email).toBe('a@b.com')
+  })
+
+  it('findUnique returns the matched row', async () => {
+    await seed()
+    const u = await db.query.users.findUnique({
+      where: (_u, eb) => eb('email', '=', 'c@d.com'),
+    })
+    expect(u?.email).toBe('c@d.com')
+  })
+
+  it('per-relation where + limit filters the inner aggregation', async () => {
+    await seed()
+    const rows = await db.query.users.findMany({
+      with: {
+        posts: {
+          where: (_p, eb) => eb('title', '=', 'first'),
+          limit: 1,
+        },
+      },
+      orderBy: (_u, eb) => eb.ref('id'),
+    })
+    const u1 = rows.find((r) => r.email === 'a@b.com')!
+    expect(u1.posts.map((p) => p.title)).toEqual(['first'])
+    const u2 = rows.find((r) => r.email === 'c@d.com')!
+    expect(u2.posts).toEqual([])
+  })
+
+  it('ParseJSONResultsPlugin auto-attached — nested rows arrive as JS objects, not strings', async () => {
+    await seed()
+    const rows = await db.query.users.findMany({
+      with: { posts: true },
+      orderBy: (_u, eb) => eb.ref('id'),
+    })
+    // posts is a real array of objects, not a JSON string. Without
+    // ParseJSONResultsPlugin, this would be `typeof posts === 'string'`.
+    expect(Array.isArray(rows[0].posts)).toBe(true)
+    expect(typeof rows[0].posts).toBe('object')
+    expect(typeof rows[0].posts[0]).toBe('object')
+  })
+})
+
+describe('sqliteAdapter — migration table contract', () => {
+  it('ensureMigrationTables creates idempotent tables', async () => {
+    const adapter = sqliteAdapter({ database })
+    await adapter.ensureMigrationTables()
+    await adapter.ensureMigrationTables() // second call must not error
+    const tables = database
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'kick_migrations%' ORDER BY name`,
+      )
+      .all<{ name: string }>()
+    expect(tables.map((t) => t.name)).toEqual(['kick_migrations', 'kick_migrations_lock'])
+  })
+
+  it('listApplied / recordApplied / removeApplied round-trip', async () => {
+    const adapter = sqliteAdapter({ database })
+    await adapter.ensureMigrationTables()
+    expect(await adapter.listApplied()).toEqual([])
+
+    await adapter.recordApplied({
+      id: '20260505_010000_a',
+      name: 'a',
+      hash: 'sha256:abc',
+      batch: 1,
+      direction: 'up',
+    })
+    const applied = await adapter.listApplied()
+    expect(applied).toHaveLength(1)
+    expect(applied[0]).toMatchObject({
+      id: '20260505_010000_a',
+      name: 'a',
+      hash: 'sha256:abc',
+      batch: 1,
+      direction: 'up',
+    })
+
+    await adapter.removeApplied('20260505_010000_a')
+    expect(await adapter.listApplied()).toEqual([])
+  })
+
+  it('acquireLock / releaseLock — only one acquirer wins', async () => {
+    const adapter = sqliteAdapter({ database })
+    await adapter.ensureMigrationTables()
+    expect(await adapter.acquireLock('proc-1')).toBe(true)
+    expect(await adapter.acquireLock('proc-2')).toBe(false)
+    await adapter.releaseLock()
+    expect(await adapter.acquireLock('proc-3')).toBe(true)
+    await adapter.releaseLock()
+  })
+
+  it('introspect throws — drift detection lands in a follow-up', async () => {
+    const adapter = sqliteAdapter({ database })
+    await expect(adapter.introspect()).rejects.toThrow(/not supported in v1/)
+  })
+})

--- a/packages/db-sqlite/package.json
+++ b/packages/db-sqlite/package.json
@@ -26,7 +26,9 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
     "build": "wireit",
@@ -56,14 +58,14 @@
   },
   "peerDependencies": {
     "@forinda/kickjs-db": "workspace:*",
-    "better-sqlite3": ">=11.0.0"
+    "better-sqlite3": ">=12.0.0"
   },
   "devDependencies": {
     "@forinda/kickjs": "workspace:*",
     "@forinda/kickjs-db": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.6.0",
-    "better-sqlite3": "^11.10.0",
+    "better-sqlite3": "^12.9.0",
     "kysely": "^0.28.16",
     "typescript": "^6.0.3"
   },

--- a/packages/db-sqlite/package.json
+++ b/packages/db-sqlite/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@forinda/kickjs-db-pg",
-  "version": "6.0.0",
-  "description": "node-postgres adapter for @forinda/kickjs-db — MigrationAdapter + Kysely PostgresDialect",
+  "name": "@forinda/kickjs-db-sqlite",
+  "version": "0.1.0",
+  "description": "better-sqlite3 adapter for @forinda/kickjs-db — MigrationAdapter + Kysely SqliteDialect",
   "keywords": [
     "kickjs",
-    "postgres",
-    "pg",
+    "sqlite",
+    "better-sqlite3",
     "orm",
     "migrations",
     "query-builder",
@@ -56,16 +56,15 @@
   },
   "peerDependencies": {
     "@forinda/kickjs-db": "workspace:*",
-    "pg": ">=8.11.0"
+    "better-sqlite3": ">=11.0.0"
   },
   "devDependencies": {
     "@forinda/kickjs": "workspace:*",
     "@forinda/kickjs-db": "workspace:*",
-    "@testcontainers/postgresql": "^10.16.0",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.6.0",
-    "@types/pg": "^8.11.10",
+    "better-sqlite3": "^11.10.0",
     "kysely": "^0.28.16",
-    "pg": "^8.13.1",
     "typescript": "^6.0.3"
   },
   "publishConfig": {
@@ -80,7 +79,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/forinda/kick-js.git",
-    "directory": "packages/db-pg"
+    "directory": "packages/db-sqlite"
   },
   "bugs": {
     "url": "https://github.com/forinda/kick-js/issues"

--- a/packages/db-sqlite/src/adapter.ts
+++ b/packages/db-sqlite/src/adapter.ts
@@ -1,0 +1,166 @@
+import {
+  KickDbError,
+  lockTableDdl,
+  migrationsTableDdl,
+  type Dialect,
+  type MigrationAdapter,
+  type MigrationRow,
+  type SchemaSnapshot,
+} from '@forinda/kickjs-db'
+
+/**
+ * better-sqlite3-shaped database handle that `sqliteAdapter` consumes.
+ * Mirrors the methods we actually use; both `new Database(...)` from
+ * `better-sqlite3` and bun's `bun:sqlite` Database match structurally.
+ *
+ * better-sqlite3's API is synchronous — we wrap everything in `async`
+ * to match the `MigrationAdapter` contract. No I/O actually awaits;
+ * the wrapping is for shape compatibility.
+ */
+export interface SqliteStatement {
+  run(...params: readonly unknown[]): { changes: number; lastInsertRowid: number | bigint }
+  all<R = unknown>(...params: readonly unknown[]): R[]
+  get<R = unknown>(...params: readonly unknown[]): R | undefined
+}
+
+export interface SqliteDatabaseLike {
+  prepare(sql: string): SqliteStatement
+  exec(sql: string): unknown
+  close(): unknown
+}
+
+export interface SqliteAdapterOptions {
+  /**
+   * better-sqlite3 (or compatible) Database handle. Caller-owned —
+   * the adapter's `close()` does NOT close the database because
+   * adopters typically share a single handle across the migration
+   * adapter and the KickDbClient.
+   */
+  database: SqliteDatabaseLike
+}
+
+/**
+ * MigrationAdapter implementation backed by better-sqlite3.
+ *
+ * Lock semantics: single-row UPDATE WHERE locked_at IS NULL on
+ * `kick_migrations_lock`. Only the row created by `ensureMigrationTables()`
+ * exists, so the UPDATE either flips `locked_at` and returns
+ * `changes=1` (we won) or matches zero rows (someone else holds it).
+ *
+ * Introspection: not implemented in v1 — throws `KickDbError` with
+ * code `KICK_DB_INTROSPECT_NOT_SUPPORTED`. Drift detection lands in a
+ * follow-up that walks `sqlite_master` + `pragma` queries.
+ */
+export function sqliteAdapter(opts: SqliteAdapterOptions): MigrationAdapter {
+  const dialect: Dialect = 'sqlite'
+  const { database } = opts
+
+  // Multi-statement DDL runs through better-sqlite3's exec() (it
+  // handles `;`-separated batches natively).
+  const runBatch = (sql: string) => database.exec(sql)
+
+  return {
+    dialect,
+
+    async ensureMigrationTables() {
+      runBatch(migrationsTableDdl(dialect))
+      runBatch(lockTableDdl(dialect))
+    },
+
+    async listApplied(): Promise<MigrationRow[]> {
+      const rows = database
+        .prepare(
+          `SELECT id, name, hash, batch, applied_at, direction
+           FROM kick_migrations
+           ORDER BY applied_at ASC, id ASC`,
+        )
+        .all<{
+          id: string
+          name: string
+          hash: string
+          batch: number
+          applied_at: string
+          direction: 'up' | 'down'
+        }>()
+      return rows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        hash: row.hash,
+        batch: Number(row.batch),
+        appliedAt: row.applied_at,
+        direction: row.direction,
+      }))
+    },
+
+    async recordApplied(row) {
+      database
+        .prepare(
+          `INSERT INTO kick_migrations (id, name, hash, batch, direction)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run(row.id, row.name, row.hash, row.batch, row.direction)
+    },
+
+    async removeApplied(id: string) {
+      database.prepare(`DELETE FROM kick_migrations WHERE id = ?`).run(id)
+    },
+
+    async acquireLock(owner: string): Promise<boolean> {
+      const r = database
+        .prepare(
+          `UPDATE kick_migrations_lock
+           SET locked_at = datetime('now'), locked_by = ?
+           WHERE id = 1 AND locked_at IS NULL`,
+        )
+        .run(owner)
+      return r.changes === 1
+    },
+
+    async releaseLock() {
+      database
+        .prepare(
+          `UPDATE kick_migrations_lock
+           SET locked_at = NULL, locked_by = NULL
+           WHERE id = 1`,
+        )
+        .run()
+    },
+
+    async applySqlInTx(sql: string) {
+      // BEGIN / COMMIT around a multi-statement batch gives us
+      // atomicity. SQLite rolls back to pre-BEGIN on any error
+      // inside the block.
+      runBatch('BEGIN')
+      try {
+        runBatch(sql)
+        runBatch('COMMIT')
+      } catch (err) {
+        try {
+          runBatch('ROLLBACK')
+        } catch {
+          // Swallow rollback errors; we're already throwing the original.
+        }
+        throw err
+      }
+    },
+
+    async applySqlNoTx(sql: string) {
+      runBatch(sql)
+    },
+
+    async introspect(): Promise<SchemaSnapshot> {
+      throw new KickDbError(
+        'KICK_DB_INTROSPECT_NOT_SUPPORTED',
+        'SQLite introspection is not supported in v1. ' +
+          'Drift detection requires a sqlite_master + pragma walk that lands in a follow-up. ' +
+          'Set `driftCheck: "off"` on the migration runner until then.',
+      )
+    },
+
+    async close() {
+      // Caller owns the database handle. The adapter doesn't close
+      // it — adopters typically share the same handle with the
+      // KickDbClient.
+    },
+  }
+}

--- a/packages/db-sqlite/src/dialect.ts
+++ b/packages/db-sqlite/src/dialect.ts
@@ -1,0 +1,41 @@
+// sqliteDialect — thin factory over Kysely's SqliteDialect so adopters
+// never have to reach for `import { SqliteDialect } from 'kysely'`.
+// Mirrors the `@forinda/kickjs-db-pg` template; the kysely subpackage
+// is a pinned internal dep of the framework.
+
+import { SqliteDialect, type Dialect as KyselyDialect } from 'kysely'
+
+import type { SqliteDatabaseLike } from './adapter'
+
+export interface SqliteDialectOptions {
+  /**
+   * better-sqlite3-compatible database handle. Both `new Database(...)`
+   * from `better-sqlite3` and bun's `bun:sqlite` `Database` match
+   * structurally (Bun is best-effort — same `.prepare()` shape, no
+   * version assertion).
+   */
+  database: SqliteDatabaseLike
+}
+
+/**
+ * Construct the dialect that `createDbClient({ dialect })` consumes.
+ *
+ * @example
+ * ```ts
+ * import { createDbClient } from '@forinda/kickjs-db'
+ * import { sqliteDialect, sqliteAdapter } from '@forinda/kickjs-db-sqlite'
+ * import Database from 'better-sqlite3'
+ *
+ * const database = new Database(':memory:')
+ *
+ * export const db = createDbClient({
+ *   schema,
+ *   dialect: sqliteDialect({ database }),
+ * })
+ *
+ * export const migrationAdapter = sqliteAdapter({ database })
+ * ```
+ */
+export function sqliteDialect(opts: SqliteDialectOptions): KyselyDialect {
+  return new SqliteDialect({ database: opts.database as never })
+}

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -1,0 +1,7 @@
+export {
+  sqliteAdapter,
+  type SqliteAdapterOptions,
+  type SqliteDatabaseLike,
+  type SqliteStatement,
+} from './adapter'
+export { sqliteDialect, type SqliteDialectOptions } from './dialect'

--- a/packages/db-sqlite/tsconfig.json
+++ b/packages/db-sqlite/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/db-sqlite/tsconfig.test.json
+++ b/packages/db-sqlite/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "baseUrl": ".",
+    "types": [],
+    "paths": {
+      "@forinda/kickjs": ["../kickjs/src/index.ts"],
+      "@forinda/kickjs/*": ["../kickjs/src/*"],
+      "@forinda/kickjs-db/pg": ["../db/src/dsl/columns/pg.ts"],
+      "@forinda/kickjs-db": ["../db/src/index.ts"],
+      "@forinda/kickjs-db/*": ["../db/src/*"],
+      "@forinda/kickjs-db-sqlite": ["src/index.ts"],
+      "@forinda/kickjs-db-sqlite/*": ["src/*"]
+    }
+  },
+  "include": ["src", "__tests__"]
+}

--- a/packages/db-sqlite/tsdown.config.ts
+++ b/packages/db-sqlite/tsdown.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsdown'
+import { createBanner, readPkg } from '../../build.utils.mjs'
+
+const pkg = readPkg(import.meta.dirname)
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm'],
+  platform: 'node',
+  minify: { compress: true, mangle: false },
+  dts: true,
+  external: ['@forinda/kickjs', '@forinda/kickjs-db', 'kysely', 'better-sqlite3', /^node:/],
+  banner: { js: createBanner(pkg.name, pkg.version) },
+})

--- a/packages/db-sqlite/vitest.config.ts
+++ b/packages/db-sqlite/vitest.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from 'vitest/config'
+import swc from 'unplugin-swc'
+import path from 'node:path'
+
+export default defineConfig({
+  plugins: [
+    swc.vite({
+      jsc: {
+        parser: { syntax: 'typescript', decorators: true },
+        transform: { legacyDecorator: true, decoratorMetadata: true },
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      '@forinda/kickjs': path.resolve(__dirname, '../kickjs/src/index.ts'),
+      '@forinda/kickjs-db/pg': path.resolve(__dirname, '../db/src/dsl/columns/pg.ts'),
+      '@forinda/kickjs-db': path.resolve(__dirname, '../db/src/index.ts'),
+      '@forinda/kickjs-db-sqlite': path.resolve(__dirname, 'src/index.ts'),
+    },
+  },
+  test: {
+    typecheck: { tsconfig: './tsconfig.test.json' },
+    environment: 'node',
+    include: ['__tests__/**/*.test.ts'],
+    globals: false,
+    pool: 'threads',
+    maxConcurrency: 1,
+    testTimeout: 90_000,
+  },
+})

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,7 +11,12 @@
     "mysql",
     "migrations",
     "query-builder",
-    "@forinda/kickjs"
+    "@forinda/kickjs",
+    "@forinda/kickjs-db",
+    "@forinda/kickjs-db-pg",
+    "@forinda/kickjs-db-sqlite",
+    "@forinda/kickjs-db-mysql",
+    "@forinda/kickjs-cli"
   ],
   "type": "module",
   "main": "dist/index.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -917,6 +917,28 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/db-mysql:
+    dependencies:
+      kysely:
+        specifier: 0.28.16
+        version: 0.28.16
+    devDependencies:
+      '@forinda/kickjs':
+        specifier: workspace:*
+        version: link:../kickjs
+      '@forinda/kickjs-db':
+        specifier: workspace:*
+        version: link:../db
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      mysql2:
+        specifier: ^3.15.3
+        version: 3.15.3
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   packages/db-pg:
     dependencies:
       kysely:
@@ -941,6 +963,31 @@ importers:
       pg:
         specifier: ^8.13.1
         version: 8.20.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
+  packages/db-sqlite:
+    dependencies:
+      kysely:
+        specifier: 0.28.16
+        version: 0.28.16
+    devDependencies:
+      '@forinda/kickjs':
+        specifier: workspace:*
+        version: link:../kickjs
+      '@forinda/kickjs-db':
+        specifier: workspace:*
+        version: link:../db
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -8186,7 +8233,6 @@ snapshots:
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 25.6.0
-    optional: true
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -8790,14 +8836,12 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
-    optional: true
 
   binary-extensions@2.3.0: {}
 
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
-    optional: true
 
   birpc@2.9.0: {}
 
@@ -9110,10 +9154,8 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
-    optional: true
 
-  deep-extend@0.6.0:
-    optional: true
+  deep-extend@0.6.0: {}
 
   deepmerge-ts@7.1.5: {}
 
@@ -9410,8 +9452,7 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.6
 
-  expand-template@2.0.3:
-    optional: true
+  expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
 
@@ -9503,8 +9544,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  file-uri-to-path@1.0.0:
-    optional: true
+  file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -9612,8 +9652,7 @@ snapshots:
 
   giget@3.2.0: {}
 
-  github-from-package@0.0.0:
-    optional: true
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -9737,8 +9776,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@1.3.8:
-    optional: true
+  ini@1.3.8: {}
 
   ioredis@5.10.1:
     dependencies:
@@ -10108,8 +10146,7 @@ snapshots:
 
   mime@2.6.0: {}
 
-  mimic-response@3.1.0:
-    optional: true
+  mimic-response@3.1.0: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -10231,8 +10268,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  napi-build-utils@2.0.0:
-    optional: true
+  napi-build-utils@2.0.0: {}
 
   negotiator@0.6.3: {}
 
@@ -10243,7 +10279,6 @@ snapshots:
   node-abi@3.90.0:
     dependencies:
       semver: 7.7.4
-    optional: true
 
   node-abort-controller@3.1.1: {}
 
@@ -10541,7 +10576,6 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
-    optional: true
 
   prettier@2.8.8: {}
 
@@ -10648,7 +10682,6 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-    optional: true
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -10984,15 +11017,13 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1:
-    optional: true
+  simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
     dependencies:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
-    optional: true
 
   sisteransi@1.0.5: {}
 
@@ -11151,8 +11182,7 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
-  strip-json-comments@2.0.1:
-    optional: true
+  strip-json-comments@2.0.1: {}
 
   strip-json-comments@5.0.3: {}
 
@@ -11365,7 +11395,6 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   tweetnacl@0.14.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,7 +373,7 @@ importers:
         version: 10.0.1
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@11.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.8)(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@11.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))
+        version: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(kysely@0.28.16)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.8)(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))
       express:
         specifier: ^5.1.0
         version: 5.2.1
@@ -673,7 +673,7 @@ importers:
         version: 7.8.0
       '@prisma/client':
         specifier: ^7.8.0
-        version: 7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@11.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3)
+        version: 7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3)
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -752,7 +752,7 @@ importers:
         version: 3.8.3
       prisma:
         specifier: ^7.8.0
-        version: 7.8.0(@types/react@19.2.14)(better-sqlite3@11.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3)
+        version: 7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3)
       supertest:
         specifier: ^7.1.0
         version: 7.2.2
@@ -986,8 +986,8 @@ importers:
         specifier: ^25.6.0
         version: 25.6.0
       better-sqlite3:
-        specifier: ^11.10.0
-        version: 11.10.0
+        specifier: ^12.9.0
+        version: 12.9.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1075,7 +1075,7 @@ importers:
     dependencies:
       drizzle-orm:
         specifier: '>=0.45.2'
-        version: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@11.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.8)(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@11.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))
+        version: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(kysely@0.28.16)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.8)(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1201,7 +1201,7 @@ importers:
     dependencies:
       '@prisma/client':
         specifier: '>=5.0.0'
-        version: 7.5.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@11.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3)
+        version: 7.5.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -3778,8 +3778,9 @@ packages:
   better-result@2.9.1:
     resolution: {integrity: sha512-tPWnUPD8oLESRXMykkuTvi9tJVwaFSVfdhp1/WRd1q04SqengKdYt27avogObRC/BgH+zDqSo713dUEKkXbG5w==}
 
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+  better-sqlite3@12.9.0:
+    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -7671,18 +7672,18 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.8.0': {}
 
-  '@prisma/client@7.5.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@11.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3)':
+  '@prisma/client@7.5.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@prisma/client-runtime-utils': 7.5.0
     optionalDependencies:
-      prisma: 7.8.0(@types/react@19.2.14)(better-sqlite3@11.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3)
+      prisma: 7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3)
       typescript: 6.0.3
 
-  '@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@11.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3)':
+  '@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@prisma/client-runtime-utils': 7.8.0
     optionalDependencies:
-      prisma: 7.8.0(@types/react@19.2.14)(better-sqlite3@11.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3)
+      prisma: 7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3)
       typescript: 6.0.3
 
   '@prisma/config@7.8.0':
@@ -8832,7 +8833,7 @@ snapshots:
 
   better-result@2.9.1: {}
 
-  better-sqlite3@11.10.0:
+  better-sqlite3@12.9.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
@@ -9224,19 +9225,19 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@11.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(kysely@0.28.16)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.8)(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@11.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3)):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(kysely@0.28.16)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.8)(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3)):
     optionalDependencies:
       '@electric-sql/pglite': 0.4.1
       '@opentelemetry/api': 1.9.1
-      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@11.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3)
+      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3)
       '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.20.0
-      better-sqlite3: 11.10.0
+      better-sqlite3: 12.9.0
       kysely: 0.28.16
       mysql2: 3.15.3
       pg: 8.20.0
       postgres: 3.4.8
-      prisma: 7.8.0(@types/react@19.2.14)(better-sqlite3@11.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3)
+      prisma: 7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3)
 
   dts-resolver@2.1.3: {}
 
@@ -10583,7 +10584,7 @@ snapshots:
 
   pretty-bytes@5.6.0: {}
 
-  prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@11.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3):
+  prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3):
     dependencies:
       '@prisma/config': 7.8.0
       '@prisma/dev': 0.24.3(typescript@6.0.3)
@@ -10592,7 +10593,7 @@ snapshots:
       mysql2: 3.15.3
       postgres: 3.4.7
     optionalDependencies:
-      better-sqlite3: 11.10.0
+      better-sqlite3: 12.9.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/react'


### PR DESCRIPTION
## Summary

Closes M4.A.5 from `docs/db/m4-plan.md` — two new peer adapter packages mirroring the `@forinda/kickjs-db-pg` template. After this lands, adopters use kickjs-db end-to-end on **all three dialects** with a single, consistent integration shape:

```ts
// PG
const db = createDbClient({ schema, dialect: pgDialect({ pool }) })
// SQLite
const db = createDbClient({ schema, dialect: sqliteDialect({ database }) })
// MySQL 8.0+
const db = createDbClient({ schema, dialect: mysqlDialect({ pool }) })
```

## What ships

### `@forinda/kickjs-db-sqlite@0.1.0` (new)

- `sqliteDialect({ database })` — wraps Kysely's `SqliteDialect`.
- `sqliteAdapter({ database })` — `MigrationAdapter` for the kickjs migration runner. Handles table creation, lock acquisition, applying SQL in / out of a transaction.
- Pairs with `@forinda/kickjs-db`'s SQLite relational compiler (M4.A.2) — `db.query.X.findMany({ with })` round-trips via the auto-attached `ParseJSONResultsPlugin`.

### `@forinda/kickjs-db-mysql@0.1.0` (new)

- `mysqlDialect({ pool })` — wraps Kysely's `MysqlDialect`.
- `mysqlAdapter({ pool })` — `MigrationAdapter` with **MySQL 8.0+ version assertion** at first connection (lazy — no I/O at construction time). MySQL 5.x / unparseable versions throw `KickDbError(KICK_DB_RELATIONAL_NOT_SUPPORTED)` with the detected version. MariaDB 10.x is treated as supported.
- `parseMysqlMajorVersion(version)` exported for adopters who want to run the same check in their own boot logic.

### Both packages

`introspect()` throws `KICK_DB_INTROSPECT_NOT_SUPPORTED`. Drift detection lands in a follow-up — adopters set `driftCheck: 'off'` until then.

## Keyword sweep

Cleaned up the keyword sets across the entire `@forinda/kickjs-*` family for consistent npm discovery:

- Every package now has bare `"kickjs"` (for plain-text npm search), `"@forinda/kickjs"` (the framework), the package's own name, and the related-package siblings.
- `@forinda/kickjs-db` + `@forinda/kickjs-db-pg` gained the new `db-sqlite` / `db-mysql` siblings so adopters discover all three dialect adapters on the same npmjs.com listing.

No code changes from the sweep — pure metadata.

## Tests

| Package | Files | Tests | Notes |
|---|---|---|---|
| `@forinda/kickjs-db-sqlite` | 1 | **10** | Real-driver via in-memory `better-sqlite3`. Relational query round-trip + migration adapter contract. |
| `@forinda/kickjs-db-mysql` | 1 | **11** | Unit only — version-string parser + version-assertion gate (MySQL 8 / MariaDB 10 pass; 5.x / unparseable throw; cached after first success). Real-driver Testcontainers test deferred. |

Existing suites unchanged: `@forinda/kickjs-db` 55f/341t, `@forinda/kickjs-db-pg` 4f/23t. Build + typecheck clean across all four db-family packages.

## Test plan

- [x] `pnpm test` green across `db-sqlite` + `db-mysql` + existing db-family packages.
- [x] `pnpm typecheck` clean across all four.
- [x] `pnpm build` produces correct dist for both new packages.
- [x] Keyword sweep verified — every `@forinda/kickjs-*` package starts with `"kickjs"` as the first keyword.
- [ ] **Deferred:** Real-driver Testcontainers MySQL integration test. Tracked for a follow-up to keep CI cheap.
- [ ] **Deferred:** `introspect()` impls (sqlite_master walk for SQLite, information_schema walk for MySQL). Adopters use `driftCheck: 'off'` until then.

## What this unlocks

After this lands, M4.A is **complete**. Adopters using SQLite or MySQL get the full kickjs-db experience: schema-first declarations, migrations via `kick db migrate`, and relational queries via `db.query.X.findMany({ with })`. Three changesets staged on this branch covering both new packages + patch bumps on `db` / `db-pg` for the keyword sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
