### PR TITLE
fix(cli): drop legacy assets.d.ts + sweep typegen orphans

### DIFF
--- a/.changeset/typegen-duplicate-legacy-types.md
+++ b/.changeset/typegen-duplicate-legacy-types.md
@@ -1,0 +1,23 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+Fix duplicate `KickAssets` augmentation in `.kickjs/types/`.
+
+The legacy generator kept emitting `assets.d.ts` after the `kick/assets`
+typegen plugin carved out (M2.B-T8), so adopters got two declarations of
+`interface KickAssets` — one in `assets.d.ts`, one in `kick__assets.d.ts`.
+TypeScript merged them silently, but the next field rename or removal
+would surface as TS2717. The plugin is now the sole owner of the
+augmentation.
+
+`kick typegen` (and `kick dev`'s typegen pass) now sweep stale
+top-level files in `.kickjs/types/` against the union of generator +
+plugin outputs, so projects upgrading from older CLI versions self-heal
+the orphaned `env.ts` / `routes.ts` / `assets.d.ts` from the M2.B-T8
+carve in one run. The output dir is fully owned by typegen (writes its
+own `.gitignore`), so this is non-destructive.
+
+`index.d.ts` now omits the `import './kick__assets'` side-effect line
+when the project has no `assetMap` entries — the plugin skips emission
+in that case, so importing it would dangle.

--- a/packages/cli/__tests__/typegen-legacy-cleanup.test.ts
+++ b/packages/cli/__tests__/typegen-legacy-cleanup.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Regressions for the duplicate-legacy-types fix:
+ *
+ *  1. `generateTypes` no longer writes `assets.d.ts`. The KickAssets
+ *     augmentation is owned exclusively by the `kick/assets` typegen
+ *     plugin (`kick__assets.d.ts`). Pre-fix, both files existed and
+ *     adopters got `interface KickAssets` declared twice — silent
+ *     interface merge today, TS2717 on the next field rename.
+ *  2. `index.d.ts` only side-effect-imports `./kick__assets` when the
+ *     plugin actually emits it (i.e. assetMap is non-empty). With no
+ *     assets, the import would dangle.
+ *  3. `sweepStaleTypegen` removes orphaned files left by older CLI
+ *     versions (`assets.d.ts`, `env.ts`, `routes.ts`, plus any other
+ *     top-level file not in the current expected set).
+ *
+ * @module @forinda/kickjs-cli/__tests__/typegen-legacy-cleanup.test
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { generateTypes } from '../src/typegen/generator'
+import { sweepStaleTypegen } from '../src/typegen'
+
+let outDir: string
+
+beforeEach(() => {
+  outDir = mkdtempSync(join(tmpdir(), 'typegen-legacy-cleanup-'))
+})
+
+afterEach(() => {
+  try {
+    rmSync(outDir, { recursive: true, force: true })
+  } catch {
+    /* ignore cleanup races */
+  }
+})
+
+describe('generator stops emitting legacy assets.d.ts', () => {
+  it('does not write `assets.d.ts` even when assetMap entries exist', async () => {
+    await generateTypes({
+      classes: [],
+      outDir,
+      assets: {
+        count: 2,
+        entries: [
+          {
+            namespace: 'mails',
+            src: '/abs/src/mails',
+            dest: 'dist/mails',
+            keys: ['welcome', 'reset'],
+          },
+        ],
+      },
+    })
+
+    expect(existsSync(join(outDir, 'assets.d.ts'))).toBe(false)
+    // The other generator-owned files DO still exist — sanity check
+    // that the test isn't passing because the whole output dir is
+    // empty.
+    for (const f of [
+      'registry.d.ts',
+      'services.d.ts',
+      'modules.d.ts',
+      'plugins.d.ts',
+      'augmentations.d.ts',
+      'index.d.ts',
+    ]) {
+      expect(existsSync(join(outDir, f)), f).toBe(true)
+    }
+  })
+
+  it('omits the assets-import line in index.d.ts when no assets are discovered', async () => {
+    await generateTypes({
+      classes: [],
+      outDir,
+      assets: { count: 0, entries: [] },
+    })
+    const index = readFileSync(join(outDir, 'index.d.ts'), 'utf-8')
+    expect(index).not.toContain("import './kick__assets'")
+    expect(index).not.toContain("import './assets'")
+  })
+
+  it('side-effect-imports `./kick__assets` (not `./assets`) when assetMap is populated', async () => {
+    await generateTypes({
+      classes: [],
+      outDir,
+      assets: {
+        count: 1,
+        entries: [
+          {
+            namespace: 'mails',
+            src: '/abs/src/mails',
+            dest: 'dist/mails',
+            keys: ['welcome'],
+          },
+        ],
+      },
+    })
+    const index = readFileSync(join(outDir, 'index.d.ts'), 'utf-8')
+    expect(index).toContain("import './kick__assets'")
+    expect(index).not.toContain("import './assets'\n")
+  })
+})
+
+describe('sweepStaleTypegen', () => {
+  it('removes legacy env.ts/routes.ts/assets.d.ts left by older CLI versions', async () => {
+    await mkdir(outDir, { recursive: true })
+    // Seed: stale legacy outputs from a pre-carve CLI.
+    for (const f of ['env.ts', 'routes.ts', 'assets.d.ts']) {
+      writeFileSync(join(outDir, f), '/* legacy */')
+    }
+    // Plus the current expected outputs from generator + plugin runner.
+    const expected = [
+      'registry.d.ts',
+      'services.d.ts',
+      'modules.d.ts',
+      'plugins.d.ts',
+      'augmentations.d.ts',
+      'index.d.ts',
+    ]
+    for (const f of expected) writeFileSync(join(outDir, f), '/* current */')
+    const pluginResults = [
+      { id: 'kick/routes', status: 'written' as const, outFile: join(outDir, 'kick__routes.ts') },
+      { id: 'kick/env', status: 'written' as const, outFile: join(outDir, 'kick__env.ts') },
+    ]
+    for (const r of pluginResults) writeFileSync(r.outFile!, '/* plugin */')
+
+    const removed = await sweepStaleTypegen(
+      outDir,
+      expected.map((f) => join(outDir, f)),
+      pluginResults,
+      true,
+    )
+
+    expect(removed.toSorted()).toEqual(['assets.d.ts', 'env.ts', 'routes.ts'])
+    expect(existsSync(join(outDir, 'assets.d.ts'))).toBe(false)
+    expect(existsSync(join(outDir, 'env.ts'))).toBe(false)
+    expect(existsSync(join(outDir, 'routes.ts'))).toBe(false)
+    // Current outputs survive.
+    for (const f of expected) expect(existsSync(join(outDir, f)), f).toBe(true)
+    expect(existsSync(join(outDir, 'kick__routes.ts'))).toBe(true)
+    expect(existsSync(join(outDir, 'kick__env.ts'))).toBe(true)
+  })
+
+  it('returns an empty list when there are no orphans', async () => {
+    await mkdir(outDir, { recursive: true })
+    const expected = ['registry.d.ts', 'services.d.ts', 'index.d.ts']
+    for (const f of expected) writeFileSync(join(outDir, f), '/* current */')
+
+    const removed = await sweepStaleTypegen(
+      outDir,
+      expected.map((f) => join(outDir, f)),
+      [],
+      true,
+    )
+    expect(removed).toEqual([])
+  })
+
+  it('tolerates a missing outDir without throwing', async () => {
+    const removed = await sweepStaleTypegen(join(outDir, 'does-not-exist'), [], [], true)
+    expect(removed).toEqual([])
+  })
+
+  it('skips orphan removal for plugin outputs that the runner reported', async () => {
+    // Reproduces the upgrade case: the plugin runner names its output
+    // `kick__assets.d.ts` based on the plugin id; sweep must keep
+    // that file even though no generator wrote it.
+    await mkdir(outDir, { recursive: true })
+    writeFileSync(join(outDir, 'kick__assets.d.ts'), '/* plugin */')
+    writeFileSync(join(outDir, 'leftover.d.ts'), '/* orphan */')
+
+    const removed = await sweepStaleTypegen(
+      outDir,
+      [],
+      [
+        {
+          id: 'kick/assets',
+          status: 'written',
+          outFile: join(outDir, 'kick__assets.d.ts'),
+        },
+      ],
+      true,
+    )
+    expect(removed).toEqual(['leftover.d.ts'])
+    expect(existsSync(join(outDir, 'kick__assets.d.ts'))).toBe(true)
+  })
+})

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -9,7 +9,8 @@
  */
 
 import type { Command } from 'commander'
-import { runTypegen, TokenCollisionError, watchTypegen } from '../typegen'
+import { resolve } from 'node:path'
+import { runTypegen, sweepStaleTypegen, TokenCollisionError, watchTypegen } from '../typegen'
 import { runAllPluginTypegens } from '../typegen/run-plugins'
 import { loadKickConfig } from '../config'
 
@@ -141,7 +142,7 @@ export function registerTypegenCommand(program: Command): void {
           // Keep the event loop alive until shutdown
           await new Promise<void>(() => {})
         } else {
-          await runTypegen(baseOpts)
+          const { result } = await runTypegen(baseOpts)
 
           // Plugin-typegen pipeline runs after the legacy pass. The
           // helper handles merging builtins with user plugins, applies
@@ -155,6 +156,15 @@ export function registerTypegenCommand(program: Command): void {
           })
           if (opts.check && results.some((r) => r.status === 'written')) {
             process.exit(1)
+          }
+
+          // Sweep orphans from older CLI versions (e.g. legacy
+          // `assets.d.ts`/`env.ts`/`routes.ts` left behind after the
+          // M2.B-T8 carve). Skipped under --check so the gate stays
+          // strictly diagnostic.
+          if (!opts.check) {
+            const outDir = resolve(cwd, opts.out ?? config?.typegen?.outDir ?? '.kickjs/types')
+            await sweepStaleTypegen(outDir, result.written, results, opts.silent ?? false)
           }
         }
       } catch (err: unknown) {

--- a/packages/cli/src/typegen/builtin/assets.ts
+++ b/packages/cli/src/typegen/builtin/assets.ts
@@ -1,11 +1,10 @@
 // kick/assets typegen plugin — M2.B-T8.
 //
-// Walks the project's `assetMap` and emits the same KickAssets
-// augmentation the legacy generator produces, but routed through the
-// TypegenPlugin contract. During the transition both this plugin and
-// the legacy generator's `assets.d.ts` emission run; TS merges the
-// two interface declarations safely (identical content). The legacy
-// emission removes once routes/env land as plugins too.
+// Walks the project's `assetMap` and emits the KickAssets augmentation
+// to `.kickjs/types/kick__assets.d.ts` via the TypegenPlugin contract.
+// Sole owner of asset typegen — the legacy generator's `assets.d.ts`
+// emission was retired once routes/env carved out, so adopters no
+// longer get duplicate `interface KickAssets` declarations.
 //
 // Resolution: returns null when there's no assetMap or it's empty.
 

--- a/packages/cli/src/typegen/generator.ts
+++ b/packages/cli/src/typegen/generator.ts
@@ -41,7 +41,7 @@ import type {
   DiscoveredRoute,
   DiscoveredToken,
 } from './scanner'
-import { renderAssetTypes, type DiscoveredAssets } from './asset-types'
+import type { DiscoveredAssets } from './asset-types'
 
 /** Header written to every generated file */
 const HEADER = `/* eslint-disable */
@@ -168,13 +168,17 @@ ${sorted.map((n) => `  | '${n}'`).join('\n')}
 }
 
 /** Render the barrel index that re-exports the union types */
-function renderIndex(includeEnv: boolean): string {
-  // The kick/routes + kick/env TypegenPlugins write their output to
-  // `kick__routes.ts` / `kick__env.ts` (see typegen runner + builtin
-  // plugins). The index re-exports them via side-effect imports so
-  // `tsconfig include` of `.kickjs/types/` is enough to wire up the
-  // augmentations — same surface adopters had before the carve.
+function renderIndex(includeEnv: boolean, includeAssets: boolean): string {
+  // The kick/routes + kick/env + kick/assets TypegenPlugins write their
+  // output to `kick__routes.ts` / `kick__env.ts` / `kick__assets.d.ts`
+  // (see typegen runner + builtin plugins). The index re-exports them
+  // via side-effect imports so `tsconfig include` of `.kickjs/types/`
+  // is enough to wire up the augmentations — same surface adopters had
+  // before the carve. Assets/env are conditional: the plugins skip
+  // emission when there's nothing to declare, so the import would
+  // dangle.
   const envImport = includeEnv ? "import './kick__env'\n" : ''
+  const assetsImport = includeAssets ? "import './kick__assets'\n" : ''
   return `${HEADER}
 export type { ServiceToken } from './services'
 export type { ModuleToken } from './modules'
@@ -189,8 +193,7 @@ import './registry'
 import './kick__routes'
 import './plugins'
 import './augmentations'
-import './assets'
-${envImport}`
+${assetsImport}${envImport}`
 }
 
 /**
@@ -394,13 +397,14 @@ export async function generateTypes(opts: GenerateOptions): Promise<GenerateResu
   const registryFile = join(outDir, 'registry.d.ts')
   const servicesFile = join(outDir, 'services.d.ts')
   const modulesFile = join(outDir, 'modules.d.ts')
-  // routes.ts + env.ts are now owned by the `kick/routes` and
-  // `kick/env` typegen plugins (M2.B-T8 carve). They write
-  // `kick__routes.ts` / `kick__env.ts` via the plugin runner. Legacy
-  // emissions of those files are gone.
+  // routes.ts + env.ts + assets.d.ts are owned by the `kick/routes`,
+  // `kick/env`, and `kick/assets` typegen plugins (M2.B-T8 carve).
+  // They write `kick__routes.ts` / `kick__env.ts` / `kick__assets.d.ts`
+  // via the plugin runner. Legacy emissions of all three files are
+  // gone — `assets.d.ts` was the last holdover (#TBD) and stopped
+  // emitting once the plugin pipeline proved stable.
   const pluginsFile = join(outDir, 'plugins.d.ts')
   const augmentationsFile = join(outDir, 'augmentations.d.ts')
-  const assetsFile = join(outDir, 'assets.d.ts')
   const indexFile = join(outDir, 'index.d.ts')
 
   const collidingNames = new Set(collisions.map((c) => c.className))
@@ -429,15 +433,13 @@ export async function generateTypes(opts: GenerateOptions): Promise<GenerateResu
   )
   const pluginsContent = renderPlugins(pluginsAndAdapters)
   const augmentationsContent = renderAugmentations(augmentations)
-  const assetsContent = renderAssetTypes(assets)
-  const indexContent = renderIndex(env !== null)
+  const indexContent = renderIndex(env !== null, assets.count > 0)
 
   await writeFile(registryFile, registryContent, 'utf-8')
   await writeFile(servicesFile, servicesContent, 'utf-8')
   await writeFile(modulesFile, modulesContent, 'utf-8')
   await writeFile(pluginsFile, pluginsContent, 'utf-8')
   await writeFile(augmentationsFile, augmentationsContent, 'utf-8')
-  await writeFile(assetsFile, assetsContent, 'utf-8')
   await writeFile(indexFile, indexContent, 'utf-8')
 
   const written = [
@@ -446,7 +448,6 @@ export async function generateTypes(opts: GenerateOptions): Promise<GenerateResu
     modulesFile,
     pluginsFile,
     augmentationsFile,
-    assetsFile,
     indexFile,
   ]
 

--- a/packages/cli/src/typegen/index.ts
+++ b/packages/cli/src/typegen/index.ts
@@ -8,12 +8,14 @@
  * @module @forinda/kickjs-cli/typegen
  */
 
-import { resolve } from 'node:path'
+import { resolve, basename } from 'node:path'
+import { readdir, stat, unlink } from 'node:fs/promises'
 import { scanProject, type ScanResult } from './scanner'
 import { generateTypes, type GenerateResult, TokenCollisionError } from './generator'
 import { validateTokenConventions, type TokenConventionWarning } from './token-conventions'
 import { discoverAssets } from './asset-types'
 import type { AssetMapEntry } from '../config'
+import type { TypegenPluginResult } from './plugin'
 
 export type {
   DiscoveredClass,
@@ -148,12 +150,13 @@ export async function runTypegen(opts: RunTypegenOptions = {}): Promise<{
   // and the `kick typegen` / `kick dev` / `kick build` CLI paths
   // opt out (`runPlugins: false`) because they drive the plugin
   // pass externally and would otherwise double-run it.
+  let pluginResults: TypegenPluginResult[] = []
   if (opts.runPlugins !== false) {
     try {
       const { runAllPluginTypegens } = await import('./run-plugins')
       const { loadKickConfig } = await import('../config')
       const pluginConfig = await loadKickConfig(cwd)
-      await runAllPluginTypegens({ cwd, config: pluginConfig, silent: true })
+      pluginResults = await runAllPluginTypegens({ cwd, config: pluginConfig, silent: true })
     } catch (err) {
       // Broken plugins shouldn't block dev tooling — generators have
       // already written the rest of `.kickjs/types/`, and surfacing
@@ -165,6 +168,20 @@ export async function runTypegen(opts: RunTypegenOptions = {}): Promise<{
         console.warn(`  kick typegen: plugin pipeline failed (${msg}) — continuing`)
       }
     }
+  }
+
+  // Sweep stale `.kickjs/types/*` files. Older CLI versions emitted
+  // `env.ts`, `routes.ts`, and (until this fix) `assets.d.ts` directly
+  // from the legacy generator. Once those carved out into `kick/env`,
+  // `kick/routes`, and `kick/assets` typegen plugins, the legacy
+  // file names became orphans — but were never deleted on subsequent
+  // runs, so adopters who upgraded saw `KickAssets`/`KickEnv`/
+  // `KickRoutes` declared twice (once legacy, once `kick__*`). Sweep
+  // walks the output dir at the end of every pass and unlinks any
+  // top-level file not in the expected set, so a single `kick typegen`
+  // run after upgrade self-heals.
+  if (opts.runPlugins !== false) {
+    await sweepStaleTypegen(outDir, result.written, pluginResults, silent)
   }
 
   const tokenWarnings = validateTokenConventions(scan.tokens)
@@ -222,8 +239,8 @@ export async function watchTypegen(opts: RunTypegenOptions = {}): Promise<() => 
   // Watch mode always tolerates collisions — otherwise an in-progress
   // rename would crash the dev loop. The error is still printed.
   // `runPlugins: false` keeps `runTypegen` from double-running the
-  // plugin pipeline; the watcher already calls `runPlugins()`
-  // explicitly after each `safeRun`.
+  // plugin pipeline; the watcher invokes `runPlugins()` explicitly
+  // after each `runLegacy()` so both phases land before the sweep.
   const runOpts: RunTypegenOptions = { ...resolved, allowDuplicates: true, runPlugins: false }
 
   // Polling is the right strategy for Docker bind mounts, WSL crosses,
@@ -241,11 +258,40 @@ export async function watchTypegen(opts: RunTypegenOptions = {}): Promise<() => 
     import('../config'),
   ])
   const pluginConfig = await loadKickConfig(cwd)
-  const runPlugins = () =>
-    runAllPluginTypegens({ cwd, config: pluginConfig, silent: true }).catch(() => {})
+  // Track the most recent generator + plugin outputs so the post-run
+  // sweep knows the full expected set. The legacy generator returns
+  // its written list on each call (captured below via a closure), and
+  // the plugin pipeline returns one per plugin.
+  let lastGeneratorWritten: readonly string[] = []
+  const runLegacy = async () => {
+    try {
+      const out = await runTypegen({ ...runOpts })
+      lastGeneratorWritten = out.result.written
+    } catch (err) {
+      if (silent) return
+      if (err instanceof TokenCollisionError) {
+        console.error('\n' + err.message + '\n')
+      } else {
+        const msg = err instanceof Error ? err.message : String(err)
+        console.error(`  kick typegen failed: ${msg}`)
+      }
+    }
+  }
+  const runPlugins = async () => {
+    try {
+      const pluginResults = await runAllPluginTypegens({
+        cwd,
+        config: pluginConfig,
+        silent: true,
+      })
+      await sweepStaleTypegen(resolved.outDir, lastGeneratorWritten, pluginResults, true)
+    } catch {
+      /* swallow — watcher must never die */
+    }
+  }
 
   // Initial run — legacy pass first, then plugin typegens.
-  await safeRun(runOpts, silent)
+  await runLegacy()
   await runPlugins()
 
   const { watch } = await import('node:fs')
@@ -260,8 +306,7 @@ export async function watchTypegen(opts: RunTypegenOptions = {}): Promise<() => 
 
     if (timer) clearTimeout(timer)
     timer = setTimeout(() => {
-      safeRun(runOpts, silent)
-      void runPlugins()
+      void runLegacy().then(runPlugins)
     }, 100)
   }
 
@@ -315,4 +360,57 @@ async function safeRun(opts: RunTypegenOptions, silent: boolean): Promise<void> 
       console.error(`  kick typegen failed: ${msg}`)
     }
   }
+}
+
+/**
+ * Remove orphaned typegen output. The legacy generator emitted
+ * `assets.d.ts`, `env.ts`, and `routes.ts` directly; once those carved
+ * into the `kick/assets`, `kick/env`, and `kick/routes` plugins, the
+ * legacy file names became stale on disk for any project that had run
+ * an older CLI. Without a sweep, both copies coexist and adopters get
+ * duplicated `KickAssets` / `KickEnv` / `KickRoutes` augmentations.
+ *
+ * Strategy: enumerate the top level of `outDir`, keep the union of
+ * generator-written files + plugin-written files, unlink anything
+ * else. Subdirectories are left alone — typegen never creates them.
+ * Errors are swallowed (silent → no log) so a transient ENOENT or
+ * permission glitch never aborts the wider command.
+ */
+export async function sweepStaleTypegen(
+  outDir: string,
+  generatorWritten: readonly string[],
+  pluginResults: readonly TypegenPluginResult[],
+  silent: boolean,
+): Promise<string[]> {
+  const expected = new Set<string>()
+  for (const file of generatorWritten) expected.add(basename(file))
+  for (const r of pluginResults) {
+    if (r.outFile) expected.add(basename(r.outFile))
+  }
+  // Hidden files we own at the types/ level — none today, but the
+  // gitignore at .kickjs/.gitignore lives one level up so it's not
+  // a candidate here.
+  let entries: string[]
+  try {
+    entries = await readdir(outDir)
+  } catch {
+    return []
+  }
+  const removed: string[] = []
+  for (const name of entries) {
+    if (expected.has(name)) continue
+    const abs = resolve(outDir, name)
+    try {
+      const s = await stat(abs)
+      if (!s.isFile()) continue
+      await unlink(abs)
+      removed.push(name)
+    } catch {
+      // Best-effort; don't crash the typegen pass on a stat/unlink miss.
+    }
+  }
+  if (removed.length > 0 && !silent) {
+    console.log(`  kick typegen: swept ${removed.length} stale file(s): ${removed.join(', ')}`)
+  }
+  return removed
 }


### PR DESCRIPTION
## Why

Bug surfaced after the latest release (`@forinda/kickjs-cli@5.4.1`): adopters with a populated `assetMap` get **two** `interface KickAssets` declarations inside `declare module '@forinda/kickjs'` after one `kick typegen` run.

Repro on `/home/forinda/Desktop/my-app-new/`:

```bash
$ rm -rf .kickjs/types
$ bun kick typegen
$ ls .kickjs/types
assets.d.ts        ← legacy generator emission (stale)
kick__assets.d.ts  ← kick/assets typegen plugin emission (current)
augmentations.d.ts
index.d.ts
…
```

Both files contain identical `declare module '@forinda/kickjs' { interface KickAssets { … } }`. TS merges them silently today, but the next field rename or removal — or any non-trivial type-level branching — surfaces as TS2717.

The bug was self-documented: `packages/cli/src/typegen/builtin/assets.ts` carried a comment from the M2.B-T8 carve saying *"during the transition both run; legacy emission removes once routes/env land as plugins too."* Routes/env did land (commits `70b5212e` + `1c47a35f`). The legacy `assets.d.ts` write at `generator.ts:438` was forgotten.

## What changed

1. **Generator no longer emits `assets.d.ts`.** The `kick/assets` typegen plugin is now the sole owner of the `KickAssets` augmentation (writes `kick__assets.d.ts` via the plugin runner).
2. **`renderIndex(env, assets)` takes an extra flag** so `index.d.ts` only side-effect-imports `./kick__assets` when the plugin will actually write it (i.e. `assetMap` is non-empty). With no assets, the import would dangle.
3. **`sweepStaleTypegen(outDir, generatorWritten, pluginResults, silent)`** — new helper exported from `@forinda/kickjs-cli/typegen`. Lists the top level of `outDir`, keeps the union of generator + plugin outputs, unlinks anything else. Wired into `commands/typegen` (one-shot) and `watchTypegen` (every retrigger).

After the fix, the same project self-heals on the next run:

```text
$ bun kick typegen
  kick/db: skipped
  kick/assets: unchanged
  kick/routes: unchanged
  kick/env: unchanged
  kick typegen: swept 3 stale file(s): env.ts, routes.ts, assets.d.ts
```

`.kickjs/` is fully owned by typegen (writes its own `.gitignore`), so the sweep is non-destructive — only files at the top level of `.kickjs/types/` and only those not in the current expected set.

## Tests

`packages/cli/__tests__/typegen-legacy-cleanup.test.ts` (new, 7 cases):

- `generateTypes` does not write `assets.d.ts` even when assetMap entries exist
- `index.d.ts` omits the assets-import line when no assets are discovered
- `index.d.ts` side-effect-imports `./kick__assets` (not `./assets`) when assetMap is populated
- `sweepStaleTypegen` removes legacy `env.ts` / `routes.ts` / `assets.d.ts`
- Returns `[]` when no orphans
- Tolerates a missing `outDir` without throwing
- Keeps plugin-runner outputs even when no generator wrote them

CLI suite: 265 → **272 passing**.

## Test plan

- [x] CLI test suite passes (`pnpm --filter @forinda/kickjs-cli test` → 272/272)
- [x] Live repro on `/home/forinda/Desktop/my-app-new/` shows only `kick__assets.d.ts` after fresh typegen
- [x] Sweep removes planted `env.ts` / `routes.ts` / `assets.d.ts` orphans on retrigger
- [ ] CodeRabbit pass

## Changeset

`.changeset/typegen-duplicate-legacy-types.md` — patch bump for `@forinda/kickjs-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate TypeScript module augmentation that could cause declaration conflicts and `TS2717` errors.

* **Chores**
  * Improved cleanup of orphaned generated type artifacts.
  * Optimized type imports to avoid unnecessary side-effect imports when assets are not present.

* **Tests**
  * Added regression test coverage for type generation cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->