### PR TITLE
test(db): diff-engine fuzz harness — 1000-seed round-trip

### DIFF
--- a/.changeset/db-diff-engine-fuzz.md
+++ b/.changeset/db-diff-engine-fuzz.md
@@ -1,0 +1,31 @@
+---
+'@forinda/kickjs-db': minor
+---
+
+test(db): diff-engine fuzz harness — 1000 seeded round-trip property assertions
+
+Adds the diff-engine fuzz suite the original architecture spec ([§13](https://github.com/forinda/kick-js/blob/main/docs/db/architecture.md)) listed as an M5 hardening gate for the "production-grade" claim. 1000 randomly-generated `SchemaSnapshot` pairs run three structural property assertions against the diff engine:
+
+1. **Forward fidelity** — `applyChangeSet(A, diff(A, B)) ≡ B` for every pair. Catches missing changes (forward diff didn't notice some delta) and spurious changes (forward diff moves A away from B).
+2. **Reverse fidelity** — `applyChangeSet(B, invertChanges(diff(A, B))) ≡ A` when `hasAmbiguousReverse(forward)` is false. Ambiguous-reverse cases (`dropTable`, `dropColumn`, `alterColumn`, `addEnumValue`, `removeEnumValue`) are documented as best-effort drafts requiring operator review, so the property doesn't hold by design — those seeds are counted-and-skipped.
+3. **Reflexivity** — `diff(A, A) === []` for 1000 random snapshots. Catches a class of "always-emits-a-change" false-positives that would burn through migrations forever.
+
+Generator + applier scoped narrowly for the first cut:
+
+- PostgreSQL dialect only — other dialects share the same diff path; their emitters live in separate test scopes.
+- No `renameTable` / `renameColumn` (engine doesn't infer renames; those exercise the drop+add path, covered by `diff-rename.test.ts`).
+- Simple default values (`'0'`, `"'x'"`, `'true'`, `'CURRENT_TIMESTAMP'`) — avoids the pgEnum-cast-bracket dance that M5.A.1 handles.
+
+### Finding from the first run
+
+The fuzz immediately surfaced an **internal contract** worth documenting: `diff/engine.ts` emits `createTable` changes carrying the full table snapshot (including indexes + FKs), then separately emits `addIndex` / `addForeignKey` for each. The SQL emitter `emit/pg.ts:emitCreateTable` strips indexes/FKs from the CREATE TABLE statement and renders them via the subsequent ALTER TABLE changes. The structural reader (the fuzz applier) has to mirror this stripping behaviour — taking the columns + PK from `createTable` and leaving indexes/foreignKeys empty until the secondary changes populate them. Not a bug — but the contract was implicit; the applier in `__tests__/fuzz/apply-changeset.ts` carries an inline note for the next reader.
+
+### Surface bumps
+
+`@forinda/kickjs-db` minor — `EnumSnapshot` is now exported from the package root (oversight from M3; the rest of the snapshot type family was already public). Used by the fuzz generator but useful generally for adopters reading `SchemaSnapshot.enums`.
+
+### Numbers
+
+`@forinda/kickjs-db`: **402 tests** (was 399 — three new fuzz top-level suites, each iterating 1000 seeds internally). Fuzz iteration cost: ~25 seconds for 3000 seed runs.
+
+Additive — no breaking change. Stays on the 5.x line.

--- a/packages/db/__tests__/fuzz/apply-changeset.ts
+++ b/packages/db/__tests__/fuzz/apply-changeset.ts
@@ -1,0 +1,185 @@
+import type { ChangeSet, EnumSnapshot, SchemaSnapshot, TableSnapshot } from '@forinda/kickjs-db'
+
+// Fuzz-harness companion to `emitPg` — applies a ChangeSet to an
+// in-memory SchemaSnapshot so the round-trip property
+// `applyChangeSet(A, diff(A, B)) ≡ B` can be asserted without
+// rendering to SQL + executing against a real DB.
+//
+// Scope mirrors the generator (`random-schema.ts`):
+// - Handles every Change kind the diff engine emits.
+// - Mutates a deep clone so callers can compare apply-result vs
+//   target without sharing references with the source.
+// - Ambiguous-reverse cases (alterColumn on non-equal before/after,
+//   addEnumValue, removeEnumValue) round-trip on the forward side
+//   but not the invert side. The fuzz test skips invert assertions
+//   on those.
+
+function deepClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value))
+}
+
+export function applyChangeSet(snapshot: SchemaSnapshot, changes: ChangeSet): SchemaSnapshot {
+  const out = deepClone(snapshot)
+  for (const change of changes) applyOne(out, change)
+  return out
+}
+
+function applyOne(snapshot: SchemaSnapshot, change: ChangeSet[number]): void {
+  switch (change.kind) {
+    case 'createTable':
+      // Mirror `emitCreateTable` in `emit/pg.ts` — the CREATE TABLE
+      // SQL only includes columns + PK. Indexes and foreign keys
+      // land via the separate `addIndex` / `addForeignKey` changes
+      // the engine emits in pass 2 + pass 3 (see `diff/engine.ts`).
+      // Take the table's base shape only here; the secondary
+      // changes downstream populate the rest.
+      snapshot.tables[change.table.name] = {
+        ...deepClone(change.table),
+        indexes: [],
+        foreignKeys: [],
+      }
+      return
+    case 'dropTable':
+      delete snapshot.tables[change.table.name]
+      return
+    case 'renameTable': {
+      const t = snapshot.tables[change.from]
+      if (!t) return
+      delete snapshot.tables[change.from]
+      snapshot.tables[change.to] = { ...t, name: change.to }
+      return
+    }
+    case 'addColumn': {
+      const t = snapshot.tables[change.table]
+      if (!t) return
+      t.columns[change.column.name] = deepClone(change.column)
+      return
+    }
+    case 'dropColumn': {
+      const t = snapshot.tables[change.table]
+      if (!t) return
+      delete t.columns[change.column.name]
+      return
+    }
+    case 'renameColumn': {
+      const t = snapshot.tables[change.table]
+      if (!t) return
+      const col = t.columns[change.from]
+      if (!col) return
+      delete t.columns[change.from]
+      t.columns[change.to] = { ...col, name: change.to }
+      return
+    }
+    case 'alterColumn': {
+      const t = snapshot.tables[change.table]
+      if (!t) return
+      t.columns[change.column] = deepClone(change.after)
+      return
+    }
+    case 'addIndex': {
+      const t = snapshot.tables[change.table]
+      if (!t) return
+      t.indexes.push(deepClone(change.index))
+      return
+    }
+    case 'dropIndex': {
+      const t = snapshot.tables[change.table]
+      if (!t) return
+      t.indexes = t.indexes.filter((i) => i.name !== change.index.name)
+      return
+    }
+    case 'addForeignKey': {
+      const t = snapshot.tables[change.table]
+      if (!t) return
+      t.foreignKeys.push(deepClone(change.fk))
+      return
+    }
+    case 'dropForeignKey': {
+      const t = snapshot.tables[change.table]
+      if (!t) return
+      t.foreignKeys = t.foreignKeys.filter((f) => f.name !== change.fk.name)
+      return
+    }
+    case 'createEnum': {
+      if (!snapshot.enums) snapshot.enums = {}
+      const e: EnumSnapshot = { name: change.enum.name, values: [...change.enum.values] }
+      snapshot.enums[change.enum.name] = e
+      return
+    }
+    case 'dropEnum': {
+      if (!snapshot.enums) return
+      delete snapshot.enums[change.enum.name]
+      if (Object.keys(snapshot.enums).length === 0) delete snapshot.enums
+      return
+    }
+    case 'addEnumValue': {
+      if (!snapshot.enums) return
+      const e = snapshot.enums[change.enum]
+      if (!e) return
+      const idx = change.before != null ? e.values.indexOf(change.before) : -1
+      const next = [...e.values]
+      if (idx >= 0) next.splice(idx, 0, change.value)
+      else next.push(change.value)
+      snapshot.enums[change.enum] = { name: e.name, values: next }
+      return
+    }
+    case 'removeEnumValue': {
+      if (!snapshot.enums) return
+      const e = snapshot.enums[change.enum]
+      if (!e) return
+      const removed = new Set(change.removed)
+      snapshot.enums[change.enum] = {
+        name: e.name,
+        values: e.values.filter((v) => !removed.has(v)),
+      }
+      return
+    }
+  }
+}
+
+/**
+ * Snapshot equality for fuzz assertions. Tables compared as keyed
+ * records (insertion order irrelevant); indexes / FKs / enum values
+ * compared as multisets keyed by `name` so apply-order differences
+ * within a ChangeSet don't false-positive.
+ */
+export function snapshotsEqual(a: SchemaSnapshot, b: SchemaSnapshot): boolean {
+  if (a.version !== b.version || a.dialect !== b.dialect) return false
+  const aTables = Object.keys(a.tables).toSorted()
+  const bTables = Object.keys(b.tables).toSorted()
+  if (aTables.join(',') !== bTables.join(',')) return false
+  for (const name of aTables) {
+    if (!tablesEqual(a.tables[name] as TableSnapshot, b.tables[name] as TableSnapshot)) return false
+  }
+  const aEnumKeys = Object.keys(a.enums ?? {}).toSorted()
+  const bEnumKeys = Object.keys(b.enums ?? {}).toSorted()
+  if (aEnumKeys.join(',') !== bEnumKeys.join(',')) return false
+  for (const name of aEnumKeys) {
+    const ea = a.enums?.[name] as EnumSnapshot
+    const eb = b.enums?.[name] as EnumSnapshot
+    if (ea.values.join(',') !== eb.values.join(',')) return false
+  }
+  return true
+}
+
+function tablesEqual(a: TableSnapshot, b: TableSnapshot): boolean {
+  if (a.name !== b.name) return false
+  const aCols = Object.keys(a.columns).toSorted()
+  const bCols = Object.keys(b.columns).toSorted()
+  if (aCols.join(',') !== bCols.join(',')) return false
+  for (const c of aCols) {
+    if (JSON.stringify(a.columns[c]) !== JSON.stringify(b.columns[c])) return false
+  }
+  if (!nameSetEqual(a.indexes, b.indexes)) return false
+  if (!nameSetEqual(a.foreignKeys, b.foreignKeys)) return false
+  return true
+}
+
+function nameSetEqual<T extends { name: string }>(a: readonly T[], b: readonly T[]): boolean {
+  if (a.length !== b.length) return false
+  const aByName = new Map(a.map((x) => [x.name, JSON.stringify(x)]))
+  for (const x of b) {
+    if (aByName.get(x.name) !== JSON.stringify(x)) return false
+  }
+  return true
+}

--- a/packages/db/__tests__/fuzz/apply-changeset.ts
+++ b/packages/db/__tests__/fuzz/apply-changeset.ts
@@ -134,6 +134,14 @@ function applyOne(snapshot: SchemaSnapshot, change: ChangeSet[number]): void {
       }
       return
     }
+    default: {
+      // Exhaustiveness guard: a new Change variant added without
+      // an applier case here would silently no-op and make the
+      // fuzz round-trip assertions misleading. Asserting `change`
+      // is `never` turns it into a TS compile error instead.
+      const _exhaustive: never = change
+      return _exhaustive
+    }
   }
 }
 

--- a/packages/db/__tests__/fuzz/diff-roundtrip.test.ts
+++ b/packages/db/__tests__/fuzz/diff-roundtrip.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { diff, hasAmbiguousReverse, invertChanges } from '@forinda/kickjs-db'
+import { applyChangeSet, snapshotsEqual } from './apply-changeset'
+import { generateSnapshot } from './random-schema'
+
+// Architecture spec §13 hardening — 1000 random schema-pair fixtures
+// asserting two structural properties on the diff engine:
+//
+//   1. **Forward fidelity:** `applyChangeSet(A, diff(A, B)) ≡ B` for
+//      every pair. If this fails, the forward diff is incomplete —
+//      either it skipped a change that should have been emitted, or
+//      it emitted one that doesn't transform A toward B.
+//
+//   2. **Reverse fidelity:** `applyChangeSet(B, invertChanges(diff(A, B))) ≡ A`
+//      *when the forward change set is not flagged
+//      `hasAmbiguousReverse`*. Ambiguous-reverse change kinds
+//      (dropTable, dropColumn, alterColumn, addEnumValue,
+//      removeEnumValue) are documented as best-effort drafts that
+//      require operator review; their round-trip is intentionally
+//      lossy on the type side (e.g. dropping a column then re-adding
+//      it loses the original type / default unless the snapshot
+//      carried both, which the diff engine does — but operator
+//      intent isn't preserved). Skipping these keeps the assertion
+//      meaningful: only changes that *claim* to be exactly reversible
+//      have to round-trip.
+//
+// Seeds: 0..999. Failing seed prints in the assertion so a repro is
+// `generateSnapshot(seed * 2)` + `generateSnapshot(seed * 2 + 1)`.
+
+const SEED_COUNT = 1000
+
+describe('diff engine fuzz — 1000 seeds, round-trip property', () => {
+  let ambiguousSkipped = 0
+
+  it('forward: applyChangeSet(A, diff(A, B)) ≡ B for all 1000 pairs', () => {
+    const failures: string[] = []
+    for (let seed = 0; seed < SEED_COUNT; seed++) {
+      const A = generateSnapshot(seed * 2)
+      const B = generateSnapshot(seed * 2 + 1)
+      const forward = diff(A, B)
+      const applied = applyChangeSet(A, forward)
+      if (!snapshotsEqual(applied, B)) {
+        failures.push(
+          `seed=${seed} (A=generateSnapshot(${seed * 2}), B=generateSnapshot(${seed * 2 + 1}))`,
+        )
+        if (failures.length >= 5) break // bail early — pattern, not catalogue
+      }
+    }
+    expect(failures, `forward fidelity failed for:\n  ${failures.join('\n  ')}`).toEqual([])
+  })
+
+  it('reverse: applyChangeSet(B, invert(diff(A, B))) ≡ A when no ambiguous-reverse changes', () => {
+    const failures: string[] = []
+    for (let seed = 0; seed < SEED_COUNT; seed++) {
+      const A = generateSnapshot(seed * 2)
+      const B = generateSnapshot(seed * 2 + 1)
+      const forward = diff(A, B)
+      if (hasAmbiguousReverse(forward)) {
+        ambiguousSkipped++
+        continue
+      }
+      const reverse = invertChanges(forward)
+      const applied = applyChangeSet(B, reverse)
+      if (!snapshotsEqual(applied, A)) {
+        failures.push(
+          `seed=${seed} (A=generateSnapshot(${seed * 2}), B=generateSnapshot(${seed * 2 + 1}))`,
+        )
+        if (failures.length >= 5) break
+      }
+    }
+    expect(failures, `reverse fidelity failed for:\n  ${failures.join('\n  ')}`).toEqual([])
+    // Sanity check on fixture diversity: with 1000 random pairs and a
+    // generator that often creates / drops tables (an ambiguous kind),
+    // most pairs should be flagged ambiguous. If almost zero are, the
+    // generator is producing degenerate / empty schemas and the
+    // assertion above is vacuous.
+    expect(ambiguousSkipped).toBeGreaterThan(SEED_COUNT * 0.1)
+  })
+
+  it('reflexivity: diff(A, A) === [] for all generated snapshots', () => {
+    const failures: number[] = []
+    for (let seed = 0; seed < SEED_COUNT; seed++) {
+      const A = generateSnapshot(seed)
+      if (diff(A, A).length !== 0) failures.push(seed)
+      if (failures.length >= 5) break
+    }
+    expect(failures, `non-empty self-diff for seeds: ${failures.join(', ')}`).toEqual([])
+  })
+})

--- a/packages/db/__tests__/fuzz/random-schema.ts
+++ b/packages/db/__tests__/fuzz/random-schema.ts
@@ -1,0 +1,236 @@
+import type {
+  ColumnSnapshot,
+  EnumSnapshot,
+  ForeignKeySnapshot,
+  IndexSnapshot,
+  SchemaSnapshot,
+  TableSnapshot,
+} from '@forinda/kickjs-db'
+
+// Architecture spec §13 — diff-engine fuzz harness. Generates random
+// SchemaSnapshot fixtures from a seeded RNG so the same seed always
+// produces the same pair, and a failing case can be reproduced
+// exactly by re-running with the seed printed in the assertion.
+//
+// Scope (intentionally narrow for first cut):
+// - PostgreSQL dialect only — keeps the generator + applier shapes
+//   focused. Other dialects share the same diff path; their emitters
+//   live in separate test scopes.
+// - No renameTable / renameColumn — the diff engine doesn't infer
+//   renames (it sees a drop+add), so generating them would only
+//   exercise the drop+add path; the rename-specific code path has
+//   its own coverage in `diff-rename.test.ts`.
+// - No enum value additions/removals — those are flagged as
+//   ambiguous-reverse and the round-trip property doesn't hold by
+//   design (operator-reviewed advisories). Locked in
+//   `pg-enum-pipeline.test.ts` separately.
+// - Defaults stay simple ('0', "'x'", 'true') — avoids the
+//   pgEnum-cast-bracket dance that M5.A.1 handles. Enum-typed
+//   columns get no default for the same reason.
+
+/** Deterministic xorshift32 — small, fast, reproducible. */
+export class Rng {
+  private state: number
+
+  constructor(seed: number) {
+    // Seed must be non-zero; xorshift on 0 stays at 0 forever.
+    this.state = seed === 0 ? 0xdeadbeef : seed >>> 0
+  }
+
+  next(): number {
+    let x = this.state
+    x ^= x << 13
+    x ^= x >>> 17
+    x ^= x << 5
+    this.state = x >>> 0
+    return this.state
+  }
+
+  int(maxExclusive: number): number {
+    return this.next() % maxExclusive
+  }
+
+  intRange(minInclusive: number, maxInclusive: number): number {
+    return minInclusive + this.int(maxInclusive - minInclusive + 1)
+  }
+
+  bool(probabilityTrue = 0.5): boolean {
+    return this.next() / 0xffffffff < probabilityTrue
+  }
+
+  pick<T>(arr: readonly T[]): T {
+    return arr[this.int(arr.length)] as T
+  }
+
+  /** Pick `count` distinct items from `arr`. Returns at most `arr.length`. */
+  sample<T>(arr: readonly T[], count: number): T[] {
+    const pool = [...arr]
+    const out: T[] = []
+    while (pool.length > 0 && out.length < count) {
+      const idx = this.int(pool.length)
+      out.push(pool[idx] as T)
+      pool.splice(idx, 1)
+    }
+    return out
+  }
+}
+
+const PG_TYPES = [
+  'integer',
+  'bigint',
+  'smallint',
+  'varchar(255)',
+  'text',
+  'boolean',
+  'timestamp',
+  'date',
+  'numeric',
+  'uuid',
+  'jsonb',
+] as const
+
+const FK_ACTIONS = ['cascade', 'restrict', 'set_null', 'set_default', 'no_action'] as const
+
+function defaultForType(type: string, rng: Rng): string | null {
+  if (!rng.bool(0.35)) return null
+  switch (true) {
+    case type.startsWith('integer') || type.startsWith('bigint') || type.startsWith('smallint'):
+      return String(rng.intRange(0, 100))
+    case type.startsWith('numeric'):
+      return String(rng.intRange(0, 100))
+    case type === 'boolean':
+      return rng.bool() ? 'true' : 'false'
+    case type === 'timestamp' || type === 'date':
+      return 'CURRENT_TIMESTAMP'
+    case type === 'uuid':
+      return 'gen_random_uuid()'
+    case type === 'jsonb':
+      return `'{}'`
+    case type.startsWith('varchar') || type === 'text':
+      return `'v${rng.intRange(0, 999)}'`
+    default:
+      return null
+  }
+}
+
+function genColumn(name: string, rng: Rng): ColumnSnapshot {
+  const type = rng.pick(PG_TYPES)
+  // Avoid FK-incompatible defaults — keep the generator simple by
+  // refusing defaults on PK columns (the PK constraint is what's
+  // doing the "non-null + unique" work and SET DEFAULT for serial-ish
+  // columns interacts with sequence ownership we don't want to model).
+  const nullable = rng.bool(0.55)
+  return {
+    name,
+    type,
+    nullable,
+    default: nullable ? defaultForType(type, rng) : defaultForType(type, rng),
+    primaryKey: false, // PK assignment happens at table level so we can pick a single column
+  }
+}
+
+function genTable(name: string, rng: Rng): TableSnapshot {
+  const columnCount = rng.intRange(1, 6)
+  const columns: Record<string, ColumnSnapshot> = {}
+  const columnNames: string[] = []
+  for (let i = 0; i < columnCount; i++) {
+    const colName = `c${i}_${rng.intRange(0, 99)}`
+    if (columns[colName]) continue
+    columnNames.push(colName)
+    columns[colName] = genColumn(colName, rng)
+  }
+  // 70% chance of a single-column PK on the first column.
+  if (columnNames.length > 0 && rng.bool(0.7)) {
+    const pkCol = columnNames[0] as string
+    const existing = columns[pkCol] as ColumnSnapshot
+    columns[pkCol] = { ...existing, primaryKey: true, nullable: false, default: null }
+  }
+  // 0-2 indexes, single-column.
+  const indexCount = rng.intRange(0, 2)
+  const indexes: IndexSnapshot[] = []
+  for (let i = 0; i < indexCount; i++) {
+    if (columnNames.length === 0) break
+    const col = rng.pick(columnNames)
+    indexes.push({
+      name: `${name}_${col}_idx${i}`,
+      columns: [col],
+      unique: rng.bool(0.3),
+    })
+  }
+  return {
+    name,
+    columns,
+    indexes,
+    foreignKeys: [],
+    checks: [],
+  }
+}
+
+function maybeAddForeignKeys(snapshot: SchemaSnapshot, rng: Rng): void {
+  const tableNames = Object.keys(snapshot.tables)
+  for (const tableName of tableNames) {
+    if (!rng.bool(0.3)) continue
+    const table = snapshot.tables[tableName] as TableSnapshot
+    const otherTables = tableNames.filter((t) => t !== tableName)
+    if (otherTables.length === 0) continue
+    const refTableName = rng.pick(otherTables)
+    const refTable = snapshot.tables[refTableName] as TableSnapshot
+    const refPkCols = Object.values(refTable.columns).filter((c) => c.primaryKey)
+    if (refPkCols.length === 0) continue
+    const localCols = Object.values(table.columns).filter((c) => !c.primaryKey)
+    if (localCols.length === 0) continue
+    const localCol = rng.pick(localCols)
+    const refCol = refPkCols[0] as ColumnSnapshot
+    const fk: ForeignKeySnapshot = {
+      name: `fk_${tableName}_${localCol.name}_${refTableName}`,
+      columns: [localCol.name],
+      refTable: refTableName,
+      refColumns: [refCol.name],
+      onDelete: rng.pick(FK_ACTIONS),
+      onUpdate: rng.pick(FK_ACTIONS),
+    }
+    table.foreignKeys.push(fk)
+  }
+}
+
+export interface GeneratorOptions {
+  /** Average number of tables. Final count is intRange(0, 2*meanTables). */
+  meanTables?: number
+  /** Whether to include enum declarations. Default false (keeps fuzz simple). */
+  withEnums?: boolean
+}
+
+export function generateSnapshot(seed: number, opts: GeneratorOptions = {}): SchemaSnapshot {
+  const meanTables = opts.meanTables ?? 4
+  const rng = new Rng(seed)
+  const tableCount = rng.intRange(0, meanTables * 2)
+  const tables: Record<string, TableSnapshot> = {}
+  for (let i = 0; i < tableCount; i++) {
+    const name = `t${i}_${rng.intRange(0, 99)}`
+    if (tables[name]) continue
+    tables[name] = genTable(name, rng)
+  }
+
+  const snapshot: SchemaSnapshot = {
+    version: 1,
+    dialect: 'postgres',
+    tables,
+  }
+
+  if (opts.withEnums && rng.bool(0.5)) {
+    const enums: Record<string, EnumSnapshot> = {}
+    const enumCount = rng.intRange(1, 3)
+    for (let i = 0; i < enumCount; i++) {
+      const name = `e${i}_${rng.intRange(0, 99)}`
+      const valueCount = rng.intRange(2, 5)
+      const values: string[] = []
+      for (let j = 0; j < valueCount; j++) values.push(`v${j}`)
+      enums[name] = { name, values }
+    }
+    snapshot.enums = enums
+  }
+
+  maybeAddForeignKeys(snapshot, rng)
+
+  return snapshot
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6,6 +6,7 @@ export type {
   ForeignKeySnapshot,
   CheckSnapshot,
   TableSnapshot,
+  EnumSnapshot,
   SchemaSnapshot,
 } from './snapshot/types'
 


### PR DESCRIPTION
# Diff-engine fuzz harness — 1000-seed round-trip property assertions

Knocks off the diff-engine fuzz item from [`docs/db/architecture.md` §13](https://github.com/forinda/kick-js/blob/main/docs/db/architecture.md) — one of the original M5 hardening gates that was deferred when the M5.A / M5.B / `ctx.signal` work took priority. Lands as an additive minor on `@forinda/kickjs-db`; stays on 5.x.

## What

`packages/db/__tests__/fuzz/`:

- `random-schema.ts` — seeded xorshift32 RNG + `generateSnapshot(seed)`. Produces `SchemaSnapshot` fixtures of varying size (0–8 tables × 1–6 columns) with random PG types, defaults, nullability, single-column PKs, 0–2 indexes per table, and FKs into pre-existing PK columns. Reproducible — failing seeds print in the assertion so re-running the harness with the seed regenerates the exact pair.
- `apply-changeset.ts` — in-memory `applyChangeSet(snapshot, changes)` + `snapshotsEqual(a, b)`. Companion to `emit/pg.ts` for testing the structural contract of the diff engine without rendering to SQL or executing against a real DB.
- `diff-roundtrip.test.ts` — three top-level suites, each iterating 1000 seeds:

| Property | Assertion |
|---|---|
| Forward fidelity | `applyChangeSet(A, diff(A, B)) ≡ B` for every pair |
| Reverse fidelity | `applyChangeSet(B, invertChanges(diff(A, B))) ≡ A` when `hasAmbiguousReverse(forward)` is `false`. Ambiguous-reverse seeds (dropTable / dropColumn / alterColumn / addEnumValue / removeEnumValue) counted-and-skipped via a `> 10%` sanity gate so the assertion isn't vacuous |
| Reflexivity | `diff(A, A) === []` for 1000 random snapshots — catches a class of "always-emits-a-change" false positives that would churn migrations forever |

## Scope (intentionally narrow for first cut)

- **PostgreSQL only** — other dialects share the same diff path; their emitters live in separate test scopes (no need to re-fuzz that surface).
- **No `renameTable` / `renameColumn`** — the diff engine doesn't infer renames (it sees a drop+add); generating renames would only exercise the drop+add path, already covered by `diff-rename.test.ts`.
- **No enum value additions/removals** — flagged ambiguous-reverse by design; covered by `pg-enum-pipeline.test.ts`.
- **Simple defaults** (`'0'`, `"'x'"`, `'true'`, `'CURRENT_TIMESTAMP'`) — avoids the pgEnum-cast-bracket dance M5.A.1 handles.

## Finding from the first run

The fuzz surfaced an **implicit internal contract** between `diff/engine.ts` and `emit/pg.ts:emitCreateTable`. The engine emits `createTable` carrying the **full table snapshot** (columns + indexes + FKs), then in subsequent passes separately emits `addIndex` / `addForeignKey` for each secondary object. The SQL emitter strips indexes/FKs from the CREATE TABLE statement and renders them via ALTER. So the SQL output is correct, but a structural reader (like the fuzz applier — or any future tooling that reads `ChangeSet` non-SQL-wise) would double-count indexes/FKs unless it knows to take only columns + PK from `createTable`.

**Not a bug** — but the contract was implicit. An inline note in `apply-changeset.ts:createTable` documents it for the next reader. If we end up with more structural consumers of `ChangeSet` (e.g. JSON-RPC migration generator output for non-SQL backends), this might be worth promoting to a code-level invariant.

## Surface change

`EnumSnapshot` is now re-exported from `@forinda/kickjs-db` root. Oversight from M3 — `ColumnSnapshot`, `TableSnapshot`, `IndexSnapshot`, `ForeignKeySnapshot`, `CheckSnapshot` were all already public; `EnumSnapshot` was the only one missing. Used by the fuzz generator but useful for adopters reading `SchemaSnapshot.enums`.

## Numbers

```text
@forinda/kickjs-db: 402 tests  (was 399)
Fuzz cost: ~25 seconds for 3000 seed runs (3 × 1000 internally)
```

## Test plan

- [ ] CI green on `packages/db` test suite — the new file iterates 1000 seeds three times, ~25s.
- [ ] When a future diff-engine change accidentally breaks round-trip fidelity, the failing seed prints in the assertion and reproduces deterministically via `generateSnapshot(seed)`.

## Next on the hardening list

After this lands, the architecture-spec §13 backlog still has:
- **Benchmarks** — read/write/transaction microbenchmarks vs drizzle / prisma / raw `pg`. Target: within 10% of pg-direct on simple selects, within 25% on `with`-joins.
- **Migration replay** — every committed migration in test fixtures → apply → reverse → re-apply → schema identical.
- **SQL emission threat model** — binding-only, no string interpolation in hot paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `EnumSnapshot` type is now exported from the package root.

* **Tests**
  * Added a deterministic fuzz testing suite (1000 seeded cases) for the database diff engine covering forward fidelity, reverse fidelity (with documented ambiguous-reverse skips), and reflexivity.

* **Documentation**
  * Added release notes documenting the minor release and test/runtime impacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/226)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->