### PR TITLE
feat(db): safeNullComparison() workaround for Kysely upstream (#220)

### DIFF
--- a/.changeset/db-safe-null-comparison-workaround.md
+++ b/.changeset/db-safe-null-comparison-workaround.md
@@ -1,0 +1,31 @@
+---
+'@forinda/kickjs-db': minor
+'@forinda/kickjs-db-pg': patch
+---
+
+feat(db): `safeNullComparison()` plugin — kickjs-side workaround for Kysely's broken upstream
+
+`@forinda/kickjs-db` now exports its own `safeNullComparison()` plugin. Wire it through `createDbClient({ plugins: [...] })` so `eb('col', '=', null)` (plus `!=` / `<>`) compiles to `IS NULL` / `IS NOT NULL` instead of the silently-false `= NULL` default.
+
+```ts
+import { createDbClient, safeNullComparison } from '@forinda/kickjs-db'
+
+const db = createDbClient({
+  schema,
+  dialect: pgDialect({ pool }),
+  plugins: [safeNullComparison()],
+})
+
+await db.selectFrom('users').where('deletedAt', '=', null).selectAll().execute()
+// → SQL: select * from "users" where "deletedAt" is null   (no parameter)
+```
+
+The kickjs version emits the literal `null` keyword inline using `ValueNode.createImmediate(null)`, producing valid PostgreSQL. Pass this — NOT Kysely's `SafeNullComparisonPlugin` — through `plugins`. The Kysely upstream version is broken on PG (rewrites the operator but keeps the null operand parameterised, producing `WHERE "col" IS $1` which PG rejects with `syntax error at or near "$1"`); tracked upstream at <https://github.com/forinda/kick-js/issues/220>.
+
+When upstream Kysely fixes their transformer, this kickjs wrapper can collapse to a one-line re-export of Kysely's plugin.
+
+Tests: 7 new unit cases in `packages/db/__tests__/unit/safe-null-comparison.test.ts` (broken-default lock, `=` / `!=` / `<>` rewrite + non-null-passthrough + `is` passthrough). 3 new integration cases in `packages/db-pg/__tests__/integration/kysely-safe-null-broken-pg.test.ts` — Testcontainers PG 16 row-level verification. The existing locks on Kysely's broken upstream behaviour stay so an upstream fix surfaces loudly.
+
+`@forinda/kickjs-db`: 399 tests (was 392). `@forinda/kickjs-db-pg`: 35 tests (was 32). Patch on `@forinda/kickjs-db-pg` (test-only — no src change in the peer adapter).
+
+Additive — no breaking change.

--- a/packages/db-pg/__tests__/integration/kysely-safe-null-broken-pg.test.ts
+++ b/packages/db-pg/__tests__/integration/kysely-safe-null-broken-pg.test.ts
@@ -40,7 +40,14 @@ import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testconta
 import pg from 'pg'
 import { SafeNullComparisonPlugin } from 'kysely'
 
-import { createDbClient, serial, table, timestamp, varchar } from '@forinda/kickjs-db'
+import {
+  createDbClient,
+  safeNullComparison,
+  serial,
+  table,
+  timestamp,
+  varchar,
+} from '@forinda/kickjs-db'
 import { pgDialect } from '@forinda/kickjs-db-pg'
 
 let container: StartedPostgreSqlContainer
@@ -149,5 +156,57 @@ describe('Kysely 0.29 SafeNullComparisonPlugin — broken upstream on PG', () =>
       .where('deletedAt', '=', null)
       .execute()
     expect(rows).toEqual([])
+  })
+})
+
+describe('@forinda/kickjs-db safeNullComparison() — working PG behaviour', () => {
+  it("eb('col', '=', null) returns rows where deletedAt IS NULL", async () => {
+    const db = createDbClient({
+      schema,
+      dialect: pgDialect({ pool }),
+      plugins: [safeNullComparison()],
+    })
+
+    const rows = await db
+      .selectFrom('users')
+      .select(['email'])
+      .where('deletedAt', '=', null)
+      .orderBy('email')
+      .execute()
+
+    expect(rows).toEqual([{ email: 'live@example.com' }])
+  })
+
+  it("eb('col', '!=', null) returns rows where deletedAt IS NOT NULL", async () => {
+    const db = createDbClient({
+      schema,
+      dialect: pgDialect({ pool }),
+      plugins: [safeNullComparison()],
+    })
+
+    const rows = await db
+      .selectFrom('users')
+      .select(['email'])
+      .where('deletedAt', '!=', null)
+      .orderBy('email')
+      .execute()
+
+    expect(rows).toEqual([{ email: 'deleted@example.com' }])
+  })
+
+  it('non-null comparisons stay parameterised (plugin only rewrites the literal-null case)', async () => {
+    const db = createDbClient({
+      schema,
+      dialect: pgDialect({ pool }),
+      plugins: [safeNullComparison()],
+    })
+
+    const rows = await db
+      .selectFrom('users')
+      .select(['email'])
+      .where('email', '=', 'live@example.com')
+      .execute()
+
+    expect(rows).toEqual([{ email: 'live@example.com' }])
   })
 })

--- a/packages/db/__tests__/unit/safe-null-comparison.test.ts
+++ b/packages/db/__tests__/unit/safe-null-comparison.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  DummyDriver,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+  type Dialect,
+} from 'kysely'
+
+import {
+  createDbClient,
+  table,
+  serial,
+  varchar,
+  timestamp,
+  type KickDbClient,
+} from '@forinda/kickjs-db'
+import { safeNullComparison } from '@forinda/kickjs-db/client/plugins'
+
+// M5 follow-up — locks the compiled-SQL shape kickjs's
+// `safeNullComparison()` plugin produces when wired through
+// `createDbClient({ plugins: [...] })`.
+//
+// The default (no plugin) compiles `eb('col', '=', null)` to
+// `"col" = $1` with the null bound as a parameter — PG evaluates
+// the comparison to UNKNOWN under three-valued logic, filtering out
+// rows the adopter expected to match. With our plugin, the operator
+// becomes `is` / `is not` AND the null operand is emitted inline as
+// a literal `null` keyword (no `$N` binding), producing valid
+// `WHERE "col" IS NULL` / `WHERE "col" IS NOT NULL` PostgreSQL.
+//
+// This is intentionally different from Kysely 0.29's upstream
+// `SafeNullComparisonPlugin`, which keeps the null operand
+// parameterised and produces invalid `WHERE "col" IS $1` SQL —
+// locked separately in
+// `packages/db-pg/__tests__/integration/kysely-safe-null-broken-pg.test.ts`.
+
+const dummy: Dialect = {
+  createAdapter: () => new PostgresAdapter(),
+  createDriver: () => new DummyDriver(),
+  createIntrospector: (db) => new PostgresIntrospector(db),
+  createQueryCompiler: () => new PostgresQueryCompiler(),
+}
+
+const users = table('users', {
+  id: serial().primaryKey(),
+  email: varchar(255).notNull(),
+  deletedAt: timestamp(),
+})
+const schema = { users }
+
+interface QueryPayload {
+  sql: string
+  parameters: readonly unknown[]
+  durationMs: number
+}
+
+async function captureSql<DB>(
+  db: KickDbClient<DB>,
+  exec: () => Promise<unknown>,
+): Promise<QueryPayload> {
+  const onQuery = vi.fn()
+  db.on('query', onQuery)
+  await exec()
+  expect(onQuery).toHaveBeenCalledTimes(1)
+  return onQuery.mock.calls[0][0] as QueryPayload
+}
+
+describe('safeNullComparison() — broken default without the plugin', () => {
+  it("eb('col', '=', null) compiles to `= $1` with null bound — silently-false comparison", async () => {
+    const db = createDbClient({ schema, dialect: dummy, events: true })
+    const { sql, parameters } = await captureSql(db, () =>
+      db.selectFrom('users').selectAll().where('deletedAt', '=', null).execute(),
+    )
+    expect(sql).toMatch(/select \* from "users" where "deletedAt" = \$1/i)
+    expect(parameters).toEqual([null])
+  })
+
+  it("eb('col', '!=', null) compiles to `!= $1` with null bound — silently-false comparison", async () => {
+    const db = createDbClient({ schema, dialect: dummy, events: true })
+    const { sql, parameters } = await captureSql(db, () =>
+      db.selectFrom('users').selectAll().where('deletedAt', '!=', null).execute(),
+    )
+    expect(sql).toMatch(/select \* from "users" where "deletedAt" != \$1/i)
+    expect(parameters).toEqual([null])
+  })
+})
+
+describe('safeNullComparison() — corrected semantics with the plugin', () => {
+  it("eb('col', '=', null) rewrites to `IS NULL` with no bound parameter", async () => {
+    const db = createDbClient({
+      schema,
+      dialect: dummy,
+      events: true,
+      plugins: [safeNullComparison()],
+    })
+    const { sql, parameters } = await captureSql(db, () =>
+      db.selectFrom('users').selectAll().where('deletedAt', '=', null).execute(),
+    )
+    expect(sql).toMatch(/select \* from "users" where "deletedAt" is null/i)
+    expect(parameters).toEqual([])
+  })
+
+  it("eb('col', '!=', null) rewrites to `IS NOT NULL` with no bound parameter", async () => {
+    const db = createDbClient({
+      schema,
+      dialect: dummy,
+      events: true,
+      plugins: [safeNullComparison()],
+    })
+    const { sql, parameters } = await captureSql(db, () =>
+      db.selectFrom('users').selectAll().where('deletedAt', '!=', null).execute(),
+    )
+    expect(sql).toMatch(/select \* from "users" where "deletedAt" is not null/i)
+    expect(parameters).toEqual([])
+  })
+
+  it("eb('col', '<>', null) rewrites to `IS NOT NULL` (same as `!=`)", async () => {
+    const db = createDbClient({
+      schema,
+      dialect: dummy,
+      events: true,
+      plugins: [safeNullComparison()],
+    })
+    const { sql, parameters } = await captureSql(db, () =>
+      db.selectFrom('users').selectAll().where('deletedAt', '<>', null).execute(),
+    )
+    expect(sql).toMatch(/select \* from "users" where "deletedAt" is not null/i)
+    expect(parameters).toEqual([])
+  })
+
+  it('does not touch comparisons against non-null values — only the literal-null rewrite fires', async () => {
+    const db = createDbClient({
+      schema,
+      dialect: dummy,
+      events: true,
+      plugins: [safeNullComparison()],
+    })
+    const { sql, parameters } = await captureSql(db, () =>
+      db.selectFrom('users').selectAll().where('email', '=', 'a@b.com').execute(),
+    )
+    expect(sql).toMatch(/select \* from "users" where "email" = \$1/i)
+    expect(parameters).toEqual(['a@b.com'])
+  })
+
+  it('does not touch operators other than `=` / `!=` / `<>` against null', async () => {
+    // Kysely's expression builder rejects most operators against
+    // literal null at the type level, but `is` / `is not` against
+    // null are valid and the plugin should pass them through
+    // unchanged (no double-rewrite).
+    const db = createDbClient({
+      schema,
+      dialect: dummy,
+      events: true,
+      plugins: [safeNullComparison()],
+    })
+    const { sql, parameters } = await captureSql(db, () =>
+      db.selectFrom('users').selectAll().where('deletedAt', 'is', null).execute(),
+    )
+    expect(sql).toMatch(/select \* from "users" where "deletedAt" is null/i)
+    expect(parameters).toEqual([])
+  })
+})

--- a/packages/db/src/client/plugins.ts
+++ b/packages/db/src/client/plugins.ts
@@ -1,0 +1,116 @@
+import {
+  BinaryOperationNode,
+  OperationNodeTransformer,
+  OperatorNode,
+  ValueNode,
+  type KyselyPlugin,
+  type PluginTransformQueryArgs,
+  type PluginTransformResultArgs,
+  type QueryResult,
+  type RootOperationNode,
+  type UnknownRow,
+} from 'kysely'
+
+// M5 follow-up — kickjs-side workaround for the broken
+// SafeNullComparisonPlugin shipped in Kysely 0.29
+// (kysely/dist/plugin/safe-null-comparison/safe-null-comparison-transformer.js).
+//
+// The upstream transformer rewrites `=` / `!=` / `<>` against
+// literal `null` to `IS` / `IS NOT` at AST level but keeps the null
+// operand as a `ValueNode(null)`, which the PG compiler then
+// parameterises. Result: `WHERE "col" IS $1` with `$1=null` —
+// invalid PostgreSQL syntax. PG's `IS` predicate grammar requires
+// specific predicates (`NULL`, `TRUE`, `FALSE`, `UNKNOWN`,
+// `DISTINCT FROM ...`), not an arbitrary parameter placeholder.
+//
+// Verified empirically against postgres:16-alpine in
+// `packages/db-pg/__tests__/integration/kysely-safe-null-broken-pg.test.ts`.
+// Tracked for upstream follow-up at #220.
+//
+// Fix: identical AST rewrite, but replace the null `ValueNode` with
+// `ValueNode.createImmediate(null)` so the PG compiler emits the
+// bare SQL keyword `null` inline (no parameter binding). Output is
+// `WHERE "col" IS NULL` / `WHERE "col" IS NOT NULL` — valid PG and
+// semantically correct under three-valued logic.
+//
+// When upstream Kysely fixes their transformer (issue #220), this
+// wrapper can collapse to a one-line re-export of
+// `kysely`'s plugin. The unit test in
+// `__tests__/unit/safe-null-comparison.test.ts` and the PG
+// integration test pin the current output, so the diff will surface
+// loudly at upgrade time.
+
+class SafeNullComparisonTransformer extends OperationNodeTransformer {
+  protected override transformBinaryOperation(node: BinaryOperationNode): BinaryOperationNode {
+    const transformed = super.transformBinaryOperation(node)
+    const { operator, leftOperand, rightOperand } = transformed
+
+    if (!OperatorNode.is(operator)) return transformed
+    if (!ValueNode.is(rightOperand) || rightOperand.value !== null) return transformed
+
+    const op = operator.operator
+    if (op !== '=' && op !== '!=' && op !== '<>') return transformed
+
+    return BinaryOperationNode.create(
+      leftOperand,
+      OperatorNode.create(op === '=' ? 'is' : 'is not'),
+      // KEY DIFFERENCE vs Kysely's upstream transformer — `createImmediate`
+      // marks the value for inline emission, so the compiler writes the
+      // SQL keyword `null` instead of binding the value as a `$N` parameter.
+      ValueNode.createImmediate(null),
+    )
+  }
+}
+
+class SafeNullComparisonPlugin implements KyselyPlugin {
+  readonly #transformer = new SafeNullComparisonTransformer()
+
+  transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
+    return this.#transformer.transformNode(args.node)
+  }
+
+  async transformResult(args: PluginTransformResultArgs): Promise<QueryResult<UnknownRow>> {
+    return args.result
+  }
+}
+
+/**
+ * Pass this to `createDbClient({ plugins: [...] })` so
+ * `eb('col', '=', null)` (plus `!=` / `<>`) compiles to `IS NULL` /
+ * `IS NOT NULL` instead of the silently-false `= NULL` default.
+ *
+ * Without the plugin, Kysely passes `null` through as a bound
+ * parameter — the resulting `col = $1` evaluates to UNKNOWN under
+ * three-valued logic, which filters out every row including the
+ * ones the adopter intended to match. The plugin rewrites the AST
+ * before compilation so the operator becomes `IS` / `IS NOT` and
+ * the null literal flows inline (no `$N` parameter binding).
+ *
+ * ```ts
+ * import { createDbClient, safeNullComparison } from '@forinda/kickjs-db'
+ *
+ * const db = createDbClient({
+ *   schema,
+ *   dialect: pgDialect({ pool }),
+ *   plugins: [safeNullComparison()],
+ * })
+ *
+ * await db.selectFrom('users').where('deletedAt', '=', null).selectAll().execute()
+ * // → SQL: select * from "users" where "deletedAt" is null
+ * ```
+ *
+ * Opt-in; default `createDbClient` chains stay byte-identical so
+ * existing repos that work around the gotcha manually don't see a
+ * behaviour change.
+ *
+ * **Why a kickjs-side helper rather than re-exporting Kysely's?**
+ * Kysely 0.29's own `SafeNullComparisonPlugin` ships broken on PG —
+ * it rewrites the operator but keeps the null operand parameterised,
+ * producing `WHERE "col" IS $1` with `$1=null`, which PG rejects
+ * with `syntax error at or near "$1"`. The kickjs version emits the
+ * literal `null` keyword inline so PG accepts it. Tracked upstream
+ * at <https://github.com/forinda/kick-js/issues/220>.
+ */
+export function safeNullComparison(): KyselyPlugin {
+  return new SafeNullComparisonPlugin()
+}

--- a/packages/db/src/client/types.ts
+++ b/packages/db/src/client/types.ts
@@ -196,21 +196,27 @@ export interface CreateDbClientOptions<TSchema, _DB = unknown> {
    * byte-identical chain to pre-M5.B clients (only the built-in
    * plugins run).
    *
-   * **Heads-up — Kysely 0.29's `SafeNullComparisonPlugin` ships
-   * broken on PG.** The plugin rewrites `=` / `!=` against literal
-   * `null` to `IS` / `IS NOT` but keeps the null as a parameterised
-   * `ValueNode`, producing `WHERE "col" IS $1` with `$1=null` —
-   * which PG rejects with `syntax error at or near "$1"`. The
-   * `kickjs-db-pg` test suite locks this in
-   * `kysely-safe-null-broken-pg.test.ts` so an upstream fix
-   * surfaces immediately; until then, don't pass it through
-   * `plugins`. Spell null comparisons with the explicit operators
-   * (`is`, `is not`) via the Kysely expression builder instead:
+   * Reach for `safeNullComparison()` here when you want
+   * `eb('col', '=', null)` to compile to `IS NULL` instead of the
+   * silently-false `= NULL`:
    *
    * ```ts
-   * .where('deletedAt', 'is', null)        // OK — emits IS NULL
-   * .where('deletedAt', 'is not', null)    // OK — emits IS NOT NULL
+   * import { createDbClient, safeNullComparison } from '@forinda/kickjs-db'
+   *
+   * const db = createDbClient({
+   *   schema,
+   *   dialect: pgDialect({ pool }),
+   *   plugins: [safeNullComparison()],
+   * })
    * ```
+   *
+   * **Heads-up — pass `safeNullComparison()` from
+   * `@forinda/kickjs-db`, NOT Kysely's `SafeNullComparisonPlugin`.**
+   * Kysely 0.29's upstream version is broken on PG (rewrites the
+   * operator but keeps the null operand parameterised, producing
+   * `WHERE "col" IS $1` which PG rejects with `syntax error at or
+   * near "$1"`). The kickjs version emits the literal `null` keyword
+   * inline. Tracked upstream at <https://github.com/forinda/kick-js/issues/220>.
    */
   plugins?: KyselyPlugin[]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -64,6 +64,7 @@ export { kickDbAdapter, type KickDbAdapterConfig, type MigrationsOnBoot } from '
 export { DB_PRIMARY, DB_REPLICA, DB_CLIENT } from './tokens'
 
 export { createDbClient } from './client/create'
+export { safeNullComparison } from './client/plugins'
 export type {
   KickDbClient,
   KickDbClientEvents,

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -31,11 +31,15 @@ export default defineConfig({
         find: '@forinda/kickjs-db/pg',
         replacement: path.resolve(__dirname, 'src/dsl/columns/pg.ts'),
       },
-      // M5.B — internal-only alias so tests can reach the ALTER TYPE
-      // helpers that aren't part of the public `package.json` exports.
+      // M5.B — internal-only aliases so tests can reach helpers that
+      // aren't part of the public `package.json` exports.
       {
         find: '@forinda/kickjs-db/emit/alter-type',
         replacement: path.resolve(__dirname, 'src/emit/alter-type.ts'),
+      },
+      {
+        find: '@forinda/kickjs-db/client/plugins',
+        replacement: path.resolve(__dirname, 'src/client/plugins.ts'),
       },
       {
         find: '@forinda/kickjs-db',


### PR DESCRIPTION
# `safeNullComparison()` — kickjs-side workaround for Kysely's broken upstream

Closes / unblocks #220 from the adopter side while we wait on the upstream Kysely fix.

## Why

Kysely 0.29's `SafeNullComparisonPlugin` rewrites the operator (`=` → `is`, `!=` → `is not`) at AST level but keeps the null operand as a `ValueNode(null)`, which the PG compiler then parameterises. Result: `WHERE "col" IS $1` with `$1=null` — PG rejects with `syntax error at or near "$1"`. Verified empirically against `postgres:16-alpine` in `kysely-safe-null-broken-pg.test.ts` (already on main). Full diagnosis + proposed upstream PR direction in #220.

So far we'd dropped the originally-planned `safeNullComparison()` wrapper from M5.B and pointed adopters at the explicit `.where('col', 'is', null)` form via the expression builder. That works but loses the drop-in DX a plugin offers (one line in `createDbClient` config vs touching every call site). This PR adds a working kickjs-side plugin so adopters get the original promised UX.

## What

### `@forinda/kickjs-db` — new exported `safeNullComparison()`

Custom `OperationNodeTransformer` subclass that mirrors Kysely's transformer logic but swaps the preserved null `ValueNode` for `ValueNode.createImmediate(null)`. The compiler then emits the bare SQL `null` keyword inline (no `$N` binding) — output: `WHERE "col" IS NULL` / `WHERE "col" IS NOT NULL`, valid PG.

```ts
import { createDbClient, safeNullComparison } from '@forinda/kickjs-db'

const db = createDbClient({
  schema,
  dialect: pgDialect({ pool }),
  plugins: [safeNullComparison()],
})

await db.selectFrom('users').where('deletedAt', '=', null).selectAll().execute()
// → SQL: select * from "users" where "deletedAt" is null   (no parameter)
```

Source: `packages/db/src/client/plugins.ts`. Re-exported from the package root.

### `CreateDbClientOptions.plugins` docstring updated

Previously warned "don't pass Kysely's `SafeNullComparisonPlugin`". Now recommends `safeNullComparison()` from `@forinda/kickjs-db` directly, with the same warning carried forward against the upstream version.

### Tests

- **`packages/db/__tests__/unit/safe-null-comparison.test.ts`** — 7 cases:
  - Broken-default lock without the plugin: `eb('col', '=', null)` → `= $1` with `[null]`, `eb('col', '!=', null)` → `!= $1`.
  - With the plugin: `=` / `!=` / `<>` rewrite to `IS NULL` / `IS NOT NULL` with **empty parameters**.
  - Non-null comparisons stay parameterised (`= $1` with `['a@b.com']`).
  - Explicit `is null` operator passes through unchanged (no double-rewrite).
- **`packages/db-pg/__tests__/integration/kysely-safe-null-broken-pg.test.ts`** — adds 3 positive cases for the kickjs plugin alongside the existing 4 evidence-lock cases for Kysely's broken upstream behaviour. Real Testcontainers PG 16; row-level assertions on a fixture with mixed `null` / non-null `deletedAt`.

When Kysely upstream fixes their transformer (one-line change documented in #220), the kickjs wrapper collapses to a one-line re-export and the integration test's "Kysely broken" describe block can be deleted. The diff surfaces loudly because the locked Kysely-output assertion would start failing.

## Verification

```text
pnpm --filter @forinda/kickjs-db test       # 399 passed (was 392 at M5.B cut)
pnpm --filter @forinda/kickjs-db-pg test    # 35 passed (was 32)
pnpm --filter @forinda/kickjs-db build      # OK
```

## Test plan

- [ ] CI green across db core + peer adapters.
- [ ] Adopter test: in `examples/task-kickdb-api` (or any consumer), `pnpm add @forinda/kickjs-db@latest` after release, wire `plugins: [safeNullComparison()]`, run a soft-delete-style query against PG.

## Bumps

- `@forinda/kickjs-db`: **minor** (additive — new exported helper).
- `@forinda/kickjs-db-pg`: **patch** (test-only — no src change in the peer adapter).

Respects the M5 "no major bumps" rule + the durable "stay on 5.x" preference.

## Follow-up after upstream fix

When `kysely-org/kysely` releases the transformer fix:

1. Re-test against the new Kysely version (the existing `kysely-safe-null-broken-pg.test.ts` will start failing — that's the signal).
2. Collapse `packages/db/src/client/plugins.ts` to `export function safeNullComparison(): KyselyPlugin { return new SafeNullComparisonPlugin() }`.
3. Drop the warning from `CreateDbClientOptions.plugins` docstring.
4. Delete the "Kysely broken upstream" describe block from the integration test.
5. Bump the kysely peer-range floor to the fix's minimum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved PostgreSQL database query handling to ensure null comparisons generate correct SQL syntax with proper IS NULL / IS NOT NULL semantics instead of invalid parameterized expressions.

* **Documentation**
  * Updated guidance for PostgreSQL null comparison configuration and usage.

* **Tests**
  * Added comprehensive test coverage for null comparison behavior validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/224)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->