### PR TITLE
feat(db,cli): refuse pgEnum value removal when composite type references the enum (M4.C)

### DIFF
--- a/.changeset/db-m4c-composite-detect.md
+++ b/.changeset/db-m4c-composite-detect.md
@@ -1,0 +1,14 @@
+---
+'@forinda/kickjs-db': minor
+'@forinda/kickjs-cli': patch
+---
+
+feat(db): refuse `pgEnum` value removal when a composite type references the enum (M4.C)
+
+The M3.B rename-recreate dance assumes the enum is referenced only by table columns. PG composite types / arrays-of-composite / domains containing the enum break that approach — the `ALTER COLUMN TYPE … USING column::text::foo` clause can't reach into composite fields, so the migration would fail opaquely at apply time.
+
+Generate-time gate added: when `kick db generate` produces one or more `removeEnumValue` changes, the CLI queries `pg_type` + `pg_attribute` against the configured PG connection. If any composite type holds the enum (directly or as an array element), it refuses to write the migration with a new `CompositeEnumReferenceError` listing every offending `<composite>.<attribute>`.
+
+The check runs only on the built-in pgAdapter path (`dialect: 'postgres'` + `connectionString`/`DATABASE_URL`). Adopters using the `db.adapter` factory escape hatch get the helper exported from `@forinda/kickjs-db` (`detectCompositeReferences`, `CompositeQueryRunner`, `CompositeRef`) so they can wire it themselves.
+
+No behavior change when no composite references the enum; no behavior change for non-PG dialects.

--- a/packages/cli/__tests__/config-db-block.test.ts
+++ b/packages/cli/__tests__/config-db-block.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Locks the type contract for the `db` block on `KickConfig`. Adopters
+ * who hit the M4.C composite-detect path set this in `kick.config.ts`;
+ * before this addition the field type-checked as an unknown excess
+ * property and the CLI's `resolveDbConfig` read it via untyped
+ * fallthrough — TS rejected the literal even though runtime worked.
+ */
+
+import { describe, it, expect, expectTypeOf } from 'vitest'
+
+import { defineConfig, type KickDbConfigBlock } from '../src/config'
+
+describe('KickConfig.db block', () => {
+  it('defineConfig accepts a fully-populated db block', () => {
+    const config = defineConfig({
+      db: {
+        schemaPath: 'src/db/schema.ts',
+        migrationsDir: 'db/migrations',
+        dialect: 'postgres',
+        connectionString: 'postgres://x:y@localhost:5432/test',
+      },
+    })
+
+    expect(config.db?.dialect).toBe('postgres')
+    expect(config.db?.connectionString).toContain('localhost')
+  })
+
+  it('defineConfig accepts an adapter factory in lieu of connectionString', () => {
+    const config = defineConfig({
+      db: {
+        schemaPath: 'src/db/schema.ts',
+        migrationsDir: 'db/migrations',
+        adapter: () => ({ dialect: 'postgres' as const }),
+      },
+    })
+
+    expect(typeof config.db?.adapter).toBe('function')
+  })
+
+  it('every db field is optional (resolveDbConfig fills defaults)', () => {
+    const cfg = defineConfig({ db: {} })
+    expect(cfg.db).toEqual({})
+  })
+
+  it('KickDbConfigBlock typing matches the exported shape', () => {
+    expectTypeOf<KickDbConfigBlock>().toEqualTypeOf<{
+      schemaPath?: string
+      migrationsDir?: string
+      dialect?: 'postgres' | 'sqlite' | 'mysql'
+      connectionString?: string
+      adapter?: () => unknown | Promise<unknown>
+    }>()
+  })
+})

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -66,6 +66,13 @@ async function resolveAdapter(config: DbConfig): Promise<{
   }
 }
 
+interface PgQueryRunnerProbe {
+  runner: {
+    query: (sql: string, params?: readonly unknown[]) => Promise<{ rows: unknown[] }>
+  }
+  cleanup: () => Promise<void>
+}
+
 /**
  * Resolve a pg-protocol-compatible query runner for the M4.C
  * composite-type check at `kick db generate` time. Only fires for the
@@ -78,10 +85,7 @@ async function resolveAdapter(config: DbConfig): Promise<{
  * factory). Adopters who need detection on a custom factory can call
  * `detectCompositeReferences` directly against their own pool.
  */
-async function tryResolvePgQueryRunner(config: DbConfig): Promise<{
-  runner: { query: (sql: string, params?: readonly unknown[]) => Promise<{ rows: unknown[] }> }
-  cleanup: () => Promise<void>
-} | null> {
+async function tryResolvePgQueryRunner(config: DbConfig): Promise<PgQueryRunnerProbe | null> {
   if (config.adapter) return null
   if ((config.dialect ?? 'postgres') !== 'postgres') return null
   if (!config.connectionString) return null

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -4,6 +4,7 @@ import type { Command } from 'commander'
 import { writeFile } from 'node:fs/promises'
 
 import {
+  detectCompositeReferences,
   generate,
   resolveDbConfig,
   migrateLatest,
@@ -65,6 +66,36 @@ async function resolveAdapter(config: DbConfig): Promise<{
   }
 }
 
+/**
+ * Resolve a pg-protocol-compatible query runner for the M4.C
+ * composite-type check at `kick db generate` time. Only fires for the
+ * built-in pgAdapter path (dialect=postgres + connection string set):
+ * the `db.adapter` factory escape hatch returns an opaque
+ * MigrationAdapter, so we skip the check there.
+ *
+ * Returns null when detection is not wired (non-postgres dialect, no
+ * connection string, or the adopter is using a custom adapter
+ * factory). Adopters who need detection on a custom factory can call
+ * `detectCompositeReferences` directly against their own pool.
+ */
+async function tryResolvePgQueryRunner(config: DbConfig): Promise<{
+  runner: { query: (sql: string, params?: readonly unknown[]) => Promise<{ rows: unknown[] }> }
+  cleanup: () => Promise<void>
+} | null> {
+  if (config.adapter) return null
+  if ((config.dialect ?? 'postgres') !== 'postgres') return null
+  if (!config.connectionString) return null
+
+  const pg = await import('pg')
+  const pool = new pg.default.Pool({ connectionString: config.connectionString })
+  return {
+    runner: pool,
+    cleanup: async () => {
+      await pool.end()
+    },
+  }
+}
+
 function printStatusTable(status: Awaited<ReturnType<typeof migrateStatus>>): void {
   if (status.length === 0) {
     console.log('No migrations.')
@@ -94,20 +125,41 @@ export function registerDbCommands(program: Command): void {
     .action(async (name: string, opts: BaseOpts & { empty?: boolean }) => {
       const cwd = process.cwd()
       const config = await loadConfig(opts)
-      const result = await generate({ name, config, cwd, empty: opts.empty })
 
-      if (result.status === 'no-changes') {
-        console.log('No schema changes detected.')
-        return
+      // M4.C — wire composite-type detection when we can resolve a PG pool
+      // ourselves (built-in pgAdapter path, dialect=postgres, connection
+      // string available). When the operator uses the `adapter` factory
+      // escape hatch we skip the check — they can run
+      // `detectCompositeReferences` manually if needed.
+      const probe = await tryResolvePgQueryRunner(config)
+      const detectCompositeRefs = probe
+        ? (enumName: string) => detectCompositeReferences(probe.runner, enumName)
+        : undefined
+
+      try {
+        const result = await generate({
+          name,
+          config,
+          cwd,
+          empty: opts.empty,
+          detectCompositeRefs,
+        })
+
+        if (result.status === 'no-changes') {
+          console.log('No schema changes detected.')
+          return
+        }
+        if (result.empty) {
+          console.log(`Created empty migration ${result.migrationDir} (author up.sql + down.sql).`)
+          return
+        }
+        const plural = result.changeCount === 1 ? '' : 's'
+        console.log(
+          `Created migration ${result.migrationDir} (${result.changeCount} change${plural}).`,
+        )
+      } finally {
+        await probe?.cleanup()
       }
-      if (result.empty) {
-        console.log(`Created empty migration ${result.migrationDir} (author up.sql + down.sql).`)
-        return
-      }
-      const plural = result.changeCount === 1 ? '' : 's'
-      console.log(
-        `Created migration ${result.migrationDir} (${result.changeCount} change${plural}).`,
-      )
     })
 
   // ── migrate runner subcommands ─────────────────────────────────────────

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -103,6 +103,57 @@ export interface AssetMapEntry {
   keys?: 'auto' | 'strip' | 'with-extension'
 }
 
+/**
+ * Database settings consumed by `kick db generate`, `kick db migrate`,
+ * and the M4.C composite-type detection gate. Mirrors the runtime
+ * `DbConfig` shape from `@forinda/kickjs-db` — duplicated here so
+ * adopters who only install `@forinda/kickjs-cli` can set the block
+ * without pulling `@forinda/kickjs-db` types into their kick.config.ts
+ * resolution. The CLI loads kick.config.ts through `loadKickConfig`,
+ * then `resolveDbConfig` re-reads this block from the same module and
+ * normalises defaults (`schemaPath` / `migrationsDir` / `dialect`).
+ *
+ * @example
+ * ```ts
+ * defineConfig({
+ *   db: {
+ *     schemaPath: 'src/db/schema.ts',
+ *     migrationsDir: 'db/migrations',
+ *     dialect: 'postgres',
+ *     connectionString: process.env.DATABASE_URL,
+ *   },
+ * })
+ * ```
+ */
+export interface KickDbConfigBlock {
+  /**
+   * Path to the schema module (`pgEnum` / `table` declarations).
+   * Defaults to `'src/db/schema.ts'`.
+   */
+  schemaPath?: string
+  /**
+   * Where `kick db generate` writes migration directories. Defaults
+   * to `'db/migrations'`.
+   */
+  migrationsDir?: string
+  /** SQL dialect. Defaults to `'postgres'`. */
+  dialect?: 'postgres' | 'sqlite' | 'mysql'
+  /**
+   * Postgres connection string for the built-in pgAdapter path. Read
+   * from the `DATABASE_URL` env var when omitted. Used by
+   * `kick db migrate*` and the M4.C composite-type gate at
+   * `kick db generate`.
+   */
+  connectionString?: string
+  /**
+   * Escape hatch: a factory returning a fully-constructed
+   * MigrationAdapter (typed loosely here so the CLI types don't pull
+   * `@forinda/kickjs-db` into adopter projects that don't import it).
+   * Takes precedence over `connectionString` when both are set.
+   */
+  adapter?: () => unknown | Promise<unknown>
+}
+
 /** Typegen settings — controls .kickjs/types/* generation */
 export interface TypegenConfig {
   /**
@@ -343,6 +394,12 @@ export interface KickConfig {
    * ```
    */
   typegen?: TypegenConfig
+  /**
+   * Database settings — schema path, migrations dir, dialect,
+   * connection string, optional adapter factory. Consumed by
+   * `kick db generate` / `kick db migrate*`. See {@link KickDbConfigBlock}.
+   */
+  db?: KickDbConfigBlock
   /** Custom commands that extend the CLI */
   commands?: KickCommandDefinition[]
   /**

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,7 +10,7 @@ export { initProject } from './generators/project'
 
 // Config
 export { defineConfig, loadKickConfig } from './config'
-export type { KickConfig, KickCommandDefinition } from './config'
+export type { KickConfig, KickCommandDefinition, KickDbConfigBlock } from './config'
 
 // CLI Plugin contract — adopters write `defineCliPlugin({...})` and add
 // it to `kick.config.ts > plugins[]`. Built-in commands use the same

--- a/packages/db/__tests__/fixtures/schema.enum-removal.ts
+++ b/packages/db/__tests__/fixtures/schema.enum-removal.ts
@@ -1,0 +1,15 @@
+// Fixture for the M4.C composite-detect gate test in
+// __tests__/unit/cli-generate-composite-gate.test.ts.
+//
+// The exported enum has TWO values; the test's planted prior snapshot
+// has THREE — `diff()` produces a single `removeEnumValue` change for
+// `legacy`, which is what the gate keys off.
+
+import { table, serial } from '@forinda/kickjs-db'
+import { pgEnum } from '@forinda/kickjs-db/pg'
+
+export const status = pgEnum('status', 'active', 'banned')
+
+export const users = table('users', {
+  id: serial().primaryKey(),
+})

--- a/packages/db/__tests__/integration/composite-detect.test.ts
+++ b/packages/db/__tests__/integration/composite-detect.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Real-PG round trip for `detectCompositeReferences` (M4.C).
+ *
+ * Boots a Postgres 16 Testcontainer, plants:
+ *   - an enum (`user_status`),
+ *   - a composite type whose attribute holds the enum, and
+ *   - a second composite whose attribute holds an array of the enum,
+ * and asserts the helper finds both rows. Also verifies the
+ * negative path (no composite references the enum) and the qualified-
+ * name path (the helper restricts to the named schema).
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql'
+import pg from 'pg'
+
+import { detectCompositeReferences } from '@forinda/kickjs-db'
+
+let container: StartedPostgreSqlContainer
+let client: pg.Client
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer('postgres:16-alpine').start()
+  client = new pg.Client({
+    host: container.getHost(),
+    port: container.getMappedPort(5432),
+    user: container.getUsername(),
+    password: container.getPassword(),
+    database: container.getDatabase(),
+  })
+  await client.connect()
+}, 90_000)
+
+afterAll(async () => {
+  await client?.end()
+  await container?.stop()
+})
+
+beforeEach(async () => {
+  // Drop everything between tests so the catalog state stays scoped.
+  await client.query(`
+    DO $$ DECLARE
+      r RECORD;
+    BEGIN
+      FOR r IN (SELECT typname, n.nspname FROM pg_type t
+                JOIN pg_namespace n ON n.oid = t.typnamespace
+                WHERE t.typtype IN ('c', 'e') AND n.nspname IN ('public', 'analytics')
+                  AND t.typname NOT LIKE 'pg_%' AND NOT EXISTS (
+                    SELECT 1 FROM pg_class c WHERE c.reltype = t.oid AND c.relkind != 'c'
+                  )) LOOP
+        EXECUTE 'DROP TYPE IF EXISTS "' || r.nspname || '"."' || r.typname || '" CASCADE';
+      END LOOP;
+    END $$;
+    DROP SCHEMA IF EXISTS analytics CASCADE;
+  `)
+})
+
+describe('detectCompositeReferences (real PG)', () => {
+  it('returns [] when the enum has no composite references', async () => {
+    await client.query(`CREATE TYPE user_status AS ENUM ('active', 'banned')`)
+
+    const refs = await detectCompositeReferences(client, 'user_status')
+
+    expect(refs).toEqual([])
+  })
+
+  it('finds composite types whose attributes hold the enum directly', async () => {
+    await client.query(`
+      CREATE TYPE user_status AS ENUM ('active', 'banned');
+      CREATE TYPE address_t AS (
+        line1 text,
+        status user_status
+      );
+    `)
+
+    const refs = await detectCompositeReferences(client, 'user_status')
+
+    expect(refs).toEqual([
+      {
+        composite: 'public.address_t',
+        attribute: 'status',
+        enum: 'public.user_status',
+      },
+    ])
+  })
+
+  it('finds composite attributes that hold an array of the enum', async () => {
+    await client.query(`
+      CREATE TYPE user_status AS ENUM ('active', 'banned');
+      CREATE TYPE membership_t AS (
+        kind text,
+        history user_status[]
+      );
+    `)
+
+    const refs = await detectCompositeReferences(client, 'user_status')
+
+    expect(refs).toHaveLength(1)
+    expect(refs[0]).toMatchObject({
+      composite: 'public.membership_t',
+      attribute: 'history',
+      enum: 'public.user_status',
+    })
+  })
+
+  it('respects schema qualification when the caller passes one', async () => {
+    await client.query(`
+      CREATE SCHEMA analytics;
+      CREATE TYPE analytics.event_kind AS ENUM ('click', 'view');
+      CREATE TYPE public.event_kind AS ENUM ('click', 'view');
+      CREATE TYPE public.row_t AS (
+        kind public.event_kind
+      );
+    `)
+
+    // Looking for the public-schema enum should only find the public composite.
+    const publicRefs = await detectCompositeReferences(client, 'public.event_kind')
+    expect(publicRefs).toEqual([
+      {
+        composite: 'public.row_t',
+        attribute: 'kind',
+        enum: 'public.event_kind',
+      },
+    ])
+
+    // Looking for the analytics-schema enum should find nothing.
+    const analyticsRefs = await detectCompositeReferences(client, 'analytics.event_kind')
+    expect(analyticsRefs).toEqual([])
+  })
+})

--- a/packages/db/__tests__/unit/cli-generate-composite-gate.test.ts
+++ b/packages/db/__tests__/unit/cli-generate-composite-gate.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Generate-time gate for the M4.C composite-detect helper.
+ *
+ * Plants a prior snapshot with an extra enum value so the diff
+ * produces `removeEnumValue`, then calls `generate()` with a stub
+ * `detectCompositeRefs` callback. Verifies:
+ *   1. `generate()` invokes the callback exactly once per distinct enum,
+ *   2. a non-empty result aborts with `CompositeEnumReferenceError`
+ *      and DOES NOT write a migration directory,
+ *   3. an empty result lets the migration write normally.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm, mkdir, writeFile, readdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  CompositeEnumReferenceError,
+  generate,
+  type CompositeRef,
+  type SchemaSnapshot,
+} from '@forinda/kickjs-db'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const fixtureSchema = path.resolve(here, '../fixtures/schema.enum-removal.ts')
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), 'kickdb-m4c-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+/**
+ * Plants a fake prior migration directory whose snapshot.json declares
+ * the `status` enum with one extra value (`legacy`). When generate()
+ * runs against the fixture schema (which has only `active` + `banned`),
+ * `diff()` produces a single `removeEnumValue` change.
+ */
+async function plantPriorSnapshotWithExtraEnumValue(migrationsDir: string): Promise<void> {
+  const priorDir = path.join(migrationsDir, '20260101_000000_init')
+  await mkdir(priorDir, { recursive: true })
+
+  const snapshot: SchemaSnapshot = {
+    version: 1,
+    dialect: 'postgres',
+    tables: {
+      users: {
+        name: 'users',
+        columns: {
+          id: { name: 'id', type: 'serial', nullable: false, default: null, primaryKey: true },
+        },
+        indexes: [],
+        foreignKeys: [],
+        checks: [],
+      },
+    },
+    enums: {
+      status: { name: 'status', values: ['active', 'banned', 'legacy'] },
+    },
+  }
+  await writeFile(path.join(priorDir, 'snapshot.json'), JSON.stringify(snapshot), 'utf8')
+  await writeFile(path.join(priorDir, 'up.sql'), '-- REVIEWED: true\n', 'utf8')
+  await writeFile(path.join(priorDir, 'down.sql'), '-- REVIEWED: true\n', 'utf8')
+  await writeFile(
+    path.join(priorDir, 'meta.json'),
+    JSON.stringify({
+      id: '20260101_000000_init',
+      name: 'init',
+      reviewed: true,
+      dialect: 'postgres',
+      previousId: null,
+      downIsDraft: false,
+    }),
+    'utf8',
+  )
+
+  const journal = {
+    version: 1,
+    dialect: 'postgres',
+    entries: [
+      {
+        id: '20260101_000000_init',
+        tag: 'init',
+        hash: 'fixture',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+  }
+  await writeFile(path.join(migrationsDir, '_journal.json'), JSON.stringify(journal), 'utf8')
+}
+
+describe('generate() — M4.C composite-type gate', () => {
+  it('aborts with CompositeEnumReferenceError when the detector finds a composite reference', async () => {
+    const migrationsDir = path.join(dir, 'migrations')
+    await plantPriorSnapshotWithExtraEnumValue(migrationsDir)
+
+    const calls: string[] = []
+    const detector = async (enumName: string): Promise<readonly CompositeRef[]> => {
+      calls.push(enumName)
+      return [{ composite: 'public.row_t', attribute: 'kind', enum: `public.${enumName}` }]
+    }
+
+    await expect(
+      generate({
+        name: 'remove_legacy_status',
+        config: { schemaPath: fixtureSchema, migrationsDir, dialect: 'postgres' },
+        cwd: process.cwd(),
+        detectCompositeRefs: detector,
+      }),
+    ).rejects.toBeInstanceOf(CompositeEnumReferenceError)
+
+    expect(calls).toEqual(['status'])
+
+    // The new migration directory must not exist — generate aborted before writing.
+    const entries = await readdir(migrationsDir)
+    expect(entries.toSorted()).toEqual(['20260101_000000_init', '_journal.json'])
+  })
+
+  it('lets the migration write normally when the detector returns no references', async () => {
+    const migrationsDir = path.join(dir, 'migrations')
+    await plantPriorSnapshotWithExtraEnumValue(migrationsDir)
+
+    const detector = async (): Promise<readonly CompositeRef[]> => []
+
+    const result = await generate({
+      name: 'remove_legacy_status',
+      config: { schemaPath: fixtureSchema, migrationsDir, dialect: 'postgres' },
+      cwd: process.cwd(),
+      detectCompositeRefs: detector,
+    })
+
+    expect(result.status).toBe('created')
+    const entries = (await readdir(migrationsDir)).filter((e) => e !== '_journal.json')
+    expect(entries).toHaveLength(2) // prior + the new one
+  })
+
+  it('skips the gate entirely when no detector is supplied', async () => {
+    const migrationsDir = path.join(dir, 'migrations')
+    await plantPriorSnapshotWithExtraEnumValue(migrationsDir)
+
+    const result = await generate({
+      name: 'remove_legacy_status',
+      config: { schemaPath: fixtureSchema, migrationsDir, dialect: 'postgres' },
+      cwd: process.cwd(),
+    })
+
+    expect(result.status).toBe('created')
+  })
+
+  it('invokes the detector once per distinct enum even with multiple removeEnumValue changes', async () => {
+    // Same fixture only has one enum, so the per-enum dedupe is exercised on
+    // a single enum here. The dedupe semantics matter when a future fixture
+    // adds two enums with values being dropped from each.
+    const migrationsDir = path.join(dir, 'migrations')
+    await plantPriorSnapshotWithExtraEnumValue(migrationsDir)
+
+    const calls: string[] = []
+    const detector = async (enumName: string): Promise<readonly CompositeRef[]> => {
+      calls.push(enumName)
+      return []
+    }
+
+    await generate({
+      name: 'remove_legacy_status',
+      config: { schemaPath: fixtureSchema, migrationsDir, dialect: 'postgres' },
+      cwd: process.cwd(),
+      detectCompositeRefs: detector,
+    })
+
+    expect(calls).toEqual(['status'])
+  })
+})

--- a/packages/db/__tests__/unit/composite-detect.test.ts
+++ b/packages/db/__tests__/unit/composite-detect.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit-level coverage for `detectCompositeReferences` against a fake
+ * query runner. Validates:
+ *  - the SQL is parameterised with `(name, schema-or-null)`
+ *  - the result mapper turns rows into `CompositeRef[]`
+ *  - schema-qualified vs unqualified enum names route correctly
+ *  - empty result yields an empty array
+ *
+ * Real-PG round-trip lives under __tests__/integration so this file
+ * stays no-Docker.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import {
+  detectCompositeReferences,
+  CompositeEnumReferenceError,
+  type CompositeQueryRunner,
+  type CompositeRef,
+} from '@forinda/kickjs-db'
+
+function fakeRunner(rows: Record<string, unknown>[]): {
+  runner: CompositeQueryRunner
+  calls: { sql: string; params: readonly unknown[] | undefined }[]
+} {
+  const calls: { sql: string; params: readonly unknown[] | undefined }[] = []
+  return {
+    runner: {
+      async query<R = unknown>(sql: string, params?: readonly unknown[]): Promise<{ rows: R[] }> {
+        calls.push({ sql, params })
+        return { rows: rows as R[] }
+      },
+    },
+    calls,
+  }
+}
+
+describe('detectCompositeReferences', () => {
+  it('returns an empty array when no composite references the enum', async () => {
+    const { runner, calls } = fakeRunner([])
+    const refs = await detectCompositeReferences(runner, 'user_status')
+
+    expect(refs).toEqual([])
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.params).toEqual(['user_status', null])
+  })
+
+  it('maps rows to CompositeRef shape with qualified type names', async () => {
+    const { runner } = fakeRunner([
+      {
+        composite_schema: 'public',
+        composite_name: 'address_t',
+        attribute_name: 'status',
+        enum_schema: 'public',
+        enum_name: 'user_status',
+      },
+      {
+        composite_schema: 'app',
+        composite_name: 'profile_t',
+        attribute_name: 'visibility',
+        enum_schema: 'public',
+        enum_name: 'user_status',
+      },
+    ])
+
+    const refs = await detectCompositeReferences(runner, 'user_status')
+
+    const expected: CompositeRef[] = [
+      { composite: 'public.address_t', attribute: 'status', enum: 'public.user_status' },
+      { composite: 'app.profile_t', attribute: 'visibility', enum: 'public.user_status' },
+    ]
+    expect(refs).toEqual(expected)
+  })
+
+  it('passes a non-null schema parameter when the enum name is qualified', async () => {
+    const { runner, calls } = fakeRunner([])
+    await detectCompositeReferences(runner, 'analytics.event_kind')
+
+    expect(calls[0]!.params).toEqual(['event_kind', 'analytics'])
+  })
+
+  it('CompositeEnumReferenceError surfaces every reference in its message', () => {
+    const refs: CompositeRef[] = [
+      { composite: 'public.address_t', attribute: 'status', enum: 'public.user_status' },
+      { composite: 'public.profile_t', attribute: 'tier', enum: 'public.user_status' },
+    ]
+    const err = new CompositeEnumReferenceError(refs)
+
+    expect(err.code).toBe('composite_enum_reference')
+    expect(err.refs).toEqual(refs)
+    expect(err.message).toContain('public.address_t.status')
+    expect(err.message).toContain('public.profile_t.tier')
+    expect(err.message).toContain('rename-recreate')
+  })
+})

--- a/packages/db/src/cli/generate.ts
+++ b/packages/db/src/cli/generate.ts
@@ -6,10 +6,12 @@ import { existsSync } from 'node:fs'
 import { extractSnapshot } from '../snapshot/extract'
 import { diff } from '../diff/engine'
 import { invertChanges, hasAmbiguousReverse } from '../diff/invert'
+import { CompositeEnumReferenceError, type CompositeRef } from '../diff/composite-detect'
 import { emitPg } from '../emit/pg'
 import { appendJournalEntry, computeMigrationHash } from '../migrate/journal'
 import type { DbConfig } from './config'
 import type { SchemaSnapshot } from '../snapshot/types'
+import type { Change, RemoveEnumValue } from '../diff/types'
 
 export interface GenerateOptions {
   name: string
@@ -23,6 +25,17 @@ export interface GenerateOptions {
    * change the diff engine can't author. Matches knex's `migrate:make`.
    */
   empty?: boolean
+  /**
+   * M4.C — generate-time gate for `removeEnumValue` changes. When the
+   * diff produces one or more, this callback is invoked once per
+   * affected enum to surface PG composite-type references. A non-empty
+   * result aborts generate with `CompositeEnumReferenceError` (the
+   * rename-recreate USING-cast can't reach into composite fields).
+   *
+   * Optional: when omitted, generate skips the check (no DB connection
+   * required). The CLI wires this for `dialect=postgres` workflows.
+   */
+  detectCompositeRefs?: (enumName: string) => Promise<readonly CompositeRef[]>
 }
 
 export interface GenerateResult {
@@ -60,6 +73,8 @@ export async function generate(opts: GenerateOptions): Promise<GenerateResult> {
   if (changes.length === 0) {
     return { status: 'no-changes', changeCount: 0 }
   }
+
+  await assertNoCompositeReferences(changes, opts.detectCompositeRefs)
 
   return await writeMigration({
     opts,
@@ -160,6 +175,37 @@ async function readLatestSnapshotEntry(migrationsDir: string): Promise<LatestEnt
   const file = path.join(migrationsDir, latest, 'snapshot.json')
   const snapshot = JSON.parse(await readFile(file, 'utf8')) as SchemaSnapshot
   return { snapshot, id: latest }
+}
+
+/**
+ * M4.C gate. Walk the diff for `removeEnumValue` changes; if any are
+ * present and the caller supplied a composite-detector, run it once
+ * per enum and aggregate the references. Throws
+ * `CompositeEnumReferenceError` when any references are found so the
+ * operator restructures the composite before the migration is
+ * committed to disk.
+ */
+async function assertNoCompositeReferences(
+  changes: readonly Change[],
+  detect: ((enumName: string) => Promise<readonly CompositeRef[]>) | undefined,
+): Promise<void> {
+  if (!detect) return
+  const removals = changes.filter((c): c is RemoveEnumValue => c.kind === 'removeEnumValue')
+  if (removals.length === 0) return
+
+  const allRefs: CompositeRef[] = []
+  // Detect once per distinct enum — multiple removals on the same enum
+  // collapse into a single check; the caller probably batched them.
+  const seen = new Set<string>()
+  for (const r of removals) {
+    if (seen.has(r.enum)) continue
+    seen.add(r.enum)
+    const refs = await detect(r.enum)
+    allRefs.push(...refs)
+  }
+  if (allRefs.length > 0) {
+    throw new CompositeEnumReferenceError(allRefs)
+  }
 }
 
 function formatId(date: Date, name: string): string {

--- a/packages/db/src/diff/composite-detect.ts
+++ b/packages/db/src/diff/composite-detect.ts
@@ -1,0 +1,134 @@
+/**
+ * PG composite-type detection for `removeEnumValue` migrations (M4.C).
+ *
+ * The M3.B rename-recreate dance assumes the enum is referenced only by
+ * table columns — each affected column gets a single `ALTER TABLE …
+ * ALTER COLUMN … TYPE foo USING column::text::foo` clause. PG composite
+ * types / arrays-of-composite / domains containing the enum break that
+ * approach: the USING clause can't reach into composite fields, so the
+ * migration fails opaquely at apply time with `type X is being used by
+ * table Y`.
+ *
+ * `detectCompositeReferences` queries `pg_type` + `pg_attribute` to
+ * surface those references at generate time. The CLI `kick db generate`
+ * command then refuses to emit a migration when any are found, telling
+ * the operator to drop or restructure the composite first.
+ *
+ * Driver-agnostic: takes a structural query runner (any pg-protocol-
+ * compatible client). The CLI wires this against the same pool used for
+ * `kick db migrate` so adopters don't configure a second connection.
+ *
+ * Spec: docs/db/m4-plan.md §M4.C.
+ */
+
+import { KickDbError } from '../errors'
+
+/**
+ * One composite-type field that holds the target enum. The composite
+ * may itself be referenced by table columns; that second level is not
+ * surfaced — the goal here is to refuse the rename-recreate, not to
+ * map the full dependency graph.
+ */
+export interface CompositeRef {
+  /** Schema-qualified composite type name, e.g. `"public.address_t"`. */
+  composite: string
+  /** Attribute (field) within the composite that holds the enum. */
+  attribute: string
+  /** Schema-qualified enum type name. */
+  enum: string
+}
+
+/**
+ * Slim contract for a pg-protocol-compatible query function. Both
+ * `pg.Pool` and `@neondatabase/serverless`'s Pool match this shape, as
+ * does the `query` method on a pooled client.
+ */
+export interface CompositeQueryRunner {
+  query<R = unknown>(sql: string, params?: readonly unknown[]): Promise<{ rows: R[] }>
+}
+
+interface CompositeRow {
+  composite_schema: string
+  composite_name: string
+  attribute_name: string
+  enum_schema: string
+  enum_name: string
+}
+
+/**
+ * Find every PG composite type whose attribute(s) hold the given enum
+ * type. `enumName` may be unqualified (treated as `public.<name>`) or
+ * schema-qualified (`schema.name`).
+ *
+ * Returns an empty array when:
+ *  - the enum doesn't exist in the live DB (the diff engine raised it
+ *    against a snapshot, but the DB hasn't applied the prior migration
+ *    yet — generate-time refusal would be a false alarm), or
+ *  - no composite references the enum (the M3.B path is safe).
+ */
+export async function detectCompositeReferences(
+  runner: CompositeQueryRunner,
+  enumName: string,
+): Promise<CompositeRef[]> {
+  const { schema, name } = splitQualifiedName(enumName)
+
+  const sql = `
+    SELECT
+      ns_comp.nspname AS composite_schema,
+      t_comp.typname AS composite_name,
+      a.attname AS attribute_name,
+      ns_enum.nspname AS enum_schema,
+      t_enum.typname AS enum_name
+    FROM pg_type t_comp
+    JOIN pg_namespace ns_comp ON ns_comp.oid = t_comp.typnamespace
+    JOIN pg_class c ON c.oid = t_comp.typrelid
+    JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped
+    JOIN pg_type t_enum_or_arr ON t_enum_or_arr.oid = a.atttypid
+    JOIN pg_type t_enum ON t_enum.oid = COALESCE(NULLIF(t_enum_or_arr.typelem, 0), t_enum_or_arr.oid)
+    JOIN pg_namespace ns_enum ON ns_enum.oid = t_enum.typnamespace
+    WHERE t_comp.typtype = 'c'
+      AND c.relkind = 'c'
+      AND t_enum.typtype = 'e'
+      AND t_enum.typname = $1
+      AND ($2::text IS NULL OR ns_enum.nspname = $2)
+  `
+
+  const result = await runner.query<CompositeRow>(sql, [name, schema])
+  return result.rows.map((r) => ({
+    composite: `${r.composite_schema}.${r.composite_name}`,
+    attribute: r.attribute_name,
+    enum: `${r.enum_schema}.${r.enum_name}`,
+  }))
+}
+
+function splitQualifiedName(qualified: string): { schema: string | null; name: string } {
+  const dot = qualified.indexOf('.')
+  if (dot === -1) return { schema: null, name: qualified }
+  return { schema: qualified.slice(0, dot), name: qualified.slice(dot + 1) }
+}
+
+/**
+ * Thrown by `kick db generate` when the diff would emit one or more
+ * `removeEnumValue` changes against an enum that is referenced by a
+ * PG composite type. The rename-recreate dance can't reach into
+ * composite fields, so the generator refuses to write the migration
+ * rather than letting it fail at apply time.
+ *
+ * The operator's options: drop the composite, restructure it not to
+ * use the enum, or keep the value and ship the change later.
+ */
+export class CompositeEnumReferenceError extends KickDbError {
+  readonly refs: readonly CompositeRef[]
+
+  constructor(refs: readonly CompositeRef[]) {
+    const summary = refs.map((r) => `${r.composite}.${r.attribute} → ${r.enum}`).join(', ')
+    super(
+      'composite_enum_reference',
+      `Cannot generate migration: the enum value(s) being removed are reachable through ` +
+        `composite type field(s) [${summary}]. PostgreSQL's USING-cast in the rename-recreate ` +
+        `path can't reach into composite fields, so the migration would fail at apply time. ` +
+        `Drop or restructure the composite type(s) first, then re-run \`kick db generate\`.`,
+    )
+    this.refs = refs
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -15,6 +15,12 @@ export { renderSchemaSource } from './snapshot/render'
 export type * from './diff/types'
 export { diff } from './diff/engine'
 export { invertChanges, hasAmbiguousReverse } from './diff/invert'
+export {
+  detectCompositeReferences,
+  CompositeEnumReferenceError,
+  type CompositeRef,
+  type CompositeQueryRunner,
+} from './diff/composite-detect'
 
 export { KickDbError } from './errors'
 export {


### PR DESCRIPTION
## Why

M3.B shipped lossless `pgEnum` value removal via a rename-recreate dance gated behind `--confirm-enum-drop`. The dance assumes the enum is referenced only by table columns: each affected column gets one `ALTER TABLE … ALTER COLUMN … TYPE foo USING column::text::foo` clause inside the rename-recreate block. PG composite types / arrays-of-composite / domains containing the enum break that approach — the `USING` cast can't reach into composite fields, so the migration fails opaquely at apply time with `type X is being used by table Y`.

m4-plan.md §M4.C reserved a generate-time gate slot for this. This PR fills it.

## What changed

1. **`detectCompositeReferences(runner, enumName)`** — new helper at `packages/db/src/diff/composite-detect.ts`. Takes a structurally-typed pg-protocol query function (matches `pg.Pool` / neon-serverless Pool / pooled clients), queries `pg_type` + `pg_attribute`, returns a `CompositeRef[]` describing every composite-type field that holds the enum (directly or via array). Schema-qualified enum names (`schema.name`) restrict to the named schema; unqualified names match any schema.

2. **`generate()` gate** — `GenerateOptions` gains an optional `detectCompositeRefs` callback. When the diff produces one or more `removeEnumValue` changes and the callback is set, generate runs detection once per distinct enum and aggregates the references. Non-empty result throws `CompositeEnumReferenceError` listing every `<composite>.<attribute>` and the migration is NOT written to disk. Empty result lets the migration proceed normally.

3. **CLI wiring** — `kick db generate` resolves a `pg.Pool` directly (separate from `resolveAdapter` which returns a wrapped MigrationAdapter) when `dialect === 'postgres'` and `connectionString` is available. The pool is passed to `detectCompositeReferences` via the new callback. Adopters using the `db.adapter` factory escape hatch skip the check (they can call the helper manually against their own pool).

4. **New error class** — `CompositeEnumReferenceError extends KickDbError`. Code: `composite_enum_reference`.

## Tests

- **Unit (`composite-detect.test.ts`)** — fake query runner, validates SQL parameters (`(name, schema|null)`), row-to-`CompositeRef` mapping, error message shape.
- **Integration (`composite-detect.test.ts` under `__tests__/integration/`)** — Testcontainers PG 16, four cases: no references, direct composite-attribute reference, array-of-enum composite reference, schema-qualified isolation.
- **Generate-time gate (`cli-generate-composite-gate.test.ts`)** — plants a prior snapshot with one extra enum value to force a `removeEnumValue` diff, then verifies:
  - non-empty detector result aborts with `CompositeEnumReferenceError` AND no migration directory is written,
  - empty detector result lets generate proceed,
  - missing detector skips the gate entirely (back-compat),
  - the detector is invoked once per distinct enum.

`pnpm --filter @forinda/kickjs-db test` → 353/353 passing (was 349). CLI suite unaffected → 272/272.

## Public surface added

```ts
export {
  detectCompositeReferences,
  CompositeEnumReferenceError,
  type CompositeRef,
  type CompositeQueryRunner,
} from '@forinda/kickjs-db'
```

## Test plan

- [x] Unit suite passes (`pnpm --filter @forinda/kickjs-db test`)
- [x] CLI suite passes (`pnpm --filter @forinda/kickjs-cli test`)
- [x] `pnpm format:check` clean
- [x] `pnpm --filter @forinda/kickjs-db build` clean
- [ ] CodeRabbit pass

## Changeset

`.changeset/db-m4c-composite-detect.md` — minor on `@forinda/kickjs-db` (additive: new exported helper + new error class), patch on `@forinda/kickjs-cli` (new import wiring, no behavior change for non-PG paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostgreSQL migration safety: `kick db generate` now detects composite types that reference enums slated for removal and prevents generation, showing a detailed error listing each affected composite attribute.
  * Configuration: CLI config gains an optional database config block to enable/describe DB settings used by the command.

* **Tests**
  * Added unit and integration suites covering composite-reference detection and generation behavior across schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->