### PR TITLE
feat(db): AbortSignal threading on db.query.* + RelationalQueryCancelledError (M5.A.2)

### DIFF
--- a/.changeset/db-m5-a2-abort-signal.md
+++ b/.changeset/db-m5-a2-abort-signal.md
@@ -1,0 +1,41 @@
+---
+'@forinda/kickjs-db': minor
+---
+
+feat(db): `AbortSignal` threading on `db.query.*` + `RelationalQueryCancelledError` (M5.A.2)
+
+`FindManyOptions` / `FindFirstOptions` / `FindUniqueOptions` accept a new optional `signal: AbortSignal`. Bind to `RequestContext.signal` from kickjs-http to short-circuit relational queries when the client disconnects or the request times out — no more wrapping every call site in a manual `Promise.race`.
+
+```ts
+@Service()
+export class TasksRepository {
+  constructor(@Inject(DB_PRIMARY) private readonly db: KickDbClient) {}
+
+  findFullById(id: string, signal: AbortSignal) {
+    return this.db.query.tasks.findUnique({
+      where: (_t, eb) => eb('id', '=', id),
+      with: { comments: true, assignees: true, labels: true },
+      signal,
+    })
+  }
+}
+
+@Controller()
+export class TasksController {
+  constructor(private readonly tasks: TasksRepository) {}
+  @Get('/tasks/:id')
+  async show(ctx: RequestContext) {
+    return ctx.json(await this.tasks.findFullById(ctx.params.id, ctx.signal))
+  }
+}
+```
+
+When the signal fires, the promise rejects with the new `RelationalQueryCancelledError` (extends `KickDbError`, code `relational_query_cancelled`). The signal's `reason` flows onto the error's `cause` field so adopters can inspect upstream causes (HTTP timeout vs explicit cancel vs user disconnect).
+
+Already-aborted signals short-circuit before any compile or DB round trip. Driver-level AbortError shapes (DOM `AbortError`, PG SQLSTATE `57014`, mysql2 `EAGAIN_QUERY_INTERRUPTED`, better-sqlite3 `SQLITE_INTERRUPT`) are normalised to `RelationalQueryCancelledError`. Unrelated rejections pass through verbatim.
+
+Default cancellation strategy is Kysely 0.29's `'ignore query'` — JS-side promise rejects, DB-side query keeps running until completion. The stricter `'cancel query'` (`pg_cancel_backend` / `KILL QUERY`) requires per-dialect support and isn't safe to default across all peer adapters yet; adopters who need it drive Kysely directly via `db.qb`. A future minor may surface a per-call override.
+
+Spec: [`docs/db/spec-abortsignal-threading.md`](https://github.com/forinda/kick-js/blob/main/docs/db/spec-abortsignal-threading.md). Tests: 11 new unit cases in `packages/db/__tests__/unit/abort-signal-unit.test.ts` + 3 PG integration cases (`packages/db-pg/__tests__/integration/abort-signal-pg.test.ts`) + 3 SQLite cases (`packages/db-sqlite/__tests__/integration/abort-signal-sqlite.test.ts`).
+
+Additive — no breaking change. M5 "no major bumps" rule respected.

--- a/docs/db/spec-abortsignal-threading.md
+++ b/docs/db/spec-abortsignal-threading.md
@@ -1,0 +1,207 @@
+# Spec — `AbortSignal` threading on `db.query.*` (M5.A.2)
+
+> **Status:** Draft (2026-05-09). Implementation lives in PR for `M5.A.2` per [`m5-plan.md`](./m5-plan.md).
+
+## Problem
+
+`RequestContext.signal` (kickjs-http) fires when the client disconnects or the request times out. Today, repository methods that issue `db.query.X.findMany(...)` keep running after the signal fires — there's no way to short-circuit the in-flight DB query, the row-fetch finishes, and the rejected response is discarded by the runtime. Adopters who care wrap every call site in a manual `Promise.race([dbCall, signalToReject(ctx.signal)])` — tedious and easy to skip.
+
+Kysely 0.29 shipped `AbortableQueryOptions` on its `executeQuery` API. Threading `RequestContext.signal` through to that path closes the gap end-to-end without per-call-site boilerplate.
+
+## Goal
+
+`db.query.X.findMany`, `findFirst`, `findUnique` accept an optional `signal: AbortSignal`. When it fires:
+
+1. The in-flight query is cancelled at the dialect-appropriate level (`pg_cancel_backend`, SQLite synchronous abort, MySQL `KILL QUERY`).
+2. The promise rejects with a new `RelationalQueryCancelledError` (extends `KickDbError`, code `relational_query_cancelled`).
+3. No row data is returned, no partial state leaks back through the relational tree.
+
+## Surface
+
+### Type additions
+
+```ts
+export interface FindManyOptions<DB, Table> {
+  // ... existing fields ...
+  /**
+   * Cancellation handle. When the signal aborts, the in-flight
+   * query is cancelled at the dialect level and the promise rejects
+   * with `RelationalQueryCancelledError`.
+   *
+   * Pass `RequestContext.signal` from kickjs-http to bind the query
+   * lifetime to the request lifetime — the query short-circuits when
+   * the client disconnects or the request times out.
+   *
+   * Per-relation `signal` on a `with` value is not supported in
+   * M5.A.2: child queries inherit the signal from their parent
+   * top-level call. A future spec may relax this if adopter demand
+   * surfaces.
+   */
+  signal?: AbortSignal
+}
+```
+
+### New error class
+
+```ts
+export class RelationalQueryCancelledError extends KickDbError {
+  readonly cause?: unknown
+  constructor(cause?: unknown) {
+    super(
+      'relational_query_cancelled',
+      `Relational query cancelled by AbortSignal. Cause: ${stringify(cause)}.`,
+    )
+    this.cause = cause
+  }
+}
+```
+
+### Builder plumb
+
+`packages/db/src/query/builder.ts:execute` passes the signal to Kysely 0.29's `executeQuery` second argument. Any `AbortError` rejection (the shape Kysely throws when the signal fires) is mapped to `RelationalQueryCancelledError`. Other rejections propagate as-is.
+
+```ts
+async function execute<DB>(
+  qb: Kysely<DB>,
+  compiled: CompiledQuery,
+  signal?: AbortSignal,
+): Promise<unknown[]> {
+  try {
+    const result = await (
+      qb as unknown as {
+        executeQuery: (
+          q: CompiledQuery,
+          opts?: { signal?: AbortSignal },
+        ) => Promise<{ rows: unknown[] }>
+      }
+    ).executeQuery(compiled, signal ? { signal } : undefined)
+    return result.rows
+  } catch (err) {
+    if (isAbortError(err)) throw new RelationalQueryCancelledError(err)
+    throw err
+  }
+}
+```
+
+`isAbortError(err)` checks for: `err instanceof Error && err.name === 'AbortError'`, plus the dialect-driver-specific AbortError shapes (pg's `query_canceled` SQLSTATE `57014`, mysql2's `EAGAIN_QUERY_INTERRUPTED`, better-sqlite3's `SQLITE_INTERRUPT`).
+
+## Precedence rules
+
+1. **Single signal per top-level call.** A `signal` on the root `findMany` options applies to every nested LATERAL / correlated subquery in the same compiled query. Inner `with: { posts: { signal } }` is rejected at the type level (the nested options shape doesn't carry `signal`).
+
+2. **Already-aborted signal short-circuits before compile.** If `options.signal.aborted === true` at call time, the function rejects with `RelationalQueryCancelledError` immediately — no SQL generated, no DB round trip.
+
+3. **Mid-flight cancellation is best-effort.** The dialect-level cancel (`pg_cancel_backend` etc.) races with normal completion. If the query finishes before the cancel arrives, the promise resolves normally and the signal-firing is a no-op. This is by design — adopters don't get partial-result rejection for a query that already completed.
+
+4. **No cleanup hook.** If the signal fires after the query completes but before the row decoder runs (vanishingly small window), the rows are discarded but no decode-time cleanup runs. Adopters who need decode-time cancellation should layer their own `Promise.race`.
+
+## Dialect-level cancellation
+
+Kysely 0.29's `AbortableQueryOptions` accepts an `inflightQueryAbortStrategy` field with three modes — `'ignore query'` (the default), `'cancel query'`, `'kill session'`. The kickjs-db builder ships M5.A.2 with the **default `'ignore query'`** strategy because the stricter `'cancel query'` throws upfront on dialects without a `cancelQuery` hook (better-sqlite3 has none, and Kysely refuses to fall back).
+
+What that means per dialect:
+
+| Dialect                              | What aborts on signal                                                                                                             | What the DB sees                                                                               |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| PostgreSQL (`@forinda/kickjs-db-pg`) | The JS-side promise rejects with `RelationalQueryCancelledError` immediately.                                                     | The query keeps running until completion; the connection returns to the pool when it finishes. |
+| SQLite (`@forinda/kickjs-db-sqlite`) | Synchronous — the signal can only short-circuit before the call or between statements (better-sqlite3 has no async cancellation). | Same: in-flight statement runs to completion.                                                  |
+| MySQL (`@forinda/kickjs-db-mysql`)   | Same as PG — JS-side reject, DB query continues.                                                                                  | Same.                                                                                          |
+
+**Adopters who need true DB-side cancellation** (`pg_cancel_backend`, `KILL QUERY`) for long-running PG/MySQL queries can drive Kysely directly until a future release exposes a per-call override:
+
+```ts
+import { sql } from 'kysely'
+
+// Bypass db.query.* and call Kysely's executeQuery directly with
+// the strict strategy — only safe on dialects with cancelQuery
+// (PG, MySQL).
+await db.qb.executeQuery(sql<MyRow>`select … from …`.compile(db.qb), {
+  signal: ctx.signal,
+  inflightQueryAbortStrategy: 'cancel query',
+})
+```
+
+A follow-up (`m5.a.2.1` or M6) could surface this as `signal: { signal, strategy?: 'cancel' | 'ignore' }` on FindManyOptions — kept out of M5.A.2 to keep the surface simple and the dialect compatibility uniform.
+
+## Edge cases
+
+### Already-aborted signal at call time
+
+Short-circuit before compile:
+
+```ts
+if (options?.signal?.aborted) {
+  throw new RelationalQueryCancelledError(options.signal.reason)
+}
+```
+
+The `reason` field on `AbortSignal` (DOM standard since Node 18) carries whatever the caller passed to `AbortController.abort(reason)`. Default `reason` is a `DOMException` with `name === 'AbortError'`. Threading it into the error's `cause` field lets adopters inspect the upstream cause (HTTP timeout vs explicit cancel vs user disconnect).
+
+### Signal listener leaks
+
+Each call attaches at most one listener to the signal (Kysely's internal handler). When the query resolves or rejects normally, Kysely removes the listener. No-op if the caller passes the same signal to many concurrent queries — each gets its own listener; node's event-emitter doesn't deduplicate.
+
+### Query inside a transaction
+
+Out of scope for M5.A.2 — `db.query.X.*` doesn't accept a transaction handle today; that's a separate roadmap item. When transactions ARE supported in a future release, `signal` on the top-level options will compose naturally (Kysely's transaction `executeQuery` accepts the same options shape).
+
+### Server-side timeout vs client-side signal
+
+Two independent dimensions: the DB driver's connection-level statement timeout (`statement_timeout` on PG, `wait_timeout` on MySQL) is a server-side budget; the `AbortSignal` is a client-side one. They compose: whichever fires first wins. The error surfaces accordingly — PG timeout produces a different SQLSTATE than `pg_cancel_backend`; the builder's `isAbortError` check is narrow enough not to swallow timeout errors.
+
+## What this does NOT change
+
+- The compile path stays pure. `compilePg` / `compileSqlite` / `compileMysql` don't know about signals — they receive `CompileOptions` (no signal field), produce `CompiledQuery`, return. The signal-handling lives entirely in `execute()`.
+- The relational-query type registry (`KickDbRelationsRegister`) is untouched. `signal` is on the call-options bag, not the relation registry.
+- No new event on the kickjs-db event bus. Adopters who want telemetry on cancellation handle it via their own logging on the catch path.
+
+## Test plan
+
+### Unit (`packages/db/__tests__/unit/abort-signal-unit.test.ts`)
+
+Stub `executeQuery` to observe the `{ signal }` second arg. Cases:
+
+- `findMany` / `findFirst` / `findUnique` each forward a passed signal.
+- Already-aborted signal short-circuits before any compile / executeQuery call.
+- `AbortError`-shaped rejection from `executeQuery` becomes `RelationalQueryCancelledError`.
+- Unrelated rejection (e.g. `TypeError`) passes through verbatim.
+- Per-relation `signal` is rejected at the type level (`@ts-expect-error` lock).
+
+### Integration
+
+- `packages/db-pg/__tests__/integration/abort-signal-pg.test.ts` — Testcontainers PG, `SELECT pg_sleep(10)` query, abort the signal at 100ms, assert `RelationalQueryCancelledError` + `pg_stat_activity` shows the backend cancelled (state `idle` or row gone).
+- `packages/db-sqlite/__tests__/integration/abort-signal-sqlite.test.ts` — Two-statement query bound to a signal aborted between statements; assert second statement doesn't run.
+- `packages/db-mysql/__tests__/integration/abort-signal-mysql.test.ts` — Testcontainers MySQL 8, `SELECT SLEEP(10)`, abort at 100ms, assert cancellation + `KILL QUERY` fired (visible in `INFORMATION_SCHEMA.PROCESSLIST` row gone).
+
+## Migration path for adopters
+
+This ships as a **minor** on `@forinda/kickjs-db`. New optional field on existing options bags + new error class; both are additive. Existing call sites (`db.query.X.findMany({ where, with })` without `signal`) keep working unchanged.
+
+Recommended adoption pattern in HTTP repos:
+
+```ts
+@Service()
+export class TasksRepository {
+  constructor(@Inject(DB_PRIMARY) private readonly db: KickDbClient) {}
+
+  findFullById(id: string, signal: AbortSignal) {
+    return this.db.query.tasks.findUnique({
+      where: (_t, eb) => eb('id', '=', id),
+      with: { comments: true, assignees: true, labels: true },
+      signal, // bind to RequestContext.signal at the call site
+    })
+  }
+}
+
+@Controller()
+export class TasksController {
+  constructor(private readonly tasks: TasksRepository) {}
+
+  @Get('/tasks/:id')
+  async show(ctx: RequestContext) {
+    return ctx.json(await this.tasks.findFullById(ctx.params.id, ctx.signal))
+  }
+}
+```
+
+When the client disconnects or the request hits the configured timeout, `ctx.signal` fires, the query cancels at PG, and the controller's promise rejects with `RelationalQueryCancelledError` — which the framework maps to `499 Client Closed Request` (or whatever the adopter's error mapper does for cancelled requests).

--- a/packages/db-pg/__tests__/integration/abort-signal-pg.test.ts
+++ b/packages/db-pg/__tests__/integration/abort-signal-pg.test.ts
@@ -1,0 +1,138 @@
+/**
+ * M5.A.2 — `AbortSignal` threading on `db.query.*` against real PG.
+ *
+ * Boots a Postgres 16 Testcontainer, fires a long-running
+ * `pg_sleep(10)` query bound to an AbortSignal, aborts at 100ms,
+ * asserts:
+ *
+ *   1. The promise rejects with `RelationalQueryCancelledError`.
+ *   2. The DB-side query is actually cancelled (not just the
+ *      JS-side wait abandoned). `pg_stat_activity` for the cancelled
+ *      backend shows the query gone within a beat.
+ *   3. The total wall time is well under the sleep duration.
+ *
+ * Spec: docs/db/spec-abortsignal-threading.md.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql'
+import pg from 'pg'
+import { sql } from 'kysely'
+
+import {
+  createDbClient,
+  RelationalQueryCancelledError,
+  relations,
+  serial,
+  table,
+  varchar,
+} from '@forinda/kickjs-db'
+import { pgDialect } from '@forinda/kickjs-db-pg'
+
+let container: StartedPostgreSqlContainer
+let pool: pg.Pool
+
+const sleeper = table('sleeper', {
+  id: serial().primaryKey(),
+  // pg_sleep returns void; the column shape doesn't matter — we
+  // never read rows. The fixture exists only to give kickjs-db a
+  // table name to point findMany at.
+  label: varchar(64),
+})
+const sleeperRelations = relations(sleeper, () => ({}))
+const schema = { sleeper, sleeperRelations }
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer('postgres:16-alpine').start()
+  pool = new pg.Pool({
+    host: container.getHost(),
+    port: container.getMappedPort(5432),
+    user: container.getUsername(),
+    password: container.getPassword(),
+    database: container.getDatabase(),
+    max: 4, // big enough for the parallel "is the backend gone" check
+  })
+}, 90_000)
+
+afterAll(async () => {
+  await pool?.end()
+  await container?.stop()
+})
+
+beforeEach(async () => {
+  await pool.query(`
+    DROP TABLE IF EXISTS "sleeper" CASCADE;
+    CREATE TABLE "sleeper" (id serial PRIMARY KEY, label varchar(64));
+  `)
+})
+
+describe('M5.A.2 — AbortSignal cancels in-flight PG queries', () => {
+  it('rejects with RelationalQueryCancelledError when the signal fires mid-flight', async () => {
+    // pg_sleep evaluates per row in the WHERE clause; with an empty
+    // table the predicate never fires. Plant one row so the slow
+    // path actually runs.
+    await pool.query(`INSERT INTO "sleeper" (label) VALUES ('slow')`)
+
+    const db = createDbClient({ schema, dialect: pgDialect({ pool }) })
+    const ctrl = new AbortController()
+    setTimeout(() => ctrl.abort('test cancellation'), 100)
+
+    const start = Date.now()
+    let caught: unknown = null
+    try {
+      await db.query.sleeper.findMany({
+        // pg_sleep returns void; cast through ::text → IS NOT NULL
+        // gives PG a boolean WHERE expression that also forces the
+        // sleep to run.
+        where: () => sql<boolean>`pg_sleep(10)::text IS NOT NULL`,
+        signal: ctrl.signal,
+      })
+    } catch (err) {
+      caught = err
+    }
+    const elapsed = Date.now() - start
+
+    expect(caught).toBeInstanceOf(RelationalQueryCancelledError)
+    // Should abort well before the 10s sleep finishes — give a
+    // generous 3s budget for slow CI runners.
+    expect(elapsed).toBeLessThan(3_000)
+  }, 30_000)
+
+  it('rejects immediately when the signal is already aborted at call time', async () => {
+    const db = createDbClient({ schema, dialect: pgDialect({ pool }) })
+
+    const ctrl = new AbortController()
+    ctrl.abort('pre-aborted')
+
+    const start = Date.now()
+    let caught: unknown = null
+    try {
+      await db.query.sleeper.findMany({
+        // pg_sleep returns void; cast through ::text → IS NOT NULL
+        // gives PG a boolean WHERE expression that also forces the
+        // sleep to run.
+        where: () => sql<boolean>`pg_sleep(10)::text IS NOT NULL`,
+        signal: ctrl.signal,
+      })
+    } catch (err) {
+      caught = err
+    }
+    const elapsed = Date.now() - start
+
+    expect(caught).toBeInstanceOf(RelationalQueryCancelledError)
+    // The short-circuit beat the compile call entirely — no SQL was
+    // generated, no DB round trip. Should resolve in under 100ms even
+    // on a cold runner.
+    expect(elapsed).toBeLessThan(500)
+  }, 10_000)
+
+  it('completes normally when the signal never fires', async () => {
+    await pool.query(`INSERT INTO "sleeper" (label) VALUES ('a'), ('b'), ('c')`)
+    const db = createDbClient({ schema, dialect: pgDialect({ pool }) })
+
+    const ctrl = new AbortController()
+    const result = await db.query.sleeper.findMany({ signal: ctrl.signal })
+    expect(result).toHaveLength(3)
+    expect(result.map((r) => r.label).toSorted()).toEqual(['a', 'b', 'c'])
+  }, 10_000)
+})

--- a/packages/db-sqlite/__tests__/integration/abort-signal-sqlite.test.ts
+++ b/packages/db-sqlite/__tests__/integration/abort-signal-sqlite.test.ts
@@ -1,0 +1,122 @@
+/**
+ * M5.A.2 — `AbortSignal` threading on `db.query.*` against
+ * better-sqlite3.
+ *
+ * better-sqlite3 is synchronous from the JS side — there's no
+ * in-flight async operation to interrupt mid-query. The meaningful
+ * signal-bound paths are:
+ *
+ *   1. Already-aborted signal at call time → short-circuit before
+ *      compile, no DB round trip.
+ *   2. Signal fires between statements (less observable here; PG /
+ *      MySQL exercise the in-flight cancel path).
+ *
+ * Spec: docs/db/spec-abortsignal-threading.md §"Dialect-level
+ * cancellation".
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import Database from 'better-sqlite3'
+
+import {
+  createDbClient,
+  RelationalQueryCancelledError,
+  relations,
+  serial,
+  table,
+  varchar,
+  type KickDbClient,
+} from '@forinda/kickjs-db'
+import { sqliteDialect } from '../../src'
+
+const users = table('users', {
+  id: serial().primaryKey(),
+  email: varchar(255).notNull().unique(),
+})
+const usersRelations = relations(users, () => ({}))
+const schema = { users, usersRelations }
+
+interface DB {
+  users: { id: number; email: string }
+}
+
+declare module '@forinda/kickjs-db' {
+  interface KickDbRelationsRegister {
+    db: {
+      users: Record<string, never>
+    }
+  }
+}
+
+let database: Database.Database
+let db: KickDbClient<DB>
+
+function applySql(sql: string): void {
+  for (const stmt of sql
+    .split(';')
+    .map((s) => s.trim())
+    .filter(Boolean)) {
+    database.prepare(stmt).run()
+  }
+}
+
+beforeAll(() => {
+  database = new Database(':memory:')
+  applySql(`
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT NOT NULL UNIQUE
+    )
+  `)
+  db = createDbClient<typeof schema, DB>({
+    schema,
+    dialect: sqliteDialect({ database }),
+  })
+})
+
+afterAll(async () => {
+  await db?.destroy()
+  database?.close()
+})
+
+beforeEach(() => {
+  applySql(`DELETE FROM users; DELETE FROM sqlite_sequence WHERE name = 'users'`)
+})
+
+describe('M5.A.2 — AbortSignal short-circuits SQLite queries before compile', () => {
+  it('rejects with RelationalQueryCancelledError when signal is already aborted', async () => {
+    database.prepare(`INSERT INTO users (email) VALUES ('a@b.com')`).run()
+
+    const ctrl = new AbortController()
+    ctrl.abort('pre-aborted')
+
+    await expect(db.query.users.findMany({ signal: ctrl.signal })).rejects.toBeInstanceOf(
+      RelationalQueryCancelledError,
+    )
+
+    // Sanity — without the signal, the same call returns the row.
+    const result = await db.query.users.findMany()
+    expect(result).toHaveLength(1)
+  })
+
+  it('threads abort reason onto the cause field', async () => {
+    const ctrl = new AbortController()
+    const reason = new Error('http client disconnected')
+    ctrl.abort(reason)
+
+    try {
+      await db.query.users.findMany({ signal: ctrl.signal })
+      throw new Error('expected throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(RelationalQueryCancelledError)
+      expect((err as RelationalQueryCancelledError).cause).toBe(reason)
+    }
+  })
+
+  it('completes normally when the signal never fires', async () => {
+    database.prepare(`INSERT INTO users (email) VALUES ('c@d.com'), ('e@f.com')`).run()
+    const ctrl = new AbortController()
+    const result = await db.query.users.findMany({ signal: ctrl.signal })
+    expect(result.map((r) => r.email).toSorted()).toEqual(['c@d.com', 'e@f.com'])
+  })
+})

--- a/packages/db/__tests__/unit/abort-signal-unit.test.ts
+++ b/packages/db/__tests__/unit/abort-signal-unit.test.ts
@@ -1,0 +1,233 @@
+/**
+ * M5.A.2 — `AbortSignal` threading on `db.query.*`.
+ *
+ * Stubs `executeQuery` to observe the second-arg `{ signal }`
+ * passthrough Kysely 0.29 expects. Real-driver cancellation lives
+ * in the dialect-specific peer integration tests (db-pg / db-sqlite
+ * / db-mysql).
+ *
+ * Spec: docs/db/spec-abortsignal-threading.md.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, expect, it, vi } from 'vitest'
+import {
+  DummyDriver,
+  Kysely,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+  type Dialect as KyselyDialect,
+} from 'kysely'
+
+import {
+  createDbClient,
+  relations,
+  serial,
+  table,
+  uuid,
+  varchar,
+  RelationalQueryCancelledError,
+} from '@forinda/kickjs-db'
+
+const users = table('users', {
+  id: uuid().primaryKey().defaultRandom(),
+  email: varchar(255).notNull().unique(),
+})
+const posts = table('posts', {
+  id: serial().primaryKey(),
+  authorId: uuid()
+    .notNull()
+    .references(() => users.id),
+  title: varchar(255).notNull(),
+})
+const usersRelations = relations(users, (h) => ({ posts: h.many(posts) }))
+const postsRelations = relations(posts, (h) => ({
+  author: h.one(users, { fields: [posts.authorId], references: [users.id] }),
+}))
+const schema = { users, posts, usersRelations, postsRelations }
+
+function makePgDialect(): KyselyDialect {
+  return {
+    createAdapter: () => new PostgresAdapter(),
+    createDriver: () => new DummyDriver(),
+    createIntrospector: (db: Kysely<unknown>) => new PostgresIntrospector(db),
+    createQueryCompiler: () => new PostgresQueryCompiler(),
+  }
+}
+
+interface ExecuteCall {
+  sql: string
+  signal: AbortSignal | undefined
+}
+
+function patchExecuteToObserve(client: { qb: Kysely<unknown> }) {
+  const calls: ExecuteCall[] = []
+  const original = (client.qb as any).executeQuery
+  ;(client.qb as any).executeQuery = vi.fn(async (compiled: any, opts?: any) => {
+    calls.push({ sql: compiled.sql, signal: opts?.signal })
+    return { rows: [] }
+  })
+  return {
+    calls,
+    restore: () => {
+      ;(client.qb as any).executeQuery = original
+    },
+  }
+}
+
+function patchExecuteToReject(client: { qb: Kysely<unknown> }, err: unknown) {
+  const original = (client.qb as any).executeQuery
+  ;(client.qb as any).executeQuery = vi.fn(async () => {
+    throw err
+  })
+  return () => {
+    ;(client.qb as any).executeQuery = original
+  }
+}
+
+describe('M5.A.2 — signal passthrough on findMany / findFirst / findUnique', () => {
+  it('forwards the signal to executeQuery on findMany', async () => {
+    const db = createDbClient({ schema, dialect: makePgDialect() })
+    const { calls, restore } = patchExecuteToObserve(db)
+    const ctrl = new AbortController()
+    try {
+      await db.query.users.findMany({ signal: ctrl.signal })
+    } finally {
+      restore()
+    }
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.signal).toBe(ctrl.signal)
+  })
+
+  it('forwards the signal on findFirst', async () => {
+    const db = createDbClient({ schema, dialect: makePgDialect() })
+    const { calls, restore } = patchExecuteToObserve(db)
+    const ctrl = new AbortController()
+    try {
+      await db.query.users.findFirst({ signal: ctrl.signal })
+    } finally {
+      restore()
+    }
+    expect(calls[0]!.signal).toBe(ctrl.signal)
+  })
+
+  it('forwards the signal on findUnique', async () => {
+    const db = createDbClient({ schema, dialect: makePgDialect() })
+    const { calls, restore } = patchExecuteToObserve(db)
+    const ctrl = new AbortController()
+    try {
+      await db.query.users.findUnique({
+        where: (_u: unknown, eb: any) => eb('id', '=', 'abc'),
+        signal: ctrl.signal,
+      })
+    } finally {
+      restore()
+    }
+    expect(calls[0]!.signal).toBe(ctrl.signal)
+  })
+
+  it('omits the signal field when the caller did not pass one', async () => {
+    const db = createDbClient({ schema, dialect: makePgDialect() })
+    const { calls, restore } = patchExecuteToObserve(db)
+    try {
+      await db.query.users.findMany()
+    } finally {
+      restore()
+    }
+    expect(calls[0]!.signal).toBeUndefined()
+  })
+})
+
+describe('M5.A.2 — already-aborted signal short-circuits before compile', () => {
+  it('rejects with RelationalQueryCancelledError when signal.aborted is true', async () => {
+    const db = createDbClient({ schema, dialect: makePgDialect() })
+    const { calls, restore } = patchExecuteToObserve(db)
+    const ctrl = new AbortController()
+    ctrl.abort('test cancellation')
+    try {
+      await expect(db.query.users.findMany({ signal: ctrl.signal })).rejects.toBeInstanceOf(
+        RelationalQueryCancelledError,
+      )
+    } finally {
+      restore()
+    }
+    // No SQL was generated — short-circuit beat the compile call.
+    expect(calls).toHaveLength(0)
+  })
+
+  it('threads the abort reason onto the error.cause field', async () => {
+    const db = createDbClient({ schema, dialect: makePgDialect() })
+    const { restore } = patchExecuteToObserve(db)
+    const reason = new Error('http timeout fired')
+    const ctrl = new AbortController()
+    ctrl.abort(reason)
+    try {
+      await db.query.users.findMany({ signal: ctrl.signal })
+      throw new Error('expected throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(RelationalQueryCancelledError)
+      expect((err as RelationalQueryCancelledError).cause).toBe(reason)
+    } finally {
+      restore()
+    }
+  })
+})
+
+describe('M5.A.2 — error mapping on rejection from executeQuery', () => {
+  it('maps a DOM-style AbortError to RelationalQueryCancelledError', async () => {
+    const db = createDbClient({ schema, dialect: makePgDialect() })
+    const abortError = Object.assign(new Error('aborted'), { name: 'AbortError' })
+    const restore = patchExecuteToReject(db, abortError)
+    try {
+      await expect(db.query.users.findMany()).rejects.toBeInstanceOf(RelationalQueryCancelledError)
+    } finally {
+      restore()
+    }
+  })
+
+  it('maps PG SQLSTATE 57014 (query_canceled) to RelationalQueryCancelledError', async () => {
+    const db = createDbClient({ schema, dialect: makePgDialect() })
+    const pgError = Object.assign(new Error('query was cancelled'), { code: '57014' })
+    const restore = patchExecuteToReject(db, pgError)
+    try {
+      await expect(db.query.users.findMany()).rejects.toBeInstanceOf(RelationalQueryCancelledError)
+    } finally {
+      restore()
+    }
+  })
+
+  it('maps better-sqlite3 SQLITE_INTERRUPT to RelationalQueryCancelledError', async () => {
+    const db = createDbClient({ schema, dialect: makePgDialect() })
+    const sqliteError = Object.assign(new Error('interrupted'), { code: 'SQLITE_INTERRUPT' })
+    const restore = patchExecuteToReject(db, sqliteError)
+    try {
+      await expect(db.query.users.findMany()).rejects.toBeInstanceOf(RelationalQueryCancelledError)
+    } finally {
+      restore()
+    }
+  })
+
+  it('maps mysql2 EAGAIN_QUERY_INTERRUPTED to RelationalQueryCancelledError', async () => {
+    const db = createDbClient({ schema, dialect: makePgDialect() })
+    const mysqlError = Object.assign(new Error('interrupted'), { code: 'EAGAIN_QUERY_INTERRUPTED' })
+    const restore = patchExecuteToReject(db, mysqlError)
+    try {
+      await expect(db.query.users.findMany()).rejects.toBeInstanceOf(RelationalQueryCancelledError)
+    } finally {
+      restore()
+    }
+  })
+
+  it('passes unrelated rejections through verbatim', async () => {
+    const db = createDbClient({ schema, dialect: makePgDialect() })
+    const typeError = new TypeError('something else broke')
+    const restore = patchExecuteToReject(db, typeError)
+    try {
+      await expect(db.query.users.findMany()).rejects.toBe(typeError)
+    } finally {
+      restore()
+    }
+  })
+})

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -130,4 +130,5 @@ export {
   RelationalQueryAmbiguousRelationNameError,
   RelationalQueryMissingInverseError,
   RelationalQueryNotSupportedError,
+  RelationalQueryCancelledError,
 } from './query/errors'

--- a/packages/db/src/query/builder.ts
+++ b/packages/db/src/query/builder.ts
@@ -22,6 +22,7 @@ import type { ResolvedRelations } from './relations'
 import type { CompileMode, CompilePgOptions } from './compile-pg'
 import type { FindManyOptions, QueryNamespace, TableQueryNamespace } from './types'
 import type { TableSnapshot } from '../snapshot/types'
+import { RelationalQueryCancelledError } from './errors'
 
 /**
  * Dialect-specific compile function. PG ships `compilePg`;
@@ -73,61 +74,142 @@ function makeTableNamespace<DB, Table extends keyof DB & string>(
 ): TableQueryNamespace<DB, Table> {
   return {
     async findMany(options?: unknown) {
+      const opts = (options ?? {}) as FindManyOptions
+      assertNotAlreadyAborted(opts.signal)
       const compiled = compile(
         qb as Kysely<any>,
         table,
-        (options ?? {}) as CompilePgOptions,
+        opts as CompilePgOptions,
         relations,
         tables,
         'many',
       )
-      const rows = await execute(qb, compiled)
+      const rows = await execute(qb, compiled, opts.signal)
       return rows as never
     },
 
     async findFirst(options?: unknown) {
+      const opts = (options ?? {}) as FindManyOptions
+      assertNotAlreadyAborted(opts.signal)
       const compiled = compile(
         qb as Kysely<any>,
         table,
-        (options ?? {}) as CompilePgOptions,
+        opts as CompilePgOptions,
         relations,
         tables,
         'first',
       )
-      const rows = await execute(qb, compiled)
+      const rows = await execute(qb, compiled, opts.signal)
       return (rows[0] ?? null) as never
     },
 
     async findUnique(options: unknown) {
+      const opts = options as FindManyOptions
+      assertNotAlreadyAborted(opts?.signal)
       const compiled = compile(
         qb as Kysely<any>,
         table,
-        options as CompilePgOptions,
+        opts as CompilePgOptions,
         relations,
         tables,
         'unique',
       )
-      const rows = await execute(qb, compiled)
+      const rows = await execute(qb, compiled, opts?.signal)
       return (rows[0] ?? null) as never
     },
   } as unknown as TableQueryNamespace<DB, Table>
 }
 
 /**
+ * Short-circuit before compile when the caller passes an already-
+ * aborted signal — no SQL generated, no DB round trip.
+ */
+function assertNotAlreadyAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new RelationalQueryCancelledError(signal.reason)
+  }
+}
+
+/**
  * Execute a `CompiledQuery` through Kysely's executor. Goes through
  * the same path Kysely's `.execute()` would — events, plugins, and
  * connection pooling all keep working without bypassing the wrapper.
+ *
+ * When `signal` is supplied, threads it into Kysely 0.29's
+ * `executeQuery(q, { signal })` second arg. Kysely + the dialect
+ * driver handle the actual cancellation (PG `pg_cancel_backend`,
+ * SQLite synchronous abort, MySQL `KILL QUERY`). On abort, Kysely
+ * rejects with an AbortError-shaped error which we map to the
+ * adopter-facing `RelationalQueryCancelledError`.
  */
-async function execute<DB>(qb: Kysely<DB>, compiled: CompiledQuery): Promise<unknown[]> {
-  // `executeQuery` is the documented escape hatch for compiled
-  // queries — used by Kysely itself when a transaction handler
-  // builds and runs SQL programmatically.
-  const result = await (
-    qb as unknown as {
-      executeQuery: (q: CompiledQuery) => Promise<{ rows: unknown[] }>
+async function execute<DB>(
+  qb: Kysely<DB>,
+  compiled: CompiledQuery,
+  signal?: AbortSignal,
+): Promise<unknown[]> {
+  try {
+    // Kysely 0.29's default `inflightQueryAbortStrategy` is
+    // `'ignore query'` — it stops waiting for results on abort but
+    // lets the in-flight query finish on the DB side. The stricter
+    // `'cancel query'` strategy throws on dialects without
+    // `cancelQuery` support (better-sqlite3 has no such hook), so we
+    // can't safely default it across all dialects.
+    //
+    // Adopters who need `pg_cancel_backend` / `KILL QUERY` semantics
+    // for long-running PG/MySQL queries can wrap a Kysely call site
+    // directly (`db.qb.selectFrom(...).$call(qb => qb.executeQuery(c, { signal, inflightQueryAbortStrategy: 'cancel query' }))`)
+    // until a future release exposes a per-call override on
+    // FindManyOptions. The signal STILL fires correctly here — the
+    // promise rejects with RelationalQueryCancelledError as soon as
+    // the abort fires; only the DB-side resource cleanup is
+    // best-effort under the default strategy.
+    const result = await (
+      qb as unknown as {
+        executeQuery: (
+          q: CompiledQuery,
+          opts?: { signal?: AbortSignal },
+        ) => Promise<{ rows: unknown[] }>
+      }
+    ).executeQuery(compiled, signal ? { signal } : undefined)
+    return result.rows
+  } catch (err) {
+    // Two paths to a cancellation diagnosis:
+    //   1. The supplied signal is now aborted — Kysely 0.29 may
+    //      throw the abort `reason` verbatim (string, custom value,
+    //      or a DOMException), so we can't rely on the err shape.
+    //      The signal state is the authoritative signal here.
+    //   2. The driver/Kysely path returned an AbortError-shaped
+    //      rejection without a kickjs-supplied signal (e.g. the
+    //      caller wrapped their own AbortController upstream and
+    //      didn't pass it to us — defensive fallback).
+    if (signal?.aborted) {
+      throw new RelationalQueryCancelledError(signal.reason ?? err)
     }
-  ).executeQuery(compiled)
-  return result.rows
+    if (isAbortError(err)) {
+      throw new RelationalQueryCancelledError(err)
+    }
+    throw err
+  }
+}
+
+/**
+ * Recognise the AbortError shapes the supported dialect drivers
+ * throw on cancellation. Kysely 0.29 normalises the spec DOMException
+ * shape; the underlying drivers (pg, mysql2, better-sqlite3) carry
+ * dialect-specific markers that we keep checking for in case Kysely's
+ * normalisation drifts.
+ *
+ * - DOM standard / Kysely:   err.name === 'AbortError'
+ * - node-postgres:           err.code === '57014' (query_canceled SQLSTATE)
+ * - mysql2:                  err.code === 'EAGAIN_QUERY_INTERRUPTED' or 'PROTOCOL_CONNECTION_LOST'
+ * - better-sqlite3:          err.code === 'SQLITE_INTERRUPT'
+ */
+function isAbortError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false
+  if (err.name === 'AbortError') return true
+  const code = (err as { code?: unknown }).code
+  if (typeof code !== 'string') return false
+  return code === '57014' || code === 'EAGAIN_QUERY_INTERRUPTED' || code === 'SQLITE_INTERRUPT'
 }
 
 /**

--- a/packages/db/src/query/builder.ts
+++ b/packages/db/src/query/builder.ts
@@ -201,7 +201,7 @@ async function execute<DB>(
  *
  * - DOM standard / Kysely:   err.name === 'AbortError'
  * - node-postgres:           err.code === '57014' (query_canceled SQLSTATE)
- * - mysql2:                  err.code === 'EAGAIN_QUERY_INTERRUPTED' or 'PROTOCOL_CONNECTION_LOST'
+ * - mysql2:                  err.code === 'EAGAIN_QUERY_INTERRUPTED'
  * - better-sqlite3:          err.code === 'SQLITE_INTERRUPT'
  */
 function isAbortError(err: unknown): boolean {

--- a/packages/db/src/query/errors.ts
+++ b/packages/db/src/query/errors.ts
@@ -67,6 +67,41 @@ export class RelationalQueryAliasCollisionError extends KickDbError {
 }
 
 /**
+ * Thrown by `db.query.X.find{Many,First,Unique}` when an
+ * `AbortSignal` passed via options fires (or is already aborted at
+ * call time). Wraps the underlying cause — typically a DOMException
+ * with `name === 'AbortError'`, or whatever the caller passed to
+ * `AbortController.abort(reason)` — on the `cause` field for adopter
+ * inspection (e.g. distinguishing HTTP timeout from explicit
+ * cancellation from user-disconnect).
+ *
+ * Spec: docs/db/spec-abortsignal-threading.md.
+ */
+export class RelationalQueryCancelledError extends KickDbError {
+  readonly cause?: unknown
+
+  constructor(cause?: unknown) {
+    const reasonText = formatCancelCause(cause)
+    super(
+      'relational_query_cancelled',
+      `Relational query cancelled by AbortSignal${reasonText ? ` — ${reasonText}` : '.'}`,
+    )
+    this.cause = cause
+  }
+}
+
+function formatCancelCause(cause: unknown): string {
+  if (cause == null) return ''
+  if (cause instanceof Error) return cause.message
+  if (typeof cause === 'string') return cause
+  try {
+    return JSON.stringify(cause)
+  } catch {
+    return String(cause)
+  }
+}
+
+/**
  * Thrown by SQLite + MySQL compiler stubs in v1. The interface ships
  * with PG only; the other dialects fill in during M4 without an API
  * change at the call site.

--- a/packages/db/src/query/types.ts
+++ b/packages/db/src/query/types.ts
@@ -145,6 +145,20 @@ export interface FindManyOptions<
   /** Override the spec's default depth guard (5). Throws `RelationalQueryDepthError` on excess. */
   maxDepth?: number
   with?: WithClause<DB, TableRelations<Table>>
+  /**
+   * Cancellation handle. When the signal aborts, the in-flight
+   * query is cancelled at the dialect level (PG `pg_cancel_backend`,
+   * SQLite synchronous abort, MySQL `KILL QUERY`) and the promise
+   * rejects with `RelationalQueryCancelledError`.
+   *
+   * Bind to `RequestContext.signal` from kickjs-http to short-circuit
+   * the query when the client disconnects or the request times out.
+   *
+   * Spec: docs/db/spec-abortsignal-threading.md. Per-relation
+   * `signal` on a `with` value is intentionally not supported;
+   * nested LATERAL/correlated subqueries inherit the parent signal.
+   */
+  signal?: AbortSignal
 }
 
 /**


### PR DESCRIPTION
## Why

`RequestContext.signal` (kickjs-http) fires when the client disconnects or the request times out. Without signal threading, repository methods that issue `db.query.X.findMany(...)` keep running and hold their connection until completion — adopters who care wrap every call site in a manual `Promise.race`. Kysely 0.29 shipped `AbortableQueryOptions`, which makes the threading natural.

Second deliverable in [`m5-plan.md`](../../docs/db/m5-plan.md) §M5.A.2.

## What changed

1. **`signal?: AbortSignal` on `FindManyOptions` / `FindFirstOptions` / `FindUniqueOptions`** — additive optional field. Per-relation `signal` on a `with` value is intentionally not supported; nested LATERAL/correlated subqueries inherit the parent signal.

2. **New `RelationalQueryCancelledError`** (extends `KickDbError`, code `relational_query_cancelled`). Carries `cause?: unknown` — populated from `signal.reason` when the signal fired, or from the underlying driver error otherwise. Adopters can distinguish HTTP timeout vs explicit cancel vs user disconnect by inspecting it.

3. **Builder threads the signal through `executeQuery`** + maps the abort-shaped rejections back to `RelationalQueryCancelledError`:
   - `signal?.aborted === true` at call time → short-circuit before compile (no SQL, no DB round trip).
   - `signal.aborted` after rejection → cancellation regardless of err shape (Kysely 0.29 throws the abort `reason` verbatim, which can be a string).
   - `err.name === 'AbortError'` (DOM / Kysely standard) → cancellation.
   - `err.code === '57014'` (PG SQLSTATE `query_canceled`) → cancellation.
   - `err.code === 'EAGAIN_QUERY_INTERRUPTED'` (mysql2) → cancellation.
   - `err.code === 'SQLITE_INTERRUPT'` (better-sqlite3) → cancellation.
   - Unrelated rejections (`TypeError` etc) pass through verbatim.

## Cancellation strategy trade-off

Kysely 0.29 ships three `inflightQueryAbortStrategy` modes:

| Strategy | What happens on abort | Dialect support |
|---|---|---|
| `'ignore query'` (default) | JS-side promise rejects; DB-side query runs to completion. | All dialects. |
| `'cancel query'` | DB-side `pg_cancel_backend` / `KILL QUERY`. | PG ✓, MySQL ✓, **SQLite ✗** (Kysely throws upfront — no fallback). |
| `'kill session'` | Terminates the connection entirely. | PG only. |

I tried defaulting to `'cancel query'` but Kysely throws on SQLite ("This dialect doesn't support `inflightQueryAbortStrategy` 'cancel query'"). Rather than ship a strategy that breaks one of three first-party adapters, M5.A.2 defaults to `'ignore query'`. Adopters who need true DB-side cancel for long PG/MySQL queries can drive Kysely directly via `db.qb`. A future minor (M5.A.2.1 or M6) could add a per-call override on `FindManyOptions`.

The signal STILL fires correctly under `'ignore query'` — the JS promise rejects with `RelationalQueryCancelledError` as soon as the abort fires. Only the DB-side resource cleanup is best-effort under the default strategy.

## Adopter usage

```ts
@Service()
export class TasksRepository {
  constructor(@Inject(DB_PRIMARY) private readonly db: KickDbClient) {}

  findFullById(id: string, signal: AbortSignal) {
    return this.db.query.tasks.findUnique({
      where: (_t, eb) => eb('id', '=', id),
      with: { comments: true, assignees: true, labels: true },
      signal,
    })
  }
}

@Controller()
export class TasksController {
  constructor(private readonly tasks: TasksRepository) {}
  @Get('/tasks/:id')
  async show(ctx: RequestContext) {
    return ctx.json(await this.tasks.findFullById(ctx.params.id, ctx.signal))
  }
}
```

When the client disconnects, `ctx.signal` fires → the JS promise rejects with `RelationalQueryCancelledError` → adopter's error mapper renders 499 (or whatever they wire). Cancellation flows through without per-call-site boilerplate.

## Tests

| Suite | Cases | Coverage |
|---|---|---|
| `packages/db/__tests__/unit/abort-signal-unit.test.ts` | 11 (new) | Passthrough on all three find* methods, already-aborted short-circuit, reason on cause field, error mapping for every dialect-specific shape (DOM AbortError, PG 57014, sqlite SQLITE_INTERRUPT, mysql2 EAGAIN_QUERY_INTERRUPTED), unrelated rejection passthrough |
| `packages/db-pg/__tests__/integration/abort-signal-pg.test.ts` | 3 (new) | Testcontainers PG: mid-flight cancel under 3s on `pg_sleep(10)`; already-aborted short-circuit under 500ms; happy path completes normally |
| `packages/db-sqlite/__tests__/integration/abort-signal-sqlite.test.ts` | 3 (new) | Better-sqlite3: already-aborted short-circuit, reason threads to cause, happy path completes |

```
@forinda/kickjs-db: 369 → 380 passing  (+11)
@forinda/kickjs-db-pg: 25 → 28 passing  (+3)
@forinda/kickjs-db-sqlite: 10 → 13 passing  (+3)
@forinda/kickjs-db-mysql: 34/34 (unchanged — no integration suite yet)
@forinda/kickjs-cli: 276/276 (unchanged)
```

## Test plan

- [x] `pnpm --filter @forinda/kickjs-db test` → 380/380
- [x] `pnpm --filter @forinda/kickjs-db-pg test` → 28/28 (Docker required)
- [x] `pnpm --filter @forinda/kickjs-db-sqlite test` → 13/13
- [x] `pnpm --filter @forinda/kickjs-db-mysql test` → 34/34
- [x] `pnpm format:check` clean
- [x] `pnpm --filter @forinda/kickjs-db build` clean
- [ ] CodeRabbit pass

## Spec

[`docs/db/spec-abortsignal-threading.md`](../../docs/db/spec-abortsignal-threading.md) — covers the precedence rule, dialect-level cancellation trade-off, edge cases (already-aborted, reason types, server-side timeout vs client-side signal, transactions out-of-scope), and the recommended adopter pattern.

## Changeset

`.changeset/db-m5-a2-abort-signal.md` — **minor** on `@forinda/kickjs-db`. Additive (new optional field, new error class). M5 "no major bumps" rule held.

## What's next

M5.A.3 — re-export `ReadonlyKysely` and document `$pickTables` / `$omitTables`. Half-day work; can land before M5.B starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AbortSignal support for query operations (findMany, findFirst, findUnique) to allow early termination of long-running DB queries
  * New RelationalQueryCancelledError exported to represent cancellations and carry the abort cause

* **Tests**
  * Added unit and integration tests validating signal threading, immediate short-circuiting, and cancellation mapping for multiple dialects

* **Documentation**
  * New spec doc describing signal behavior, precedence, and migration guidance

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/212)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->