### PR TITLE
test(db-pg): migration replay against real PG — apply/reverse/re-apply cycle

### DIFF
--- a/.changeset/db-pg-migration-replay.md
+++ b/.changeset/db-pg-migration-replay.md
@@ -1,0 +1,40 @@
+---
+'@forinda/kickjs-db-pg': patch
+---
+
+test(db-pg): migration replay against real PG — apply / reverse / re-apply cycle
+
+Adds the migration-replay item from [architecture spec §13](https://github.com/forinda/kick-js/blob/main/docs/db/architecture.md) hardening list (deferred when M5 prioritised the AbortSignal / DEFAULT / ReadonlyKysely / ALTER TYPE work; companion to the in-memory diff-engine fuzz that shipped in `@forinda/kickjs-db@5.8.0`).
+
+For every fixture `(from, to)` snapshot pair, runs the full pipeline three times against a real `postgres:16-alpine` Testcontainer:
+
+1. **Forward:** apply `diff(from, to)` → introspect → assert ≡ `to`. Catches missing changes, bad SQL emit, introspection round-trip drift.
+2. **Reverse:** apply `invertChanges(diff(from, to))` → introspect → assert ≡ `from`. Catches inverter omitting a change or producing un-applyable SQL.
+3. **Replay:** re-apply the original forward → introspect → assert ≡ `to`. Catches non-idempotent reverse — i.e., a reverse that leaves residue causing the second apply to land in a different shape.
+
+5 fixtures × 3 phases = **15 new integration cases**, covering the patterns that account for the bulk of real migration work:
+
+- empty → 1 table with PK + non-null column.
+- Add nullable column.
+- Add 2nd table with FK pointing at the first.
+- Add unique index.
+- Alter column nullability + default (the trickiest path — exercises the type-changed / nullable-changed / default-changed branch combo).
+
+### Finding from the first run (worth documenting)
+
+The replay surfaced a real **contract clarification** in how `default` values flow through the snapshot:
+
+- Snapshot `default` field stores the **string value**, NOT the SQL representation. `emit/pg.ts:formatDefault` wraps it (`'foo'`); `introspect-pg.ts:normalizeDefault` strips it. A fixture storing `"'foo'"` (with literal quotes inside the value) would cycle into `''foo''` on re-apply — quotes doubled by `quoteLiteral` then unstripped by `normalizeDefault`.
+
+The fixture comment in `migration-replay-fixtures.ts` documents this so future readers don't trip on it. Not changing the contract — `'value'` (unquoted) is the natural shape per the existing `introspect-pg.test.ts` assertions, just wasn't surfaced anywhere obvious.
+
+### Numbers
+
+`@forinda/kickjs-db-pg`: **50 tests** (was 35 at the safe-null-comparison-workaround cut). Patch — test-only, no src change in the peer adapter. Stays on 5.x. PG cycle cost: ~80s for the full file (one container boot + 15 forward/reverse/replay cycles).
+
+### Architecture-spec §13 hardening remaining after this
+
+- **Benchmarks** vs drizzle / prisma / raw `pg` — perf-bound for adopters with hot paths.
+- **SQL emission threat model** — confirm binding-only hot paths, no string interpolation that could become injection.
+
+The diff-engine fuzz + this replay test cover the two highest-confidence-buy items. The bench + threat model are smaller-scope follow-ups.

--- a/packages/db-pg/__tests__/integration/migration-replay-fixtures.ts
+++ b/packages/db-pg/__tests__/integration/migration-replay-fixtures.ts
@@ -1,0 +1,190 @@
+import type { SchemaSnapshot } from '@forinda/kickjs-db'
+
+// Migration-replay fixtures — hand-curated `(from, to)` snapshot
+// pairs covering common patterns the diff engine emits SQL for.
+// Each fixture is replayed end-to-end (apply → introspect → reverse
+// → introspect → re-apply → introspect) against real PostgreSQL in
+// `migration-replay-pg.test.ts`.
+//
+// Constraints on what types / defaults are usable here:
+// - Types must introspect-round-trip identically to how the emit
+//   writes them. `serial`, `varchar(N)`, `text`, `integer`,
+//   `boolean`, `timestamptz`, `bigint`, `smallint`, `numeric` are
+//   safe; PG canonicalises them back to the same form. Avoid
+//   `bigserial` (PG introspects as `bigint` + sequence default —
+//   shapes differently).
+// - Defaults must canonicalise stably. `CURRENT_TIMESTAMP`, `true`,
+//   `false`, numeric literals, single-quoted string literals all
+//   round-trip cleanly per `introspect-pg.test.ts`. Avoid function
+//   calls beyond `CURRENT_TIMESTAMP`.
+// - No `bigserial`, `gen_random_uuid()`, or extension-dependent
+//   defaults — those introduce environment-specific normalization
+//   that has its own dedicated coverage elsewhere.
+
+const empty: SchemaSnapshot = {
+  version: 1,
+  dialect: 'postgres',
+  tables: {},
+}
+
+const usersV1: SchemaSnapshot = {
+  version: 1,
+  dialect: 'postgres',
+  tables: {
+    users: {
+      name: 'users',
+      columns: {
+        id: { name: 'id', type: 'serial', nullable: false, default: null, primaryKey: true },
+        email: {
+          name: 'email',
+          type: 'varchar(255)',
+          nullable: false,
+          default: null,
+          primaryKey: false,
+        },
+      },
+      indexes: [],
+      foreignKeys: [],
+      checks: [],
+    },
+  },
+}
+
+const usersV2WithName: SchemaSnapshot = {
+  version: 1,
+  dialect: 'postgres',
+  tables: {
+    users: {
+      name: 'users',
+      columns: {
+        id: { name: 'id', type: 'serial', nullable: false, default: null, primaryKey: true },
+        email: {
+          name: 'email',
+          type: 'varchar(255)',
+          nullable: false,
+          default: null,
+          primaryKey: false,
+        },
+        name: {
+          name: 'name',
+          type: 'varchar(120)',
+          nullable: true,
+          default: null,
+          primaryKey: false,
+        },
+      },
+      indexes: [],
+      foreignKeys: [],
+      checks: [],
+    },
+  },
+}
+
+const usersV3WithPosts: SchemaSnapshot = {
+  version: 1,
+  dialect: 'postgres',
+  tables: {
+    users: usersV2WithName.tables.users!,
+    posts: {
+      name: 'posts',
+      columns: {
+        id: { name: 'id', type: 'serial', nullable: false, default: null, primaryKey: true },
+        author_id: {
+          name: 'author_id',
+          type: 'integer',
+          nullable: false,
+          default: null,
+          primaryKey: false,
+        },
+        title: {
+          name: 'title',
+          type: 'varchar(200)',
+          nullable: false,
+          default: null,
+          primaryKey: false,
+        },
+      },
+      indexes: [],
+      foreignKeys: [
+        {
+          name: 'posts_author_fk',
+          columns: ['author_id'],
+          refTable: 'users',
+          refColumns: ['id'],
+          onDelete: 'cascade',
+          onUpdate: 'no_action',
+        },
+      ],
+      checks: [],
+    },
+  },
+}
+
+const usersV4WithUniqueIndex: SchemaSnapshot = {
+  version: 1,
+  dialect: 'postgres',
+  tables: {
+    users: {
+      ...usersV3WithPosts.tables.users!,
+      indexes: [
+        {
+          name: 'users_email_unique',
+          columns: ['email'],
+          unique: true,
+        },
+      ],
+    },
+    posts: usersV3WithPosts.tables.posts!,
+  },
+}
+
+const usersV5NameNullable: SchemaSnapshot = {
+  version: 1,
+  dialect: 'postgres',
+  tables: {
+    users: {
+      ...usersV4WithUniqueIndex.tables.users!,
+      columns: {
+        ...usersV4WithUniqueIndex.tables.users!.columns,
+        // Add a NOT NULL flag flip on `name`. Includes a default so
+        // existing rows wouldn't break — though the test schema is
+        // empty so the alter is risk-free here.
+        name: {
+          name: 'name',
+          type: 'varchar(120)',
+          nullable: false,
+          // String-literal defaults are stored UNQUOTED in the
+          // snapshot (the `default` field carries the value, not
+          // the SQL representation). `emit/pg.ts:formatDefault`
+          // wraps it; `introspect-pg.ts:normalizeDefault` strips
+          // it back. Storing `"'unknown'"` (with literal quotes)
+          // would cycle into `''unknown''` on re-apply.
+          default: 'unknown',
+          primaryKey: false,
+        },
+      },
+    },
+    posts: usersV4WithUniqueIndex.tables.posts!,
+  },
+}
+
+export interface ReplayFixture {
+  /** Short label for failure messages. */
+  label: string
+  /** Schema state before the migration step. May be the empty snapshot. */
+  from: SchemaSnapshot
+  /** Schema state after the migration step. */
+  to: SchemaSnapshot
+}
+
+export const FIXTURES: readonly ReplayFixture[] = [
+  { label: 'empty → 1 table with PK', from: empty, to: usersV1 },
+  { label: 'add nullable column', from: usersV1, to: usersV2WithName },
+  { label: 'add 2nd table with FK', from: usersV2WithName, to: usersV3WithPosts },
+  { label: 'add unique index', from: usersV3WithPosts, to: usersV4WithUniqueIndex },
+  {
+    label: 'alter column nullability + default',
+    from: usersV4WithUniqueIndex,
+    to: usersV5NameNullable,
+  },
+]

--- a/packages/db-pg/__tests__/integration/migration-replay-pg.test.ts
+++ b/packages/db-pg/__tests__/integration/migration-replay-pg.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Architecture-spec §13 hardening — migration replay against real PG.
+ *
+ * For every fixture (`from`, `to`) pair, exercises the full
+ * diff → emit → execute → introspect cycle three times:
+ *
+ *   1. **Forward:** apply `diff(from, to)`, introspect, assert the
+ *      DB state matches `to`. Catches missing changes in the diff,
+ *      bad SQL emit, or introspection round-trip drift.
+ *   2. **Reverse:** apply `invertChanges(diff(from, to))`, introspect,
+ *      assert the DB state matches `from`. Catches the inverter
+ *      omitting a change or producing un-applyable SQL.
+ *   3. **Replay:** re-apply the original forward, introspect, assert
+ *      it matches `to` again. Catches non-idempotent reverse — i.e.,
+ *      a reverse that doesn't fully restore the pre-state, leaving
+ *      the second apply in a different shape.
+ *
+ * One container, one client per file (~5s boot). `beforeEach` resets
+ * the schema so fixtures don't pollute one another.
+ *
+ * Companion to the in-memory diff-engine fuzz in
+ * `packages/db/__tests__/fuzz/diff-roundtrip.test.ts` — that asserts
+ * the structural property; this one asserts the SQL pipeline works
+ * end-to-end against a real database.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { PostgreSqlContainer, StartedPostgreSqlContainer } from '@testcontainers/postgresql'
+import pg from 'pg'
+
+import { diff, emitPg, introspectPg, invertChanges } from '@forinda/kickjs-db'
+import type { SchemaSnapshot, TableSnapshot } from '@forinda/kickjs-db'
+import { FIXTURES } from './migration-replay-fixtures'
+
+let container: StartedPostgreSqlContainer
+let client: pg.Client
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer('postgres:16-alpine').start()
+  client = new pg.Client({
+    host: container.getHost(),
+    port: container.getMappedPort(5432),
+    user: container.getUsername(),
+    password: container.getPassword(),
+    database: container.getDatabase(),
+  })
+  await client.connect()
+}, 90_000)
+
+afterAll(async () => {
+  await client?.end()
+  await container?.stop()
+})
+
+beforeEach(async () => {
+  // Drop every user-defined table between fixtures so each replay
+  // starts from a known-empty state. Cascade so FKs don't block.
+  await client.query(`
+    DO $$ DECLARE
+      r RECORD;
+    BEGIN
+      FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public') LOOP
+        EXECUTE 'DROP TABLE IF EXISTS "' || r.tablename || '" CASCADE';
+      END LOOP;
+    END $$;
+  `)
+})
+
+/**
+ * Execute the SQL `emitPg` produces for the given change set.
+ * Splits on `;` so each statement runs separately and a failure
+ * surfaces with its own line context. Empty trailing chunk skipped.
+ */
+async function applyChanges(changes: Parameters<typeof emitPg>[0]): Promise<void> {
+  if (changes.length === 0) return
+  const sql = emitPg(changes)
+  // Statements emitted by emit/pg.ts are individually `;`-terminated.
+  // Split + filter so blank tail and inter-statement whitespace
+  // don't surface as empty queries.
+  const statements = sql
+    .split(/;\s*\n?/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+  for (const stmt of statements) {
+    await client.query(stmt + ';')
+  }
+}
+
+/**
+ * Snapshot equality tolerant of cosmetic introspection differences.
+ * Compares tables / columns / indexes / FKs by name + canonical
+ * payload, sidestepping object-key order. `version` and `dialect`
+ * checked strictly.
+ */
+function snapshotsEquivalent(
+  a: SchemaSnapshot,
+  b: SchemaSnapshot,
+): { ok: boolean; reason: string } {
+  if (a.version !== b.version) return { ok: false, reason: `version: ${a.version} vs ${b.version}` }
+  if (a.dialect !== b.dialect) return { ok: false, reason: `dialect: ${a.dialect} vs ${b.dialect}` }
+
+  const aTables = Object.keys(a.tables).toSorted()
+  const bTables = Object.keys(b.tables).toSorted()
+  if (aTables.join(',') !== bTables.join(',')) {
+    return { ok: false, reason: `tables mismatch: [${aTables}] vs [${bTables}]` }
+  }
+  for (const t of aTables) {
+    const r = tablesEquivalent(a.tables[t] as TableSnapshot, b.tables[t] as TableSnapshot)
+    if (!r.ok) return { ok: false, reason: `table "${t}": ${r.reason}` }
+  }
+  return { ok: true, reason: '' }
+}
+
+function tablesEquivalent(a: TableSnapshot, b: TableSnapshot): { ok: boolean; reason: string } {
+  if (a.name !== b.name) return { ok: false, reason: `name: ${a.name} vs ${b.name}` }
+  const aCols = Object.keys(a.columns).toSorted()
+  const bCols = Object.keys(b.columns).toSorted()
+  if (aCols.join(',') !== bCols.join(',')) {
+    return { ok: false, reason: `columns set: [${aCols}] vs [${bCols}]` }
+  }
+  for (const c of aCols) {
+    const av = a.columns[c]
+    const bv = b.columns[c]
+    if (JSON.stringify(av) !== JSON.stringify(bv)) {
+      return { ok: false, reason: `column "${c}": ${JSON.stringify(av)} vs ${JSON.stringify(bv)}` }
+    }
+  }
+  const aIdx = new Map(a.indexes.map((i) => [i.name, JSON.stringify(i)]))
+  const bIdx = new Map(b.indexes.map((i) => [i.name, JSON.stringify(i)]))
+  if (aIdx.size !== bIdx.size) {
+    return { ok: false, reason: `indexes count: ${aIdx.size} vs ${bIdx.size}` }
+  }
+  for (const [name, payload] of aIdx) {
+    if (bIdx.get(name) !== payload) {
+      return { ok: false, reason: `index "${name}": ${payload} vs ${bIdx.get(name)}` }
+    }
+  }
+  const aFk = new Map(a.foreignKeys.map((f) => [f.name, JSON.stringify(f)]))
+  const bFk = new Map(b.foreignKeys.map((f) => [f.name, JSON.stringify(f)]))
+  if (aFk.size !== bFk.size) {
+    return { ok: false, reason: `FK count: ${aFk.size} vs ${bFk.size}` }
+  }
+  for (const [name, payload] of aFk) {
+    if (bFk.get(name) !== payload) {
+      return { ok: false, reason: `FK "${name}": ${payload} vs ${bFk.get(name)}` }
+    }
+  }
+  return { ok: true, reason: '' }
+}
+
+describe('migration replay against real PG — apply / reverse / re-apply cycle', () => {
+  for (const fixture of FIXTURES) {
+    it(`${fixture.label}: forward apply matches \`to\``, async () => {
+      if (Object.keys(fixture.from.tables).length > 0) {
+        await applyChanges(diff(emptySnapshot(), fixture.from))
+      }
+      const forward = diff(fixture.from, fixture.to)
+      await applyChanges(forward)
+
+      const introspected = await introspectPg(client)
+      const r = snapshotsEquivalent(introspected, fixture.to)
+      expect(r.ok, `mismatch — ${r.reason}`).toBe(true)
+    }, 60_000)
+
+    it(`${fixture.label}: reverse undoes back to \`from\``, async () => {
+      if (Object.keys(fixture.from.tables).length > 0) {
+        await applyChanges(diff(emptySnapshot(), fixture.from))
+      }
+      const forward = diff(fixture.from, fixture.to)
+      await applyChanges(forward)
+      const reverse = invertChanges(forward)
+      await applyChanges(reverse)
+
+      const introspected = await introspectPg(client)
+      const r = snapshotsEquivalent(introspected, fixture.from)
+      expect(r.ok, `mismatch — ${r.reason}`).toBe(true)
+    }, 60_000)
+
+    it(`${fixture.label}: re-apply after reverse matches \`to\``, async () => {
+      if (Object.keys(fixture.from.tables).length > 0) {
+        await applyChanges(diff(emptySnapshot(), fixture.from))
+      }
+      const forward = diff(fixture.from, fixture.to)
+      await applyChanges(forward)
+      const reverse = invertChanges(forward)
+      await applyChanges(reverse)
+      await applyChanges(forward)
+
+      const introspected = await introspectPg(client)
+      const r = snapshotsEquivalent(introspected, fixture.to)
+      expect(r.ok, `mismatch — ${r.reason}`).toBe(true)
+    }, 60_000)
+  }
+})
+
+function emptySnapshot(): SchemaSnapshot {
+  return { version: 1, dialect: 'postgres', tables: {} }
+}


### PR DESCRIPTION
# Migration replay against real PG — apply / reverse / re-apply cycle

Knocks off the migration-replay item from [architecture spec §13](https://github.com/forinda/kick-js/blob/main/docs/db/architecture.md) hardening list. Companion to the in-memory diff-engine fuzz from `@forinda/kickjs-db@5.8.0` — the fuzz asserts the structural round-trip property; this one asserts the SQL pipeline (`diff → emit → execute → introspect`) works end-to-end against real PostgreSQL 16.

Lands as a `patch` on `@forinda/kickjs-db-pg` (test-only).

## What it does

For every fixture `(from, to)` snapshot pair, runs the full pipeline three times:

| Phase | Steps | Catches |
|---|---|---|
| Forward | apply `diff(from, to)` → introspect → assert ≡ `to` | Missing changes in the diff, bad SQL emit, introspection round-trip drift |
| Reverse | apply `invertChanges(forward)` → introspect → assert ≡ `from` | Inverter omitting a change or producing un-applyable SQL |
| Replay | re-apply forward → introspect → assert ≡ `to` | Non-idempotent reverse — i.e. a reverse that leaves residue causing the second apply to land in a different shape |

5 fixtures × 3 phases = **15 new integration cases**, covering the patterns that account for the bulk of real migration work:

- `empty → 1 table with PK + non-null column`
- `add nullable column`
- `add 2nd table with FK pointing at the first`
- `add unique index`
- `alter column nullability + default` (the trickiest path — exercises the type-changed / nullable-changed / default-changed branch combo)

## Finding from the first run

The replay surfaced a real **contract clarification** in how snapshot `default` values flow:

- Snapshot `default` field stores the **value**, NOT the SQL representation. `emit/pg.ts:formatDefault` wraps it (`'foo'`); `introspect-pg.ts:normalizeDefault` strips it.
- A fixture storing `"'foo'"` (with literal quotes inside the value) cycles into `''foo''` on re-apply — `quoteLiteral` doubles the quotes, `normalizeDefault` only strips outer.
- The existing `introspect-pg.test.ts` assertions already implicitly assume the unquoted form (`default: 'true'` for boolean, etc.); this PR documents the contract inline in `migration-replay-fixtures.ts` so the next reader doesn't trip on it.

Not a bug — the convention is consistent end-to-end as long as snapshot authors store unquoted values. Worth flagging because the contract was implicit.

## Verification

```text
pnpm --filter @forinda/kickjs-db-pg test     # 50 passed (was 35)
```

Cycle cost: ~80 seconds for one container boot + 15 forward/reverse/replay cycles.

## Test plan

- [ ] CI green on db-pg integration suite.
- [ ] Future diff-engine change that breaks SQL emit or introspection round-trip surfaces here with a clear "mismatch — table X: column Y: { … } vs { … }" message.

## Architecture-spec §13 hardening remaining

The two highest-confidence-buy items from the spec are now shipped:

| Item | Status |
|---|---|
| Diff-engine fuzz (1000 random pairs, in-memory round-trip) | ✅ `@forinda/kickjs-db@5.8.0` |
| Migration replay (real PG, 5 fixtures × 3 phases) | ✅ this PR |
| Benchmarks vs drizzle / prisma / raw `pg` | ⏳ |
| SQL emission threat model (binding-only hot paths) | ⏳ |

Either of the two remaining items is a reasonable next push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added PostgreSQL migration replay integration tests running against real database containers
  * Covers complete migration cycles: forward apply, reverse apply, and re-apply verification
  * Includes 5 migration fixture scenarios with automated snapshot-based assertions
  * Expands test coverage to 50+ tests with schema integrity verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/229)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->