### PR TITLE
feat(cli): kick.config.ts > modules.style ('define' | 'class')

### DIFF
--- a/.changeset/cli-module-style-config.md
+++ b/.changeset/cli-module-style-config.md
@@ -1,0 +1,34 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+`kick.config.ts > modules.style: 'define' | 'class'` — opt-out flag for projects that prefer the legacy `class FooModule implements AppModule { ... }` form over the new `defineModule({...})` factory.
+
+```ts
+// kick.config.ts
+export default defineConfig({
+  modules: {
+    style: 'class', // pin to legacy form; default is 'define'
+  },
+})
+```
+
+The framework runtime accepts both shapes regardless of this setting — the flag controls codegen output only:
+
+- **`'define'`** (default) — `defineModule({ name, build: () => ({...}) })` factory form, with the orchestrator inserting `TaskModule()` (factory call) into `src/modules/index.ts`.
+- **`'class'`** — legacy `class FooModule implements AppModule { ... }`, with the orchestrator inserting bare `TaskModule` (no call) into the modules array.
+
+`kick rm module` matches both `Module` and `Module()` forms, so a project that flips the flag mid-stream can keep adding/removing modules without breakage. Mixing styles in the same project works (loader discriminates `typeof entry === 'function'` at boot).
+
+## What changed
+
+- `ModuleConfig.style?: 'define' | 'class'` added to `kick.config.ts` schema. Unknown values warn + fall back to `'define'`.
+- All four pattern generators (DDD, REST, CQRS, minimal) + the `kick g scaffold` template branch on the resolved style.
+- `kick g module`'s array-insertion regex emits `Module()` for `'define'` and bare `Module` for `'class'`.
+- New tests cover both branches: `kick g module` with no config (default 'define') AND with `kick.config.json: { modules: { style: 'class' } }`.
+
+Suite: 231 → 234 (+3 new style tests). Build + typecheck clean.
+
+## Related — migration command (deferred)
+
+A future `kick migrate modules --experimental` command will rewrite class-form modules to the `defineModule` factory form via TypeScript AST transforms. Out of scope for this PR; the config flag covers the inverse direction (pin to class form) for projects that don't want to migrate.

--- a/.changeset/cli-module-style-config.md
+++ b/.changeset/cli-module-style-config.md
@@ -2,33 +2,83 @@
 '@forinda/kickjs-cli': minor
 ---
 
-`kick.config.ts > modules.style: 'define' | 'class'` — opt-out flag for projects that prefer the legacy `class FooModule implements AppModule { ... }` form over the new `defineModule({...})` factory.
+`modules.style` config flag + `kick codemod modules` migration command + style-drift gate on `kick g module`.
+
+## What's new
+
+### Config flag — `kick.config.ts > modules.style: 'define' | 'class'`
 
 ```ts
-// kick.config.ts
 export default defineConfig({
   modules: {
-    style: 'class', // pin to legacy form; default is 'define'
+    style: 'class', // pin to legacy class form; default is 'define'
   },
 })
 ```
 
-The framework runtime accepts both shapes regardless of this setting — the flag controls codegen output only:
+The framework runtime accepts both shapes regardless of this setting — `Application` discriminates `typeof entry === 'function'` at boot. The flag controls codegen output only:
 
-- **`'define'`** (default) — `defineModule({ name, build: () => ({...}) })` factory form, with the orchestrator inserting `TaskModule()` (factory call) into `src/modules/index.ts`.
-- **`'class'`** — legacy `class FooModule implements AppModule { ... }`, with the orchestrator inserting bare `TaskModule` (no call) into the modules array.
+| Style                | Module file                                     | Modules registry |
+| -------------------- | ----------------------------------------------- | ---------------- |
+| `'define'` (default) | `defineModule({ name, build: () => ({...}) })`  | `[TaskModule()]` |
+| `'class'`            | `class TaskModule implements AppModule { ... }` | `[TaskModule]`   |
 
-`kick rm module` matches both `Module` and `Module()` forms, so a project that flips the flag mid-stream can keep adding/removing modules without breakage. Mixing styles in the same project works (loader discriminates `typeof entry === 'function'` at boot).
+`kick rm module` matches both forms, so flipping the flag mid-project doesn't break un-registration.
+
+### `kick codemod modules` — bidirectional migration
+
+Experimental command that rewrites between the two shapes. **Direction defaults to `modules.style`** from kick.config (or `'define'` when unset), so `kick codemod modules` "just does the right thing" for the project.
+
+```bash
+# Default direction = modules.style from kick.config
+kick codemod modules --experimental                 # dry-run preview
+kick codemod modules --experimental --apply         # write changes
+
+# Override direction explicitly
+kick codemod modules --experimental --apply --target class
+```
+
+- **Backup before rewrite** — `--apply` writes a timestamped snapshot to `.kickjs/codemod-backups/<iso-stamp>-modules/` before touching any module file. Adopters not tracking with git can revert with `rm -rf <modulesDir> && mv "<backup>" <modulesDir>`. Skip with `--no-backup`.
+- **Idempotent** — re-running on already-migrated code is a no-op (returns `'already in target form'` per file).
+- **Both module file conventions** — picks up `<modulesDir>/<sub>/<name>.module.ts` (current) AND `<modulesDir>/<sub>/index.ts` (legacy).
+- **Conservative** — files with multiple module classes, decorators on the class, or unrecognized method signatures are reported as `skipped` with a reason and left untouched.
+
+### Style-drift gate on `kick g module`
+
+When `style: 'define'` resolves AND the project still has class-form modules, `kick g module` refuses with an actionable error pointing at `kick codemod modules`:
+
+```
+Error: 1 module file(s) still use the legacy `class … implements AppModule` shape.
+  Project setting: modules.style: 'define' (default)
+
+  Files needing migration:
+    - src/modules/users/user.module.ts
+
+  Pick one:
+    1. Migrate everything to defineModule:
+       $ kick codemod modules --experimental --apply
+    2. Keep the class form — pin it in kick.config.ts:
+       // kick.config.ts
+       export default defineConfig({ modules: { style: 'class' } })
+```
+
+The gate runs only for `'define'`; `'class'` projects accept either shape since defineModule modules pass through Application's class-vs-instance discriminator at boot.
 
 ## What changed
 
-- `ModuleConfig.style?: 'define' | 'class'` added to `kick.config.ts` schema. Unknown values warn + fall back to `'define'`.
-- All four pattern generators (DDD, REST, CQRS, minimal) + the `kick g scaffold` template branch on the resolved style.
-- `kick g module`'s array-insertion regex emits `Module()` for `'define'` and bare `Module` for `'class'`.
-- New tests cover both branches: `kick g module` with no config (default 'define') AND with `kick.config.json: { modules: { style: 'class' } }`.
+- New `packages/cli/src/generators/migrate-modules.ts` — bidirectional class ↔ defineModule rewriter, registry rewriter (`AppModuleClass[]` ↔ `AppModuleEntry[]` + factory-call vs bare-reference), file walker that handles both `*.module.ts` and legacy `<sub>/index.ts` patterns, backup helper.
+- New `packages/cli/src/commands/codemod.ts` — `kick codemod` namespace (distinct from `kick db migrate`).
+- `kick g module` orchestrator gates on style drift before generating.
+- All four pattern generators (DDD/REST/CQRS/minimal) + scaffold template branch on the resolved style.
+- `kick rm module` + `kick g scaffold` register-loader emit the matching shape.
 
-Suite: 231 → 234 (+3 new style tests). Build + typecheck clean.
+## Tests
 
-## Related — migration command (deferred)
+- 11 new unit tests for the migrator: class→define, define→class, idempotency, register-less modules, multi-class refusal, registry rewrites both directions, `index.ts` detection, backup behavior (creates timestamped dir, dry-run skips, --no-backup skips).
+- 3 new integration tests on the gate: default style refuses on legacy modules; style='class' proceeds without checks; style='class' emits class form.
 
-A future `kick migrate modules --experimental` command will rewrite class-form modules to the `defineModule` factory form via TypeScript AST transforms. Out of scope for this PR; the config flag covers the inverse direction (pin to class form) for projects that don't want to migrate.
+Suite: 231 → 253 (+22). Build + typecheck clean.
+
+## Docs
+
+`docs/guide/generators.md` "Module declaration style" section covers the flag's effect on codegen output. The `kick codemod modules` command surface lives in the command's `--help` output for now.

--- a/.changeset/cli-module-style-config.md
+++ b/.changeset/cli-module-style-config.md
@@ -47,7 +47,7 @@ kick codemod modules --experimental --apply --target class
 
 When `style: 'define'` resolves AND the project still has class-form modules, `kick g module` refuses with an actionable error pointing at `kick codemod modules`:
 
-```
+```text
 Error: 1 module file(s) still use the legacy `class … implements AppModule` shape.
   Project setting: modules.style: 'define' (default)
 

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -187,8 +187,27 @@ export default defineConfig({
     repo: 'drizzle',
     pluralize: true,
     schemaDir: 'src/db/schema',
+    style: 'define', // 'define' (default) or 'class' — see below
   },
 })
+```
+
+### Module declaration style
+
+The `modules.style` field controls what `kick g module` and `kick g scaffold` emit for the module declaration:
+
+- **`'define'`** (default) — `defineModule({ name, build: () => ({...}) })` factory form. Mirrors `defineAdapter` / `definePlugin` / `defineContextDecorator`. The orchestrator inserts the factory-call form (`TaskModule()`) into `src/modules/index.ts`.
+- **`'class'`** — legacy `class FooModule implements AppModule { ... }` form. The orchestrator inserts the bare class reference (`TaskModule`) into the modules array.
+
+The framework runtime accepts both shapes regardless of this setting — the flag controls codegen output only. `kick rm module` matches both forms, so flipping the flag mid-project doesn't break un-registration.
+
+```bash
+# Pin a project to class form (existing-codebase consistency, etc.)
+# kick.config.ts → modules: { style: 'class' }
+kick g module task
+# → src/modules/tasks/task.module.ts emits:
+#     export class TaskModule implements AppModule { register() {...} routes() {...} }
+# → src/modules/index.ts: [TaskModule]
 ```
 
 ```bash

--- a/packages/cli/__tests__/migrate-modules.test.ts
+++ b/packages/cli/__tests__/migrate-modules.test.ts
@@ -329,3 +329,102 @@ export const modules: AppModuleClass[] = [TaskModule]
     expect(existsSync(join(dir, '.kickjs', 'codemod-backups'))).toBe(false)
   })
 })
+
+describe('CodeRabbit fixes', () => {
+  describe('migrateDefineToClass — adds ContributorRegistrations import when contributors() present', () => {
+    it('imports ContributorRegistrations alongside the class form', () => {
+      const input = `import { defineModule } from '@forinda/kickjs'
+import { LoadTenant } from './load-tenant'
+
+export const TaskModule = defineModule({
+  name: 'TaskModule',
+  build: () => ({
+    contributors() {
+      return [LoadTenant.registration]
+    },
+    routes() {
+      return { path: '/tasks', controller: TaskController }
+    },
+  }),
+})
+`
+      const result = migrateDefineToClass(input)
+      expect(result.migrated).not.toBeNull()
+      expect(result.migrated).toContain('contributors(): ContributorRegistrations {')
+      expect(result.migrated).toContain('type ContributorRegistrations')
+    })
+  })
+
+  describe('findModuleFiles — depth-aware legacy index.ts discovery', () => {
+    let dir: string
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), 'kick-depth-'))
+      // Direct child — legacy module convention. Should be picked up.
+      mkdirSync(join(dir, 'modules', 'tasks'), { recursive: true })
+      writeFileSync(
+        join(dir, 'modules', 'tasks', 'index.ts'),
+        'export class TaskModule implements AppModule { routes(): ModuleRoutes { return null as never } }',
+      )
+      // Nested barrel files (DDD layout) — must NOT be picked up.
+      mkdirSync(join(dir, 'modules', 'tasks', 'application'), { recursive: true })
+      writeFileSync(
+        join(dir, 'modules', 'tasks', 'application', 'index.ts'),
+        'export * from "./create-task.use-case"',
+      )
+      mkdirSync(join(dir, 'modules', 'tasks', 'domain'), { recursive: true })
+      writeFileSync(
+        join(dir, 'modules', 'tasks', 'domain', 'index.ts'),
+        'export * from "./task.entity"',
+      )
+      // Registry at modulesDir root — excluded.
+      writeFileSync(join(dir, 'modules', 'index.ts'), 'export const modules = []')
+    })
+
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true })
+    })
+
+    it('picks up only the depth-1 legacy index.ts, not nested barrels or the registry', async () => {
+      const files = await findModuleFiles(join(dir, 'modules'))
+      expect(files).toEqual([join(dir, 'modules', 'tasks', 'index.ts')])
+    })
+  })
+
+  describe('migrateModulesDir — backup when registry-only changes', () => {
+    let dir: string
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), 'kick-registry-backup-'))
+      mkdirSync(join(dir, 'src', 'modules'), { recursive: true })
+      // No module files; only a stale-typed registry that needs the
+      // type rename + factory-call rewrite.
+      writeFileSync(
+        join(dir, 'src', 'modules', 'index.ts'),
+        `import type { AppModuleClass } from '@forinda/kickjs'
+import { TaskModule } from './tasks/task.module'
+
+export const modules: AppModuleClass[] = [TaskModule]
+`,
+      )
+    })
+
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true })
+    })
+
+    it('snapshots before rewriting a registry-only project', async () => {
+      const result = await migrateModulesDir(join(dir, 'src', 'modules'), {
+        target: 'define',
+        cwd: dir,
+        dryRun: false,
+      })
+      expect(result.backupDir).not.toBeNull()
+      const backupRegistry = readFileSync(join(result.backupDir!, 'index.ts'), 'utf-8')
+      expect(backupRegistry).toContain('AppModuleClass[]')
+      const liveRegistry = readFileSync(join(dir, 'src', 'modules', 'index.ts'), 'utf-8')
+      expect(liveRegistry).toContain('AppModuleEntry[]')
+      expect(liveRegistry).toContain('[TaskModule()]')
+    })
+  })
+})

--- a/packages/cli/__tests__/migrate-modules.test.ts
+++ b/packages/cli/__tests__/migrate-modules.test.ts
@@ -1,0 +1,331 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, it, expect } from 'vitest'
+import {
+  findModuleFiles,
+  findStyleDriftModules,
+  migrateClassToDefine,
+  migrateDefineToClass,
+  migrateModulesDir,
+  migrateModulesIndex,
+} from '../src/generators/migrate-modules'
+
+describe('migrateClassToDefine', () => {
+  it('rewrites a basic class module to defineModule', () => {
+    const input = `import { Container, type AppModule, type ModuleRoutes } from '@forinda/kickjs'
+import { TaskController } from './task.controller'
+import { TASK_REPOSITORY } from './task.repository'
+import { InMemoryTaskRepository } from './in-memory-task.repository'
+
+export class TaskModule implements AppModule {
+  register(container: Container): void {
+    container.registerFactory(TASK_REPOSITORY, () =>
+      container.resolve(InMemoryTaskRepository),
+    )
+  }
+
+  routes(): ModuleRoutes {
+    return {
+      path: '/tasks',
+      controller: TaskController,
+    }
+  }
+}
+`
+    const result = migrateClassToDefine(input)
+    expect(result.migrated).not.toBeNull()
+    expect(result.migrated).toContain("import { defineModule } from '@forinda/kickjs'")
+    expect(result.migrated).toContain('export const TaskModule = defineModule({')
+    expect(result.migrated).toContain("name: 'TaskModule'")
+    expect(result.migrated).toContain('register(container) {')
+    expect(result.migrated).toContain('routes() {')
+    expect(result.migrated).not.toContain('implements AppModule')
+    expect(result.migrated).not.toContain('Container')
+  })
+
+  it('skips files already in defineModule form', () => {
+    const input = `import { defineModule } from '@forinda/kickjs'
+export const TaskModule = defineModule({ name: 'TaskModule', build: () => ({ routes: () => null }) })
+`
+    const result = migrateClassToDefine(input)
+    expect(result.migrated).toBeNull()
+    expect(result.reason).toContain('already in target form')
+  })
+
+  it('skips files without a class declaration', () => {
+    const result = migrateClassToDefine(`export const X = 1\n`)
+    expect(result.migrated).toBeNull()
+    expect(result.reason).toContain('no class form')
+  })
+
+  it('handles modules without register() (routes-only)', () => {
+    const input = `import { type AppModule, type ModuleRoutes } from '@forinda/kickjs'
+import { TaskController } from './task.controller'
+
+export class TaskModule implements AppModule {
+  routes(): ModuleRoutes {
+    return { path: '/tasks', controller: TaskController }
+  }
+}
+`
+    const result = migrateClassToDefine(input)
+    expect(result.migrated).not.toBeNull()
+    expect(result.migrated).toContain('defineModule({')
+    expect(result.migrated).not.toContain('register(')
+  })
+
+  it('refuses files with multiple module classes', () => {
+    const input = `import { type AppModule, type ModuleRoutes } from '@forinda/kickjs'
+
+export class AModule implements AppModule { routes(): ModuleRoutes { return null as never } }
+export class BModule implements AppModule { routes(): ModuleRoutes { return null as never } }
+`
+    const result = migrateClassToDefine(input)
+    expect(result.migrated).toBeNull()
+    expect(result.reason).toContain('multiple module classes')
+  })
+})
+
+describe('migrateDefineToClass', () => {
+  it('rewrites a defineModule factory to class form', () => {
+    const input = `import { defineModule } from '@forinda/kickjs'
+import { TaskController } from './task.controller'
+import { TASK_REPOSITORY } from './task.repository'
+
+export const TaskModule = defineModule({
+  name: 'TaskModule',
+  build: () => ({
+    register(container) {
+      container.registerFactory(TASK_REPOSITORY, () =>
+        container.resolve(TaskRepoImpl),
+      )
+    },
+
+    routes() {
+      return {
+        path: '/tasks',
+        controller: TaskController,
+      }
+    },
+  }),
+})
+`
+    const result = migrateDefineToClass(input)
+    expect(result.migrated).not.toBeNull()
+    expect(result.migrated).toContain('export class TaskModule implements AppModule {')
+    expect(result.migrated).toContain('register(container: Container): void {')
+    expect(result.migrated).toContain('routes(): ModuleRoutes {')
+    expect(result.migrated).toContain('import { Container, type AppModule, type ModuleRoutes }')
+    expect(result.migrated).not.toContain('defineModule')
+  })
+
+  it('skips files already in class form', () => {
+    const input = `export class TaskModule implements AppModule { routes() { return null } }`
+    const result = migrateDefineToClass(input)
+    expect(result.migrated).toBeNull()
+    expect(result.reason).toContain('already in target form')
+  })
+
+  it('handles defineModule without register()', () => {
+    const input = `import { defineModule } from '@forinda/kickjs'
+import { TaskController } from './task.controller'
+
+export const TaskModule = defineModule({
+  name: 'TaskModule',
+  build: () => ({
+    routes() {
+      return { path: '/tasks', controller: TaskController }
+    },
+  }),
+})
+`
+    const result = migrateDefineToClass(input)
+    expect(result.migrated).not.toBeNull()
+    expect(result.migrated).toContain('export class TaskModule implements AppModule {')
+    expect(result.migrated).not.toContain('Container')
+    expect(result.migrated).not.toContain('register(')
+  })
+})
+
+describe('migrateModulesIndex', () => {
+  it('rewrites AppModuleClass[] → AppModuleEntry[] with factory-call form (target=define)', () => {
+    const input = `import type { AppModuleClass } from '@forinda/kickjs'
+import { UserModule } from './users/user.module'
+import { TaskModule } from './tasks/task.module'
+
+export const modules: AppModuleClass[] = [UserModule, TaskModule]
+`
+    const result = migrateModulesIndex(input, 'define')
+    expect(result.migrated).not.toBeNull()
+    expect(result.migrated).toContain('AppModuleEntry[]')
+    expect(result.migrated).toContain('[UserModule(), TaskModule()]')
+    expect(result.migrated).not.toContain('AppModuleClass')
+  })
+
+  it('rewrites AppModuleEntry[] → AppModuleClass[] with bare references (target=class)', () => {
+    const input = `import type { AppModuleEntry } from '@forinda/kickjs'
+import { UserModule } from './users/user.module'
+
+export const modules: AppModuleEntry[] = [UserModule(), TaskModule()]
+`
+    const result = migrateModulesIndex(input, 'class')
+    expect(result.migrated).not.toBeNull()
+    expect(result.migrated).toContain('AppModuleClass[]')
+    expect(result.migrated).toContain('[UserModule, TaskModule]')
+    expect(result.migrated).not.toContain('UserModule()')
+  })
+
+  it('is idempotent on already-migrated index files', () => {
+    const defined = `import type { AppModuleEntry } from '@forinda/kickjs'
+export const modules: AppModuleEntry[] = [UserModule()]
+`
+    expect(migrateModulesIndex(defined, 'define').migrated).toBeNull()
+
+    const classed = `import type { AppModuleClass } from '@forinda/kickjs'
+export const modules: AppModuleClass[] = [UserModule]
+`
+    expect(migrateModulesIndex(classed, 'class').migrated).toBeNull()
+  })
+})
+
+describe('findModuleFiles — supports both <name>.module.ts AND legacy <sub>/index.ts', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'kick-migrate-'))
+    mkdirSync(join(dir, 'modules', 'users'), { recursive: true })
+    mkdirSync(join(dir, 'modules', 'tasks'), { recursive: true })
+    mkdirSync(join(dir, 'modules', 'orders'), { recursive: true })
+
+    // Current convention — <name>.module.ts.
+    writeFileSync(
+      join(dir, 'modules', 'users', 'user.module.ts'),
+      'export class UserModule implements AppModule { routes(): ModuleRoutes { return null as never } }',
+    )
+    // Legacy convention — index.ts inside the module folder.
+    writeFileSync(
+      join(dir, 'modules', 'tasks', 'index.ts'),
+      'export class TaskModule implements AppModule { routes(): ModuleRoutes { return null as never } }',
+    )
+    // Mixed — folder has BOTH; both should be picked up.
+    writeFileSync(
+      join(dir, 'modules', 'orders', 'order.module.ts'),
+      'export class OrderModule implements AppModule { routes(): ModuleRoutes { return null as never } }',
+    )
+    writeFileSync(
+      join(dir, 'modules', 'orders', 'index.ts'),
+      `export { OrderModule } from './order.module'`,
+    )
+
+    // The registry at the modulesDir root — must NOT be picked up.
+    writeFileSync(
+      join(dir, 'modules', 'index.ts'),
+      `import type { AppModuleClass } from '@forinda/kickjs'
+export const modules: AppModuleClass[] = []`,
+    )
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('finds all three module-declaration files (current + legacy index)', async () => {
+    const files = await findModuleFiles(join(dir, 'modules'))
+    expect(files.length).toBe(4)
+    expect(files.some((f) => f.endsWith('users/user.module.ts'))).toBe(true)
+    expect(files.some((f) => f.endsWith('tasks/index.ts'))).toBe(true)
+    expect(files.some((f) => f.endsWith('orders/order.module.ts'))).toBe(true)
+    expect(files.some((f) => f.endsWith('orders/index.ts'))).toBe(true)
+  })
+
+  it('excludes <modulesDir>/index.ts (the registry)', async () => {
+    const files = await findModuleFiles(join(dir, 'modules'))
+    const rootIndex = join(dir, 'modules', 'index.ts')
+    expect(files.includes(rootIndex)).toBe(false)
+  })
+
+  it('findStyleDriftModules picks up class form in legacy index.ts files', async () => {
+    const drift = await findStyleDriftModules(join(dir, 'modules'), 'define')
+    // Three of the four files actually have a `class … implements AppModule`
+    // declaration; the orders/index.ts only re-exports.
+    expect(drift.length).toBeGreaterThanOrEqual(2)
+    expect(drift.some((p) => p.endsWith('tasks/index.ts'))).toBe(true)
+  })
+})
+
+describe('migrateModulesDir — backup behavior', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'kick-backup-'))
+    mkdirSync(join(dir, 'src', 'modules', 'tasks'), { recursive: true })
+    writeFileSync(
+      join(dir, 'src', 'modules', 'tasks', 'task.module.ts'),
+      `import { type AppModule, type ModuleRoutes } from '@forinda/kickjs'
+import { TaskController } from './task.controller'
+
+export class TaskModule implements AppModule {
+  routes(): ModuleRoutes {
+    return { path: '/tasks', controller: TaskController }
+  }
+}
+`,
+    )
+    writeFileSync(
+      join(dir, 'src', 'modules', 'index.ts'),
+      `import type { AppModuleClass } from '@forinda/kickjs'
+import { TaskModule } from './tasks/task.module'
+
+export const modules: AppModuleClass[] = [TaskModule]
+`,
+    )
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('writes a timestamped backup under .kickjs/codemod-backups/ when applying', async () => {
+    const result = await migrateModulesDir(join(dir, 'src', 'modules'), {
+      target: 'define',
+      cwd: dir,
+      dryRun: false,
+    })
+
+    expect(result.backupDir).not.toBeNull()
+    expect(result.backupDir!).toMatch(/\.kickjs[\/\\]codemod-backups/)
+
+    // Backup contains the original (pre-migration) file content.
+    const backupModule = readFileSync(join(result.backupDir!, 'tasks', 'task.module.ts'), 'utf-8')
+    expect(backupModule).toContain('class TaskModule implements AppModule')
+
+    // The actual file was rewritten to defineModule form.
+    const liveModule = readFileSync(join(dir, 'src', 'modules', 'tasks', 'task.module.ts'), 'utf-8')
+    expect(liveModule).toContain('defineModule(')
+    expect(liveModule).not.toContain('implements AppModule')
+  })
+
+  it('skips backup on dry-run', async () => {
+    const result = await migrateModulesDir(join(dir, 'src', 'modules'), {
+      target: 'define',
+      cwd: dir,
+      dryRun: true,
+    })
+    expect(result.backupDir).toBeNull()
+    // The original file was NOT rewritten on dry-run.
+    const liveModule = readFileSync(join(dir, 'src', 'modules', 'tasks', 'task.module.ts'), 'utf-8')
+    expect(liveModule).toContain('class TaskModule implements AppModule')
+  })
+
+  it('skips backup when explicitly disabled', async () => {
+    const result = await migrateModulesDir(join(dir, 'src', 'modules'), {
+      target: 'define',
+      cwd: dir,
+      dryRun: false,
+      backup: false,
+    })
+    expect(result.backupDir).toBeNull()
+    expect(existsSync(join(dir, '.kickjs', 'codemod-backups'))).toBe(false)
+  })
+})

--- a/packages/cli/__tests__/module.test.ts
+++ b/packages/cli/__tests__/module.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { assertCliOk, cleanupFixture, createFixtureProject, runCli, runTsc } from './helpers'
 
@@ -88,5 +88,55 @@ describe('kick g module', () => {
     const indexContent = readFileSync(join(fixture, 'src/modules/index.ts'), 'utf-8')
     expect(indexContent).toContain('UserModule')
     expect(indexContent).toContain('PostModule')
+  })
+
+  it('emits the defineModule factory by default', () => {
+    runCli(fixture, ['g', 'module', 'task'])
+    const moduleFile = readFileSync(join(fixture, 'src/modules/tasks/task.module.ts'), 'utf-8')
+    expect(moduleFile).toContain("import { defineModule } from '@forinda/kickjs'")
+    expect(moduleFile).toContain('export const TaskModule = defineModule({')
+    expect(moduleFile).toContain("name: 'TaskModule'")
+    expect(moduleFile).not.toContain('implements AppModule')
+
+    // The orchestrator inserts the factory-call form at the registration site.
+    const indexContent = readFileSync(join(fixture, 'src/modules/index.ts'), 'utf-8')
+    expect(indexContent).toContain('[TaskModule()]')
+  })
+})
+
+describe("kick g module — modules.style: 'class' opt-out", () => {
+  let fixture: string
+
+  beforeEach(() => {
+    fixture = createFixtureProject('module-style-class')
+    // Pin the project to the legacy class form before generating.
+    // JSON config avoids needing `@forinda/kickjs-cli` resolution in
+    // the temp fixture; the loader handles `kick.config.json` the
+    // same as a TS config file.
+    writeFileSync(
+      join(fixture, 'kick.config.json'),
+      JSON.stringify({ pattern: 'ddd', modules: { style: 'class' } }, null, 2),
+    )
+  })
+
+  afterEach(() => {
+    cleanupFixture(fixture)
+  })
+
+  it('emits class FooModule implements AppModule when style is "class"', () => {
+    runCli(fixture, ['g', 'module', 'task'])
+    const moduleFile = readFileSync(join(fixture, 'src/modules/tasks/task.module.ts'), 'utf-8')
+    expect(moduleFile).toContain('export class TaskModule implements AppModule {')
+    expect(moduleFile).toContain('register(container: Container): void {')
+    expect(moduleFile).toContain('routes(): ModuleRoutes {')
+    // Should NOT contain the factory-form noise.
+    expect(moduleFile).not.toContain('defineModule({')
+  })
+
+  it('inserts the bare class reference (no factory call) into src/modules/index.ts', () => {
+    runCli(fixture, ['g', 'module', 'task'])
+    const indexContent = readFileSync(join(fixture, 'src/modules/index.ts'), 'utf-8')
+    expect(indexContent).toContain('[TaskModule]')
+    expect(indexContent).not.toContain('[TaskModule()]')
   })
 })

--- a/packages/cli/__tests__/module.test.ts
+++ b/packages/cli/__tests__/module.test.ts
@@ -104,6 +104,70 @@ describe('kick g module', () => {
   })
 })
 
+describe('kick g module — style-drift gate', () => {
+  let fixture: string
+
+  beforeEach(() => {
+    fixture = createFixtureProject('module-style-gate')
+  })
+
+  afterEach(() => {
+    cleanupFixture(fixture)
+  })
+
+  it('refuses to generate when style="define" but class-form modules exist', () => {
+    // Drop a class-form module into the project, then try to add a
+    // new module while style defaults to 'define'. The gate should
+    // refuse with a pointer to `kick codemod modules`.
+    const legacyDir = join(fixture, 'src/modules/users')
+    require('node:fs').mkdirSync(legacyDir, { recursive: true })
+    writeFileSync(
+      join(legacyDir, 'user.module.ts'),
+      `import { type AppModule, type ModuleRoutes } from '@forinda/kickjs'
+
+export class UserModule implements AppModule {
+  routes(): ModuleRoutes {
+    return null as never
+  }
+}
+`,
+    )
+
+    const result = runCli(fixture, ['g', 'module', 'task'])
+    expect(result.exitCode).not.toBe(0)
+    const combined = `${result.stdout}\n${result.stderr}`
+    expect(combined).toMatch(/legacy.*class.*AppModule.*shape/i)
+    expect(combined).toContain('kick codemod modules')
+    expect(combined).toMatch(/style:\s*'class'/)
+  })
+
+  it('proceeds when style="class" is set, even with class-form modules', () => {
+    // Pin to class form — the gate is skipped.
+    writeFileSync(
+      join(fixture, 'kick.config.json'),
+      JSON.stringify({ pattern: 'ddd', modules: { style: 'class' } }),
+    )
+
+    const legacyDir = join(fixture, 'src/modules/users')
+    require('node:fs').mkdirSync(legacyDir, { recursive: true })
+    writeFileSync(
+      join(legacyDir, 'user.module.ts'),
+      `import { type AppModule, type ModuleRoutes } from '@forinda/kickjs'
+
+export class UserModule implements AppModule {
+  routes(): ModuleRoutes {
+    return null as never
+  }
+}
+`,
+    )
+
+    const result = runCli(fixture, ['g', 'module', 'task'])
+    assertCliOk(result, 'kick g module task (style: class with legacy)')
+    expect(existsSync(join(fixture, 'src/modules/tasks/task.module.ts'))).toBe(true)
+  })
+})
+
 describe("kick g module — modules.style: 'class' opt-out", () => {
   let fixture: string
 

--- a/packages/cli/__tests__/scaffold.test.ts
+++ b/packages/cli/__tests__/scaffold.test.ts
@@ -114,10 +114,10 @@ describe('kick g scaffold', () => {
     const moduleIndex = readFileSync(join(fixture, 'src/modules/widgets/widget.module.ts'), 'utf-8')
     // Regression: we previously emitted { prefix, controllers } which
     // was the legacy shape and broke the framework. The current shape
-    // must include path/router/controller — verified by the assertions
-    // below AND by the tsc test in the next case.
+    // is `{ path, controller }` — the framework derives the Express
+    // Router from the controller via `buildRoutes()` internally so
+    // the redundant `router:` field is no longer emitted.
     expect(moduleIndex).toContain("path: '/widgets'")
-    expect(moduleIndex).toContain('buildRoutes(WidgetController)')
     expect(moduleIndex).toContain('controller: WidgetController')
     // The legacy shape must NOT appear
     expect(moduleIndex).not.toContain('prefix:')

--- a/packages/cli/src/commands/codemod.ts
+++ b/packages/cli/src/commands/codemod.ts
@@ -5,9 +5,14 @@ import { migrateModulesDir, type MigrationTarget } from '../generators/migrate-m
 import { colors } from '../utils/colors'
 import { setDryRun } from '../utils/fs'
 
-/** Read --dry-run from the parent `codemod` command's options. */
+/**
+ * Read --dry-run from the merged options chain. `optsWithGlobals()`
+ * walks parent commands so a top-level `kick --dry-run codemod
+ * modules --apply` resolves correctly, not just `--dry-run` declared
+ * directly on the subcommand.
+ */
 function isDryRun(cmd: Command): boolean {
-  return (cmd.parent?.opts() as { dryRun?: boolean } | undefined)?.dryRun ?? false
+  return (cmd.optsWithGlobals() as { dryRun?: boolean }).dryRun ?? false
 }
 
 interface CodemodModulesOpts {

--- a/packages/cli/src/commands/codemod.ts
+++ b/packages/cli/src/commands/codemod.ts
@@ -1,0 +1,137 @@
+import { resolve } from 'node:path'
+import type { Command } from 'commander'
+import { loadKickConfig, resolveModuleConfig } from '../config'
+import { migrateModulesDir, type MigrationTarget } from '../generators/migrate-modules'
+import { colors } from '../utils/colors'
+import { setDryRun } from '../utils/fs'
+
+/** Read --dry-run from the parent `codemod` command's options. */
+function isDryRun(cmd: Command): boolean {
+  return (cmd.parent?.opts() as { dryRun?: boolean } | undefined)?.dryRun ?? false
+}
+
+interface CodemodModulesOpts {
+  modulesDir?: string
+  apply?: boolean
+  experimental?: boolean
+  target?: string
+  backup?: boolean
+}
+
+/**
+ * Register `kick codemod` and its subcommands. Distinct from
+ * `kick db migrate` — that's the database-migration runner;
+ * `kick codemod` is the AST-style codebase rewrite namespace.
+ *
+ * Currently exposes `kick codemod modules` (experimental) which
+ * rewrites between the two module declaration shapes:
+ *
+ *   - `class FooModule implements AppModule { ... }` (legacy)
+ *   - `defineModule({ name, build: () => ({...}) })`  (factory)
+ *
+ * Direction defaults to whatever `kick.config.ts > modules.style`
+ * resolves to (or `'define'` when unset). Override with
+ * `--target define|class`.
+ */
+export function registerCodemodCommands(program: Command): void {
+  const codemod = program
+    .command('codemod')
+    .description('Codebase migration commands (AST-style rewrites — distinct from db migrate)')
+
+  codemod
+    .command('modules')
+    .description(
+      'Rewrite module declarations between class form and the defineModule factory.\n' +
+        '  Direction defaults to `modules.style` from kick.config (or "define").\n' +
+        '  --target define|class  Override the migration direction.\n' +
+        '  --apply                Apply the changes (default: dry-run preview).\n' +
+        '  --experimental         Acknowledge that AST migration is experimental.',
+    )
+    .option('--modules-dir <dir>', 'Modules directory (default: src/modules from kick.config)')
+    .option('--apply', 'Apply the migration to disk (default: dry-run)')
+    .option('--experimental', 'Acknowledge that this command is experimental')
+    .option('--target <style>', "Migration direction — 'define' or 'class'")
+    .option('--no-backup', 'Skip the .kickjs/codemod-backups/ snapshot (default: backup on)')
+    .action(async (opts: CodemodModulesOpts, cmd: Command) => {
+      const dryRun = isDryRun(cmd) || !opts.apply
+      setDryRun(dryRun)
+
+      if (!opts.experimental) {
+        console.error(
+          '\n  ' +
+            colors.red('Error:') +
+            ' kick codemod modules is experimental — pass --experimental to acknowledge.\n' +
+            '  The regex-based rewrite handles the shapes our templates produce.\n' +
+            '  Hand-rolled modules with non-standard structures may be skipped.\n' +
+            '  Always commit before running with --apply.\n',
+        )
+        process.exit(1)
+      }
+
+      const config = await loadKickConfig(process.cwd())
+      const mc = resolveModuleConfig(config)
+      const modulesDir = resolve(opts.modulesDir ?? mc.dir ?? 'src/modules')
+
+      // Resolution order: --target flag > kick.config modules.style > 'define'
+      let target: MigrationTarget
+      if (opts.target === 'define' || opts.target === 'class') {
+        target = opts.target
+      } else if (opts.target !== undefined) {
+        console.error(
+          `\n  ${colors.red('Error:')} --target must be 'define' or 'class' (got '${opts.target}').\n`,
+        )
+        process.exit(1)
+      } else {
+        target = mc.style ?? 'define'
+      }
+
+      const arrow = colors.dim(`→ ${target}`)
+      const modeLabel = dryRun ? colors.dim('(dry-run)') : colors.bold('(applying)')
+      console.log(`\n  ${colors.bold('kick codemod modules')} ${arrow} ${modeLabel}`)
+      console.log(`  modulesDir: ${colors.dim(modulesDir)}\n`)
+
+      // Backup defaults to ON when applying. `--no-backup` flips to
+      // false (commander wires `--no-X` automatically). Dry-run skips
+      // the backup since nothing's being rewritten.
+      const backup = opts.backup !== false && !dryRun
+      const result = await migrateModulesDir(modulesDir, { dryRun, target, backup })
+
+      if (result.backupDir) {
+        const backupRel = result.backupDir
+        console.log(
+          `  ${colors.green('✓')} backup: ${colors.dim(backupRel)}\n` +
+            `    ${colors.dim('(restore: rm -rf <modulesDir> && mv "<backup>" <modulesDir>)')}\n`,
+        )
+      } else if (!dryRun && opts.backup === false) {
+        console.log(`  ${colors.dim('(--no-backup — skipping snapshot)')}\n`)
+      }
+
+      let migrated = 0
+      let skipped = 0
+      for (const file of result.files) {
+        if (file.status === 'migrated') {
+          migrated++
+          console.log(`    ${colors.green('✓')} ${file.path}`)
+        } else {
+          skipped++
+          const reasonLabel = colors.dim(`(${file.reason ?? 'skipped'})`)
+          console.log(`    ${colors.dim('-')} ${file.path} ${reasonLabel}`)
+        }
+      }
+
+      console.log()
+      if (result.indexStatus === 'migrated') {
+        console.log(`    ${colors.green('✓')} ${result.indexPath}`)
+      } else if (result.indexStatus === 'skipped') {
+        const reasonLabel = colors.dim(`(${result.indexReason ?? 'skipped'})`)
+        console.log(`    ${colors.dim('-')} ${result.indexPath} ${reasonLabel}`)
+      } else {
+        console.log(`    ${colors.dim('-')} ${result.indexPath} ${colors.dim('(not found)')}`)
+      }
+
+      const dryNote = dryRun ? colors.dim(' (dry-run — pass --apply to write)') : ''
+      console.log(
+        `\n  ${colors.bold(String(migrated))} migrated, ${colors.bold(String(skipped))} skipped${dryNote}\n`,
+      )
+    })
+}

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'node:path'
+import { relative, resolve } from 'node:path'
 import type { Command } from 'commander'
 import { listPluginGenerators, tryDispatchPluginGenerator } from '../generator-extension'
 import { mergeCliPlugins } from '../plugin'
@@ -13,6 +13,8 @@ import { generateController } from '../generators/controller'
 import { generateDto } from '../generators/dto'
 import { generateConfig } from '../generators/config'
 import { generateAgentDocs } from '../generators/agent-docs'
+import { findStyleDriftModules } from '../generators/migrate-modules'
+import { colors } from '../utils/colors'
 import { generateAuthScaffold } from '../generators/auth-scaffold'
 import { generateJob } from '../generators/job'
 import { generateScaffold, parseFields } from '../generators/scaffold'
@@ -200,6 +202,48 @@ async function runModuleGeneration(
   const pattern = opts.pattern ?? config?.pattern ?? 'ddd'
   const shouldPluralize = opts.pluralize === false ? false : (mc.pluralize ?? true)
   const tokenScope = resolveTokenScope(config, process.cwd())
+  const resolvedStyle = mc.style ?? 'define'
+
+  // Style-drift gate. When the project pins `modules.style: 'define'`
+  // (the default), refuse to add a new module if the existing
+  // codebase still has class-form modules — mixed styles are a
+  // hygiene smell. The fix is one of:
+  //
+  //   1. Run `kick codemod modules --experimental --apply` to migrate
+  //      every existing module to the `defineModule` shape.
+  //   2. Pin `modules.style: 'class'` in kick.config.ts and keep
+  //      the legacy form across the project.
+  //
+  // The gate runs only for `define`; `class` projects accept either
+  // shape since defineModule modules pass through Application's
+  // class-vs-instance discriminator at boot.
+  if (!dryRun && resolvedStyle === 'define') {
+    const drift = await findStyleDriftModules(resolve(modulesDir), 'define')
+    if (drift.length > 0) {
+      const cwd = process.cwd()
+      console.error(
+        `\n  ${colors.red('Error:')} ${drift.length} module file(s) still use the legacy ` +
+          `\`class … implements AppModule\` shape.\n` +
+          `  ${colors.dim('Project setting:')} modules.style: 'define' (default)\n\n` +
+          `  ${colors.bold('Files needing migration:')}`,
+      )
+      for (const path of drift.slice(0, 5)) {
+        console.error(`    - ${relative(cwd, path)}`)
+      }
+      if (drift.length > 5) {
+        console.error(`    … and ${drift.length - 5} more`)
+      }
+      console.error(
+        `\n  ${colors.bold('Pick one:')}\n` +
+          `    1. Migrate everything to defineModule:\n` +
+          `       ${colors.dim('$')} kick codemod modules --experimental --apply\n` +
+          `    2. Keep the class form — pin it in kick.config.ts:\n` +
+          `       ${colors.dim('// kick.config.ts')}\n` +
+          `       ${colors.dim("export default defineConfig({ modules: { style: 'class' } })")}\n`,
+      )
+      process.exit(1)
+    }
+  }
 
   const allFiles: string[] = []
   for (const name of names) {

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,4 +1,4 @@
-import { relative, resolve } from 'node:path'
+import { resolve } from 'node:path'
 import type { Command } from 'commander'
 import { listPluginGenerators, tryDispatchPluginGenerator } from '../generator-extension'
 import { mergeCliPlugins } from '../plugin'
@@ -220,15 +220,16 @@ async function runModuleGeneration(
   if (!dryRun && resolvedStyle === 'define') {
     const drift = await findStyleDriftModules(resolve(modulesDir), 'define')
     if (drift.length > 0) {
-      const cwd = process.cwd()
       console.error(
         `\n  ${colors.red('Error:')} ${drift.length} module file(s) still use the legacy ` +
           `\`class … implements AppModule\` shape.\n` +
           `  ${colors.dim('Project setting:')} modules.style: 'define' (default)\n\n` +
           `  ${colors.bold('Files needing migration:')}`,
       )
+      // Print absolute paths so adopters can cmd-click straight to
+      // the file from their terminal — relative paths break that flow.
       for (const path of drift.slice(0, 5)) {
-        console.error(`    - ${relative(cwd, path)}`)
+        console.error(`    - ${path}`)
       }
       if (drift.length > 5) {
         console.error(`    … and ${drift.length - 5} more`)

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -216,6 +216,7 @@ async function runModuleGeneration(
       pluralize: shouldPluralize,
       prismaClientPath: mc.prismaClientPath,
       tokenScope,
+      style: mc.style,
     })
     allFiles.push(...files)
   }
@@ -551,6 +552,7 @@ export function registerGenerateCommand(program: Command): void {
         noTests: opts.tests === false,
         pluralize: opts.pluralize === false ? false : (mc.pluralize ?? true),
         tokenScope,
+        style: mc.style,
       })
       console.log(`\n  Scaffolded ${name} with ${fields.length} field(s):`)
       for (const f of fields) {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -194,6 +194,26 @@ export interface ModuleConfig {
    * prismaClientPath: './generated/prisma/client'   // relative
    */
   prismaClientPath?: string
+  /**
+   * Module declaration style emitted by `kick g module` and the
+   * project scaffold.
+   *
+   * - `'define'` (default) — `defineModule({ name, build: () => ({...}) })`
+   *   factory form. Mirrors `defineAdapter` / `definePlugin` /
+   *   `defineContextDecorator`.
+   * - `'class'` — legacy `class FooModule implements AppModule { ... }`
+   *   form. Still fully supported by the framework loader; pin to this
+   *   value for projects that prefer the class shape (existing-codebase
+   *   consistency, class-decorator setups, etc).
+   *
+   * The framework runtime accepts both shapes regardless of this
+   * setting — the flag controls codegen output only. `kick g module`
+   * inserts the matching call form into `src/modules/index.ts`
+   * (`Module()` vs `Module`); `kick rm module` matches both.
+   *
+   * @default 'define'
+   */
+  style?: 'define' | 'class'
 }
 
 /** Configuration for the kick.config.ts file */
@@ -408,6 +428,18 @@ export function resolveModuleConfig(config: KickConfig | null): ModuleConfig {
     schemaDir: config.modules?.schemaDir,
     pluralize: config.modules?.pluralize,
     prismaClientPath: config.modules?.prismaClientPath,
+    style: config.modules?.style,
+  }
+  // Validate `style` — silently coerce unknown values to the default.
+  // The CLI surface only documents 'define' and 'class'; anything else
+  // is a typo (e.g. 'defineModule') we'd rather see than silently
+  // emit class form.
+  if (mc.style !== undefined && mc.style !== 'define' && mc.style !== 'class') {
+    console.warn(
+      `  Warning: modules.style '${mc.style as string}' is not a valid value ` +
+        `(expected 'define' or 'class'). Falling back to 'define'.`,
+    )
+    mc.style = 'define'
   }
 
   // Warn if a string repo value isn't a known built-in

--- a/packages/cli/src/generators/migrate-modules.ts
+++ b/packages/cli/src/generators/migrate-modules.ts
@@ -74,7 +74,12 @@ function rewriteImportsForDefine(beforeBlock: string): string {
 
 function rewriteImportsForClass(
   beforeBlock: string,
-  needs: { container: boolean; appModule: boolean; moduleRoutes: boolean },
+  needs: {
+    container: boolean
+    appModule: boolean
+    moduleRoutes: boolean
+    contributorRegistrations: boolean
+  },
 ): string {
   return beforeBlock.replace(
     /import\s*\{\s*([^}]+)\s*\}\s*from\s*'@forinda\/kickjs'/g,
@@ -92,6 +97,14 @@ function rewriteImportsForClass(
         !parts.some((p) => p === 'ModuleRoutes' || p === 'type ModuleRoutes')
       ) {
         parts.push('type ModuleRoutes')
+      }
+      if (
+        needs.contributorRegistrations &&
+        !parts.some(
+          (p) => p === 'ContributorRegistrations' || p === 'type ContributorRegistrations',
+        )
+      ) {
+        parts.push('type ContributorRegistrations')
       }
       return `import { ${parts.join(', ')} } from '@forinda/kickjs'`
     },
@@ -227,6 +240,9 @@ export function migrateDefineToClass(content: string): MigrationResult {
     container: registerBody !== null,
     appModule: true,
     moduleRoutes: true,
+    // contributors() in class form is typed as `ContributorRegistrations`,
+    // so its import must follow when the source had a contributors block.
+    contributorRegistrations: contributorsBody !== null,
   }
   const newImports = rewriteImportsForClass(beforeBlock, needs)
 
@@ -311,10 +327,10 @@ export function migrateModulesIndex(content: string, target: MigrationTarget): M
 export async function findModuleFiles(modulesDir: string): Promise<string[]> {
   const out: string[] = []
   const rootAbs = resolvePath(modulesDir)
-  await walk(rootAbs, true)
+  await walk(rootAbs, 0)
   return out
 
-  async function walk(dir: string, isRoot: boolean): Promise<void> {
+  async function walk(dir: string, depth: number): Promise<void> {
     let entries: string[]
     try {
       entries = await readdir(dir)
@@ -331,13 +347,19 @@ export async function findModuleFiles(modulesDir: string): Promise<string[]> {
         continue
       }
       if (st.isDirectory()) {
-        await walk(full, false)
+        await walk(full, depth + 1)
       } else if (name.endsWith('.module.ts')) {
         out.push(full)
-      } else if (name === 'index.ts' && !isRoot) {
-        // Older convention: module lives in `<modulesDir>/<sub>/index.ts`.
-        // The registry at `<modulesDir>/index.ts` is excluded because
-        // we only descend into it when `isRoot === false`.
+      } else if (name === 'index.ts' && depth === 1) {
+        // Older convention: module lives at
+        // `<modulesDir>/<sub>/index.ts` (depth=1, the immediate
+        // child directory's index file). Deeper `index.ts` files
+        // (e.g. `<sub>/application/index.ts` or `<sub>/domain/index.ts`)
+        // are barrel files for the DDD layout, NOT module
+        // declarations — sweeping those in would false-positive
+        // the drift gate and let the codemod rewrite unrelated code.
+        // depth=0 is the registry at `<modulesDir>/index.ts`,
+        // intentionally excluded.
         out.push(full)
       }
     }
@@ -433,11 +455,19 @@ export async function migrateModulesDir(
   const { dryRun = false, cwd = process.cwd(), target } = options
   const shouldBackup = options.backup ?? !dryRun
   const moduleFiles = await findModuleFiles(modulesDir)
+  const indexExists = await readFile(join(modulesDir, 'index.ts'), 'utf-8').then(
+    () => true,
+    () => false,
+  )
 
   // Take the backup before any rewrite so a partial-migration
-  // failure still leaves a recoverable snapshot.
+  // failure still leaves a recoverable snapshot. Snapshot when
+  // EITHER module files OR the registry index exists — registry-only
+  // rewrites (e.g. `[Module]` → `[Module()]` after every module file
+  // is already migrated) still touch the project, so they deserve
+  // the same safety net.
   let backupDir: string | null = null
-  if (shouldBackup && moduleFiles.length > 0) {
+  if (shouldBackup && (moduleFiles.length > 0 || indexExists)) {
     backupDir = makeBackupPath(cwd)
     await copyDirectory(modulesDir, backupDir)
   }

--- a/packages/cli/src/generators/migrate-modules.ts
+++ b/packages/cli/src/generators/migrate-modules.ts
@@ -1,5 +1,5 @@
 import { copyFile, mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises'
-import { dirname, join, resolve as resolvePath, sep } from 'node:path'
+import { join, resolve as resolvePath } from 'node:path'
 
 /**
  * Direction the migrator rewrites in. Resolved by the caller from
@@ -50,7 +50,7 @@ function reindent(body: string, fromOuterIndent: number, toOuterIndent: number):
 }
 
 function rewriteImportsForDefine(beforeBlock: string): string {
-  return beforeBlock.replace(
+  return beforeBlock.replaceAll(
     /import\s*\{\s*([^}]+)\s*\}\s*from\s*'@forinda\/kickjs'/g,
     (_match, names: string) => {
       const parts = names
@@ -81,7 +81,7 @@ function rewriteImportsForClass(
     contributorRegistrations: boolean
   },
 ): string {
-  return beforeBlock.replace(
+  return beforeBlock.replaceAll(
     /import\s*\{\s*([^}]+)\s*\}\s*from\s*'@forinda\/kickjs'/g,
     (_match, names: string) => {
       const parts = names
@@ -131,14 +131,14 @@ export function migrateClassToDefine(content: string): MigrationResult {
 
   const match = matches[0]
   const moduleName = match[1]
-  const classOpenIdx = match.index! + match[0].length - 1
+  const classOpenIdx = match.index + match[0].length - 1
   const classCloseIdx = findMatchingBrace(content, classOpenIdx)
   if (classCloseIdx === -1) {
     return { migrated: null, reason: 'unbalanced class braces' }
   }
 
   const classBody = content.slice(classOpenIdx + 1, classCloseIdx)
-  const beforeClass = content.slice(0, match.index!)
+  const beforeClass = content.slice(0, match.index)
   const afterClass = content.slice(classCloseIdx + 1)
 
   const registerBody = extractMethodBody(classBody, /register\s*\(([^)]*)\)\s*:\s*void\s*\{/)
@@ -195,7 +195,7 @@ export function migrateDefineToClass(content: string): MigrationResult {
 
   const match = matches[0]
   const moduleName = match[1]
-  const objOpenIdx = match.index! + match[0].length - 1
+  const objOpenIdx = match.index + match[0].length - 1
   const objCloseIdx = findMatchingBrace(content, objOpenIdx)
   if (objCloseIdx === -1) {
     return { migrated: null, reason: 'unbalanced defineModule braces' }
@@ -207,7 +207,7 @@ export function migrateDefineToClass(content: string): MigrationResult {
   }
 
   const objBody = content.slice(objOpenIdx + 1, objCloseIdx)
-  const beforeBlock = content.slice(0, match.index!)
+  const beforeBlock = content.slice(0, match.index)
   let afterIdx = callCloseIdx + 1
   while (afterIdx < content.length && (content[afterIdx] === '\n' || content[afterIdx] === '\r')) {
     afterIdx++
@@ -273,16 +273,19 @@ export function migrateModulesIndex(content: string, target: MigrationTarget): M
 
   if (target === 'define') {
     if (/\bAppModuleClass\b/.test(next)) {
-      next = next.replace(/\bAppModuleClass\b/g, 'AppModuleEntry')
+      next = next.replaceAll(/\bAppModuleClass\b/g, 'AppModuleEntry')
       changed = true
     }
+    // arrayRegex is intentionally single-match (no `/g`) — the
+    // modules array appears once per file, so we replace the first
+    // hit only and leave any non-array `[ … ]` literal alone.
     const arrayRegex = /(=\s*\[)([\s\S]*?)(])/
     const arrayMatch = arrayRegex.exec(next)
     if (arrayMatch) {
       const open = arrayMatch[1]
       const close = arrayMatch[3]
       const body = arrayMatch[2]
-      const rewritten = body.replace(/(\b\w+Module)(?!\(|\.)/g, '$1()')
+      const rewritten = body.replaceAll(/(\b\w+Module)(?![(.])/g, '$1()')
       if (rewritten !== body) {
         next = next.replace(arrayRegex, `${open}${rewritten}${close}`)
         changed = true
@@ -290,7 +293,7 @@ export function migrateModulesIndex(content: string, target: MigrationTarget): M
     }
   } else {
     if (/\bAppModuleEntry\b/.test(next)) {
-      next = next.replace(/\bAppModuleEntry\b/g, 'AppModuleClass')
+      next = next.replaceAll(/\bAppModuleEntry\b/g, 'AppModuleClass')
       changed = true
     }
     const arrayRegex = /(=\s*\[)([\s\S]*?)(])/
@@ -299,7 +302,7 @@ export function migrateModulesIndex(content: string, target: MigrationTarget): M
       const open = arrayMatch[1]
       const close = arrayMatch[3]
       const body = arrayMatch[2]
-      const rewritten = body.replace(/(\b\w+Module)\s*\(\s*\)/g, '$1')
+      const rewritten = body.replaceAll(/(\b\w+Module)\s*\(\s*\)/g, '$1')
       if (rewritten !== body) {
         next = next.replace(arrayRegex, `${open}${rewritten}${close}`)
         changed = true
@@ -431,7 +434,7 @@ async function copyDirectory(srcRoot: string, destRoot: string): Promise<number>
  * (manual; the codemod doesn't provide a revert command yet).
  */
 function makeBackupPath(projectRoot: string): string {
-  const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+  const stamp = new Date().toISOString().replaceAll(/[:.]/g, '-')
   return join(projectRoot, '.kickjs', 'codemod-backups', `${stamp}-modules`)
 }
 
@@ -553,6 +556,6 @@ export async function findStyleDriftModules(
   return drift
 }
 
-// `dirname` and `sep` are exported so tests / future helpers can
+// `dirname` and `sep` re-exported so tests / future helpers can
 // reuse them via the same import surface.
-export { dirname, sep }
+export { dirname, sep } from 'node:path'

--- a/packages/cli/src/generators/migrate-modules.ts
+++ b/packages/cli/src/generators/migrate-modules.ts
@@ -1,0 +1,524 @@
+import { copyFile, mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises'
+import { dirname, join, relative, resolve as resolvePath, sep } from 'node:path'
+
+/**
+ * Direction the migrator rewrites in. Resolved by the caller from
+ * `kick.config.ts > modules.style` (or an explicit `--target` flag),
+ * so adopters can move either direction.
+ */
+export type MigrationTarget = 'define' | 'class'
+
+export interface MigrationResult {
+  migrated: string | null
+  reason?: string
+}
+
+function findMatchingBrace(text: string, openIdx: number): number {
+  if (text[openIdx] !== '{') return -1
+  let depth = 1
+  for (let i = openIdx + 1; i < text.length; i++) {
+    const ch = text[i]
+    if (ch === '{') depth++
+    else if (ch === '}') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return -1
+}
+
+function extractMethodBody(classBody: string, methodRegex: RegExp): string | null {
+  const m = methodRegex.exec(classBody)
+  if (!m) return null
+  const openIdx = m.index + m[0].length - 1
+  const closeIdx = findMatchingBrace(classBody, openIdx)
+  if (closeIdx === -1) return null
+  return classBody.slice(openIdx + 1, closeIdx)
+}
+
+function reindent(body: string, fromOuterIndent: number, toOuterIndent: number): string {
+  const pad = ' '.repeat(toOuterIndent)
+  return body
+    .split('\n')
+    .map((line) => {
+      if (line.trim() === '') return line
+      const stripPattern = new RegExp(`^ {0,${fromOuterIndent}}`)
+      const stripped = line.replace(stripPattern, '')
+      return pad + stripped
+    })
+    .join('\n')
+}
+
+function rewriteImportsForDefine(beforeBlock: string): string {
+  return beforeBlock.replace(
+    /import\s*\{\s*([^}]+)\s*\}\s*from\s*'@forinda\/kickjs'/g,
+    (_match, names: string) => {
+      const parts = names
+        .split(',')
+        .map((p) => p.trim())
+        .filter(
+          (p) =>
+            p &&
+            p !== 'Container' &&
+            p !== 'type Container' &&
+            p !== 'type AppModule' &&
+            p !== 'AppModule' &&
+            p !== 'type ModuleRoutes' &&
+            p !== 'ModuleRoutes',
+        )
+      if (!parts.includes('defineModule')) parts.push('defineModule')
+      return `import { ${parts.join(', ')} } from '@forinda/kickjs'`
+    },
+  )
+}
+
+function rewriteImportsForClass(
+  beforeBlock: string,
+  needs: { container: boolean; appModule: boolean; moduleRoutes: boolean },
+): string {
+  return beforeBlock.replace(
+    /import\s*\{\s*([^}]+)\s*\}\s*from\s*'@forinda\/kickjs'/g,
+    (_match, names: string) => {
+      const parts = names
+        .split(',')
+        .map((p) => p.trim())
+        .filter((p) => p && p !== 'defineModule')
+      if (needs.container && !parts.includes('Container')) parts.push('Container')
+      if (needs.appModule && !parts.some((p) => p === 'AppModule' || p === 'type AppModule')) {
+        parts.push('type AppModule')
+      }
+      if (
+        needs.moduleRoutes &&
+        !parts.some((p) => p === 'ModuleRoutes' || p === 'type ModuleRoutes')
+      ) {
+        parts.push('type ModuleRoutes')
+      }
+      return `import { ${parts.join(', ')} } from '@forinda/kickjs'`
+    },
+  )
+}
+
+export function migrateClassToDefine(content: string): MigrationResult {
+  if (/\bdefineModule\s*\(/.test(content)) {
+    return { migrated: null, reason: 'already in target form' }
+  }
+
+  const classRegex = /export\s+class\s+(\w+Module)\s+implements\s+AppModule\s*\{/g
+  const matches = [...content.matchAll(classRegex)]
+
+  if (matches.length === 0) {
+    return { migrated: null, reason: 'no class form detected' }
+  }
+  if (matches.length > 1) {
+    return {
+      migrated: null,
+      reason: 'multiple module classes in one file — migrate manually',
+    }
+  }
+
+  const match = matches[0]
+  const moduleName = match[1]
+  const classOpenIdx = match.index! + match[0].length - 1
+  const classCloseIdx = findMatchingBrace(content, classOpenIdx)
+  if (classCloseIdx === -1) {
+    return { migrated: null, reason: 'unbalanced class braces' }
+  }
+
+  const classBody = content.slice(classOpenIdx + 1, classCloseIdx)
+  const beforeClass = content.slice(0, match.index!)
+  const afterClass = content.slice(classCloseIdx + 1)
+
+  const registerBody = extractMethodBody(classBody, /register\s*\(([^)]*)\)\s*:\s*void\s*\{/)
+  const contributorsBody = extractMethodBody(
+    classBody,
+    /contributors\s*\(\s*\)\s*:\s*ContributorRegistrations\s*\{/,
+  )
+  const routesBody = extractMethodBody(classBody, /routes\s*\(\s*\)\s*:\s*[A-Za-z|[\]\s]+\{/)
+  if (!routesBody) {
+    return {
+      migrated: null,
+      reason: 'routes() method missing or signature unrecognized',
+    }
+  }
+
+  const newImports = rewriteImportsForDefine(beforeClass)
+
+  let buildBody = ''
+  if (registerBody) {
+    buildBody += `    register(container) {${reindent(registerBody, 4, 6)}    },\n\n`
+  }
+  if (contributorsBody) {
+    buildBody += `    contributors() {${reindent(contributorsBody, 4, 6)}    },\n\n`
+  }
+  buildBody += `    routes() {${reindent(routesBody, 4, 6)}    },`
+
+  const declaration = `export const ${moduleName} = defineModule({
+  name: '${moduleName}',
+  build: () => ({
+${buildBody}
+  }),
+})`
+
+  return { migrated: `${newImports}${declaration}${afterClass}` }
+}
+
+export function migrateDefineToClass(content: string): MigrationResult {
+  if (/export\s+class\s+\w+Module\s+implements\s+AppModule\s*\{/.test(content)) {
+    return { migrated: null, reason: 'already in target form' }
+  }
+
+  const declRegex = /export\s+const\s+(\w+Module)\s*=\s*defineModule\s*\(\s*\{/g
+  const matches = [...content.matchAll(declRegex)]
+
+  if (matches.length === 0) {
+    return { migrated: null, reason: 'no defineModule form detected' }
+  }
+  if (matches.length > 1) {
+    return {
+      migrated: null,
+      reason: 'multiple defineModule blocks in one file — migrate manually',
+    }
+  }
+
+  const match = matches[0]
+  const moduleName = match[1]
+  const objOpenIdx = match.index! + match[0].length - 1
+  const objCloseIdx = findMatchingBrace(content, objOpenIdx)
+  if (objCloseIdx === -1) {
+    return { migrated: null, reason: 'unbalanced defineModule braces' }
+  }
+
+  const callCloseIdx = content.indexOf(')', objCloseIdx)
+  if (callCloseIdx === -1) {
+    return { migrated: null, reason: 'unbalanced defineModule call parens' }
+  }
+
+  const objBody = content.slice(objOpenIdx + 1, objCloseIdx)
+  const beforeBlock = content.slice(0, match.index!)
+  let afterIdx = callCloseIdx + 1
+  while (afterIdx < content.length && (content[afterIdx] === '\n' || content[afterIdx] === '\r')) {
+    afterIdx++
+  }
+  const afterBlock = content.slice(afterIdx)
+
+  const buildRegex = /build\s*:\s*\([^)]*\)\s*=>\s*\(\s*\{/g
+  const buildMatch = buildRegex.exec(objBody)
+  if (!buildMatch) {
+    return { migrated: null, reason: 'build: () => ({...}) not found in defineModule' }
+  }
+  const buildOpenIdx = buildMatch.index + buildMatch[0].length - 1
+  const buildCloseIdx = findMatchingBrace(objBody, buildOpenIdx)
+  if (buildCloseIdx === -1) {
+    return { migrated: null, reason: 'unbalanced build() braces' }
+  }
+  const buildBody = objBody.slice(buildOpenIdx + 1, buildCloseIdx)
+
+  const registerBody = extractMethodBody(buildBody, /register\s*\(([^)]*)\)\s*\{/)
+  const contributorsBody = extractMethodBody(buildBody, /contributors\s*\(\s*\)\s*\{/)
+  const routesBody = extractMethodBody(buildBody, /routes\s*\(\s*\)\s*\{/)
+  if (!routesBody) {
+    return {
+      migrated: null,
+      reason: 'routes() method missing inside build()',
+    }
+  }
+
+  const needs = {
+    container: registerBody !== null,
+    appModule: true,
+    moduleRoutes: true,
+  }
+  const newImports = rewriteImportsForClass(beforeBlock, needs)
+
+  let classBody = ''
+  if (registerBody !== null) {
+    classBody += `  register(container: Container): void {${reindent(registerBody, 6, 4)}  }\n\n`
+  }
+  if (contributorsBody !== null) {
+    classBody += `  contributors(): ContributorRegistrations {${reindent(contributorsBody, 6, 4)}  }\n\n`
+  }
+  classBody += `  routes(): ModuleRoutes {${reindent(routesBody, 6, 4)}  }`
+
+  const declaration = `export class ${moduleName} implements AppModule {
+${classBody}
+}
+`
+
+  return { migrated: `${newImports}${declaration}${afterBlock}` }
+}
+
+export function migrateModuleFile(content: string, target: MigrationTarget): MigrationResult {
+  return target === 'class' ? migrateDefineToClass(content) : migrateClassToDefine(content)
+}
+
+export function migrateModulesIndex(content: string, target: MigrationTarget): MigrationResult {
+  let next = content
+  let changed = false
+
+  if (target === 'define') {
+    if (/\bAppModuleClass\b/.test(next)) {
+      next = next.replace(/\bAppModuleClass\b/g, 'AppModuleEntry')
+      changed = true
+    }
+    const arrayRegex = /(=\s*\[)([\s\S]*?)(])/
+    const arrayMatch = arrayRegex.exec(next)
+    if (arrayMatch) {
+      const open = arrayMatch[1]
+      const close = arrayMatch[3]
+      const body = arrayMatch[2]
+      const rewritten = body.replace(/(\b\w+Module)(?!\(|\.)/g, '$1()')
+      if (rewritten !== body) {
+        next = next.replace(arrayRegex, `${open}${rewritten}${close}`)
+        changed = true
+      }
+    }
+  } else {
+    if (/\bAppModuleEntry\b/.test(next)) {
+      next = next.replace(/\bAppModuleEntry\b/g, 'AppModuleClass')
+      changed = true
+    }
+    const arrayRegex = /(=\s*\[)([\s\S]*?)(])/
+    const arrayMatch = arrayRegex.exec(next)
+    if (arrayMatch) {
+      const open = arrayMatch[1]
+      const close = arrayMatch[3]
+      const body = arrayMatch[2]
+      const rewritten = body.replace(/(\b\w+Module)\s*\(\s*\)/g, '$1')
+      if (rewritten !== body) {
+        next = next.replace(arrayRegex, `${open}${rewritten}${close}`)
+        changed = true
+      }
+    }
+  }
+
+  return changed ? { migrated: next } : { migrated: null, reason: 'no changes needed' }
+}
+
+/**
+ * Walk `modulesDir` recursively and collect every file that
+ * declares a module. Two patterns are recognized:
+ *
+ *   - `<modulesDir>/<sub>/<name>.module.ts` — current convention,
+ *     emitted by `kick g module`.
+ *   - `<modulesDir>/<sub>/index.ts` — older convention; the module
+ *     lives in `<sub>/index.ts` rather than a named file.
+ *
+ * `<modulesDir>/index.ts` itself is **excluded** because it's the
+ * registry (`export const modules = [...]`), not a module
+ * declaration. Same for `node_modules`, `dist`, and `.kickjs`
+ * caches.
+ */
+export async function findModuleFiles(modulesDir: string): Promise<string[]> {
+  const out: string[] = []
+  const rootAbs = resolvePath(modulesDir)
+  await walk(rootAbs, true)
+  return out
+
+  async function walk(dir: string, isRoot: boolean): Promise<void> {
+    let entries: string[]
+    try {
+      entries = await readdir(dir)
+    } catch {
+      return
+    }
+    for (const name of entries) {
+      if (name === 'node_modules' || name === 'dist' || name === '.kickjs') continue
+      const full = join(dir, name)
+      let st
+      try {
+        st = await stat(full)
+      } catch {
+        continue
+      }
+      if (st.isDirectory()) {
+        await walk(full, false)
+      } else if (name.endsWith('.module.ts')) {
+        out.push(full)
+      } else if (name === 'index.ts' && !isRoot) {
+        // Older convention: module lives in `<modulesDir>/<sub>/index.ts`.
+        // The registry at `<modulesDir>/index.ts` is excluded because
+        // we only descend into it when `isRoot === false`.
+        out.push(full)
+      }
+    }
+  }
+}
+
+export interface MigrateRunResult {
+  target: MigrationTarget
+  files: Array<{ path: string; status: 'migrated' | 'skipped'; reason?: string }>
+  indexStatus: 'migrated' | 'skipped' | 'not-found'
+  indexPath: string
+  indexReason?: string
+  /**
+   * Backup directory created before applying changes (when the
+   * caller didn't pass `dryRun: true` or `backup: false`). Always
+   * absolute; `null` when no backup was made (dry-run, no files to
+   * migrate, or backup explicitly disabled).
+   */
+  backupDir: string | null
+}
+
+/**
+ * Copy every file under `srcRoot` into `destRoot`, mirroring the
+ * directory structure. Used to snapshot `modulesDir` before the
+ * codemod rewrites in place — adopters who aren't tracking with
+ * git can revert by replacing the modulesDir with the backup.
+ *
+ * Skips `node_modules`, `dist`, and `.kickjs` to keep backup size
+ * sane. Symlinks are followed (we copy the resolved file), since
+ * the only symlink we expect inside a project's modulesDir is the
+ * test-fixture workspace link to `@forinda/kickjs` — not modules.
+ */
+async function copyDirectory(srcRoot: string, destRoot: string): Promise<number> {
+  let count = 0
+  await walk(srcRoot, destRoot)
+  return count
+
+  async function walk(src: string, dest: string): Promise<void> {
+    let entries: string[]
+    try {
+      entries = await readdir(src)
+    } catch {
+      return
+    }
+    await mkdir(dest, { recursive: true })
+    for (const name of entries) {
+      if (name === 'node_modules' || name === 'dist' || name === '.kickjs') continue
+      const srcFull = join(src, name)
+      const destFull = join(dest, name)
+      let st
+      try {
+        st = await stat(srcFull)
+      } catch {
+        continue
+      }
+      if (st.isDirectory()) {
+        await walk(srcFull, destFull)
+      } else {
+        await copyFile(srcFull, destFull)
+        count++
+      }
+    }
+  }
+}
+
+/**
+ * Build a timestamped backup directory under `<projectRoot>/.kickjs/codemod-backups/<isoStamp>-modules/`.
+ * Returns the absolute path. Adopters revert by `rm -rf <modulesDir>; mv <backup> <modulesDir>`
+ * (manual; the codemod doesn't provide a revert command yet).
+ */
+function makeBackupPath(projectRoot: string): string {
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+  return join(projectRoot, '.kickjs', 'codemod-backups', `${stamp}-modules`)
+}
+
+export interface MigrateModulesDirOptions {
+  dryRun?: boolean
+  cwd?: string
+  target: MigrationTarget
+  /**
+   * Snapshot `modulesDir` to a timestamped backup folder before
+   * rewriting. Defaults to `true` for `--apply` runs (catches
+   * adopters not tracking with git); `false` for `dryRun: true`
+   * (nothing is rewritten so a backup is moot).
+   */
+  backup?: boolean
+}
+
+export async function migrateModulesDir(
+  modulesDir: string,
+  options: MigrateModulesDirOptions,
+): Promise<MigrateRunResult> {
+  const { dryRun = false, cwd = process.cwd(), target } = options
+  const shouldBackup = options.backup ?? !dryRun
+  const moduleFiles = await findModuleFiles(modulesDir)
+
+  // Take the backup before any rewrite so a partial-migration
+  // failure still leaves a recoverable snapshot.
+  let backupDir: string | null = null
+  if (shouldBackup && moduleFiles.length > 0) {
+    backupDir = makeBackupPath(cwd)
+    await copyDirectory(modulesDir, backupDir)
+  }
+
+  const files: MigrateRunResult['files'] = []
+
+  for (const path of moduleFiles) {
+    const content = await readFile(path, 'utf-8')
+    const result = migrateModuleFile(content, target)
+    if (result.migrated == null) {
+      files.push({ path: relative(cwd, path), status: 'skipped', reason: result.reason })
+      continue
+    }
+    if (!dryRun) {
+      await writeFile(path, result.migrated, 'utf-8')
+    }
+    files.push({ path: relative(cwd, path), status: 'migrated' })
+  }
+
+  const indexPath = join(modulesDir, 'index.ts')
+  let indexContent: string | null = null
+  try {
+    indexContent = await readFile(indexPath, 'utf-8')
+  } catch {
+    return {
+      target,
+      files,
+      indexStatus: 'not-found',
+      indexPath: relative(cwd, indexPath),
+      backupDir,
+    }
+  }
+
+  const indexResult = migrateModulesIndex(indexContent, target)
+  if (indexResult.migrated == null) {
+    return {
+      target,
+      files,
+      indexStatus: 'skipped',
+      indexPath: relative(cwd, indexPath),
+      indexReason: indexResult.reason,
+      backupDir,
+    }
+  }
+  if (!dryRun) {
+    await writeFile(indexPath, indexResult.migrated, 'utf-8')
+  }
+  return {
+    target,
+    files,
+    indexStatus: 'migrated',
+    indexPath: relative(cwd, indexPath),
+    backupDir,
+  }
+}
+
+/**
+ * Quick scan for the `kick g module` gate: returns the list of
+ * module-declaration files under `modulesDir` whose shape doesn't
+ * match `expectedStyle`.
+ *
+ * Inspects both `*.module.ts` files AND legacy `<sub>/index.ts`
+ * files via {@link findModuleFiles}.
+ */
+export async function findStyleDriftModules(
+  modulesDir: string,
+  expectedStyle: MigrationTarget,
+): Promise<string[]> {
+  const moduleFiles = await findModuleFiles(modulesDir)
+  const drift: string[] = []
+  const driftPattern =
+    expectedStyle === 'define'
+      ? /export\s+class\s+\w+Module\s+implements\s+AppModule\s*\{/
+      : /export\s+const\s+\w+Module\s*=\s*defineModule\s*\(/
+  for (const path of moduleFiles) {
+    const content = await readFile(path, 'utf-8')
+    if (driftPattern.test(content)) drift.push(path)
+  }
+  return drift
+}
+
+// `dirname` and `sep` are exported so tests / future helpers can
+// reuse them via the same import surface.
+export { dirname, sep }

--- a/packages/cli/src/generators/migrate-modules.ts
+++ b/packages/cli/src/generators/migrate-modules.ts
@@ -1,5 +1,5 @@
 import { copyFile, mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises'
-import { dirname, join, relative, resolve as resolvePath, sep } from 'node:path'
+import { dirname, join, resolve as resolvePath, sep } from 'node:path'
 
 /**
  * Direction the migrator rewrites in. Resolved by the caller from
@@ -444,17 +444,21 @@ export async function migrateModulesDir(
 
   const files: MigrateRunResult['files'] = []
 
+  // Absolute paths in `files[].path` and `indexPath` so adopters can
+  // cmd-click straight to the file from terminal output. The `cwd`
+  // option is no longer needed here but stays in the option type for
+  // backwards-compatibility with callers that pass it.
   for (const path of moduleFiles) {
     const content = await readFile(path, 'utf-8')
     const result = migrateModuleFile(content, target)
     if (result.migrated == null) {
-      files.push({ path: relative(cwd, path), status: 'skipped', reason: result.reason })
+      files.push({ path, status: 'skipped', reason: result.reason })
       continue
     }
     if (!dryRun) {
       await writeFile(path, result.migrated, 'utf-8')
     }
-    files.push({ path: relative(cwd, path), status: 'migrated' })
+    files.push({ path, status: 'migrated' })
   }
 
   const indexPath = join(modulesDir, 'index.ts')
@@ -466,7 +470,7 @@ export async function migrateModulesDir(
       target,
       files,
       indexStatus: 'not-found',
-      indexPath: relative(cwd, indexPath),
+      indexPath,
       backupDir,
     }
   }
@@ -477,7 +481,7 @@ export async function migrateModulesDir(
       target,
       files,
       indexStatus: 'skipped',
-      indexPath: relative(cwd, indexPath),
+      indexPath,
       indexReason: indexResult.reason,
       backupDir,
     }
@@ -489,7 +493,7 @@ export async function migrateModulesDir(
     target,
     files,
     indexStatus: 'migrated',
-    indexPath: relative(cwd, indexPath),
+    indexPath,
     backupDir,
   }
 }

--- a/packages/cli/src/generators/module.ts
+++ b/packages/cli/src/generators/module.ts
@@ -5,6 +5,7 @@ import { colors } from '../utils/colors'
 import { toPascalCase, toKebabCase, pluralize, pluralizePascal } from '../utils/naming'
 import { readFile, writeFile } from 'node:fs/promises'
 import type { ProjectPattern, RepoTypeConfig } from '../config'
+import type { ModuleStyle } from './templates/types'
 import {
   generateMinimalFiles,
   generateRestFiles,
@@ -45,6 +46,12 @@ interface GenerateModuleOptions {
    * without a config in tests/fixtures.
    */
   tokenScope?: string
+  /**
+   * Module declaration style — `'define'` (factory, default) or
+   * `'class'` (legacy). Resolved by the orchestrating command from
+   * `kick.config.ts > modules.style`.
+   */
+  style?: ModuleStyle
 }
 
 /**
@@ -103,6 +110,7 @@ export async function generateModule(options: GenerateModuleOptions): Promise<st
     noTests: noTests ?? false,
     prismaClientPath: options.prismaClientPath ?? '@prisma/client',
     tokenScope: options.tokenScope ?? 'app',
+    style: options.style ?? 'define',
     write,
     files,
   }
@@ -125,7 +133,7 @@ export async function generateModule(options: GenerateModuleOptions): Promise<st
 
   // Auto-register in modules index (all patterns need this)
   if (!dryRun) {
-    await autoRegisterModule(modulesDir, pascal, plural, kebab)
+    await autoRegisterModule(modulesDir, pascal, plural, kebab, ctx.style)
   }
 
   return files
@@ -139,10 +147,17 @@ async function autoRegisterModule(
   pascal: string,
   plural: string,
   kebab: string,
+  style: ModuleStyle = 'define',
 ): Promise<void> {
   const indexPath = join(modulesDir, 'index.ts')
   const exists = await fileExists(indexPath)
   const importPath = `./${plural}/${kebab}.module`
+  // `defineModule` factories are called at the registration site
+  // (`${pascal}Module()`); legacy class modules are passed by reference
+  // (`${pascal}Module`). Application's loader discriminates class vs
+  // instance at boot, so both forms work — `style` only controls what
+  // the orchestrator emits.
+  const entryToken = style === 'class' ? `${pascal}Module` : `${pascal}Module()`
 
   if (!exists) {
     await writeFileSafe(
@@ -150,7 +165,7 @@ async function autoRegisterModule(
       `import type { AppModuleEntry } from '@forinda/kickjs'
 import { ${pascal}Module } from '${importPath}'
 
-export const modules: AppModuleEntry[] = [${pascal}Module()]
+export const modules: AppModuleEntry[] = [${entryToken}]
 `,
     )
     return
@@ -171,19 +186,18 @@ export const modules: AppModuleEntry[] = [${pascal}Module()]
     }
 
     // Add to modules array — handle both empty and existing entries.
-    // defineModule modules are called as factories at the registration
-    // site (`${pascal}Module()`), so emit the call form. Legacy class
-    // modules without `()` continue to work because Application's loader
-    // discriminates class vs instance at boot time.
+    // The entry shape (`Module()` vs `Module`) follows the resolved
+    // `style`. `kick rm module` matches both, so the project can mix
+    // styles freely if a user toggles the flag mid-project.
     content = content.replace(/(=\s*\[)([\s\S]*?)(])/, (_match, open, existing, close) => {
       const trimmed = existing.trim()
       if (!trimmed) {
         // Empty array: `= []`
-        return `${open}${pascal}Module()${close}`
+        return `${open}${entryToken}${close}`
       }
       // Existing entries: append with comma
       const needsComma = trimmed.endsWith(',') ? '' : ','
-      return `${open}${existing.trimEnd()}${needsComma} ${pascal}Module()${close}`
+      return `${open}${existing.trimEnd()}${needsComma} ${entryToken}${close}`
     })
   }
 

--- a/packages/cli/src/generators/patterns/cqrs.ts
+++ b/packages/cli/src/generators/patterns/cqrs.ts
@@ -29,11 +29,12 @@ export async function generateCqrsFiles(ctx: ModuleContext): Promise<void> {
     noTests,
     prismaClientPath,
     tokenScope,
+    style,
     write,
   } = ctx
 
   // Module file (named `<kebab>.module.ts` so Vite's module-discovery plugin picks it up)
-  await write(`${kebab}.module.ts`, generateCqrsModuleIndex({ pascal, kebab, plural, repo }))
+  await write(`${kebab}.module.ts`, generateCqrsModuleIndex({ pascal, kebab, plural, repo, style }))
 
   // Constants
   await write(`${kebab}.constants.ts`, generateRestConstants({ pascal, kebab }))

--- a/packages/cli/src/generators/patterns/ddd.ts
+++ b/packages/cli/src/generators/patterns/ddd.ts
@@ -32,11 +32,12 @@ export async function generateDddFiles(ctx: ModuleContext): Promise<void> {
     noTests,
     prismaClientPath,
     tokenScope,
+    style,
     write,
   } = ctx
 
   // Module file (named `<kebab>.module.ts` so Vite's module-discovery plugin picks it up)
-  await write(`${kebab}.module.ts`, generateModuleIndex({ pascal, kebab, plural, repo }))
+  await write(`${kebab}.module.ts`, generateModuleIndex({ pascal, kebab, plural, repo, style }))
 
   // Constants — use Drizzle-specific type-safe config when repo is drizzle
   await write(

--- a/packages/cli/src/generators/patterns/minimal.ts
+++ b/packages/cli/src/generators/patterns/minimal.ts
@@ -2,10 +2,10 @@ import type { ModuleContext } from './types'
 import { generateMinimalModuleIndex } from '../templates'
 
 export async function generateMinimalFiles(ctx: ModuleContext): Promise<void> {
-  const { pascal, kebab, plural, write } = ctx
+  const { pascal, kebab, plural, style, write } = ctx
 
   // Module file (named `<kebab>.module.ts` so Vite's module-discovery plugin picks it up)
-  await write(`${kebab}.module.ts`, generateMinimalModuleIndex({ pascal, kebab, plural }))
+  await write(`${kebab}.module.ts`, generateMinimalModuleIndex({ pascal, kebab, plural, style }))
 
   await write(
     `${kebab}.controller.ts`,

--- a/packages/cli/src/generators/patterns/rest.ts
+++ b/packages/cli/src/generators/patterns/rest.ts
@@ -27,11 +27,12 @@ export async function generateRestFiles(ctx: ModuleContext): Promise<void> {
     noTests,
     prismaClientPath,
     tokenScope,
+    style,
     write,
   } = ctx
 
   // Module file (named `<kebab>.module.ts` so Vite's module-discovery plugin picks it up)
-  await write(`${kebab}.module.ts`, generateRestModuleIndex({ pascal, kebab, plural, repo }))
+  await write(`${kebab}.module.ts`, generateRestModuleIndex({ pascal, kebab, plural, repo, style }))
 
   // Constants
   await write(`${kebab}.constants.ts`, generateRestConstants({ pascal, kebab }))

--- a/packages/cli/src/generators/patterns/types.ts
+++ b/packages/cli/src/generators/patterns/types.ts
@@ -1,4 +1,5 @@
 import type { RepoType } from '../module'
+import type { ModuleStyle } from '../templates/types'
 
 export interface ModuleContext {
   kebab: string
@@ -16,6 +17,13 @@ export interface ModuleContext {
    * template that emits a token. Default `'app'`.
    */
   tokenScope: string
+  /**
+   * Module declaration style — `'define'` (factory, default) or
+   * `'class'` (legacy). Resolved by the orchestrating command from
+   * `kick.config.ts > modules.style`. Threaded into every module-index
+   * template that emits the declaration.
+   */
+  style: ModuleStyle
   write: (relativePath: string, content: string) => Promise<void>
   files: string[]
 }

--- a/packages/cli/src/generators/scaffold.ts
+++ b/packages/cli/src/generators/scaffold.ts
@@ -131,6 +131,12 @@ interface ScaffoldOptions {
    * callers stay backward-compatible.
    */
   tokenScope?: string
+  /**
+   * Module declaration style — `'define'` (factory) or `'class'`
+   * (legacy). Defaults to `'define'`. Resolved by the caller from
+   * `kick.config.ts > modules.style`.
+   */
+  style?: 'define' | 'class'
 }
 
 export async function generateScaffold(options: ScaffoldOptions): Promise<string[]> {
@@ -142,6 +148,7 @@ export async function generateScaffold(options: ScaffoldOptions): Promise<string
     noTests: _noTests,
     repo = 'inmemory',
     tokenScope = 'app',
+    style = 'define',
   } = options
   const shouldPluralize = options.pluralize !== false
   const kebab = toKebabCase(name)
@@ -160,7 +167,7 @@ export async function generateScaffold(options: ScaffoldOptions): Promise<string
   }
 
   // ── Module file (named `<kebab>.module.ts` so Vite's module-discovery plugin picks it up)
-  await write(`${kebab}.module.ts`, genModuleIndex(pascal, kebab, plural))
+  await write(`${kebab}.module.ts`, genModuleIndex(pascal, kebab, plural, style))
 
   // ── Constants
   await write('constants.ts', genConstants(pascal, fields))
@@ -206,7 +213,7 @@ export async function generateScaffold(options: ScaffoldOptions): Promise<string
   }
 
   // ── Auto-register in modules index
-  await autoRegisterModule(modulesDir, pascal, plural, kebab)
+  await autoRegisterModule(modulesDir, pascal, plural, kebab, style)
 
   return files
 }
@@ -418,9 +425,13 @@ export class ${pascal}Id {
 
 // These reuse the same patterns as the existing module generator
 
-function genModuleIndex(pascal: string, kebab: string, plural: string): string {
-  return `import { defineModule } from '@forinda/kickjs'
-import { ${pascal}Controller } from './presentation/${kebab}.controller'
+function genModuleIndex(
+  pascal: string,
+  kebab: string,
+  plural: string,
+  style: 'define' | 'class' = 'define',
+): string {
+  const repoImports = `import { ${pascal}Controller } from './presentation/${kebab}.controller'
 import { ${pascal.toUpperCase()}_REPOSITORY } from './domain/repositories/${kebab}.repository'
 import { InMemory${pascal}Repository } from './infrastructure/repositories/in-memory-${kebab}.repository'
 
@@ -429,7 +440,50 @@ import { InMemory${pascal}Repository } from './infrastructure/repositories/in-me
 import.meta.glob(
   ['./domain/services/**/*.ts', './application/use-cases/**/*.ts', '!./**/*.test.ts'],
   { eager: true },
-)
+)`
+
+  const routesDoc = `    /**
+     * Declare HTTP routes. Pass \`controller\` and the framework
+     * derives the Express Router via \`buildRoutes()\`. Return an array
+     * to mount multiple route sets — each entry can override the API
+     * version with a \`version\` field:
+     *
+     *   return [
+     *     { path: '/${plural}', version: 1, controller: ${pascal}V1Controller },
+     *     { path: '/${plural}', version: 2, controller: ${pascal}V2Controller },
+     *   ]
+     */`
+
+  if (style === 'class') {
+    return `import { Container, type AppModule, type ModuleRoutes } from '@forinda/kickjs'
+${repoImports}
+
+export class ${pascal}Module implements AppModule {
+  /**
+   * Bind the repository token to its concrete implementation.
+   * Decorator-managed classes (@Service, @Controller, @Repository) are
+   * registered automatically — only token-to-impl bindings need to live here.
+   */
+  register(container: Container): void {
+    container.registerFactory(
+      ${pascal.toUpperCase()}_REPOSITORY,
+      () => container.resolve(InMemory${pascal}Repository),
+    )
+  }
+
+${routesDoc.replace(/^ {4}/gm, '  ').replace(/^ {6}/gm, '    ')}
+  routes(): ModuleRoutes {
+    return {
+      path: '/${plural}',
+      controller: ${pascal}Controller,
+    }
+  }
+}
+`
+  }
+
+  return `import { defineModule } from '@forinda/kickjs'
+${repoImports}
 
 export const ${pascal}Module = defineModule({
   name: '${pascal}Module',
@@ -446,18 +500,7 @@ export const ${pascal}Module = defineModule({
       )
     },
 
-    /**
-     * Declare HTTP routes. Pass \`controller\` and the framework
-     * derives the Express Router via \`buildRoutes()\` and uses the
-     * same controller for OpenAPI spec generation. Return an array
-     * to mount multiple route sets under the same module — each entry
-     * can override the API version with a \`version\` field:
-     *
-     *   return [
-     *     { path: '/${plural}', version: 1, controller: ${pascal}V1Controller },
-     *     { path: '/${plural}', version: 2, controller: ${pascal}V2Controller },
-     *   ]
-     */
+${routesDoc}
     routes() {
       return {
         path: '/${plural}',
@@ -669,15 +712,20 @@ async function autoRegisterModule(
   pascal: string,
   plural: string,
   kebab: string,
+  style: 'define' | 'class' = 'define',
 ): Promise<void> {
   const indexPath = join(modulesDir, 'index.ts')
   const exists = await fileExists(indexPath)
   const importPath = `./${plural}/${kebab}.module`
+  // `defineModule` factories are called at the registration site;
+  // legacy class modules are passed by reference. Application's
+  // loader discriminates at boot, so both shapes work.
+  const entryToken = style === 'class' ? `${pascal}Module` : `${pascal}Module()`
 
   if (!exists) {
     await writeFileSafe(
       indexPath,
-      `import type { AppModuleEntry } from '@forinda/kickjs'\nimport { ${pascal}Module } from '${importPath}'\n\nexport const modules: AppModuleEntry[] = [${pascal}Module()]\n`,
+      `import type { AppModuleEntry } from '@forinda/kickjs'\nimport { ${pascal}Module } from '${importPath}'\n\nexport const modules: AppModuleEntry[] = [${entryToken}]\n`,
     )
     return
   }
@@ -694,13 +742,11 @@ async function autoRegisterModule(
       content = importLine + '\n' + content
     }
 
-    // defineModule emits a factory; call it at the registration site so
-    // bootstrap receives the module instance rather than the factory itself.
     content = content.replace(/(=\s*\[)([\s\S]*?)(])/, (_match, open, existing, close) => {
       const trimmed = existing.trim()
-      if (!trimmed) return `${open}${pascal}Module()${close}`
+      if (!trimmed) return `${open}${entryToken}${close}`
       const needsComma = trimmed.endsWith(',') ? '' : ','
-      return `${open}${existing.trimEnd()}${needsComma} ${pascal}Module()${close}`
+      return `${open}${existing.trimEnd()}${needsComma} ${entryToken}${close}`
     })
   }
 

--- a/packages/cli/src/generators/templates/cqrs.ts
+++ b/packages/cli/src/generators/templates/cqrs.ts
@@ -2,7 +2,7 @@ import type { TemplateContext } from './types'
 
 /** CQRS module index — commands, queries, events, WebSocket + queue integration */
 export function generateCqrsModuleIndex(ctx: TemplateContext & { repo: string }): string {
-  const { pascal, kebab, plural = '', repo } = ctx
+  const { pascal, kebab, plural = '', repo, style } = ctx
   const repoClassMap: Record<string, string> = {
     inmemory: `InMemory${pascal}Repository`,
     drizzle: `Drizzle${pascal}Repository`,
@@ -15,8 +15,9 @@ export function generateCqrsModuleIndex(ctx: TemplateContext & { repo: string })
   }
   const repoClass = repoClassMap[repo] ?? repoClassMap.inmemory
   const repoFile = repoFileMap[repo] ?? repoFileMap.inmemory
+  const resolvedStyle = style ?? 'define'
 
-  return `/**
+  const header = `/**
  * ${pascal} Module — CQRS Pattern
  *
  * Separates read (queries) and write (commands) operations.
@@ -28,9 +29,9 @@ export function generateCqrsModuleIndex(ctx: TemplateContext & { repo: string })
  *   queries/        — Read operations (get, list)
  *   events/         — Domain events + handlers (WS broadcast, queue dispatch)
  *   dtos/           — Request/response schemas
- */
-import { defineModule } from '@forinda/kickjs'
-import { ${pascal.toUpperCase()}_REPOSITORY } from './${kebab}.repository'
+ */`
+
+  const repoImports = `import { ${pascal.toUpperCase()}_REPOSITORY } from './${kebab}.repository'
 import { ${repoClass} } from './${repoFile}.repository'
 import { ${pascal}Controller } from './${kebab}.controller'
 
@@ -43,7 +44,47 @@ import.meta.glob(
     '!./**/*.test.ts',
   ],
   { eager: true },
-)
+)`
+
+  const routesDoc = `    /**
+     * Declare HTTP routes. Pass \`controller\` and the framework
+     * derives the Express Router via \`buildRoutes()\` and uses the
+     * same controller for OpenAPI spec generation. Return an array
+     * to mount multiple route sets — each entry can override the API
+     * version with a \`version\` field:
+     *
+     *   return [
+     *     { path: '/${plural}', version: 1, controller: ${pascal}V1Controller },
+     *     { path: '/${plural}', version: 2, controller: ${pascal}V2Controller },
+     *   ]
+     */`
+
+  if (resolvedStyle === 'class') {
+    return `${header}
+import { Container, type AppModule, type ModuleRoutes } from '@forinda/kickjs'
+${repoImports}
+
+export class ${pascal}Module implements AppModule {
+  register(container: Container): void {
+    container.registerFactory(${pascal.toUpperCase()}_REPOSITORY, () =>
+      container.resolve(${repoClass}),
+    )
+  }
+
+${routesDoc.replace(/^ {4}/gm, '  ').replace(/^ {6}/gm, '    ')}
+  routes(): ModuleRoutes {
+    return {
+      path: '/${plural}',
+      controller: ${pascal}Controller,
+    }
+  }
+}
+`
+  }
+
+  return `${header}
+import { defineModule } from '@forinda/kickjs'
+${repoImports}
 
 export const ${pascal}Module = defineModule({
   name: '${pascal}Module',
@@ -54,20 +95,7 @@ export const ${pascal}Module = defineModule({
       )
     },
 
-    /**
-     * Declare HTTP routes. Pass \`controller\` and the framework
-     * derives the Express Router via \`buildRoutes()\` and uses the
-     * same controller for OpenAPI spec generation. Return an array
-     * to mount multiple route sets under the same module (side-by-side
-     * v1 + v2 controllers, admin surfaces). Each entry can override
-     * the API version with a \`version\` field — the mount path becomes
-     * \`/{apiPrefix}/v{version}{path}\`:
-     *
-     *   return [
-     *     { path: '/${plural}', version: 1, controller: ${pascal}V1Controller },
-     *     { path: '/${plural}', version: 2, controller: ${pascal}V2Controller },
-     *   ]
-     */
+${routesDoc}
     routes() {
       return {
         path: '/${plural}',

--- a/packages/cli/src/generators/templates/module-index.ts
+++ b/packages/cli/src/generators/templates/module-index.ts
@@ -1,5 +1,5 @@
 import type { RepoType } from '../module'
-import type { TemplateContext } from './types'
+import type { ModuleStyle, TemplateContext } from './types'
 
 const repoLabelMap: Record<string, string> = {
   inmemory: 'in-memory',
@@ -39,12 +39,18 @@ function repoMaps(pascal: string, kebab: string, repo: RepoType) {
   }
 }
 
+/** Resolve the style flag, defaulting to 'define' for new code. */
+function resolveStyle(style?: ModuleStyle): ModuleStyle {
+  return style ?? 'define'
+}
+
 /** DDD module index — nested folders, use-cases, domain services */
 export function generateModuleIndex(ctx: TemplateContext & { repo: RepoType }): string {
-  const { pascal, kebab, plural = '', repo } = ctx
+  const { pascal, kebab, plural = '', repo, style } = ctx
   const { repoClass, repoFile } = repoMaps(pascal, kebab, repo)
+  const resolvedStyle = resolveStyle(style)
 
-  return `/**
+  const header = `/**
  * ${pascal} Module
  *
  * Self-contained feature module following Domain-Driven Design (DDD).
@@ -55,9 +61,9 @@ export function generateModuleIndex(ctx: TemplateContext & { repo: RepoType }): 
  *   application/     — Use cases (orchestration) and DTOs (validation)
  *   domain/          — Entities, value objects, repository interfaces, domain services
  *   infrastructure/  — Repository implementations (currently ${repoLabel(repo)})
- */
-import { defineModule } from '@forinda/kickjs'
-import { ${pascal.toUpperCase()}_REPOSITORY } from './domain/repositories/${kebab}.repository'
+ */`
+
+  const repoImports = `import { ${pascal.toUpperCase()}_REPOSITORY } from './domain/repositories/${kebab}.repository'
 import { ${repoClass} } from './infrastructure/repositories/${repoFile}.repository'
 import { ${pascal}Controller } from './presentation/${kebab}.controller'
 
@@ -65,23 +71,9 @@ import { ${pascal}Controller } from './presentation/${kebab}.controller'
 import.meta.glob(
   ['./domain/services/**/*.ts', './application/use-cases/**/*.ts', '!./**/*.test.ts'],
   { eager: true },
-)
+)`
 
-export const ${pascal}Module = defineModule({
-  name: '${pascal}Module',
-  build: () => ({
-    /**
-     * Register module dependencies in the DI container.
-     * Bind repository interface tokens to their implementations here.
-     * Currently wired to ${repoLabel(repo)}. To swap implementations, change the factory target.
-     */
-    register(container) {
-      container.registerFactory(${pascal.toUpperCase()}_REPOSITORY, () =>
-        container.resolve(${repoClass}),
-      )
-    },
-
-    /**
+  const routesDoc = `    /**
      * Declare HTTP routes for this module.
      *
      * The path is prefixed with the global apiPrefix and version
@@ -98,7 +90,55 @@ export const ${pascal}Module = defineModule({
      *     { path: '/${plural}', version: 1, controller: ${pascal}V1Controller },
      *     { path: '/${plural}', version: 2, controller: ${pascal}V2Controller },
      *   ]
+     */`
+
+  if (resolvedStyle === 'class') {
+    return `${header}
+import { Container, type AppModule, type ModuleRoutes } from '@forinda/kickjs'
+${repoImports}
+
+export class ${pascal}Module implements AppModule {
+  /**
+   * Register module dependencies in the DI container.
+   * Bind repository interface tokens to their implementations here.
+   * Currently wired to ${repoLabel(repo)}. To swap implementations, change the factory target.
+   */
+  register(container: Container): void {
+    container.registerFactory(${pascal.toUpperCase()}_REPOSITORY, () =>
+      container.resolve(${repoClass}),
+    )
+  }
+
+${routesDoc.replace(/^ {4}/gm, '  ').replace(/^ {6}/gm, '    ')}
+  routes(): ModuleRoutes {
+    return {
+      path: '/${plural}',
+      controller: ${pascal}Controller,
+    }
+  }
+}
+`
+  }
+
+  return `${header}
+import { defineModule } from '@forinda/kickjs'
+${repoImports}
+
+export const ${pascal}Module = defineModule({
+  name: '${pascal}Module',
+  build: () => ({
+    /**
+     * Register module dependencies in the DI container.
+     * Bind repository interface tokens to their implementations here.
+     * Currently wired to ${repoLabel(repo)}. To swap implementations, change the factory target.
      */
+    register(container) {
+      container.registerFactory(${pascal.toUpperCase()}_REPOSITORY, () =>
+        container.resolve(${repoClass}),
+      )
+    },
+
+${routesDoc}
     routes() {
       return {
         path: '/${plural}',
@@ -112,10 +152,11 @@ export const ${pascal}Module = defineModule({
 
 /** REST module index — flat folder, service + controller, no use-cases */
 export function generateRestModuleIndex(ctx: TemplateContext & { repo: RepoType }): string {
-  const { pascal, kebab, plural = '', repo } = ctx
+  const { pascal, kebab, plural = '', repo, style } = ctx
   const { repoClass, repoFile } = repoMaps(pascal, kebab, repo)
+  const resolvedStyle = resolveStyle(style)
 
-  return `/**
+  const header = `/**
  * ${pascal} Module
  *
  * REST module with a flat folder structure.
@@ -127,14 +168,58 @@ export function generateRestModuleIndex(ctx: TemplateContext & { repo: RepoType 
  *   ${kebab}.repository.ts  — Repository interface
  *   ${repoFile}.repository.ts — Repository implementation
  *   dtos/                   — Request/response schemas
- */
-import { defineModule } from '@forinda/kickjs'
-import { ${pascal.toUpperCase()}_REPOSITORY } from './${kebab}.repository'
+ */`
+
+  const repoImports = `import { ${pascal.toUpperCase()}_REPOSITORY } from './${kebab}.repository'
 import { ${repoClass} } from './${repoFile}.repository'
 import { ${pascal}Controller } from './${kebab}.controller'
 
 // Eagerly load decorated classes so @Service()/@Repository() decorators register in the DI container
-import.meta.glob(['./**/*.service.ts', './**/*.repository.ts', '!./**/*.test.ts'], { eager: true })
+import.meta.glob(['./**/*.service.ts', './**/*.repository.ts', '!./**/*.test.ts'], { eager: true })`
+
+  const routesDoc = `    /**
+     * Declare HTTP routes for this module.
+     *
+     * Pass \`controller\` and the framework derives the Express
+     * Router via \`buildRoutes()\` and uses the same controller for
+     * OpenAPI spec generation through SwaggerAdapter.
+     *
+     * Return an **array** to mount multiple route sets under the
+     * same module (side-by-side v1 + v2 controllers, admin surfaces).
+     * Each entry can override the API version with a \`version\` field:
+     *
+     *   return [
+     *     { path: '/${plural}', version: 1, controller: ${pascal}V1Controller },
+     *     { path: '/${plural}', version: 2, controller: ${pascal}V2Controller },
+     *   ]
+     */`
+
+  if (resolvedStyle === 'class') {
+    return `${header}
+import { Container, type AppModule, type ModuleRoutes } from '@forinda/kickjs'
+${repoImports}
+
+export class ${pascal}Module implements AppModule {
+  register(container: Container): void {
+    container.registerFactory(${pascal.toUpperCase()}_REPOSITORY, () =>
+      container.resolve(${repoClass}),
+    )
+  }
+
+${routesDoc.replace(/^ {4}/gm, '  ').replace(/^ {6}/gm, '    ')}
+  routes(): ModuleRoutes {
+    return {
+      path: '/${plural}',
+      controller: ${pascal}Controller,
+    }
+  }
+}
+`
+  }
+
+  return `${header}
+import { defineModule } from '@forinda/kickjs'
+${repoImports}
 
 export const ${pascal}Module = defineModule({
   name: '${pascal}Module',
@@ -145,24 +230,7 @@ export const ${pascal}Module = defineModule({
       )
     },
 
-    /**
-     * Declare HTTP routes for this module.
-     *
-     * The path is prefixed with the global apiPrefix and version
-     * (e.g. /api/v1/${plural}). Pass \`controller\` and the framework
-     * derives the Express Router via \`buildRoutes()\` and uses the
-     * same controller for OpenAPI spec generation through SwaggerAdapter.
-     *
-     * Return an **array** to mount multiple route sets under the
-     * same module (side-by-side v1 + v2 controllers, admin surfaces).
-     * Each entry can override the API version with a \`version\` field —
-     * the mount path becomes \`/{apiPrefix}/v{version}{path}\`:
-     *
-     *   return [
-     *     { path: '/${plural}', version: 1, controller: ${pascal}V1Controller },
-     *     { path: '/${plural}', version: 2, controller: ${pascal}V2Controller },
-     *   ]
-     */
+${routesDoc}
     routes() {
       return {
         path: '/${plural}',
@@ -176,25 +244,44 @@ export const ${pascal}Module = defineModule({
 
 /** Minimal module index — just controller, no service/repo */
 export function generateMinimalModuleIndex(ctx: TemplateContext): string {
-  const { pascal, kebab, plural = '' } = ctx
+  const { pascal, kebab, plural = '', style } = ctx
+  const resolvedStyle = resolveStyle(style)
+
+  const routesDoc = `    /**
+     * Pass \`controller\` and the framework derives the Express
+     * Router via \`buildRoutes()\`. Return an array to mount multiple
+     * route sets — each entry can override the API version with a
+     * \`version\` field:
+     *
+     *   return [
+     *     { path: '/${plural}', version: 1, controller: ${pascal}V1Controller },
+     *     { path: '/${plural}', version: 2, controller: ${pascal}V2Controller },
+     *   ]
+     */`
+
+  if (resolvedStyle === 'class') {
+    return `import { type AppModule, type ModuleRoutes } from '@forinda/kickjs'
+import { ${pascal}Controller } from './${kebab}.controller'
+
+export class ${pascal}Module implements AppModule {
+${routesDoc.replace(/^ {4}/gm, '  ').replace(/^ {6}/gm, '    ')}
+  routes(): ModuleRoutes {
+    return {
+      path: '/${plural}',
+      controller: ${pascal}Controller,
+    }
+  }
+}
+`
+  }
+
   return `import { defineModule } from '@forinda/kickjs'
 import { ${pascal}Controller } from './${kebab}.controller'
 
 export const ${pascal}Module = defineModule({
   name: '${pascal}Module',
   build: () => ({
-    /**
-     * Declare HTTP routes. Pass \`controller\` and the framework
-     * derives the Express Router via \`buildRoutes()\` and uses the
-     * same controller for OpenAPI spec generation. Return an array
-     * to mount multiple route sets under the same module — each
-     * entry can override the API version with a \`version\` field:
-     *
-     *   return [
-     *     { path: '/${plural}', version: 1, controller: ${pascal}V1Controller },
-     *     { path: '/${plural}', version: 2, controller: ${pascal}V2Controller },
-     *   ]
-     */
+${routesDoc}
     routes() {
       return {
         path: '/${plural}',

--- a/packages/cli/src/generators/templates/types.ts
+++ b/packages/cli/src/generators/templates/types.ts
@@ -1,3 +1,21 @@
+/**
+ * Module declaration style emitted by the module-index templates.
+ *
+ * - `'define'` — `defineModule({ name, build: () => ({...}) })`
+ *   factory form. The recommended pattern; matches `defineAdapter`
+ *   / `definePlugin` / `defineContextDecorator` parity.
+ * - `'class'` — legacy `class FooModule implements AppModule { ... }`
+ *   form. Still fully supported by the framework loader; pin via
+ *   `kick.config.ts > modules.style: 'class'` for projects that
+ *   prefer the class shape (existing codebase consistency, custom
+ *   class-decorator setups, etc.).
+ *
+ * Default `'define'` for new code. The `kick g module` orchestrator
+ * inserts the matching shape into `src/modules/index.ts` (`Module()`
+ * vs `Module`); `kick rm module` matches both.
+ */
+export type ModuleStyle = 'define' | 'class'
+
 /** Shared context for all template generator functions */
 export interface TemplateContext {
   /** PascalCase name (e.g. 'User', 'TaskAssignee') */
@@ -25,4 +43,10 @@ export interface TemplateContext {
    * of truth for the `<scope>` portion of any emitted token literal.
    */
   tokenScope?: string
+  /**
+   * Module declaration style emitted for the module-index file.
+   * Defaults to `'define'`. Resolved from `kick.config.ts > modules.style`
+   * by the orchestrating generator before the template is invoked.
+   */
+  style?: ModuleStyle
 }

--- a/packages/cli/src/plugin/builtins.ts
+++ b/packages/cli/src/plugin/builtins.ts
@@ -21,6 +21,7 @@ import { registerRemoveCommand } from '../commands/remove'
 import { registerTypegenCommand } from '../commands/typegen'
 import { registerCheckCommand } from '../commands/check'
 import { registerDbCommands } from '../commands/db'
+import { registerCodemodCommands } from '../commands/codemod'
 import { kickDbTypegen } from '../typegen/builtin/db'
 import { kickAssetsTypegen } from '../typegen/builtin/assets'
 import { kickRoutesTypegen } from '../typegen/builtin/routes'
@@ -43,6 +44,7 @@ export const builtinCliPlugins: readonly KickCliPlugin[] = [
   defineCliPlugin({ name: 'kick/typegen', register: registerTypegenCommand }),
   defineCliPlugin({ name: 'kick/check', register: registerCheckCommand }),
   defineCliPlugin({ name: 'kick/db', register: registerDbCommands, typegens: [kickDbTypegen()] }),
+  defineCliPlugin({ name: 'kick/codemod', register: registerCodemodCommands }),
   // kick/assets, kick/routes are typegen-only — the asset manager
   // itself is wired via @forinda/kickjs runtime, not the CLI; routes
   // emit a `KickRoutes` global namespace augmentation. Both replace


### PR DESCRIPTION
## Why

Project hygiene flag for codegen. After [#191](https://github.com/forinda/kick-js/pull/191), `kick g module` and `kick g scaffold` always emit the new `defineModule({...})` factory shape. That's the right default for new code, but adopters with established class-style codebases want the orchestrator to keep emitting matching shapes — mixed styles in one repo are visible drift. This PR adds the opt-out lever.

## What's new

```ts
// kick.config.ts
export default defineConfig({
  modules: {
    style: 'class', // pin to legacy form; default is 'define'
  },
})
```

| Style | Module file | Modules registry |
| --- | --- | --- |
| `'define'` (default) | `defineModule({ name, build: () => ({...}) })` | `[TaskModule()]` |
| `'class'` | `class TaskModule implements AppModule { ... }` | `[TaskModule]` |

The framework runtime accepts both shapes regardless of this setting — `Application` discriminates `typeof entry === 'function'` at boot. The flag controls codegen output only.

`kick rm module` matches both `Module` and `Module()` forms in the modules array, so flipping the flag mid-project doesn't break un-registration. Mixing styles in the same project works.

## What changed

- **`ModuleConfig.style?: 'define' | 'class'`** added to the `kick.config.ts` schema. Unknown values warn + fall back to `'define'`.
- All four pattern generators (DDD / REST / CQRS / minimal) + `kick g scaffold`'s template branch on the resolved style.
- `kick g module` orchestrator emits `Module()` (factory call) for `'define'`, bare `Module` for `'class'`.
- `kick g scaffold`'s auto-register threads style through the same way.
- `ModuleStyle` type exported from `templates/types.ts` and threaded via `ModuleContext`.

## Tests

- `kick g module` (no config) → emits `defineModule(...)`, registry entry is `TaskModule()`.
- `kick g module` with `kick.config.json: { modules: { style: 'class' } }` → emits `class TaskModule implements AppModule`, registry entry is bare `TaskModule`.
- One existing scaffold test updated for the simplified `ModuleRoutes` shape (#191 dropped the redundant `router: buildRoutes(X)` field).

Suite: 231 → 234 (+3). Build + typecheck clean.

## Docs

`docs/guide/generators.md` "Module declaration style" section added under "Config-Aware Defaults" — covers the flag's effect on both the module file and the registry, plus the runtime guarantees.

## Related — migration command (deferred)

A future `kick migrate modules --experimental` command will rewrite class-form modules to the `defineModule` factory form via TypeScript AST transforms. Out of scope here; the config flag covers the inverse direction (pin to class form) for projects that don't want to migrate.

## Test plan

- [x] `pnpm test` (CLI) — 234/234 pass
- [x] `pnpm typecheck` (CLI) — clean
- [x] `pnpm build` (CLI) — clean
- [x] `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable modules.style ('define' | 'class') that controls generated module shape, scaffold output, and generator gating.
  * New experimental codemod (kick codemod modules) to migrate module declarations with dry-run/--apply, timestamped backups, idempotent behavior, and conservative skipping.

* **Documentation**
  * Added Module declaration style section to generator docs and CLI docs for migration/gating guidance.

* **Tests**
  * Expanded E2E/unit tests covering generation, scaffolding, migration, gate behavior, idempotency, backups, and discovery rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->