### PR TITLE
chore(db): bump kysely 0.28.16 → 0.29.0 across the db family

### DIFF
--- a/.changeset/kysely-0.29.0.md
+++ b/.changeset/kysely-0.29.0.md
@@ -1,0 +1,31 @@
+---
+'@forinda/kickjs-db': minor
+'@forinda/kickjs-db-pg': minor
+'@forinda/kickjs-db-mysql': minor
+'@forinda/kickjs-db-sqlite': minor
+---
+
+chore(db): bump kysely from `0.28.16` to `0.29.0` across the db family
+
+Direct + peer ranges bumped on `@forinda/kickjs-db`, `@forinda/kickjs-db-pg`, `@forinda/kickjs-db-mysql`, `@forinda/kickjs-db-sqlite`. Adopters who pin `kysely@0.28.x` need to update their lockfile; nothing else.
+
+Why minor: the peer floor moves from `^0.28.16` to `^0.29.0`, so adopters bumping `@forinda/kickjs-db` get a transitive Kysely major. No source changes were required for the upgrade — the breaking-change list audited clean against kickjs-db's surface:
+
+- `sql.value` / `sql.literal` removed → not used.
+- `numUpdatedOrDeletedRows` → not used.
+- `executeQuery(query, queryId)` → `(query, options?)` — kickjs's call site (`packages/db/src/query/builder.ts`) passes one arg, which stays compatible.
+- Migration exports relocated to `kysely/migration` — kickjs uses its own `MigrationAdapter` contract, doesn't import `Migrator` / `FileMigrationProvider`.
+- TS 5.4 floor → repo on TS 6.0.3.
+- CommonJS dropped → kickjs is ESM-first via tsdown; CJS-interop adopters pinned to `kysely@0.28.x` need to plan their own migration.
+
+Adopter-facing wins now reachable through `KickDbClient`:
+
+- `$pickTables<...>()` / `$omitTables<...>()` for compile-time schema narrowing.
+- `ReadonlyKysely` — type-level read-only client that prevents `insert`/`update`/`delete`/`merge` at compile time.
+- `AbortSignal` query cancellation — composable with `RequestContext.signal` (a future kickjs-db release will thread it through `db.query.X.findMany` natively).
+- `eb.case().thenRef` / `whenRef(lhs, op, rhs)` / `elseRef`.
+- ALTER TYPE PG node — opens the door to a follow-up that simplifies the M3.B `removeEnumValue` emitter.
+- `SafeNullComparisonPlugin` — `= null` → `IS NULL` automatically.
+- `with(name, query)` shape on CTEs.
+
+Test matrix: db (359), db-pg (24), db-mysql (34), db-sqlite (10), cli (276) — all green on `kysely@0.29.0`.

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -13,6 +13,7 @@ import {
   migrateRollback,
   migrateStatus,
   renderSchemaSource,
+  type CompositeQueryRunner,
   type DbConfig,
   type MigrationAdapter,
 } from '@forinda/kickjs-db'
@@ -67,9 +68,7 @@ async function resolveAdapter(config: DbConfig): Promise<{
 }
 
 interface PgQueryRunnerProbe {
-  runner: {
-    query: (sql: string, params?: readonly unknown[]) => Promise<{ rows: unknown[] }>
-  }
+  runner: CompositeQueryRunner
   cleanup: () => Promise<void>
 }
 

--- a/packages/db-mysql/package.json
+++ b/packages/db-mysql/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "kysely": "0.28.16"
+    "kysely": "0.29.0"
   },
   "peerDependencies": {
     "@forinda/kickjs-db": "workspace:*",
@@ -64,7 +64,7 @@
     "@forinda/kickjs": "workspace:*",
     "@forinda/kickjs-db": "workspace:*",
     "@types/node": "^25.6.0",
-    "kysely": "^0.28.16",
+    "kysely": "^0.29.0",
     "mysql2": "^3.15.3",
     "typescript": "^6.0.3"
   },

--- a/packages/db-pg/package.json
+++ b/packages/db-pg/package.json
@@ -52,7 +52,7 @@
     }
   },
   "dependencies": {
-    "kysely": "0.28.16"
+    "kysely": "0.29.0"
   },
   "peerDependencies": {
     "@forinda/kickjs-db": "workspace:*",
@@ -64,7 +64,7 @@
     "@testcontainers/postgresql": "^10.16.0",
     "@types/node": "^25.6.0",
     "@types/pg": "^8.11.10",
-    "kysely": "^0.28.16",
+    "kysely": "^0.29.0",
     "pg": "^8.13.1",
     "typescript": "^6.0.3"
   },

--- a/packages/db-sqlite/package.json
+++ b/packages/db-sqlite/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "kysely": "0.28.16"
+    "kysely": "0.29.0"
   },
   "peerDependencies": {
     "@forinda/kickjs-db": "workspace:*",
@@ -66,7 +66,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.6.0",
     "better-sqlite3": "^12.9.0",
-    "kysely": "^0.28.16",
+    "kysely": "^0.29.0",
     "typescript": "^6.0.3"
   },
   "publishConfig": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -62,7 +62,7 @@
     }
   },
   "dependencies": {
-    "kysely": "0.28.16"
+    "kysely": "0.29.0"
   },
   "peerDependencies": {
     "@forinda/kickjs": ">=5.0.0",
@@ -79,7 +79,7 @@
     "@testcontainers/postgresql": "^10.16.0",
     "@types/node": "^25.6.0",
     "@types/pg": "^8.11.10",
-    "kysely": "^0.28.16",
+    "kysely": "^0.29.0",
     "pg": "^8.13.1",
     "typescript": "^6.0.3"
   },

--- a/packages/swagger/src/decorators.ts
+++ b/packages/swagger/src/decorators.ts
@@ -139,7 +139,9 @@ export function ApiSecurity(
   // builder reads a single shape. Strings become `{ name, scopes: [] }`.
   const requirements: ApiSecurityRequirement[] = (
     Array.isArray(requirement) ? requirement : [requirement]
-  ).map((r) => (typeof r === 'string' ? { name: r, scopes: [] } : { scopes: [], ...r }))
+  ).map((r) =>
+    typeof r === 'string' ? { name: r, scopes: [] } : { name: r.name, scopes: r.scopes ?? [] },
+  )
 
   return (target: any, propertyKey?: string | symbol) => {
     if (propertyKey) {

--- a/packages/swagger/src/openapi-builder.ts
+++ b/packages/swagger/src/openapi-builder.ts
@@ -164,7 +164,9 @@ function normaliseSecurity(
 ): ApiSecurityRequirement[] {
   const arr = Array.isArray(raw) ? raw : [raw]
   return arr.map((entry) =>
-    typeof entry === 'string' ? { name: entry, scopes: [] } : { scopes: [], ...entry },
+    typeof entry === 'string'
+      ? { name: entry, scopes: [] }
+      : { name: entry.name, scopes: entry.scopes ?? [] },
   )
 }
 

--- a/packages/vscode-extension/scripts/build-icons.mjs
+++ b/packages/vscode-extension/scripts/build-icons.mjs
@@ -11,7 +11,7 @@
  * Run via `pnpm build:icons` (wireit step). Idempotent — safe to re-run.
  */
 
-import { readFileSync, mkdirSync, writeFileSync } from 'node:fs'
+import { readFileSync, mkdirSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import sharp from 'sharp'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,7 +373,7 @@ importers:
         version: 10.0.1
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(kysely@0.28.16)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.8)(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))
+        version: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(kysely@0.29.0)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.8)(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))
       express:
         specifier: ^5.1.0
         version: 5.2.1
@@ -892,8 +892,8 @@ importers:
   packages/db:
     dependencies:
       kysely:
-        specifier: 0.28.16
-        version: 0.28.16
+        specifier: 0.29.0
+        version: 0.29.0
     devDependencies:
       '@forinda/kickjs':
         specifier: workspace:*
@@ -920,8 +920,8 @@ importers:
   packages/db-mysql:
     dependencies:
       kysely:
-        specifier: 0.28.16
-        version: 0.28.16
+        specifier: 0.29.0
+        version: 0.29.0
     devDependencies:
       '@forinda/kickjs':
         specifier: workspace:*
@@ -942,8 +942,8 @@ importers:
   packages/db-pg:
     dependencies:
       kysely:
-        specifier: 0.28.16
-        version: 0.28.16
+        specifier: 0.29.0
+        version: 0.29.0
     devDependencies:
       '@forinda/kickjs':
         specifier: workspace:*
@@ -970,8 +970,8 @@ importers:
   packages/db-sqlite:
     dependencies:
       kysely:
-        specifier: 0.28.16
-        version: 0.28.16
+        specifier: 0.29.0
+        version: 0.29.0
     devDependencies:
       '@forinda/kickjs':
         specifier: workspace:*
@@ -1075,7 +1075,7 @@ importers:
     dependencies:
       drizzle-orm:
         specifier: '>=0.45.2'
-        version: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(kysely@0.28.16)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.8)(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))
+        version: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(kysely@0.29.0)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.8)(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -4847,6 +4847,10 @@ packages:
   kysely@0.28.16:
     resolution: {integrity: sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww==}
     engines: {node: '>=20.0.0'}
+
+  kysely@0.29.0:
+    resolution: {integrity: sha512-LrQfPUeTW7MXbMvT62moEMnpMTuj9TO3lqjCeLKjM975PJ4Alrl/43f2tlDX7xOsNptKgH4LSNGwIbXwEkLg4g==}
+    engines: {node: '>=22.0.0'}
 
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
@@ -9225,7 +9229,7 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(kysely@0.28.16)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.8)(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3)):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(kysely@0.29.0)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.8)(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3)):
     optionalDependencies:
       '@electric-sql/pglite': 0.4.1
       '@opentelemetry/api': 1.9.1
@@ -9233,7 +9237,7 @@ snapshots:
       '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.20.0
       better-sqlite3: 12.9.0
-      kysely: 0.28.16
+      kysely: 0.29.0
       mysql2: 3.15.3
       pg: 8.20.0
       postgres: 3.4.8
@@ -9911,6 +9915,8 @@ snapshots:
   kareem@3.2.0: {}
 
   kysely@0.28.16: {}
+
+  kysely@0.29.0: {}
 
   lazystream@1.0.1:
     dependencies:


### PR DESCRIPTION
## Why

Kysely [v0.29.0](https://github.com/kysely-org/kysely/releases/tag/v0.29.0) shipped 2026-05-09. Net win for kickjs-db adopters: `$pickTables` / `$omitTables` for narrowing, `ReadonlyKysely` for read-only views, `AbortSignal` query cancellation, `eb.case().thenRef`/`whenRef`/`elseRef`, `SafeNullComparisonPlugin`, and a PG `ALTER TYPE` node that opens a cleaner path for the M3.B rename-recreate.

## What changed

- `kysely` direct + peer ranges bumped from `0.28.16` to `0.29.0` on `@forinda/kickjs-db`, `@forinda/kickjs-db-pg`, `@forinda/kickjs-db-mysql`, `@forinda/kickjs-db-sqlite`.
- Lockfile refreshed.
- Changeset records a minor bump on each affected package (the peer floor moves; adopters bumping `@forinda/kickjs-db` get a transitive Kysely major).

**Zero source changes were required.** Audit against the v0.29.0 breaking-change list:

| Breaking change | kickjs-db impact |
|---|---|
| Migration exports relocated to `kysely/migration` | None — kickjs has its own `MigrationAdapter`; no `Migrator`/`FileMigrationProvider` imports |
| TS 5.4 floor | None — repo on TS 6.0.3 |
| CommonJS dropped | None — kickjs is ESM-first via tsdown |
| `sql.value` / `sql.literal` removed | Not used |
| `executeQuery(query, queryId)` → `(query, options?)` | Safe — `query/builder.ts` calls with one arg only |
| `numUpdatedOrDeletedRows` → `numAffectedRows` | Not used |
| `UniqueConstraintNode.columns` widened | Not used |
| `withTables` deprecated (still works) | Not used |

## Test matrix

```
@forinda/kickjs-db        — 359/359 passing
@forinda/kickjs-db-pg     —  24/24 (incl Testcontainers M4.E.1 enum-drop)
@forinda/kickjs-db-mysql  —  34/34
@forinda/kickjs-db-sqlite —  10/10
@forinda/kickjs-cli       — 276/276
```

## Test plan

- [x] All four db packages build clean
- [x] Full db family + cli test matrix green on `kysely@0.29.0`
- [x] `pnpm format:check` clean
- [ ] CodeRabbit pass

## Changeset

`.changeset/kysely-0.29.0.md` — minor on `@forinda/kickjs-db`, `@forinda/kickjs-db-pg`, `@forinda/kickjs-db-mysql`, `@forinda/kickjs-db-sqlite`.

## Follow-ups (not in this PR)

- Thread `AbortSignal` (RequestContext.signal) through `db.query.X.findMany` options.
- Adopt the new PG `ALTER TYPE` node in `emitRemoveEnumValueRecreate` — could collapse the rename-recreate dance and unblock the column-DEFAULT-preservation gap surfaced in M4.E.1.
- Document `$pickTables` / `ReadonlyKysely` in the relational-query guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Kysely to 0.29.0 across database packages, enabling new query capabilities (table narrowing, cancellation support, null-safe comparisons, extra expression helpers).
* **Bug Fixes / Improvements**
  * Normalize API security entries so generated OpenAPI/security docs use consistent name+scopes shapes.
  * Improve CLI composite-type detection typing for more accurate DB introspection.
* **Chores**
  * Minor build script cleanup for icon generation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/205)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->