### PR TITLE
docs(db-sqlite,db-mysql): drop Kysely mentions from adopter-facing prose

### DIFF
--- a/.changeset/db-readmes-kysely-leak.md
+++ b/.changeset/db-readmes-kysely-leak.md
@@ -1,0 +1,12 @@
+---
+'@forinda/kickjs-db-sqlite': patch
+'@forinda/kickjs-db-mysql': patch
+---
+
+Drop `Kysely` mentions from the adopter-facing README prose on the two new dialect packages so they match the `@forinda/kickjs-db-pg` template.
+
+Both packages still use the underlying engine internally — that's the point of the `*Dialect()` factories — but the README now reads like the rest of the family: "SQLite adapter", "MySQL adapter", with the implementation engine treated as an internal detail. Adopters who need to escape into the underlying surface still do so via the framework's `qb` accessor; nothing about the API surface or runtime behavior changes.
+
+Same sweep applied to `docs/guide/db-extensions.md` (the result-extension internals doc) — "Kysely plugin" reworded to "query-pipeline plugin" / "query-tree transform" so the public guide is engine-agnostic.
+
+No code changes. No public API changes. Patch bump only because npm picks up the updated README on the next publish.

--- a/docs/guide/db-extensions.md
+++ b/docs/guide/db-extensions.md
@@ -190,7 +190,7 @@ const dbX = db.$extends({
 
 ### Result extensions
 
-Add derived properties to every selected row of a table. Each computed declares which columns it `needs` and a `compute(row)` function that produces the value. The Kysely plugin rewrites the query tree before SQL emit so the listed columns are fetched whenever that table is selected:
+Add derived properties to every selected row of a table. Each computed declares which columns it `needs` and a `compute(row)` function that produces the value. A query-tree transform rewrites the query before SQL emit so the listed columns are fetched whenever that table is selected:
 
 ```ts
 const dbX = db.$extends({
@@ -216,7 +216,7 @@ const rows = await dbX.selectFrom('posts').selectAll().execute()
 - A throwing `compute()` degrades to `undefined` on that row's property; sibling computeds and rows still complete cleanly.
 - Single-table only: joins, sub-selects, multi-table FROM clauses pass through untouched. Cross-table computeds are roadmap.
 
-**How the rebuild works** — `$extends({ result })` calls `qb.withPlugin()` to append a Kysely plugin that owns the transform pair. The new client shares the original's event emitter, savepoint counter, and dialect tag, so `.transaction()` / `.on('slowQuery', …)` / per-call savepoints keep working transparently. `$extends({ model })` alone (no `result`) skips the rebuild — it stays a thin Proxy as before. Composing both in one call is the common path:
+**How the rebuild works** — `$extends({ result })` registers a query-pipeline plugin that owns the transform pair. The new client shares the original's event emitter, savepoint counter, and dialect tag, so `.transaction()` / `.on('slowQuery', …)` / per-call savepoints keep working transparently. `$extends({ model })` alone (no `result`) skips the rebuild — it stays a thin Proxy as before. Composing both in one call is the common path:
 
 ```ts
 const dbX = db.$extends({

--- a/packages/db-mysql/README.md
+++ b/packages/db-mysql/README.md
@@ -1,8 +1,13 @@
 # @forinda/kickjs-db-mysql
 
-> mysql2 adapter for `@forinda/kickjs-db` — `MigrationAdapter` + Kysely `MysqlDialect`. **MySQL 8.0+ required.**
+> MySQL adapter for [`@forinda/kickjs-db`](https://www.npmjs.com/package/@forinda/kickjs-db). **MySQL 8.0+ / MariaDB 10.5+ required.**
 
-Ships the bridge between `@forinda/kickjs-db`'s migration runner / relational query layer and a MySQL 8.0+ database via [`mysql2`](https://github.com/sidorares/node-mysql2) (or any structurally compatible pool).
+Two factories:
+
+- **`mysqlDialect({ pool })`** — query-layer dialect for `createDbClient({ dialect })`.
+- **`mysqlAdapter({ pool })`** — `MigrationAdapter` for `kick db migrate` + `kickDbAdapter` boot-time apply.
+
+Both consume an [`mysql2`](https://github.com/sidorares/node-mysql2) pool (or any structurally compatible runtime).
 
 ## Install
 
@@ -32,7 +37,7 @@ export const db = createDbClient({
 export const migrationAdapter = mysqlAdapter({ pool })
 ```
 
-`createDbClient` auto-attaches Kysely's `ParseJSONResultsPlugin` for the MySQL dialect — `db.query.X.findMany({ with })` round-trips nested rows as parsed JS objects rather than JSON-encoded TEXT.
+`db.query.X.findMany({ with })` round-trips nested rows as parsed JS objects: MySQL's JSON aggregation returns TEXT, but `createDbClient` transparently parses it on the way back so adopters never see the encoded form.
 
 ## MySQL 8.0+ / MariaDB 10.5+ required
 
@@ -47,12 +52,14 @@ The version parser (`parseMysqlVersion`) detects MariaDB via the version string 
 
 mysql2's default `Pool.query()` rejects multi-statement SQL unless the driver is configured with `multipleStatements: true`. The adapter splits SQL blobs at top-level `;` boundaries (respecting string literals and `--` / C-style block comments) so kickjs-generated migrations apply against default mysql2 settings. Adopters with `multipleStatements: true` on their pool pay no extra cost — the splitter is cheap on small DDL blobs.
 
-## What ships
+## Adopter-facing exports
 
-- **`mysqlDialect({ pool })`** — wraps Kysely's `MysqlDialect`.
-- **`mysqlAdapter({ pool })`** — implements `MigrationAdapter` for `@forinda/kickjs-db`'s migration runner (`kick db migrate` + `kickDbAdapter` boot-time apply). Handles `kick_migrations` / `kick_migrations_lock` table creation, lock acquisition, applying SQL in / out of a transaction, plus the version assertion and multi-statement splitting.
-- **`parseMysqlVersion(version)`** + **`parseMysqlMajorVersion(version)`** — exposed for adopters who want to run the same check in their own boot logic. The full parser returns `{ flavor, major, minor }` so adopters can branch on MariaDB vs MySQL; the major-only shim is kept for back-compat.
-- **`splitMysqlStatements(sql)`** — exposed for adopters who want to run the same multi-statement splitter outside the adapter (custom migration tooling, etc.).
+- **`parseMysqlVersion(version)`** — full parse returning `{ flavor, major, minor }` for branching on MariaDB vs MySQL.
+- **`parseMysqlMajorVersion(version)`** — back-compat shim; major-only result.
+- **`splitMysqlStatements(sql)`** — multi-statement splitter for custom migration tooling outside the adapter.
+
+## Notes
+
 - **Drift detection (`introspect()`) is not yet implemented in v1** — it throws `KickDbError` with code `KICK_DB_INTROSPECT_NOT_SUPPORTED`. Set `driftCheck: 'off'` on the migration runner until a follow-up adds the `information_schema` walk.
 
 ## License

--- a/packages/db-sqlite/README.md
+++ b/packages/db-sqlite/README.md
@@ -1,8 +1,13 @@
 # @forinda/kickjs-db-sqlite
 
-> better-sqlite3 adapter for `@forinda/kickjs-db` — `MigrationAdapter` + Kysely `SqliteDialect`.
+> SQLite adapter for [`@forinda/kickjs-db`](https://www.npmjs.com/package/@forinda/kickjs-db).
 
-Ships the bridge between `@forinda/kickjs-db`'s migration runner / relational query layer and an in-process SQLite database via [`better-sqlite3`](https://github.com/WiseLibs/better-sqlite3) (or any structurally compatible handle, e.g. `bun:sqlite`).
+Two factories:
+
+- **`sqliteDialect({ database })`** — query-layer dialect for `createDbClient({ dialect })`.
+- **`sqliteAdapter({ database })`** — `MigrationAdapter` for `kick db migrate` + `kickDbAdapter` boot-time apply.
+
+Both consume a [`better-sqlite3`](https://github.com/WiseLibs/better-sqlite3) handle (or any structurally compatible runtime, e.g. `bun:sqlite`).
 
 ## Install
 
@@ -27,12 +32,10 @@ export const db = createDbClient({
 export const migrationAdapter = sqliteAdapter({ database })
 ```
 
-`createDbClient` auto-attaches Kysely's `ParseJSONResultsPlugin` for the SQLite dialect — `db.query.X.findMany({ with })` round-trips nested rows as parsed JS objects rather than JSON-encoded TEXT.
+`db.query.X.findMany({ with })` round-trips nested rows as parsed JS objects: SQLite's JSON aggregation returns TEXT, but `createDbClient` transparently parses it on the way back so adopters never see the encoded form.
 
-## What ships
+## Notes
 
-- **`sqliteDialect({ database })`** — wraps Kysely's `SqliteDialect`.
-- **`sqliteAdapter({ database })`** — implements `MigrationAdapter` for `@forinda/kickjs-db`'s migration runner (`kick db migrate` + `kickDbAdapter` boot-time apply). Handles `kick_migrations` / `kick_migrations_lock` table creation, lock acquisition, applying SQL in / out of a transaction.
 - **Drift detection (`introspect()`) is not yet implemented in v1** — it throws `KickDbError` with code `KICK_DB_INTROSPECT_NOT_SUPPORTED`. Set `driftCheck: 'off'` on the migration runner until a follow-up adds the `sqlite_master` + `pragma` walk.
 
 ## License


### PR DESCRIPTION
## Why

`db-pg`'s README treats the underlying query engine as an internal detail — adopters install `@forinda/kickjs-db-pg`, get `pgDialect()` + `pgAdapter()`, and never see "Kysely" in the prose. The new `db-sqlite` + `db-mysql` READMEs (just published in [#186](https://github.com/forinda/kick-js/pull/186)) leaked it: "wraps Kysely's `SqliteDialect`", "Kysely's `ParseJSONResultsPlugin`", etc.

`@forinda` flagged the inconsistency. This PR fixes it.

## What changed

**`packages/db-sqlite/README.md`** — reshaped to match `db-pg`:
- Tagline: "SQLite adapter for `@forinda/kickjs-db`" (was: "better-sqlite3 adapter — `MigrationAdapter` + Kysely `SqliteDialect`")
- Two-bullet factory list (Dialect + Adapter), parallel to db-pg
- "JSON aggregation returns TEXT, but `createDbClient` transparently parses it on the way back" — explains the round-trip without naming the underlying plugin
- Notes section absorbed the v1 carve-out (no `introspect()`)

**`packages/db-mysql/README.md`** — same shape; kept the substantial sections (MySQL 8.0+ / MariaDB 10.5+ floor, multi-statement splitter rationale, adopter-facing exports), just dropped the Kysely prose.

**`docs/guide/db-extensions.md`** — two mentions in the result-extensions guide:
- "The Kysely plugin rewrites the query tree" → "A query-tree transform rewrites the query"
- "calls `qb.withPlugin()` to append a Kysely plugin" → "registers a query-pipeline plugin"

## What didn't change

- Source code (`*/src/dialect.ts`) — internal comments still mention Kysely. They explain why we re-export the factory rather than asking adopters to import from `kysely` directly. Same as `db-pg/src/dialect.ts`. Internal-only.
- `docs/db/architecture.md` + `stories.md` + plan/spec/release notes — these legitimately discuss the engine choice. Not adopter surface.
- CHANGELOGs — historical, not edited.
- Public API surface, runtime behavior, dependencies — all untouched.

## Changeset

`.changeset/db-readmes-kysely-leak.md` — patch bump on both packages so npm picks up the cleaner README on the next publish.

## Test plan

- [x] `grep -ni kysely packages/db-sqlite/README.md packages/db-mysql/README.md docs/guide/` returns no matches
- [x] `pnpm format` clean
- [x] No source-code changes — no test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
