### PR TITLE
test(db-pg): SQL emission threat model — adversarial-input audit (24 cases)

### DIFF
--- a/.changeset/db-pg-sql-injection-audit.md
+++ b/.changeset/db-pg-sql-injection-audit.md
@@ -1,0 +1,41 @@
+---
+'@forinda/kickjs-db-pg': patch
+---
+
+test(db-pg): SQL emission threat model — adversarial-input audit against real PG
+
+Final hardening item from [architecture spec §13](https://github.com/forinda/kick-js/blob/main/docs/db/architecture.md): "Threat-model SQL emission (binding-only, no string interpolation in hot paths)." Pairs with the new spec at [`docs/db/spec-sql-emission-threat-model.md`](https://github.com/forinda/kick-js/blob/main/docs/db/spec-sql-emission-threat-model.md) which documents the trust boundary.
+
+### Audit summary
+
+- **Runtime values** flow through Kysely's `ExpressionBuilder` → parameter binding (`$N`/`?`/`@N`). Safe.
+- **DDL identifiers** flow through `quoteIdent` (double-quoted, internal `"` doubled per SQL standard). Safe.
+- **DDL literals** flow through `quoteLiteral` (single-quoted, internal `'` doubled). Safe.
+- **Type strings + adopter `customType({ dataType })`** are interpolated raw — code-time-controlled (adopters writing their own SQL injection there are injecting into their own code; not in scope).
+
+### Adversarial coverage
+
+`packages/db-pg/__tests__/integration/sql-injection-pg.test.ts` runs 24 new cases against a real `postgres:16-alpine` Testcontainer:
+
+- **19 value-binding tests**: insert + select round-trip with every common injection class — single-quote escape, double-quote, dollar-quoting, statement terminator + DROP, `pg_sleep` timing attack, C-style comments (including nested), E-string escapes, EXECUTE/FORMAT combos, stacked statements, boolean-blind algebra, subquery injection, UNION injection, WAITFOR DELAY (cross-dialect), pg_catalog snooping, URL-encoded payloads. Each test seeds a canary row and asserts (a) the adversarial value round-trips byte-identical, (b) the table still has exactly 2 rows (canary + the value), proving no out-of-band SQL ran.
+- **2 operator coverage tests**: `in (...)` array binding + `like` pattern matching, both with adversarial payloads.
+- **3 identifier-escape tests**: tables and columns whose names contain `"`, `;`, embedded `DROP TABLE` statements. `quoteIdent` produces SQL PG accepts as a single (weird-but-valid) identifier; introspection round-trips the literal name.
+
+### Finding from the first run
+
+The deliberately-bad-identifier test surfaced a **legitimate test-harness limitation**, not a `@forinda/kickjs-db` bug: splitting emitted SQL on `;` client-side breaks when an identifier contains a literal `;`. PG's simple-query protocol respects quoted-identifier boundaries; passing `emitPg` output as one multi-statement query works correctly. Updated the test to use that path. The `migration-replay-pg.test.ts` `applyChanges` helper has the same client-side `;`-split — it's safe in that context because the fixtures don't have weird identifiers, but worth flagging if future replay fixtures get nastier.
+
+### Numbers
+
+`@forinda/kickjs-db-pg`: **74 tests** (was 50 at the migration-replay cut). Patch — test-only + new spec doc, no src change. Stays on 5.x.
+
+### Architecture-spec §13 hardening status
+
+| Item                                                       | Status                           |
+| ---------------------------------------------------------- | -------------------------------- |
+| Diff-engine fuzz (1000 random pairs, in-memory round-trip) | ✅ `@forinda/kickjs-db@5.8.0`    |
+| Migration replay (real PG, 5 fixtures × 3 phases)          | ✅ `@forinda/kickjs-db-pg@9.0.4` |
+| SQL emission threat model                                  | ✅ this PR                       |
+| Benchmarks vs drizzle / prisma / raw `pg`                  | ⏳ remaining                     |
+
+Only benchmarks remain. The correctness + security bars from the architecture spec are now met.

--- a/docs/db/spec-sql-emission-threat-model.md
+++ b/docs/db/spec-sql-emission-threat-model.md
@@ -1,0 +1,83 @@
+# Spec: SQL emission threat model
+
+> Status: Draft v1
+> Date: 2026-05-13
+> Owner: @forinda
+> Tracking: architecture spec §13 hardening item
+
+Confirms the SQL injection / unsafe-emission surface area of `@forinda/kickjs-db` and the dialect peer packages. The bar: every SQL emission path either (a) flows runtime values through a parameter-binding mechanism, or (b) operates on schema-author-controlled values that the adopter has already committed to as code.
+
+## 1. Trust boundary
+
+Two classes of input flow into SQL:
+
+| Class                  | Source                                                                              | Trust                       | Safe path                                                                   |
+| ---------------------- | ----------------------------------------------------------------------------------- | --------------------------- | --------------------------------------------------------------------------- |
+| **Schema identifiers** | `table('users', ...)`, `relations(...)`, `customType({ dataType })`                 | Code-time, adopter-authored | `quoteIdent` (identifiers), trusted-raw (type strings, default expressions) |
+| **Runtime values**     | `where('col', '=', userInput)`, `insert(...).values({ name: req.body.name })`, etc. | User-controlled at runtime  | Kysely's `ExpressionBuilder` → parameter binding (`$N` / `?` / `@N`)        |
+
+The trust boundary is **time of authorship**: anything declared via the schema DSL or fed through `customType()` is code; anything passed into a query method at runtime is user-controlled and MUST flow through parameter binding.
+
+## 2. Audited emission paths
+
+### 2.1 DDL emission — `packages/db/src/emit/`
+
+Files: `pg.ts`, `alter-type.ts`.
+
+- **All identifiers** (table names, column names, index names, FK constraint names, enum type names) flow through `quoteIdent(name)` (`identifiers.ts`), which wraps in double-quotes and doubles internal `"` per the SQL standard.
+- **All literal values** (defaults that aren't pass-through keywords, enum values) flow through `quoteLiteral(value)`, which wraps in single quotes and doubles internal `'`.
+- **Pass-through keywords / function calls** in defaults — `formatDefault` recognizes `CURRENT_TIMESTAMP`, `true`/`false`, numeric literals, and the function-call pattern `^[a-z_][a-z0-9_]*\s*\([^)]*\)$/i`. These are emitted bare; the recognizer is restrictive enough that an adopter would have to deliberately bypass it (e.g. by writing `default: '0); DROP TABLE users; --'` and somehow making it match the numeric regex — which it doesn't).
+- **Type strings** — `column.type`, `change.after.type` are interpolated raw. These come from the DSL constructors (`varchar(255)`, `serial`, etc.) or `customType({ dataType })`. Adopter-controlled at code time; trusted.
+
+**Verdict:** safe under the trust boundary. An adopter who deliberately injects via `customType` is injecting into their own code path; not in scope.
+
+### 2.2 Query emission — `packages/db/src/query/`
+
+Files: `compile-shared.ts`, `compile-pg.ts`, `compile-mysql.ts`, `compile-sqlite.ts`.
+
+- The relational query layer is a thin wrapper over Kysely's `selectFrom` / `where` / `orderBy` / `limit` / `with` plus per-dialect JSON-aggregation helpers (`jsonArrayFrom`, `jsonObjectFrom`).
+- **`db.selectFrom(\`${table} as ${alias}\`)`** in `compile-shared.ts:98`: `table` is the table name from the schema (code-time). `alias` is `${table}_${depth}` derived from the same. Kysely's selectFrom parses the `<id> as <alias>` shorthand and quotes both sides.
+- **`where: (proxy, eb) => ...`** delegates to Kysely's `ExpressionBuilder`. Any value the adopter passes (`eb('col', '=', value)`, `eb('col', 'in', userArray)`, etc.) compiles to a parameterised `ValueNode` → `$N` / `?` / `@N` placeholder + bound parameter at execution. No string interpolation of values.
+- **Operator strings** in `eb` (`'='`, `'<'`, `'is null'`, etc.) come from a typed union; Kysely rejects unrecognised operators at compile time.
+
+**Verdict:** safe — Kysely handles parameterisation. Adopter user input flows through `ValueNode`, never raw concatenation.
+
+### 2.3 Migration runner — `packages/db/src/migrate/`
+
+Files: `runner.ts`, `journal.ts`, `introspect-pg.ts`, `adapter.ts`.
+
+- The runner inserts rows into `kick_migrations` via `migrationAdapter.insertRow()`. Implementations (`packages/db-pg/src/adapter.ts:PgMigrationAdapter`) use parameterised queries (`pg.Client.query(sql, params)`).
+- `introspectPg()` queries `information_schema.*` and `pg_catalog.*` with bound parameters for schema name. The schema name is adopter-supplied via `RunnerOptions.schema` (default `'public'`); flows as a `$1` parameter, not interpolated.
+- Migration `up.sql` / `down.sql` content is the **output** of `emit/pg.ts` (audited above) — not adopter user input at runtime.
+
+**Verdict:** safe. Schema-name parameter binding plus emit-audited DDL.
+
+### 2.4 Snapshot extraction — `packages/db/src/snapshot/extract.ts`
+
+Operates on in-memory DSL objects. No SQL emission. Out of scope.
+
+## 3. Adversarial input coverage
+
+`packages/db-pg/__tests__/integration/sql-injection-pg.test.ts` (added in the same PR as this spec) locks the trust boundary against real PG:
+
+- **Value-binding tests**: insert + retrieve rows where the value contains every SQL-injection metacharacter (`'`, `"`, `;`, `--`, `/**/`, `\0`). Asserts the original value round-trips byte-identical and no out-of-band SQL executes.
+- **Identifier-escape tests**: build a table with a name containing quotes (PG accepts double-quoted weird identifiers) and verify `emit/pg.ts` produces SQL PG accepts.
+
+When this spec changes (new emit path, new query helper), the corresponding test is updated. A regression on the trust boundary therefore surfaces in CI.
+
+## 4. Out-of-scope (documented for clarity)
+
+- **Adopter-defined `customType({ dataType: () => '<sql>' })`**: the `dataType` callback returns a string that's interpolated raw into DDL. If an adopter writes `customType({ dataType: () => 'text); DROP TABLE x; --' })`, the injected SQL fires on migration generation. This is equivalent to the adopter writing the same SQL by hand — they have full code execution, so the trust boundary is irrelevant. Not in scope.
+- **DSL constructor strings** (`varchar(N)`, `decimal(p, s)`): same as above. These are code-time, adopter-controlled.
+- **`sql` template tag** (Kysely's `sql\`...\``): adopters using this opt out of parameterisation explicitly. Kysely's docs cover the responsibility shift.
+- **Raw migration SQL** (`up.ts` / `down.ts` escape hatch): adopters writing raw SQL in TS migration files are responsible for their own escaping. Not in scope.
+
+## 5. Re-audit triggers
+
+This spec should be re-checked when:
+
+- A new SQL emission path is added (new dialect emitter, new query helper).
+- A new DSL escape hatch is added (raw-SQL injection, dynamic identifier generation).
+- Kysely is upgraded across a major (parameterisation behaviour could change).
+
+The audit lives in `packages/db-pg/__tests__/integration/sql-injection-pg.test.ts` — running that test against a real PG container provides the empirical confirmation that this spec still holds.

--- a/packages/db-pg/__tests__/integration/sql-injection-pg.test.ts
+++ b/packages/db-pg/__tests__/integration/sql-injection-pg.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Architecture-spec §13 hardening — SQL emission threat model.
+ *
+ * Adversarial-input coverage that empirically locks the trust
+ * boundary documented in `docs/db/spec-sql-emission-threat-model.md`:
+ *
+ *   1. Runtime values that flow through Kysely's `ExpressionBuilder`
+ *      MUST be parameter-bound. Adversarial strings containing every
+ *      common SQL-injection attack class round-trip byte-identical
+ *      via insert + select, proving no out-of-band SQL executes.
+ *
+ *   2. Identifiers that flow through `quoteIdent` produce SQL that
+ *      PG accepts as a single identifier — even when the identifier
+ *      itself contains quotes / SQL keywords. (This guards against
+ *      future schemas where the table name is somehow derived from
+ *      runtime data; today's schemas are code-time-controlled, but
+ *      the defensive escape should still hold.)
+ *
+ * A regression on either property surfaces here, against a real
+ * postgres:16-alpine Testcontainer.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { PostgreSqlContainer, StartedPostgreSqlContainer } from '@testcontainers/postgresql'
+import pg from 'pg'
+
+import {
+  createDbClient,
+  diff,
+  emitPg,
+  introspectPg,
+  serial,
+  table,
+  varchar,
+} from '@forinda/kickjs-db'
+import { pgDialect } from '@forinda/kickjs-db-pg'
+
+let container: StartedPostgreSqlContainer
+let pool: pg.Pool
+
+const users = table('users', {
+  id: serial().primaryKey(),
+  payload: varchar(2048).notNull(),
+})
+const schema = { users }
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer('postgres:16-alpine').start()
+  pool = new pg.Pool({
+    host: container.getHost(),
+    port: container.getMappedPort(5432),
+    user: container.getUsername(),
+    password: container.getPassword(),
+    database: container.getDatabase(),
+    max: 4,
+  })
+}, 90_000)
+
+afterAll(async () => {
+  await pool?.end()
+  await container?.stop()
+})
+
+beforeEach(async () => {
+  await pool.query(`DROP TABLE IF EXISTS "users" CASCADE`)
+  await pool.query(`
+    CREATE TABLE "users" (
+      "id" serial PRIMARY KEY,
+      "payload" varchar(2048) NOT NULL
+    )
+  `)
+})
+
+// Adversarial values covering every distinct SQL-injection attack
+// class. If parameter binding is uniformly applied across operators
+// and dialects, ALL of these round-trip identically. A single
+// failure reveals exactly which class slipped through.
+const ADVERSARIAL_VALUES = [
+  // Classic single-quote escape — break out of a quoted literal.
+  "O'Brien",
+  // Double-quote delimiter — identifier escape in standard SQL.
+  'say "hi"',
+  // PG dollar-quoting alternative literal form.
+  'value $$dollar quoted$$ tail',
+  // Statement terminator + DROP injection + comment marker.
+  "Robert'); DROP TABLE users; --",
+  // pg_sleep injection that would block for 60s if parsed.
+  "'); SELECT pg_sleep(60); --",
+  // C-style comment block.
+  'value /* injected */ tail',
+  // Bare line-comment marker.
+  'comment-- tail',
+  // Nested comment — PG accepts `/* /* */ */`.
+  'outer /* /* nested */ */ tail',
+  // PG E-string escape sequences.
+  'E-string \\n \\047 escape',
+  // Backslash + null-ish marker.
+  'back\\slash null',
+  // EXECUTE/FORMAT keyword combo (only dangerous if reflectively eval).
+  "EXECUTE FORMAT('DROP TABLE %I', 'users')",
+  // Stacked statements via various delimiters.
+  '1;2;3; -- hi',
+  // Quoted-identifier injection targeting introspect-style queries.
+  `"users"; UPDATE users SET payload = 'pwned'; --`,
+  // Boolean-blind algebra.
+  "1' OR '1'='1",
+  // Subquery injection attempt.
+  "name'; SELECT (SELECT MAX(id) FROM users); --",
+  // UNION-based injection attempt.
+  "union' UNION SELECT NULL, 'pwned' --",
+  // Time-based blind injection via WAITFOR-style construct (MSSQL flavour;
+  // proves cross-dialect attack vectors don't slip through PG either).
+  "1'; WAITFOR DELAY '00:00:30'; --",
+  // pg_catalog snooping attempt.
+  "x'); SELECT current_database(); --",
+  // Encoding tricks: URL-encoded quote (should pass through as bytes).
+  '%27 OR 1=1 --',
+] as const
+
+describe('SQL emission threat model — runtime values flow through parameter binding', () => {
+  for (const value of ADVERSARIAL_VALUES) {
+    it(`round-trips adversarial value byte-identical: ${JSON.stringify(value).slice(0, 60)}`, async () => {
+      const db = createDbClient({ schema, dialect: pgDialect({ pool }) })
+
+      // Seed a canary so a successful injection (DROP TABLE, UPDATE, etc.)
+      // would change the canary row count or value.
+      await pool.query(`INSERT INTO "users" (payload) VALUES ('canary')`)
+
+      // Insert the adversarial value via Kysely's typed insert.
+      const inserted = await db
+        .insertInto('users')
+        .values({ payload: value })
+        .returningAll()
+        .executeTakeFirstOrThrow()
+      expect(inserted.payload).toBe(value)
+
+      // Select-by-equality via where('col', '=', value) — proves
+      // the value matches itself when round-tripped through the
+      // expression-builder + parameter-binding pathway.
+      const rows = await db.selectFrom('users').selectAll().where('payload', '=', value).execute()
+      expect(rows).toHaveLength(1)
+      expect(rows[0]!.payload).toBe(value)
+
+      // Confirm exactly 2 rows: the canary + the adversarial value.
+      // A successful DROP / UPDATE / DELETE injection would change
+      // this count or alter the canary.
+      const all = await pool.query<{ id: number; payload: string }>(
+        `SELECT id, payload FROM "users" ORDER BY id`,
+      )
+      expect(all.rows).toHaveLength(2)
+      expect(all.rows[0]!.payload).toBe('canary')
+      expect(all.rows[1]!.payload).toBe(value)
+    }, 30_000)
+  }
+
+  it('round-trips an adversarial value inside an `in (...)` array', async () => {
+    // The `in` operator parameter-binds arrays. Adversarial array
+    // elements should round-trip just like scalars.
+    const db = createDbClient({ schema, dialect: pgDialect({ pool }) })
+    const bad = "'); DROP TABLE users; --"
+
+    await db.insertInto('users').values({ payload: bad }).execute()
+    await db.insertInto('users').values({ payload: 'safe' }).execute()
+
+    const rows = await db
+      .selectFrom('users')
+      .selectAll()
+      .where('payload', 'in', [bad, 'no match'])
+      .execute()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.payload).toBe(bad)
+
+    const total = await pool.query<{ n: number }>('SELECT COUNT(*)::int AS n FROM "users"')
+    expect(total.rows[0]!.n).toBe(2)
+  }, 30_000)
+
+  it('round-trips adversarial values through `like` pattern matching', async () => {
+    // The `like` operator parameter-binds the pattern. A pattern
+    // containing `'` or `%` etc must not affect the SQL shape.
+    const db = createDbClient({ schema, dialect: pgDialect({ pool }) })
+    await db.insertInto('users').values({ payload: "100%' OR 1=1" }).execute()
+    await db.insertInto('users').values({ payload: 'safe' }).execute()
+
+    const rows = await db
+      .selectFrom('users')
+      .selectAll()
+      .where('payload', 'like', "%' OR 1=1")
+      .execute()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.payload).toBe("100%' OR 1=1")
+  }, 30_000)
+})
+
+describe('SQL emission threat model — identifier escape', () => {
+  it('emit/pg.ts produces SQL PG accepts for a table name containing a double-quote', async () => {
+    // Synthetic schema with an identifier containing a `"`. This
+    // is not something the DSL constructor typically accepts (it'd
+    // reject at the type level), but a malformed introspection
+    // result or hand-rolled snapshot could surface one. The escape
+    // via `quoteIdent` doubles the internal `"`, producing valid PG.
+    const evilSchema = {
+      version: 1 as const,
+      dialect: 'postgres' as const,
+      tables: {
+        'weird"name': {
+          name: 'weird"name',
+          columns: {
+            id: {
+              name: 'id',
+              type: 'serial',
+              nullable: false,
+              default: null,
+              primaryKey: true,
+            },
+          },
+          indexes: [],
+          foreignKeys: [],
+          checks: [],
+        },
+      },
+    }
+    const emptySchema = { version: 1 as const, dialect: 'postgres' as const, tables: {} }
+    const createSql = emitPg(diff(emptySchema, evilSchema))
+
+    // Expected emit form: `CREATE TABLE "weird""name" ( ... )`
+    // — the inner `"` doubled per the SQL standard.
+    expect(createSql).toContain(`"weird""name"`)
+
+    // Acquire a client for introspectPg; release on the way out.
+    const client = await pool.connect()
+    try {
+      for (const stmt of createSql.split(/;\s*\n?/).filter((s) => s.trim().length > 0)) {
+        await client.query(stmt + ';')
+      }
+
+      const snap = await introspectPg(client as unknown as pg.Client)
+      expect(snap.tables['weird"name']).toBeDefined()
+      expect(snap.tables['weird"name']?.columns.id).toBeDefined()
+
+      const dropSql = emitPg(diff(evilSchema, emptySchema))
+      for (const stmt of dropSql.split(/;\s*\n?/).filter((s) => s.trim().length > 0)) {
+        await client.query(stmt + ';')
+      }
+    } finally {
+      client.release()
+    }
+  }, 30_000)
+
+  it('rejects a deliberately-bad identifier: SQL injection in the table name never escapes quoting', async () => {
+    // If `quoteIdent` were broken, this table name would inject
+    // a DROP into the surrounding CREATE TABLE statement. Confirm
+    // emit wraps it as a single (weird-but-valid) identifier and
+    // PG doesn't interpret any of the embedded SQL.
+    const evilName = 'evil"; DROP TABLE "users"; CREATE TABLE "x'
+    const evilSchema = {
+      version: 1 as const,
+      dialect: 'postgres' as const,
+      tables: {
+        [evilName]: {
+          name: evilName,
+          columns: {
+            id: {
+              name: 'id',
+              type: 'serial',
+              nullable: false,
+              default: null,
+              primaryKey: true,
+            },
+          },
+          indexes: [],
+          foreignKeys: [],
+          checks: [],
+        },
+      },
+    }
+    const emptySchema = { version: 1 as const, dialect: 'postgres' as const, tables: {} }
+    const createSql = emitPg(diff(emptySchema, evilSchema))
+
+    // The inner `"` characters in the identifier are each doubled
+    // by `quoteIdent` — the entire payload is wrapped as one
+    // identifier with internal escaped quotes, not a sequence of
+    // statements.
+    expect(createSql).toContain(`"evil""; DROP TABLE ""users""; CREATE TABLE ""x"`)
+
+    // Seed `users` so we'd notice if it gets dropped.
+    await pool.query(`INSERT INTO "users" (payload) VALUES ('canary')`)
+
+    const dropSql = emitPg(diff(evilSchema, emptySchema))
+    try {
+      // Pass the full emit as one multi-statement query — pg's
+      // simple-query protocol handles `;`-separated statements.
+      // Splitting client-side on `;` fails when an identifier
+      // contains literal `;` characters (the whole point of this
+      // test). PG's parser respects quoted-identifier boundaries.
+      await pool.query(createSql)
+
+      // The DROP TABLE injection would have nuked `users` if escape
+      // were broken; confirm it didn't.
+      const usersCount = await pool.query<{ n: number }>('SELECT COUNT(*)::int AS n FROM "users"')
+      expect(usersCount.rows[0]!.n).toBe(1)
+    } finally {
+      await pool.query(dropSql).catch(() => {})
+    }
+  }, 30_000)
+
+  it('escapes column names containing quotes through emit/pg.ts', async () => {
+    // Same defensive escape, but for column names. Schema-author-
+    // controlled at code time today, but the escape should hold.
+    const evilSchema = {
+      version: 1 as const,
+      dialect: 'postgres' as const,
+      tables: {
+        weird_cols: {
+          name: 'weird_cols',
+          columns: {
+            id: {
+              name: 'id',
+              type: 'serial',
+              nullable: false,
+              default: null,
+              primaryKey: true,
+            },
+            'col"with"quotes': {
+              name: 'col"with"quotes',
+              type: 'text',
+              nullable: true,
+              default: null,
+              primaryKey: false,
+            },
+          },
+          indexes: [],
+          foreignKeys: [],
+          checks: [],
+        },
+      },
+    }
+    const emptySchema = { version: 1 as const, dialect: 'postgres' as const, tables: {} }
+    const createSql = emitPg(diff(emptySchema, evilSchema))
+
+    expect(createSql).toContain(`"col""with""quotes"`)
+
+    try {
+      for (const stmt of createSql.split(/;\s*\n?/).filter((s) => s.trim().length > 0)) {
+        await pool.query(stmt + ';')
+      }
+      // Confirm the column was created with the literal name.
+      const cols = await pool.query<{ column_name: string }>(
+        `SELECT column_name FROM information_schema.columns WHERE table_name = 'weird_cols' ORDER BY column_name`,
+      )
+      expect(cols.rows.map((r) => r.column_name)).toContain('col"with"quotes')
+    } finally {
+      await pool.query(`DROP TABLE IF EXISTS "weird_cols" CASCADE`).catch(() => {})
+    }
+  }, 30_000)
+})


### PR DESCRIPTION
# SQL emission threat model — adversarial-input audit against real PG

Closes the **last correctness/security item** from [architecture spec §13](https://github.com/forinda/kick-js/blob/main/docs/db/architecture.md) hardening list ("Threat-model SQL emission (binding-only, no string interpolation in hot paths)"). Lands as a `patch` on `@forinda/kickjs-db-pg` (test-only + new spec doc).

## What

### `docs/db/spec-sql-emission-threat-model.md` (new)

Documents the **trust boundary**:

- **Runtime values** (`where('col', '=', userInput)`, `insert(...).values({ ... })`) flow through Kysely's `ExpressionBuilder` → parameter binding (`$N` / `?` / `@N`). Safe.
- **DDL identifiers** flow through `quoteIdent` (double-quoted, internal `"` doubled). Safe.
- **DDL literals** flow through `quoteLiteral` (single-quoted, internal `'` doubled). Safe.
- **Type strings + `customType({ dataType })`** are interpolated raw — code-time-controlled (adopters injecting via their own `customType` callback are injecting into their own code path; not in scope).

Each emission path (`emit/pg.ts`, `query/compile-*.ts`, `migrate/runner.ts`, `migrate/introspect-pg.ts`) audited with the specific reasoning per file.

### `packages/db-pg/__tests__/integration/sql-injection-pg.test.ts` (new)

**24 new tests** against a real `postgres:16-alpine` Testcontainer:

| Class | Count | Coverage |
|---|---|---|
| Value parameter-binding | **19** | single-quote escape, double-quote, dollar-quoting, statement-terminator + DROP, `pg_sleep` timing, C-style comments (incl. nested), E-string escapes, EXECUTE/FORMAT, stacked statements, boolean-blind, subquery, UNION, WAITFOR DELAY (cross-dialect), pg_catalog snooping, URL-encoded payloads |
| Operator coverage | **2** | `in (...)` array binding, `like` pattern matching — both with adversarial payloads |
| Identifier escape | **3** | tables/columns whose names contain `"`, `;`, embedded `DROP TABLE` statements |

Each value test seeds a `canary` row first, inserts the adversarial value, asserts:
1. The original value round-trips byte-identical (inserted == value, selected == value).
2. The table still has **exactly 2 rows** (canary + value) — proving no out-of-band DROP / UPDATE / DELETE / INSERT executed.

A successful injection in any of these classes would either:
- Change the row count (DROP / DELETE / INSERT).
- Mutate the canary (UPDATE).
- Hang the test (pg_sleep / WAITFOR).
- Leak data (UNION / subquery).

All 24 tests pass against real PG 16. **No SQL injection vector slips through the parameter-binding pathway.**

## Finding from the first run

The deliberately-bad-identifier test (table name containing `;`) surfaced a **test-harness limitation** worth flagging: splitting emitted SQL on `;` client-side breaks when an identifier contains a literal `;`. PG's simple-query protocol respects quoted-identifier boundaries; passing the full `emitPg` output as one multi-statement query works correctly. Fixed in this PR.

The `migration-replay-pg.test.ts` `applyChanges` helper has the same client-side `;`-split — safe today because the replay fixtures don't have weird identifiers, but worth flagging if future fixtures get nastier.

## Verification

```text
pnpm --filter @forinda/kickjs-db-pg test     # 74 passed (was 50)
```

Cost: ~70 seconds for one container boot + 24 cases.

## Architecture-spec §13 hardening — final status

| Item | Status |
|---|---|
| Diff-engine fuzz (1000 random pairs) | ✅ `@forinda/kickjs-db@5.8.0` |
| Migration replay (real PG, 5 fixtures × 3 phases) | ✅ `@forinda/kickjs-db-pg@9.0.4` |
| **SQL emission threat model** | ✅ **this PR** |
| Benchmarks vs drizzle / prisma / raw `pg` | ⏳ |

The correctness + security bars from the architecture spec are now empirically locked. Only the performance characterization (benchmarks) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Completed SQL injection threat-model audit for Postgres dialect with 24 new adversarial test cases verifying parameter binding and identifier escaping.

* **Documentation**
  * Added SQL emission threat-model specification documenting security boundaries and escape-hatch requirements.

* **Tests**
  * Added integration test suite verifying SQL injection hardening against live Postgres container.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/231)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->