### PR TITLE
feat(db): re-export ReadonlyKysely + document $pickTables/$omitTables (M5.A.3)

### DIFF
--- a/.changeset/db-m5-a3-narrowing.md
+++ b/.changeset/db-m5-a3-narrowing.md
@@ -1,0 +1,25 @@
+---
+'@forinda/kickjs-db': minor
+---
+
+feat(db): re-export `ReadonlyKysely` + document `$pickTables` / `$omitTables` (M5.A.3)
+
+Kysely 0.29's compile-time narrowing helpers are now reachable from `@forinda/kickjs-db` directly. `ReadonlyKysely<DB>` is re-exported as a named type — adopters writing query-side repositories inject `ReadonlyKysely<KickDb>` to make `insertInto` / `updateTable` / `deleteFrom` / `mergeInto` compile errors, no runtime layer needed.
+
+```ts
+@Service()
+export class WorkspacesQueryRepository {
+  constructor(@Inject(DB_PRIMARY) private readonly db: ReadonlyKysely<KickDb>) {}
+
+  list() {
+    return this.db.selectFrom('workspaces').selectAll().execute()
+  }
+  // this.db.insertInto(...) → compile error
+}
+```
+
+`$pickTables<...>()` and `$omitTables<...>()` ship as methods on `Kysely<DB>` (which `KickDbClient<DB>` extends). They were already callable on the existing client surface; M5.A.3 surfaces them in the relational-query guide ([Narrowing the client](https://github.com/forinda/kick-js/blob/main/docs/guide/db-relational-query.md#narrowing-the-client)) so adopters discover them without reading Kysely's docs.
+
+Type-only test suite (`packages/db/__tests__/unit/pick-tables-types.test.ts`) locks the contract so a future Kysely upgrade can't silently drop the helpers from the surface.
+
+Additive — no breaking change. M5 "no major bumps" rule respected.

--- a/docs/guide/db-relational-query.md
+++ b/docs/guide/db-relational-query.md
@@ -130,6 +130,95 @@ MySQL 8+ uses `JSON_ARRAYAGG(JSON_OBJECT(...))` for `many`. MySQL's `JSON_ARRAYA
 - **`RelationalQueryAmbiguousRelationNameError`** — two relations share the same name in the registry. Disambiguate via `relationName: 'foo'` on both sides.
 - **`RelationalQueryMissingInverseError`** — a `many` relation can't find its inverse `one`. Either add the inverse in the relations file or tag both sides with `relationName: 'foo'`.
 
+## Cancelling in-flight queries
+
+`db.query.findMany` / `findFirst` / `findUnique` accept an optional `signal: AbortSignal`. Bind to `RequestContext.signal` from kickjs-http to short-circuit relational queries when the client disconnects or the request times out — no manual `Promise.race`.
+
+```ts
+@Service()
+export class TasksRepository {
+  constructor(@Inject(DB_PRIMARY) private readonly db: KickDbClient) {}
+
+  findFullById(id: string, signal: AbortSignal) {
+    return this.db.query.tasks.findUnique({
+      where: (_t, eb) => eb('id', '=', id),
+      with: { comments: true, assignees: true, labels: true },
+      signal,
+    })
+  }
+}
+
+@Controller()
+export class TasksController {
+  constructor(private readonly tasks: TasksRepository) {}
+  @Get('/tasks/:id')
+  async show(ctx: RequestContext) {
+    return ctx.json(await this.tasks.findFullById(ctx.params.id, ctx.signal))
+  }
+}
+```
+
+When the signal fires the promise rejects with `RelationalQueryCancelledError` (extends `KickDbError`, code `relational_query_cancelled`). The signal's `reason` flows onto the error's `cause` field — adopters can distinguish HTTP timeout vs explicit cancel by inspecting it.
+
+Already-aborted signals short-circuit before any compile or DB round trip. The default cancellation strategy is Kysely's `'ignore query'` — JS-side promise rejects immediately, DB-side query keeps running until completion. Adopters who need true `pg_cancel_backend` / `KILL QUERY` semantics drive Kysely directly via `db.qb.executeQuery(...)` until a future release exposes a per-call override.
+
+## Narrowing the client
+
+Kysely 0.29 adds three compile-time narrowing helpers. They live on `KickDbClient<DB>` (which extends `Kysely<DB>`) so adopters get them for free:
+
+### `ReadonlyKysely<DB>` — read-only repos
+
+```ts
+import { Inject, Service } from '@forinda/kickjs'
+import { DB_PRIMARY, type ReadonlyKysely } from '@forinda/kickjs-db'
+
+@Service()
+export class WorkspacesQueryRepository {
+  constructor(@Inject(DB_PRIMARY) private readonly db: ReadonlyKysely<KickDb>) {}
+
+  list() {
+    return this.db.selectFrom('workspaces').selectAll().execute()
+  }
+  // this.db.insertInto('workspaces')
+  //   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Property does not exist on ReadonlyKysely
+}
+```
+
+`selectFrom` / `with` / `case` / `fn` / `dynamic` / `introspection` / `isTransaction` / `destroy` are kept; `insertInto` / `updateTable` / `deleteFrom` / `mergeInto` are removed at the type level. The runtime is the same `KickDbClient` instance — TS is the gate.
+
+### `$pickTables<...>()` — module-scoped views
+
+```ts
+@Service()
+export class WorkspacesAdminQueryRepository {
+  // Inject the full client; narrow at call time so this repo can ONLY
+  // touch `workspaces` + `workspaceMembers`. Trying to selectFrom
+  // `tasks` is a compile error.
+  constructor(@Inject(DB_PRIMARY) private readonly db: KickDbClient<KickDb>) {}
+
+  listMembers(workspaceId: string) {
+    return this.db
+      .$pickTables<'workspaces' | 'workspaceMembers'>()
+      .selectFrom('workspaceMembers')
+      .where('workspaceId', '=', workspaceId)
+      .selectAll()
+      .execute()
+  }
+}
+```
+
+### `$omitTables<...>()` — soft-delete-style guards
+
+```ts
+// Layer-1 repo never touches the audit_log table — narrow it out at
+// the boundary so accidental writes are compile errors.
+db.$omitTables<'audit_log'>().updateTable('users').set({ ... }).execute()
+// db.$omitTables<'audit_log'>().updateTable('audit_log')
+//                                            ^^^^^^^^^ Argument not assignable
+```
+
+All three return Kysely instances backed by the same connection pool — narrowing is purely structural; no runtime cost.
+
 ## Reference: `task-kickdb-api`
 
 The example app uses the relational layer in three places:

--- a/packages/db/__tests__/unit/pick-tables-types.test.ts
+++ b/packages/db/__tests__/unit/pick-tables-types.test.ts
@@ -1,0 +1,73 @@
+/**
+ * M5.A.3 — type-only assertions for the Kysely 0.29 narrowing
+ * helpers as reached through `KickDbClient<DB>`.
+ *
+ * These tests exist purely so a future Kysely upgrade can't silently
+ * drop `$pickTables` / `$omitTables` / `ReadonlyKysely` from the
+ * surface adopters reach via `@forinda/kickjs-db`. There's no
+ * runtime to assert; `expectTypeOf` is the contract — and the
+ * casted fixture below is never actually executed (the methods are
+ * read off the type, never called).
+ */
+
+import { describe, expectTypeOf, it } from 'vitest'
+
+import type { Kysely } from 'kysely'
+import type { KickDbClient, ReadonlyKysely } from '@forinda/kickjs-db'
+
+interface FixtureDB {
+  users: { id: number; email: string }
+  posts: { id: number; authorId: number; title: string }
+  comments: { id: number; postId: number; body: string }
+}
+
+describe('M5.A.3 — KickDbClient narrowing helpers (type-only)', () => {
+  it('$pickTables exists on the client type and is generic over keys of DB', () => {
+    type Client = KickDbClient<FixtureDB>
+    expectTypeOf<Client>().toHaveProperty('$pickTables')
+
+    // Result of the narrowing — derived structurally without calling
+    // the method (the runtime fixture is `{} as Client` and would
+    // throw on actual invocation). Kysely's $pickTables returns a
+    // Kysely<Pick<DB, T>>; we lock that the resulting client's
+    // selectFrom only accepts the picked subset.
+    type Picked = Kysely<Pick<FixtureDB, 'users' | 'posts'>>
+    type SelectFromArg = Parameters<Picked['selectFrom']>[0]
+
+    expectTypeOf<'users'>().toMatchTypeOf<SelectFromArg>()
+    expectTypeOf<'posts'>().toMatchTypeOf<SelectFromArg>()
+    // @ts-expect-error — `comments` removed from the picked schema.
+    const _commentsFails: SelectFromArg = 'comments'
+    void _commentsFails
+  })
+
+  it('$omitTables exists on the client type and removes the omitted keys', () => {
+    type Client = KickDbClient<FixtureDB>
+    expectTypeOf<Client>().toHaveProperty('$omitTables')
+
+    type Trimmed = Kysely<Omit<FixtureDB, 'comments'>>
+    type SelectFromArg = Parameters<Trimmed['selectFrom']>[0]
+
+    expectTypeOf<'users'>().toMatchTypeOf<SelectFromArg>()
+    expectTypeOf<'posts'>().toMatchTypeOf<SelectFromArg>()
+    // @ts-expect-error — `comments` was omitted.
+    const _commentsFails: SelectFromArg = 'comments'
+    void _commentsFails
+  })
+
+  it('ReadonlyKysely<DB> drops the mutation methods', () => {
+    type Read = ReadonlyKysely<FixtureDB>
+
+    expectTypeOf<Read>().toHaveProperty('selectFrom')
+    expectTypeOf<Read>().toHaveProperty('with')
+
+    expectTypeOf<keyof Read>().not.toMatchTypeOf<'insertInto'>()
+    expectTypeOf<keyof Read>().not.toMatchTypeOf<'updateTable'>()
+    expectTypeOf<keyof Read>().not.toMatchTypeOf<'deleteFrom'>()
+    expectTypeOf<keyof Read>().not.toMatchTypeOf<'mergeInto'>()
+  })
+
+  it('KickDbClient<DB> assigns to Kysely<DB>', () => {
+    expectTypeOf<KickDbClient<FixtureDB>>().toMatchTypeOf<Kysely<FixtureDB>>()
+  })
+})

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -75,6 +75,14 @@ export type {
   CreateDbClientOptions,
 } from './client/types'
 export type { SchemaToTypes } from './client/schema-types'
+
+// Re-export Kysely 0.29's read-only client narrowing helper. Adopters
+// inject `ReadonlyKysely<KickDb>` into query-side repositories to make
+// `insertInto` / `updateTable` / `deleteFrom` / `mergeInto` compile
+// errors. `$pickTables` / `$omitTables` ship as methods on the client
+// itself (M5.A.3 doesn't add them — Kysely defines them on Kysely<DB>
+// which `KickDbClient<DB>` already extends).
+export type { ReadonlyKysely } from 'kysely/readonly'
 export type { KickDbRegister, RegisteredDB } from './client/register'
 
 export {


### PR DESCRIPTION
## Why

Kysely 0.29 shipped three compile-time narrowing helpers — `ReadonlyKysely<DB>`, `$pickTables<...>()`, `$omitTables<...>()`. They're reachable through `KickDbClient<DB>` today (it extends `Kysely<DB>`), but adopters who only import from `@forinda/kickjs-db` had no documentation, no obvious entry point for `ReadonlyKysely`, and no rendered guide showing the patterns. M5.A.3 closes that gap.

Third deliverable in [`m5-plan.md`](../../docs/db/m5-plan.md) §M5.A.3.

## What changed

1. **`ReadonlyKysely` type re-exported** from `@forinda/kickjs-db` (sourced from `kysely/readonly`). Adopters writing query-side repositories now write `@Inject(DB_PRIMARY) private readonly db: ReadonlyKysely<KickDb>` — `insertInto` / `updateTable` / `deleteFrom` / `mergeInto` become compile errors. Same runtime, types as the gate.

2. **`$pickTables<...>()` / `$omitTables<...>()`** are methods on `Kysely<DB>` itself; `KickDbClient<DB>` already extends Kysely so they were technically callable, but undocumented in our surface. M5.A.3 surfaces them.

3. **Docs:** [`docs/guide/db-relational-query.md`](../../docs/guide/db-relational-query.md) gains two new sections:
   - **"Cancelling in-flight queries"** — covers the M5.A.2 `signal: AbortSignal` plumbing + `RelationalQueryCancelledError` (retrofit; the previous M5.A.2 PR shipped without docs touching this guide).
   - **"Narrowing the client"** — three subsections walking through `ReadonlyKysely<DB>`, `$pickTables<...>()`, `$omitTables<...>()` with concrete adopter patterns (read-only repos, module-scoped views, soft-delete-style guards).

4. **Type-only tests** lock the contract so a future Kysely upgrade can't silently drop the helpers from the surface adopters reach via `@forinda/kickjs-db`.

## Tests

```
@forinda/kickjs-db: 380 → 384 passing  (+4 type-only)
@forinda/kickjs-cli: 276/276 (unchanged)
```

## Test plan

- [x] `pnpm --filter @forinda/kickjs-db test` → 384/384
- [x] `pnpm --filter @forinda/kickjs-cli test` → 276/276
- [x] `pnpm format:check` clean
- [x] `pnpm --filter @forinda/kickjs-db build` clean
- [ ] CodeRabbit pass

## Changeset

`.changeset/db-m5-a3-narrowing.md` — **minor** on `@forinda/kickjs-db`. Additive type re-export + new docs sections. No new runtime surface, no breaking change. M5 "no major bumps" rule held.

## What's next

M5.A is now complete (A.1 + A.2 + A.3). M5.B is next — ALTER TYPE node refactor + `safeNullComparison` plugin opt-in. Internal/additive; ships minor on `@forinda/kickjs-db`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `ReadonlyKysely` type now re-exported for creating read-only database client instances
  * Table narrowing helpers available to restrict database client access at compile time
  * Query cancellation support via `AbortSignal` with structured error handling

* **Documentation**
  * Added guide on narrowing database client access for enhanced type safety
  * Added guide on cancelling in-flight queries with proper error propagation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/213)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->