### PR TITLE
docs(plugins,adapters): document factory surface + flat-mount path

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -153,7 +153,7 @@ interface ModuleRoutes {
 
 ## AppAdapter
 
-Lifecycle hooks for plugging in cross-cutting concerns (database, docs, rate limiting).
+Lifecycle hooks for plugging in cross-cutting concerns (database, docs, rate limiting). Build adapters with [`defineAdapter()`](#defineadapter); the call site mounts the result via `bootstrap({ adapters: [...] })`. Full narrative at [Adapters](../guide/adapters.md).
 
 ```typescript
 interface AdapterContext {
@@ -166,12 +166,16 @@ interface AdapterContext {
 
 interface AppAdapter {
   name?: string
+  /** Other plugin/adapter names that must mount before this one. Topo-sorted at boot. */
+  dependsOn?: readonly KickJsPluginName[]
   middleware?(): AdapterMiddleware[]
   beforeMount?(ctx: AdapterContext): void
   onRouteMount?(controllerClass: any, mountPath: string): void
   beforeStart?(ctx: AdapterContext): void
   afterStart?(ctx: AdapterContext): void
   shutdown?(): void | Promise<void>
+  contributors?(): ContributorRegistrations
+  onHealthCheck?(): Promise<{ name: string; status: 'up' | 'down'; message?: string }>
 }
 
 type MiddlewarePhase = 'beforeGlobal' | 'afterGlobal' | 'beforeRoutes' | 'afterRoutes'
@@ -182,6 +186,162 @@ interface AdapterMiddleware {
   path?: string
 }
 ```
+
+### defineAdapter
+
+```typescript
+function defineAdapter<TConfig = Record<string, unknown>, TExtra = unknown>(
+  options: DefineAdapterOptions<TConfig, TExtra>,
+): AdapterFactory<TConfig, TExtra>
+
+interface DefineAdapterOptions<TConfig, TExtra = unknown> {
+  name: string
+  version?: string
+  requires?: { kickjs?: string }
+  defaults?: Partial<TConfig>
+  /** Returns the AppAdapter lifecycle object plus any extra public methods (TExtra). */
+  build(config: TConfig, ctx: BuildContext): Omit<AppAdapter, 'name'> & TExtra
+}
+```
+
+`BuildContext` is the same `{ name, scoped }` shape used by `definePlugin` — see the [Plugins reference](#plugins).
+
+::: warning `defineAdapter()` returns a factory, not an adapter
+The function returns an `AdapterFactory`, not an `AppAdapter`. `bootstrap({ adapters: [...] })` expects the **result of calling** the factory (`MyAdapter()`, `MyAdapter.scoped('x')`, or `MyAdapter.async(...)`). Passing the factory itself is a type error.
+:::
+
+### AdapterFactory
+
+The callable returned by `defineAdapter()`. Same surface as [`PluginFactory`](#pluginfactory) so the mental model is shared.
+
+```typescript
+interface AdapterFactory<TConfig, TExtra = unknown> {
+  /** Singleton form — name matches the definition. */
+  (config?: Partial<TConfig>): AppAdapter & TExtra
+  /** Multi-instance form — name becomes `${defName}:${scopeName}`. */
+  scoped(scopeName: string, config?: Partial<TConfig>): AppAdapter & TExtra
+  /** Deferred-config form — inner adapter built inside `beforeStart`. */
+  async(opts: AdapterAsyncOptions<TConfig>): AppAdapter
+  /** Read-only access to the original definition. */
+  readonly definition: Readonly<DefineAdapterOptions<TConfig, TExtra>>
+}
+
+interface AdapterAsyncOptions<TConfig> {
+  inject?: readonly unknown[]
+  useFactory(...deps: any[]): TConfig | Promise<TConfig>
+}
+```
+
+::: warning `.async()` skips early adapter hooks
+The async form resolves the config inside `beforeStart`, so the inner adapter's `middleware()`, `contributors()`, `beforeMount()`, and `onRouteMount()` are **not picked up** — those phases have already run. Only `beforeStart`, `afterStart`, `shutdown`, and `onHealthCheck` fire on the lazily-built inner adapter.
+:::
+
+The `TExtra` generic preserves any public methods `build()` exposes beyond the `AppAdapter` contract — useful for adapters that ship helpers external callers need to invoke directly (e.g. `OtelAdapter.applyRedaction`).
+
+## Plugins
+
+The highest-level extension primitive — a plugin bundles modules, adapters, middleware, DI bindings, and context contributors into one reusable unit. Build them with `definePlugin()`; mount them via the `plugins?: KickPlugin[]` field on `bootstrap()`. The full narrative lives at [Plugins](../guide/plugins.md); this section is the type reference.
+
+### definePlugin
+
+```typescript
+function definePlugin<TConfig = Record<string, unknown>>(
+  options: DefinePluginOptions<TConfig>,
+): PluginFactory<TConfig>
+
+interface DefinePluginOptions<TConfig> {
+  name: string
+  version?: string
+  requires?: { kickjs?: string }
+  defaults?: Partial<TConfig>
+  build(config: TConfig, ctx: BuildContext): Omit<KickPlugin, 'name'>
+}
+
+interface BuildContext {
+  /** Resolved instance name — definition name for the bare call, `${name}:${scope}` for `.scoped()`. */
+  name: string
+  /** True when produced by `.scoped()`. */
+  scoped: boolean
+}
+```
+
+### PluginFactory
+
+The callable returned by `definePlugin()`. Bare call produces a singleton; `.scoped()` and `.async()` cover the multi-instance and deferred-config cases.
+
+```typescript
+interface PluginFactory<TConfig> {
+  /** Singleton form — `AuthPlugin(config)`. */
+  (config?: Partial<TConfig>): KickPlugin
+  /** Multi-instance form — namespaces the resolved name to `${defName}:${scopeName}`. */
+  scoped(scopeName: string, config?: Partial<TConfig>): KickPlugin
+  /** Deferred-config form — resolves DI tokens then calls `useFactory` inside `onReady`. */
+  async(opts: PluginAsyncOptions<TConfig>): KickPlugin
+  /** Read-only access to the original definition. */
+  readonly definition: Readonly<DefinePluginOptions<TConfig>>
+}
+
+interface PluginAsyncOptions<TConfig> {
+  inject?: readonly unknown[]
+  useFactory(...deps: any[]): TConfig | Promise<TConfig>
+}
+```
+
+::: warning `.async()` skips early hooks
+The async form resolves the inner plugin lazily inside `onReady`, so any `modules()` / `setup()` / `adapters()` / `middleware()` / `contributors()` the plugin returns is **not registered** — those hooks have already run. Use the bare call or `.scoped()` when the plugin needs to contribute anything other than DI bindings or post-start work.
+:::
+
+### KickPlugin
+
+The lifecycle object returned by `build()`. Every hook is optional — emit only what the plugin needs.
+
+```typescript
+interface KickPlugin {
+  name: string
+  /** Other plugin names that must mount before this one. Topo-sorted at boot. */
+  dependsOn?: readonly KickJsPluginName[]
+
+  register?(container: Container): void
+  modules?(): AppModuleEntry[]
+  setup?(registry: ModuleRegistry): void
+  adapters?(): AppAdapter[]
+  middleware?(): any[]
+  contributors?(): ContributorRegistrations
+  onReady?(container: Container): void | Promise<void>
+  shutdown?(): void | Promise<void>
+
+  /** DevTools introspection snapshot — runs on poll, keep cheap. */
+  introspect?(): unknown | Promise<unknown>
+  /** Plugin-owned tabs rendered inside the DevTools UI. */
+  devtoolsTabs?(): readonly unknown[]
+}
+```
+
+`KickJsPluginName` resolves to `string` until `kick typegen` populates `KickJsPluginRegistry`, at which point it narrows to a string-literal union of every plugin/adapter name in the project — making `dependsOn` autocomplete-safe.
+
+### Mounting plugins
+
+Plugins flow in through `bootstrap()`:
+
+```typescript
+interface ApplicationOptions {
+  // ... other fields
+  plugins?: KickPlugin[]
+}
+```
+
+Plugin hooks fire in this order, before user-supplied modules/adapters/middleware:
+
+1. `register()` — DI bindings
+2. `middleware()` — global middleware
+3. `modules()` + user modules — route registration
+4. `setup(registry)` — imperative module mounts
+5. `adapters()` + user adapters — lifecycle hooks
+6. Server starts
+7. `onReady()` — post-startup
+8. `shutdown()` — on SIGINT/SIGTERM
+
+Cross-plugin ordering respects `dependsOn`; cycles throw `MountCycleError` and unknown names throw `MissingMountDepError`, both at boot.
 
 ## Context Contributors (#107)
 

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -20,6 +20,7 @@ class Application {
 interface ApplicationOptions {
   modules: AppModuleClass[]
   adapters?: AppAdapter[]
+  plugins?: KickPlugin[] // see ../api/core.md#plugins
   port?: number
   apiPrefix?: string // default: '/api'
   defaultVersion?: number // default: 1
@@ -30,6 +31,8 @@ interface ApplicationOptions {
 
 type MiddlewareEntry = RequestHandler | { path: string; handler: RequestHandler }
 ```
+
+Plugins (`KickPlugin[]`) are the highest-level extension primitive — they can bundle modules, adapters, middleware, DI bindings, and context contributors into one reusable unit. Build them with `definePlugin()` and pass the factory output here. See the [Plugins guide](../guide/plugins.md) and the [`definePlugin` API reference](./core.md#plugins).
 
 ## bootstrap
 

--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -4,13 +4,26 @@ Adapters plug into the KickJS application lifecycle. Use them to add health chec
 
 ## The `defineAdapter()` factory
 
-v4 declares adapters with `defineAdapter({ name, defaults?, build })` — never `class Foo implements AppAdapter`. The factory captures three things:
+v4 declares adapters with `defineAdapter({ name, defaults?, build })` — never `class Foo implements AppAdapter`.
+
+::: tip `defineAdapter()` returns a factory, not an adapter
+The value you `export` from `defineAdapter()` is an **`AdapterFactory<TConfig>`**, not an `AppAdapter`. Call the factory (`MyAdapter(config)`) to produce the mountable `AppAdapter` instance. `bootstrap({ adapters: [...] })` accepts the result of the call, never the factory itself.
+
+```ts
+export const MyAdapter = defineAdapter({ ... })   // AdapterFactory<TConfig>
+bootstrap({ adapters: [MyAdapter()] })             // AppAdapter — invoked at the call site
+bootstrap({ adapters: [MyAdapter] })               // ✗ type error — passed the factory
+```
+
+:::
+
+The factory captures three things:
 
 - `name` — string, used for diagnostics and the `KickJsPluginRegistry` typegen output. Required.
 - `defaults?` — partial config the factory pre-applies before merging the caller's options. Optional.
-- `build(config, meta)` — runs once per adapter instance and returns the lifecycle object. Closures inside `build` are how each adapter instance owns its own state (Redis client, database pool, internal Map, etc.).
+- `build(config, ctx)` — runs once per adapter instance and returns the lifecycle object. Closures inside `build` are how each adapter instance owns its own state (Redis client, database pool, internal Map, etc.). The second arg is the `BuildContext` — `{ name, scoped }`, identical to `definePlugin`'s — useful for namespacing DI tokens in [`.scoped()`](#multi-instance-adapters-scoped) adapters.
 
-The returned object implements any subset of the lifecycle hooks below. Every hook is optional — emit only what your adapter actually needs.
+`build()` returns the actual `AppAdapter` lifecycle object — any subset of the hooks below, every hook optional, plus optional extra methods (see [Extension methods (`TExtra`)](#extension-methods-textra)).
 
 ```ts
 import { defineAdapter, type AdapterContext, type AdapterMiddleware } from '@forinda/kickjs'
@@ -197,19 +210,189 @@ export const RedisAdapter = defineAdapter({
 })
 ```
 
-## Registering Adapters
+## The AdapterFactory Surface
 
-Pass adapter instances to `bootstrap()` or `Application`:
+The value returned by `defineAdapter()` is an `AdapterFactory<TConfig, TExtra>`. The bare call produces a singleton; two helpers cover the multi-instance and async-config cases — identical shape to [`PluginFactory`](./plugins.md#the-pluginfactory-surface) so the mental model is shared.
+
+```ts
+interface AdapterFactory<TConfig, TExtra = unknown> {
+  /** Singleton form — `RedisAdapter({ url })`. */
+  (config?: Partial<TConfig>): AppAdapter & TExtra
+  /** Multi-instance form — namespaces the resolved name to `${defName}:${scopeName}`. */
+  scoped(scopeName: string, config?: Partial<TConfig>): AppAdapter & TExtra
+  /** Deferred-config form — resolves DI tokens then calls `useFactory` inside `beforeStart`. */
+  async(opts: AdapterAsyncOptions<TConfig>): AppAdapter
+  /** Read-only access to the original definition. */
+  readonly definition: Readonly<DefineAdapterOptions<TConfig, TExtra>>
+}
+```
+
+### Default Mount: Just Call the Factory
+
+**This is what 90% of apps need.** No `.scoped()`, no `.async()` — just invoke the factory once and put the result in `bootstrap({ adapters: [...] })`:
 
 ```ts
 import { bootstrap } from '@forinda/kickjs'
 import { modules } from './modules'
 import { HealthAdapter } from './adapters/health.adapter'
 import { CorsAdapter } from './adapters/cors.adapter'
+import { RedisAdapter } from './adapters/redis.adapter'
 
 bootstrap({
   modules,
-  adapters: [HealthAdapter(), CorsAdapter({ origin: '*' })],
+  adapters: [
+    HealthAdapter(), // no config needed
+    CorsAdapter({ origin: '*' }), // pass config as the only argument
+    RedisAdapter({ url: process.env.REDIS_URL! }),
+  ],
+})
+```
+
+Each bare call produces one singleton `AppAdapter` whose runtime `name` matches the definition (`'HealthAdapter'`, `'CorsAdapter'`, `'RedisAdapter'`). The adapter's `defaults` are merged under the config you pass — omit the argument entirely if all defaults are fine (`HealthAdapter()` above).
+
+Mounting order in the array is mounting order at boot, unless an adapter declares [`dependsOn`](#ordering-with-dependson). Reach for `.scoped()` only when you need more than one instance of the same adapter; reach for `.async()` only when the config has to come from the DI container itself.
+
+### Multi-Instance Adapters: `.scoped()`
+
+The bare call produces a singleton whose runtime `name` matches the definition. `.scoped(scopeName, config)` produces a separate instance whose `name` becomes `${definitionName}:${scopeName}` — useful when one adapter type legitimately needs to mount more than once (sharded caches, per-region API clients):
+
+```ts
+const RedisAdapter = defineAdapter<{ url: string }>({
+  name: 'RedisAdapter',
+  build: (config, { name }) => {
+    const client = createClient({ url: config.url })
+    const token = createToken<RedisClientType>(`redis/${name}`)
+    return {
+      async beforeStart({ container }) {
+        await client.connect()
+        container.registerInstance(token, client)
+      },
+      async shutdown() {
+        await client.quit()
+      },
+    }
+  },
+})
+
+bootstrap({
+  modules,
+  adapters: [
+    RedisAdapter.scoped('cache', { url: process.env.REDIS_CACHE_URL! }), // name = 'RedisAdapter:cache'
+    RedisAdapter.scoped('sessions', { url: process.env.REDIS_SESSIONS_URL! }), // name = 'RedisAdapter:sessions'
+  ],
+})
+```
+
+### Deferred Config: `.async()`
+
+When the config an adapter needs must be resolved from the DI container itself (e.g. it depends on `ConfigService` or another adapter's registration), use `.async()`. The inner adapter is built lazily inside `beforeStart`:
+
+```ts
+bootstrap({
+  modules,
+  adapters: [
+    RedisAdapter.async({
+      inject: [CONFIG_SERVICE],
+      useFactory: (config: ConfigService) => ({ url: config.get('REDIS_URL') }),
+    }),
+  ],
+})
+```
+
+::: warning `.async()` skips early adapter hooks
+The async form resolves the config inside `beforeStart`, so anything the inner adapter would contribute via `middleware()`, `contributors()`, `beforeMount()`, or `onRouteMount()` is **not picked up** — those phases have already run. Only `beforeStart`, `afterStart`, `shutdown`, and `onHealthCheck` fire on the lazily-built inner adapter. Use the bare call or `.scoped()` when the adapter needs to contribute middleware or contributors.
+:::
+
+### Extension methods (`TExtra`)
+
+If `build()` returns methods beyond the standard `AppAdapter` contract, the factory preserves them on the returned instance — so external callers (tests, peer adapters) can invoke them directly. The factory's `TExtra` generic is inferred from the build return type:
+
+```ts
+const OtelAdapter = defineAdapter({
+  name: 'OtelAdapter',
+  build: () => ({
+    beforeStart({ container }) {
+      /* ... */
+    },
+    // Extra method, not part of AppAdapter:
+    applyRedaction(span: Span) {
+      /* ... */
+    },
+  }),
+})
+
+const instance = OtelAdapter()
+instance.applyRedaction(span) // typed and callable
+```
+
+### Introspecting a Factory: `.definition`
+
+Every `AdapterFactory` carries a read-only, frozen copy of the options you passed to `defineAdapter()`. Its type is `Readonly<DefineAdapterOptions<TConfig, TExtra>>` — same five fields you originally supplied:
+
+```ts
+factory.definition = {
+  readonly name: string
+  readonly version?: string
+  readonly requires?: { kickjs?: string }
+  readonly defaults?: Partial<TConfig>
+  readonly build: (config, ctx) => Omit<AppAdapter, 'name'> & TExtra
+}
+```
+
+For example, given:
+
+```ts
+export const RedisAdapter = defineAdapter<{ url: string; ttl?: number }>({
+  name: 'RedisAdapter',
+  version: '1.2.0',
+  defaults: { ttl: 60_000 },
+  build: (config) => ({
+    /* ... */
+  }),
+})
+
+console.log(RedisAdapter.definition.name) // 'RedisAdapter'
+console.log(RedisAdapter.definition.version) // '1.2.0'
+console.log(RedisAdapter.definition.defaults) // { ttl: 60000 }
+```
+
+The snapshot is `Object.freeze`'d — assigning to any field throws in strict mode. Use it for:
+
+**1. DevTools introspection.** The DevTools dashboard reads `definition.name` and `definition.version` to label adapters and check for available upgrades — no extra wiring needed.
+
+**2. Compatibility checks at boot.** Verify that a third-party adapter you depend on advertises a minimum version before mounting it:
+
+```ts
+if (compare(RedisAdapter.definition.version ?? '0.0.0', '1.2.0') < 0) {
+  throw new Error('RedisAdapter >= 1.2.0 required for TTL support')
+}
+```
+
+**3. Deriving a sibling factory.** Build a preconfigured variant of an existing adapter without re-defining its `build`:
+
+```ts
+export const RedisCacheAdapter = defineAdapter({
+  ...RedisAdapter.definition,
+  name: 'RedisCacheAdapter',
+  defaults: { ...RedisAdapter.definition.defaults, ttl: 5_000 },
+})
+```
+
+`.definition` is **metadata only** — it does not produce a mountable adapter. To mount, call the factory: `RedisAdapter()`, `RedisAdapter.scoped(...)`, or `RedisAdapter.async(...)`.
+
+## Ordering with `dependsOn`
+
+Adapters mount in declaration order by default — whatever order they appear in the `adapters` array. When ordering matters across adapters (e.g. `OtelAdapter` must initialize tracing before `RequestLoggerAdapter` reads the trace ID), declare `dependsOn` on the `AppAdapter` returned from `build()` — same field, same topo-sort rules as plugins:
+
+```ts
+const RequestLogger = defineAdapter({
+  name: 'RequestLoggerAdapter',
+  build: () => ({
+    dependsOn: ['OtelAdapter'],
+    middleware() {
+      /* reads otel trace id */ return []
+    },
+  }),
 })
 ```
 
@@ -222,3 +405,7 @@ onRouteMount(controllerClass: any, mountPath: string): void {
   console.log(`Mounted ${controllerClass.name} at ${mountPath}`)
 }
 ```
+
+## When to Reach for a Plugin Instead
+
+An adapter is the right tool when the extension lives entirely in the request lifecycle — middleware, route metadata, health checks, before/after hooks. If you find yourself also bundling **modules**, **DI bindings**, or **context contributors** alongside an adapter, promote the whole thing to a [Plugin](./plugins.md). A plugin can ship adapters via its `adapters()` hook and still own the DI/module surface in one place; mount it via `bootstrap({ plugins: [...] })`.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,5 +1,7 @@
 # Getting Started
 
+> 📖 **Reading this on GitHub?** The latest rendered version lives at <https://forinda.github.io/kick-js/guide/getting-started.html> — every `./*.md` link in this page resolves there too.
+
 ## Prerequisites
 
 - Node.js 20+
@@ -196,7 +198,8 @@ pnpm kick start
 
 ## Next Steps
 
-- [Dependency Injection](./dependency-injection) — learn about the DI container
-- [Controllers & Routes](./controllers) — route decorators and validation
-- [Middleware](./middleware) — class and method middleware
-- [Examples](../examples/) — see complete example applications
+- [Dependency Injection](./dependency-injection.md) — learn about the DI container
+- [Controllers & Routes](./controllers.md) — route decorators and validation
+- [Middleware](./middleware.md) — class and method middleware
+- [Plugins](./plugins.md) — bundle modules, adapters, middleware, and DI bindings into one reusable unit with `definePlugin()` and mount them via `bootstrap({ plugins: [...] })`
+- [Examples](../examples/index.md) — see complete example applications

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -77,6 +77,39 @@ export const CorsPlugin = definePlugin<CorsPluginConfig>({
 })
 ```
 
+### The `definePlugin` Options
+
+| Option     | Type                                  | Notes                                                                                                   |
+| ---------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `name`     | `string` (required)                   | Stable identity used for logging, `dependsOn` lookups, and `.scoped()` namespacing.                     |
+| `version`  | `string`                              | Surfaced to DevTools and `kick add` compatibility checks.                                               |
+| `requires` | `{ kickjs?: string }`                 | Peer-version ranges this plugin needs. Recorded as metadata today; runtime enforcement comes later.     |
+| `defaults` | `Partial<TConfig>`                    | Merged under any caller overrides before `build` runs.                                                  |
+| `build`    | `(config, ctx) => KickPluginInstance` | Returns the lifecycle object. The second arg is the [BuildContext](#buildcontext) — `{ name, scoped }`. |
+
+### BuildContext
+
+`build()` receives `(config, ctx)`. The `ctx` carries the resolved instance identity, which matters for [`.scoped()`](#multi-instance-plugins-scoped) plugins that namespace their DI tokens or resource keys:
+
+```ts
+definePlugin<{ url: string }>({
+  name: 'CachePlugin',
+  build: (config, { name, scoped }) => ({
+    register(container) {
+      // For `.scoped('users')` the name becomes 'CachePlugin:users' — use it
+      // to derive unique DI tokens or log prefixes per instance.
+      const token = createToken<RedisClient>(`cache/${name}`)
+      container.registerInstance(token, new RedisClient(config.url))
+    },
+  }),
+})
+```
+
+| Field    | Type      | Meaning                                                                                         |
+| -------- | --------- | ----------------------------------------------------------------------------------------------- |
+| `name`   | `string`  | Resolved instance name. Bare call: same as the definition `name`. `.scoped(s)`: `${name}:${s}`. |
+| `scoped` | `boolean` | `true` when produced by `.scoped()`. Use to gate behaviour that only makes sense per-scope.     |
+
 ## Plugin Surface
 
 `build()` returns any subset of these hooks. Every hook is optional — emit only what your plugin actually needs:
@@ -84,6 +117,7 @@ export const CorsPlugin = definePlugin<CorsPluginConfig>({
 ```ts
 interface KickPluginInstance {
   name: string
+  dependsOn?: readonly string[]
   register?(container: Container): void
   modules?(): AppModuleEntry[]
   setup?(registry: ModuleRegistry): void
@@ -92,19 +126,24 @@ interface KickPluginInstance {
   contributors?(): ContributorRegistrations
   onReady?(container: Container): void | Promise<void>
   shutdown?(): void | Promise<void>
+  introspect?(): unknown | Promise<unknown>
+  devtoolsTabs?(): readonly unknown[]
 }
 ```
 
-| Method           | When it runs                   | Use Case                                                                   |
-| ---------------- | ------------------------------ | -------------------------------------------------------------------------- |
-| `register()`     | Before modules load            | Bind services in DI                                                        |
-| `modules()`      | Before user modules (static)   | Add feature modules — array form, statically introspectable                |
-| `setup()`        | After `modules()`, before user | Conditionally `.mount(module)` based on captured config / env / runtime    |
-| `adapters()`     | Before user adapters           | Add lifecycle adapters                                                     |
-| `middleware()`   | Before user middleware         | Add global middleware                                                      |
-| `contributors()` | Per-route, at mount            | Ship typed [Context Contributors](./context-decorators.md) the plugin owns |
-| `onReady()`      | After server starts            | Post-startup tasks                                                         |
-| `shutdown()`     | On SIGINT/SIGTERM              | Cleanup resources                                                          |
+| Method           | When it runs                   | Use Case                                                                                  |
+| ---------------- | ------------------------------ | ----------------------------------------------------------------------------------------- |
+| `dependsOn`      | Topo-sorted at boot            | Names of other plugins that must mount first — see [Ordering](#plugin-ordering-dependson) |
+| `register()`     | Before modules load            | Bind services in DI                                                                       |
+| `modules()`      | Before user modules (static)   | Add feature modules — array form, statically introspectable                               |
+| `setup()`        | After `modules()`, before user | Conditionally `.mount(module)` based on captured config / env / runtime                   |
+| `adapters()`     | Before user adapters           | Add lifecycle adapters                                                                    |
+| `middleware()`   | Before user middleware         | Add global middleware                                                                     |
+| `contributors()` | Per-route, at mount            | Ship typed [Context Contributors](./context-decorators.md) the plugin owns                |
+| `onReady()`      | After server starts            | Post-startup tasks                                                                        |
+| `shutdown()`     | On SIGINT/SIGTERM              | Cleanup resources                                                                         |
+| `introspect()`   | DevTools poll                  | Snapshot of plugin state for the DevTools dashboard (counters, flags, tokens)             |
+| `devtoolsTabs()` | DevTools mount                 | Plugin-owned tabs rendered inside the DevTools UI                                         |
 
 ### `modules()` vs `setup()`
 
@@ -155,6 +194,155 @@ export const FlagsPlugin = definePlugin({
 ```
 
 A plugin that bundles both an adapter and a direct contributor is fine — the adapter's `contributors?()` and the plugin's `contributors?()` both feed the same `'adapter'` precedence bucket. Use whichever is more natural for the bundle's shape.
+
+## The PluginFactory Surface
+
+The value returned by `definePlugin()` is a `PluginFactory<TConfig>`. The bare call gives you a singleton; two helpers cover the multi-instance and async-config cases.
+
+```ts
+interface PluginFactory<TConfig> {
+  (config?: Partial<TConfig>): KickPlugin
+  scoped(scopeName: string, config?: Partial<TConfig>): KickPlugin
+  async(opts: {
+    inject?: readonly unknown[]
+    useFactory(...deps: any[]): TConfig | Promise<TConfig>
+  }): KickPlugin
+  readonly definition: Readonly<DefinePluginOptions<TConfig>>
+}
+```
+
+### Multi-Instance Plugins: `.scoped()`
+
+The bare call (`AuthPlugin(config)`) produces a singleton whose runtime `name` matches the definition. `.scoped(scopeName, config)` produces a separate instance whose `name` becomes `${definitionName}:${scopeName}` — perfect for plugins that legitimately need to mount more than once.
+
+```ts
+const CachePlugin = definePlugin<{ url: string; ttl?: number }>({
+  name: 'CachePlugin',
+  defaults: { ttl: 60_000 },
+  build: (config, { name }) => ({
+    register(container) {
+      container.registerInstance(createToken(`cache/${name}`), new RedisClient(config.url))
+    },
+  }),
+})
+
+bootstrap({
+  modules,
+  plugins: [
+    CachePlugin.scoped('users', { url: process.env.REDIS_USERS_URL! }), // name = 'CachePlugin:users'
+    CachePlugin.scoped('sessions', { url: process.env.REDIS_SESSIONS_URL! }), // name = 'CachePlugin:sessions'
+  ],
+})
+```
+
+Each scoped instance gets its own `BuildContext` (`scoped: true`, namespaced `name`) so it can derive unique DI tokens, log prefixes, or resource keys without clashing. The bare call still works — `CachePlugin({ url: '...' })` is equivalent to `CachePlugin.scoped('', ...)` minus the suffix.
+
+### Deferred Config: `.async()`
+
+When the config a plugin needs has to be resolved from the DI container itself (e.g. it depends on `ConfigService`, a database pool, or another plugin's registration), use `.async()`. It defers the entire build until the container is ready:
+
+```ts
+const AnalyticsPlugin = definePlugin<{ endpoint: string; apiKey: string }>({
+  name: 'AnalyticsPlugin',
+  build: (config) => ({
+    register(container) {
+      container.registerInstance(ANALYTICS, new AnalyticsClient(config))
+    },
+  }),
+})
+
+bootstrap({
+  modules,
+  plugins: [
+    AnalyticsPlugin.async({
+      inject: [CONFIG_SERVICE],
+      useFactory: (config: ConfigService) => ({
+        endpoint: config.get('ANALYTICS_ENDPOINT'),
+        apiKey: config.get('ANALYTICS_API_KEY'),
+      }),
+    }),
+  ],
+})
+```
+
+::: warning Async plugins skip early hooks
+`.async()` resolves the config lazily inside `onReady`, so anything the plugin would contribute via `modules()`, `setup()`, `adapters()`, `middleware()`, or `contributors()` is **not registered** — those hooks have already run by the time the inner plugin is built. `register()` and `onReady()` fire late but do run. Use the bare call or `.scoped()` for plugins that need to add modules or middleware; reserve `.async()` for DI-only contributions whose config truly cannot be known at boot.
+:::
+
+### Introspecting a Factory: `.definition`
+
+Every `PluginFactory` carries a read-only, frozen copy of the options you passed to `definePlugin()`. Its type is `Readonly<DefinePluginOptions<TConfig>>` — same five fields you originally supplied:
+
+```ts
+factory.definition = {
+  readonly name: string
+  readonly version?: string
+  readonly requires?: { kickjs?: string }
+  readonly defaults?: Partial<TConfig>
+  readonly build: (config, ctx) => Omit<KickPlugin, 'name'>
+}
+```
+
+For example, given:
+
+```ts
+export const AuthPlugin = definePlugin<{ secret: string; expiresIn?: string }>({
+  name: 'AuthPlugin',
+  version: '1.2.0',
+  defaults: { expiresIn: '1h' },
+  build: (config) => ({
+    /* ... */
+  }),
+})
+
+console.log(AuthPlugin.definition.name) // 'AuthPlugin'
+console.log(AuthPlugin.definition.version) // '1.2.0'
+console.log(AuthPlugin.definition.defaults) // { expiresIn: '1h' }
+```
+
+The snapshot is `Object.freeze`'d — assigning to any field throws in strict mode. Use it for:
+
+**1. DevTools introspection.** The DevTools dashboard reads `definition.name` and `definition.version` to label plugins and check for available upgrades.
+
+**2. Compatibility checks at boot.** Verify a peer plugin advertises a minimum version before mounting it:
+
+```ts
+if (compare(AuthPlugin.definition.version ?? '0.0.0', '1.2.0') < 0) {
+  throw new Error('AuthPlugin >= 1.2.0 required for refresh-token support')
+}
+```
+
+**3. Deriving a sibling factory.** Build a preconfigured variant of an existing plugin without re-defining its `build`:
+
+```ts
+export const AdminAuthPlugin = definePlugin({
+  ...AuthPlugin.definition,
+  name: 'AdminAuthPlugin',
+  defaults: { ...AuthPlugin.definition.defaults, expiresIn: '15m' },
+})
+```
+
+`.definition` is **metadata only** — it does not produce a mountable plugin. To mount, call the factory: `AuthPlugin()`, `AuthPlugin.scoped(...)`, or `AuthPlugin.async(...)`.
+
+## Plugin Ordering: `dependsOn`
+
+Plugins without `dependsOn` mount in declaration order — the order they appear in `bootstrap({ plugins: [...] })`. When one plugin needs another to have run first (e.g. a request-logger plugin that reads trace IDs an OTel plugin sets up), declare it:
+
+```ts
+const RequestLogger = definePlugin({
+  name: 'RequestLoggerPlugin',
+  build: () => ({
+    dependsOn: ['OtelPlugin'],
+    middleware() {
+      return [
+        /* reads otel trace id */
+      ]
+    },
+  }),
+})
+```
+
+The framework topologically sorts plugins at boot. Cycles throw `MountCycleError`; unknown names throw `MissingMountDepError` — both at boot, never at request time. With the `KickJsPluginRegistry` typegen pass (`kick typegen`), `dependsOn` is typed as a string-literal union of the project's actual plugin names instead of bare `string`.
 
 ## Usage
 
@@ -266,4 +454,5 @@ Promote an inline plugin to a generated file as soon as it grows beyond two or t
 
 - [Adapters](./adapters.md) — lifecycle hooks for databases, Swagger, etc.
 - [Custom Decorators](./custom-decorators.md) — extend the decorator system
+- [`definePlugin` API reference](../api/core.md#plugins) — full type signatures for `PluginFactory`, `KickPlugin`, `BuildContext`
 - [DI Container](../api/core.md) — the dependency injection system


### PR DESCRIPTION
## Why

`definePlugin()` and `defineAdapter()` return factories — `PluginFactory<TConfig>` and `AdapterFactory<TConfig, TExtra>` — not `KickPlugin` / `AppAdapter` instances. The mountable instance comes from invoking the factory (bare call, `.scoped()`, or `.async()`). This was implicit in the code but never spelled out in the docs, which is what surfaced the question that drove this PR.

The factory surface also ships `.scoped(scopeName, config)` for multi-instance plugins/adapters, `.async({ inject, useFactory })` for DI-resolved config, and a frozen `.definition` snapshot — none of which had documentation. The `KickPlugin` hook table in `docs/guide/plugins.md` was also missing three real hooks: `dependsOn`, `introspect()`, and `devtoolsTabs()`.

## What changed

### Guide updates

- **`docs/guide/plugins.md`** (+158 / -10)
  - `DefinePluginOptions` table and `BuildContext` section
  - New "PluginFactory Surface" section covering `.scoped()`, `.async()`, `.definition`
  - New "Plugin Ordering: `dependsOn`" section
  - Hook table grows from 8 to 10 entries (adds `dependsOn`, `introspect`, `devtoolsTabs`)
  - `.definition` expanded with full type shape, `console.log` example, and three use cases (DevTools introspection, compat checks, deriving sibling factories)
- **`docs/guide/adapters.md`** (+138 / -4)
  - Top-of-page tip: "`defineAdapter()` returns a factory, not an adapter" with a ✓/✗ snippet
  - New "AdapterFactory Surface" section with a dedicated **"Default Mount: Just Call the Factory"** subsection — the 90% case, no `.scoped` / `.async` noise
  - `.scoped()`, `.async()`, `TExtra` extension methods, `.definition` all documented (same template as plugins.md)
  - "Registering Adapters" replaced with focused "Ordering with `dependsOn`" block
  - "When to Reach for a Plugin Instead" pointer at the bottom

### API reference

- **`docs/api/core.md`** (+162) — full Plugins section (`definePlugin`, `PluginFactory`, `KickPlugin`, `BuildContext`, `PluginAsyncOptions`); parallel `defineAdapter` / `AdapterFactory` / `AdapterAsyncOptions` block under the existing `AppAdapter` heading. Patched the `AppAdapter` interface to include `dependsOn`, `contributors()`, and `onHealthCheck()` which were missing.
- **`docs/api/http.md`** (+3) — added `plugins?: KickPlugin[]` to `ApplicationOptions` with pointers to the guide and API ref.

### Cross-links

- **`docs/guide/getting-started.md`** (+2 / -4)
  - Added Plugins to Next Steps
  - Fixed all Next Steps internal links to include `.md` suffix so they resolve in both VitePress and GitHub source view
  - Added a small "Reading this on GitHub?" pointer to the deployed docs site at the top

## Invariant stated in three places

`defineAdapter()` and `definePlugin()` return factories — you must invoke them (bare, `.scoped()`, or `.async()`) to get the instance `bootstrap({ adapters: [...] })` / `bootstrap({ plugins: [...] })` mounts. Now spelled out in:

1. Guide tip box at the top of `adapters.md`
2. Guide "Default Mount" section in `adapters.md`
3. Warning callouts in `docs/api/core.md` for both `defineAdapter` and `definePlugin`

## Not changed

- `docs/versions/*` — frozen snapshots, intentionally left at the published surface for those releases.
- `docs/api/kickjs.md` — separate pre-existing drift (sidebar at `.vitepress/config.mts:129` points at it but the file doesn't exist). Flagging here, not fixing in this PR.

## Test plan

- [ ] `pnpm docs:dev` — render the updated guide + API pages and click through the new anchors (`#buildcontext`, `#multi-instance-plugins-scoped`, `#plugin-ordering-dependson`, `#plugins` in core.md, `#defineadapter`, `#adapterfactory`)
- [ ] `pnpm docs:build` — confirm no broken-link warnings
- [ ] View `docs/guide/getting-started.md` on github.com to confirm the `.md` Next Steps links resolve
- [ ] Spot-check that `bootstrap({ adapters: [HealthAdapter()] })` examples still compile against the current published types

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensive API reference documentation added for adapter and plugin configuration systems, including detailed `defineAdapter()` and `definePlugin()` API specifications.
  * Enhanced guides with detailed usage patterns, lifecycle documentation, dependency ordering examples, and configuration options.
  * Added clarity on when to use plugins versus adapters for different extension scenarios.
  * Improved getting-started guide with better navigation links and GitHub-specific guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/217)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->