### PR TITLE
chore(db-peers): use workspace:^ peer range to stop minor→major cascades

### DIFF
--- a/.changeset/peer-deps-no-major-cascade.md
+++ b/.changeset/peer-deps-no-major-cascade.md
@@ -1,0 +1,13 @@
+---
+'@forinda/kickjs-db-pg': patch
+'@forinda/kickjs-db-mysql': patch
+'@forinda/kickjs-db-sqlite': patch
+---
+
+chore(db-peers): use `workspace:^` instead of `workspace:*` for the `@forinda/kickjs-db` peer range — keeps minor core bumps from cascading to major peer bumps
+
+`workspace:*` was publishing as the **exact** core version (e.g. `5.6.0`). Every minor bump on `@forinda/kickjs-db` (e.g. `5.6 → 5.7`) made the peer's `peerDependencies` range string change too, which changesets-action correctly flagged as a peer-range change → escalated to a **major** bump on every peer adapter even when the peer's own source was unchanged. That's why the kysely 0.29 release shipped `db-pg@9.0.0` / `db-mysql@2.0.0` / `db-sqlite@2.0.0` from a minor changeset.
+
+`workspace:^` publishes as a caret range (e.g. `^5.6.0`), so the next `5.7.0` core release stays in-range — the peer's `peerDependencies` string doesn't change → no cascade. Only an actual major core bump (`6.0.0`) lands out of range and triggers the major-on-peers escalation, which is the correct semantic.
+
+Combined with the existing `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange: true` config (which was already present but ineffective because `workspace:*` made every change "out of range"), future iterations stay on patch + minor unless an adapter's own source changes warrant otherwise.

--- a/packages/db-mysql/package.json
+++ b/packages/db-mysql/package.json
@@ -57,7 +57,7 @@
     "kysely": "0.29.0"
   },
   "peerDependencies": {
-    "@forinda/kickjs-db": "workspace:*",
+    "@forinda/kickjs-db": "workspace:^",
     "mysql2": ">=3.0.0"
   },
   "devDependencies": {

--- a/packages/db-pg/package.json
+++ b/packages/db-pg/package.json
@@ -55,7 +55,7 @@
     "kysely": "0.29.0"
   },
   "peerDependencies": {
-    "@forinda/kickjs-db": "workspace:*",
+    "@forinda/kickjs-db": "workspace:^",
     "pg": ">=8.11.0"
   },
   "devDependencies": {

--- a/packages/db-sqlite/package.json
+++ b/packages/db-sqlite/package.json
@@ -57,7 +57,7 @@
     "kysely": "0.29.0"
   },
   "peerDependencies": {
-    "@forinda/kickjs-db": "workspace:*",
+    "@forinda/kickjs-db": "workspace:^",
     "better-sqlite3": ">=12.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Why

The kysely 0.29 release (#205 → #206) shipped:

- `@forinda/kickjs-db@5.6.0` — minor (correct)
- `@forinda/kickjs-db-pg@9.0.0` — **major** ❌
- `@forinda/kickjs-db-mysql@2.0.0` — **major** ❌
- `@forinda/kickjs-db-sqlite@2.0.0` — **major** ❌

None of those peer adapters had source changes warranting a major; the changeset I authored declared `minor` on each. Yet they all jumped major. The user pushed back: future iterations should stay on patch/minor.

## Root cause

The peer adapters declared `@forinda/kickjs-db: "workspace:*"` in `peerDependencies`. pnpm rewrites `workspace:*` on publish to the **exact** version (e.g. `5.6.0`, not `^5.6.0`). Every minor bump on `@forinda/kickjs-db` (`5.6 → 5.7 → …`) makes the peer's published `peerDependencies` range string change too. Changesets-action correctly flags a peer-range change as a breaking shift for downstream consumers and escalates the peer's bump to major — even when the peer's own source is unchanged.

The repo already had `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange: true` in `.changeset/config.json`, which is supposed to suppress this. It didn't help — because `workspace:*` makes every new core version "out of range" by definition.

## Fix

Two-character change in three `package.json` files: `workspace:*` → `workspace:^` on the `@forinda/kickjs-db` peer entry in `db-pg`, `db-mysql`, `db-sqlite`.

`workspace:^` publishes as a caret range (e.g. `^5.6.0` instead of `5.6.0`). The next minor core release (`5.7.0`) stays inside that range — the peer's `peerDependencies` string doesn't change → no cascade.

Only a real major core bump (`6.0.0`) lands out of range and correctly escalates the peer to major, which is the right semantic.

## Effect on adopters

| Scenario | Before | After |
|---|---|---|
| `db@5.6 → 5.7` | peers cascade to major | peers untouched (no release needed) |
| `db@5.7 → 6.0` | peers cascade to major | peers cascade to major (correct) |
| Peer's own source changes | peer ships its own bump | peer ships its own bump (unchanged) |

For end users: `pnpm install @forinda/kickjs-db-pg@^9` now resolves any `@forinda/kickjs-db@^5.6` instead of being pinned to `=5.6.0`, which matches the looser SemVer expectation already documented for the peer adapters.

## Test plan

- [x] All four db packages build clean (`pnpm install && pnpm --filter @forinda/kickjs-db --filter @forinda/kickjs-db-pg --filter @forinda/kickjs-db-mysql --filter @forinda/kickjs-db-sqlite build`)
- [x] `pnpm format:check` clean
- [ ] Verify the next changesets `version` PR after this merges shows the peer adapters un-bumped on a future db-only minor change.

## Changeset

`.changeset/peer-deps-no-major-cascade.md` — patch on each of the three peer adapters (no source change to `@forinda/kickjs-db`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated peer dependency version constraints for database adapter packages to improve version stability and prevent unnecessary major version escalations when core library receives minor updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/207)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->