### PR TITLE
fix: stack the four DX rough edges from forinda/kick-js#235

### DIFF
--- a/.changeset/fix-issue-235-dx-rough-edges.md
+++ b/.changeset/fix-issue-235-dx-rough-edges.md
@@ -1,0 +1,81 @@
+---
+'@forinda/kickjs': minor
+'@forinda/kickjs-cli': minor
+---
+
+fix: close the four DX rough edges from forinda/kick-js#235
+
+Bundles all four reported issues into one PR per the request. Each lands independently — the failing surface for one didn't depend on any other — but a stacked PR keeps the review and CHANGELOG entry coherent.
+
+### §1 — `ContextDecoratorTarget` is now publicly exported
+
+Adopters wrapping `defineHttpContextDecorator(...)` in a public method-decorator factory hit `TS4058` under `declaration: true` builds because the inferred return type referenced an internal symbol. The interface was already exported from `core/context-decorator.ts`; it just wasn't re-exported from `core/index.ts`. One-line fix — adopters can now annotate their wrapper's return type as `ContextDecoratorTarget` instead of re-deriving the legacy `MethodDecorator` shape locally.
+
+```ts
+import {
+  defineHttpContextDecorator,
+  type ContextDecoratorTarget,
+} from '@forinda/kickjs'
+
+const RequirePermissionContext = defineHttpContextDecorator<...>({...})
+
+export function RequirePermission(code: PermissionCode): ContextDecoratorTarget {
+  return RequirePermissionContext({ permissionCode: code })
+}
+```
+
+### §2 — `@Autowired` and `@Inject` work in either position
+
+Both decorators now accept the property-decorator position AND the constructor-parameter-decorator position. Pick whichever name reads better at the call site:
+
+```ts
+@Service()
+class UserRepo {
+  // Property position — both names work.
+  @Autowired(DB) private db1!: KickDbClient
+  @Inject(DB) private db2!: KickDbClient
+
+  // Constructor parameter position — both names work.
+  constructor(
+    @Autowired(LOGGER) private logger: Logger,
+    @Inject(CACHE) private cache: Cache,
+  ) {}
+}
+```
+
+Runtime detects the position via the standard "third arg is a number" check (TypeScript's legacy parameter decorator signature) and routes to the correct metadata bucket (`AUTOWIRED` for properties keyed by prototype + name, `INJECT` for params keyed by constructor + index). The pre-existing no-token reflection-based forms (`@Autowired() private foo!: SomeClass` and `@Inject(SomeClass) foo`) keep working unchanged — `design:type` / `design:paramtypes` fallback still fires when token is undefined.
+
+7 new unit cases in `packages/kickjs/__tests__/inject-autowired-positions.test.ts` lock the matrix.
+
+### §3 — mount-prefix `:params` propagate into `ctx.params` types
+
+Controllers mounted under a path with parameters (e.g. `/control/orgs/:id/extensions`) no longer need `params: orgIdParamsSchema` repeated on every route to type `ctx.params.id`. The typegen scanner now extracts each module's `routes()` body for `{ path, controller }` pairs and combines the mount path with the per-route path before extracting `:params`. Per-route `params: schema` declarations still override (schema wins over the URL-pattern fallback, as before).
+
+Multi-mount controllers (rare, e.g. v1 + v2 versioned variants) take the first mount's prefix; the per-route `params: schema` escape hatch handles asymmetric cases.
+
+6 new unit cases in `packages/cli/__tests__/scanner-mount-path-params.test.ts`.
+
+### §4 — typegen warns when a decorated file isn't picked up by any module glob
+
+The default module template generates `import.meta.glob([patterns])` to side-effect-register decorated classes. Adopters who add a new file type (e.g. `context-decorators/*.ts`) and forget to extend the glob got silent registration drift — the decorator never fires, downstream hits a confusing `MissingContributorError` at request time.
+
+The typegen scanner now extracts every module file's globs, matches each decorated class file in the module subtree against them, and emits a `console.warn` for orphans:
+
+```text
+  kick typegen: 1 decorated class(es) not matched by any module's import.meta.glob():
+    @Service RequireExtensionEnabled (src/modules/ext/context-decorators/require-extension.ts)
+      → not picked up by any glob in src/modules/ext/ext.module.ts
+```
+
+Surfaced at every `kick typegen` (and `kick dev` pre-typecheck) run. Doesn't fail the build — adopters who deliberately exclude files keep working — but the orphan is impossible to miss.
+
+9 new unit cases across `packages/cli/__tests__/scanner-orphaned-classes.test.ts` lock the glob-to-regex translator (`**/` → `(?:.+/)?`, `*` → `[^/]*`, `?` → `.`, negation patterns subtract) and `fileMatchesAnyGlob` semantics.
+
+### Numbers
+
+| Package               | Before    | After           |
+| --------------------- | --------- | --------------- |
+| `@forinda/kickjs`     | 408 tests | 415 tests (+7)  |
+| `@forinda/kickjs-cli` | 276 tests | 291 tests (+15) |
+
+Minor bumps — all changes additive. Both `@Autowired`/`@Inject` working in either position is a behaviour widening (previously rejected positions now accept) so technically minor; the rest are additive surface (`ContextDecoratorTarget` export, new typegen warning) or scanner internals.

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -48,16 +48,36 @@ function Transactional(): MethodDecorator
 - **PostConstruct** -- Called once after the instance is fully constructed and injected.
 - **Transactional** -- Wraps the method in a begin/commit/rollback transaction cycle.
 
-### Property and Parameter Decorators
+### Injection Decorators
 
 ```typescript
-function Autowired(token?: any): PropertyDecorator
-function Inject(token: any): ParameterDecorator
+function Autowired(token?: any): PropertyOrParameterDecorator
+function Inject(token?: any): PropertyOrParameterDecorator
 function Value(envKey: string, defaultValue?: any): PropertyDecorator
 ```
 
-- **Autowired** -- Lazy property injection resolved from the container.
-- **Inject** -- Explicit token override for constructor parameter injection.
+`@Autowired` and `@Inject` are interchangeable — same runtime, same types, two names. Each works in two positions:
+
+```typescript
+@Service()
+class UserRepo {
+  // Property position.
+  @Autowired(DB) private db!: KickDbClient
+
+  // Or constructor-parameter position — same decorator works here too.
+  constructor(@Inject(LOGGER) private logger: Logger) {}
+}
+```
+
+Calling without an explicit token resolves via the property type / constructor parameter type emitted by `emitDecoratorMetadata`:
+
+```typescript
+class UserRepo {
+  @Autowired() private db!: KickDbClient // resolved by type
+}
+```
+
+- **Autowired / Inject** -- Property or constructor-parameter dependency injection. Pick the name that reads better; the framework treats them identically.
 - **Value** -- Injects an environment variable, evaluated lazily at access time.
 
 ### HTTP Route Decorators

--- a/docs/guide/decorators.md
+++ b/docs/guide/decorators.md
@@ -180,42 +180,38 @@ class FileController {
 | `allowedTypes`  | `string[] \| function`          | all          | Accepts extensions, MIME types, wildcards, or filter function |
 | `customMimeMap` | `Record<string, string>`        | —            | Extend built-in MIME map                                      |
 
-## Property Decorators
+## Injection Decorators
 
-### @Autowired(token?)
+### @Autowired(token?) and @Inject(token?)
 
-Inject a dependency by type or token. Resolved lazily from the DI container.
+Inject a dependency by inferred type or explicit token. The two names are interchangeable — same runtime, same types. Pick whichever reads better at the call site. Each works in two positions:
 
 ```ts
 @Controller()
 class UserController {
-  @Autowired() private userService!: UserService // By type
-  @Autowired(CACHE_TOKEN) private cache!: CacheService // By token
+  // Property position — both names work.
+  @Autowired() private userService!: UserService // resolved by type
+  @Inject(CACHE_TOKEN) private cache!: CacheService // resolved by token
+
+  // Constructor-parameter position — both names work.
+  constructor(
+    @Inject(MAILER_TOKEN) private mailer: Mailer,
+    @Autowired() private logger: Logger,
+  ) {}
 }
 ```
 
+Property-position injections resolve lazily on first access. Constructor-position injections resolve at instantiation. The no-token form (`@Autowired()` / `@Inject()`) relies on TypeScript's `emitDecoratorMetadata` to resolve by the property's declared type or the constructor parameter's type.
+
 ### @Value(envKey, defaultValue?)
 
-Inject an environment variable value. Evaluated lazily at access time.
+Inject an environment variable value. Property-position only. Evaluated lazily at access time.
 
 ```ts
 @Service()
 class EmailService {
   @Value('SMTP_HOST') private host!: string
   @Value('SMTP_PORT', 587) private port!: number
-}
-```
-
-## Parameter Decorators
-
-### @Inject(token)
-
-Inject a dependency by token in constructor parameters.
-
-```ts
-@Service()
-class NotificationService {
-  constructor(@Inject(MAILER_TOKEN) private mailer: Mailer) {}
 }
 ```
 

--- a/docs/guide/decorators.md
+++ b/docs/guide/decorators.md
@@ -429,30 +429,30 @@ class TaskController {
 
 ## Summary Table
 
-| Decorator                    | Target       | Package | Purpose                                             |
-| ---------------------------- | ------------ | ------- | --------------------------------------------------- |
-| `@Controller`                | Class        | core    | Mark class as HTTP controller (prefix from module)  |
-| `@Service`                   | Class        | core    | DI-registered service                               |
-| `@Injectable`                | Class        | core    | Generic DI registration                             |
-| `@Component`                 | Class        | core    | Alias for Injectable                                |
-| `@Repository`                | Class        | core    | Data access class                                   |
-| `@Get/Post/Put/Delete/Patch` | Method       | core    | HTTP route handler                                  |
-| `@PostConstruct`             | Method       | core    | Post-instantiation hook                             |
-| `@Middleware`                | Class/Method | core    | Attach middleware                                   |
-| `@FileUpload`                | Method       | core    | Configure file upload                               |
-| `@Autowired`                 | Property     | core    | Property injection                                  |
-| `@Value`                     | Property     | core    | Env variable injection                              |
-| `@Inject`                    | Parameter    | core    | Constructor param injection                         |
-| `@Builder`                   | Class        | core    | Fluent builder via static `builder()` (opt-in type) |
-| `withBuilder()` (factory)    | Class        | core    | Same runtime as `@Builder` with inferred typing     |
-| `@ApiOperation`              | Method       | swagger | OpenAPI operation                                   |
-| `@ApiResponse`               | Method       | swagger | OpenAPI response                                    |
-| `@ApiTags`                   | Class/Method | swagger | OpenAPI tags                                        |
-| `@ApiBearerAuth`             | Class/Method | swagger | Bearer-token scheme (auto-synthesized)              |
-| `@ApiSecurity`               | Class/Method | swagger | Generic security requirement (any scheme + scopes)  |
-| `@ApiPublic`                 | Method       | swagger | Opt-out from class-level security                   |
-| `@ApiQueryParams`            | Method       | core    | Declare filterable/sortable/searchable query fields |
-| `@ApiExclude`                | Class/Method | swagger | Hide from spec                                      |
+| Decorator                    | Target               | Package | Purpose                                             |
+| ---------------------------- | -------------------- | ------- | --------------------------------------------------- |
+| `@Controller`                | Class                | core    | Mark class as HTTP controller (prefix from module)  |
+| `@Service`                   | Class                | core    | DI-registered service                               |
+| `@Injectable`                | Class                | core    | Generic DI registration                             |
+| `@Component`                 | Class                | core    | Alias for Injectable                                |
+| `@Repository`                | Class                | core    | Data access class                                   |
+| `@Get/Post/Put/Delete/Patch` | Method               | core    | HTTP route handler                                  |
+| `@PostConstruct`             | Method               | core    | Post-instantiation hook                             |
+| `@Middleware`                | Class/Method         | core    | Attach middleware                                   |
+| `@FileUpload`                | Method               | core    | Configure file upload                               |
+| `@Autowired`                 | Property / Parameter | core    | Dependency injection — either position works        |
+| `@Value`                     | Property             | core    | Env variable injection                              |
+| `@Inject`                    | Property / Parameter | core    | Dependency injection — alias for `@Autowired`       |
+| `@Builder`                   | Class                | core    | Fluent builder via static `builder()` (opt-in type) |
+| `withBuilder()` (factory)    | Class                | core    | Same runtime as `@Builder` with inferred typing     |
+| `@ApiOperation`              | Method               | swagger | OpenAPI operation                                   |
+| `@ApiResponse`               | Method               | swagger | OpenAPI response                                    |
+| `@ApiTags`                   | Class/Method         | swagger | OpenAPI tags                                        |
+| `@ApiBearerAuth`             | Class/Method         | swagger | Bearer-token scheme (auto-synthesized)              |
+| `@ApiSecurity`               | Class/Method         | swagger | Generic security requirement (any scheme + scopes)  |
+| `@ApiPublic`                 | Method               | swagger | Opt-out from class-level security                   |
+| `@ApiQueryParams`            | Method               | core    | Declare filterable/sortable/searchable query fields |
+| `@ApiExclude`                | Class/Method         | swagger | Hide from spec                                      |
 
 ## See also
 

--- a/docs/guide/dependency-injection.md
+++ b/docs/guide/dependency-injection.md
@@ -40,7 +40,7 @@ TypeScript's `emitDecoratorMetadata` resolves constructor parameter types automa
 
 ### Explicit Token Override
 
-Use `@Inject` when the type doesn't match the token — typically for **interface bindings**. **`@Inject` is for constructor parameters only** — it does not work as a property decorator.
+Use `@Inject` when the type doesn't match the token — typically for **interface bindings**. `@Inject` and `@Autowired` are interchangeable in both constructor-parameter and property positions; pick whichever name reads better at the call site.
 
 The recommended way to declare a non-class token is `createToken<T>(name)`. The returned token is a frozen object identified by reference, so collisions are impossible by construction, and the phantom type parameter `T` flows through `container.resolve()` and `@Inject()` automatically:
 
@@ -81,13 +81,14 @@ class OrderController {
 Properties are resolved lazily on first access, not at construction time.
 
 ::: tip @Inject vs @Autowired
-| Decorator | Where | Resolves by |
-|---|---|---|
-| `@Inject(token)` | Constructor parameters only | Explicit token (`createToken<T>`, class, or string) |
-| `@Autowired()` | Class properties only | Class type (from TypeScript metadata) |
-| `@Autowired(token)` | Class properties only | Explicit token |
+The two names are interchangeable — same runtime, same types. Both work in either position:
 
-Using `@Inject` on a property causes a TypeScript compile error (`TS1240`). Use `@Autowired(token)` instead.
+| Form                                   | Where                             | Resolves by                                         |
+| -------------------------------------- | --------------------------------- | --------------------------------------------------- |
+| `@Autowired(token)` / `@Inject(token)` | Property or constructor parameter | Explicit token (`createToken<T>`, class, or string) |
+| `@Autowired()` / `@Inject()`           | Property or constructor parameter | Inferred type (from TypeScript metadata)            |
+
+Pick the name that reads better at the call site; the framework treats them identically.
 :::
 
 ## DI Token Hardening

--- a/packages/cli/__tests__/scanner-mount-path-params.test.ts
+++ b/packages/cli/__tests__/scanner-mount-path-params.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extractModuleMounts,
+  extractRoutesFromSource,
+  type DiscoveredClass,
+} from '../src/typegen/scanner'
+
+// forinda/kick-js#235 §3 — when a controller is mounted under a path with
+// `:params` (e.g. `/orgs/:id/extensions`), the typegen scanner must
+// surface those params in `pathParams` so `ctx.params.id` types
+// without adopters re-declaring `params: schema` on every route.
+
+const FAKE_CWD = '/repo'
+
+function makeClass(
+  name: string,
+  filePath = '/repo/src/modules/ext/ext.controller.ts',
+): DiscoveredClass {
+  return {
+    className: name,
+    decorator: 'Controller',
+    filePath,
+    relativePath: filePath.slice(FAKE_CWD.length + 1),
+    isDefault: false,
+  }
+}
+
+describe('forinda/kick-js#235 §3 — extractModuleMounts', () => {
+  it('extracts a single mount path + controller from a routes() return', () => {
+    const source = `
+      import { type AppModule, type ModuleRoutes, buildRoutes } from '@forinda/kickjs'
+      import { ExtensionsController } from './extensions.controller'
+
+      export class ExtensionsModule implements AppModule {
+        routes(): ModuleRoutes {
+          return {
+            path: '/control/orgs/:id/extensions',
+            router: buildRoutes(ExtensionsController),
+            controller: ExtensionsController,
+          }
+        }
+      }
+    `
+    const mounts = extractModuleMounts(source)
+    expect(mounts).toEqual([
+      { controller: 'ExtensionsController', mountPath: '/control/orgs/:id/extensions' },
+    ])
+  })
+
+  it('extracts multiple mounts from an array-style routes() return', () => {
+    const source = `
+      export class MultiModule implements AppModule {
+        routes() {
+          return [
+            { path: '/v1/orgs/:id', controller: OrgsV1Controller },
+            { path: '/v2/orgs/:id', controller: OrgsV2Controller },
+          ]
+        }
+      }
+    `
+    const mounts = extractModuleMounts(source)
+    expect(mounts).toEqual([
+      { controller: 'OrgsV1Controller', mountPath: '/v1/orgs/:id' },
+      { controller: 'OrgsV2Controller', mountPath: '/v2/orgs/:id' },
+    ])
+  })
+
+  it('returns empty when the source has no routes() body', () => {
+    expect(extractModuleMounts(`export class NotAModule { foo() {} }`)).toEqual([])
+  })
+})
+
+describe('forinda/kick-js#235 §3 — extractRoutesFromSource combines mount path with route path', () => {
+  const controllerSource = `
+    import { Controller, Get, Post, Delete } from '@forinda/kickjs'
+
+    @Controller()
+    export class ExtensionsController {
+      @Get('/')
+      async list(ctx) { ctx.params.id }
+
+      @Post('/')
+      async enable(ctx) { ctx.params.id }
+
+      @Delete('/:code')
+      async disable(ctx) { ctx.params.id; ctx.params.code }
+    }
+  `
+  const cls = makeClass('ExtensionsController')
+
+  it('without a mount-path map, pathParams is per-route only (legacy behaviour)', () => {
+    const routes = extractRoutesFromSource(controllerSource, cls.filePath, FAKE_CWD, [cls])
+    // Routes come back in source order: list → enable → disable. Only
+    // the @Delete('/:code') route has a per-route param.
+    const byMethod = new Map(routes.map((r) => [r.method, r.pathParams.toSorted()]))
+    expect(byMethod.get('list')).toEqual([])
+    expect(byMethod.get('enable')).toEqual([])
+    expect(byMethod.get('disable')).toEqual(['code'])
+  })
+
+  it('with the mount-path map, pathParams surfaces `id` from the prefix on every route', () => {
+    const mounts = new Map([['ExtensionsController', '/control/orgs/:id/extensions']])
+    const routes = extractRoutesFromSource(controllerSource, cls.filePath, FAKE_CWD, [cls], mounts)
+    const byMethod = new Map(routes.map((r) => [r.method, r.pathParams.toSorted()]))
+    expect(byMethod.get('list')).toEqual(['id'])
+    expect(byMethod.get('enable')).toEqual(['id'])
+    // @Delete('/:code') — the prefix `:id` plus the per-route `:code`.
+    expect(byMethod.get('disable')).toEqual(['code', 'id'])
+  })
+
+  it('mount path without params is a no-op — base case stays unaffected', () => {
+    const mounts = new Map([['ExtensionsController', '/static-prefix']])
+    const routes = extractRoutesFromSource(controllerSource, cls.filePath, FAKE_CWD, [cls], mounts)
+    expect(routes.find((r) => r.method === 'list')?.pathParams).toEqual([])
+    expect(routes.find((r) => r.method === 'disable')?.pathParams).toEqual(['code'])
+  })
+})

--- a/packages/cli/__tests__/scanner-orphaned-classes.test.ts
+++ b/packages/cli/__tests__/scanner-orphaned-classes.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { extractGlobPatterns, fileMatchesAnyGlob } from '../src/typegen/scanner'
+
+// forinda/kick-js#235 §4 — `import.meta.glob([...])` registration in
+// module files silently misses decorator files outside the pattern
+// list. The scanner now extracts the patterns and the typegen runner
+// warns when a `@Service` / `@Controller` / `@Repository` class file
+// lives in the module directory but isn't picked up by any pattern.
+// This test locks the underlying matchers.
+
+describe('forinda/kick-js#235 §4 — extractGlobPatterns', () => {
+  it('pulls every string literal from import.meta.glob([...]) array form', () => {
+    const source = `
+      import.meta.glob(
+        [
+          './**/*.controller.ts',
+          './**/*.service.ts',
+          './**/*-repository.ts',
+          './**/*.use-case.ts',
+          '!./**/*.test.ts',
+        ],
+        { eager: true },
+      )
+    `
+    expect(extractGlobPatterns(source)).toEqual([
+      './**/*.controller.ts',
+      './**/*.service.ts',
+      './**/*-repository.ts',
+      './**/*.use-case.ts',
+      '!./**/*.test.ts',
+    ])
+  })
+
+  it('pulls a single-string pattern (no array)', () => {
+    const source = `import.meta.glob('./**/*.service.ts', { eager: true })`
+    expect(extractGlobPatterns(source)).toEqual(['./**/*.service.ts'])
+  })
+
+  it('returns empty when no import.meta.glob call exists', () => {
+    expect(extractGlobPatterns(`export class Foo {}`)).toEqual([])
+  })
+})
+
+describe('forinda/kick-js#235 §4 — fileMatchesAnyGlob', () => {
+  const patterns = [
+    './**/*.controller.ts',
+    './**/*.service.ts',
+    './**/*-repository.ts',
+    './**/*.use-case.ts',
+    '!./**/*.test.ts',
+  ]
+
+  it('matches a controller file via the recursive **/* pattern', () => {
+    expect(fileMatchesAnyGlob('domain/services/users.controller.ts', patterns)).toBe(true)
+  })
+
+  it('matches a service file', () => {
+    expect(fileMatchesAnyGlob('application/use-cases/create-user.use-case.ts', patterns)).toBe(true)
+  })
+
+  it('matches a repository file via the dash-suffix pattern', () => {
+    expect(fileMatchesAnyGlob('infrastructure/users-repository.ts', patterns)).toBe(true)
+  })
+
+  it('the issue example — context-decorators/*.ts is NOT matched', () => {
+    // The exact case from forinda/kick-js#235 §4: adding a new file
+    // type without extending the glob.
+    expect(fileMatchesAnyGlob('context-decorators/require-extension.ts', patterns)).toBe(false)
+  })
+
+  it('a test file matches a positive pattern but is excluded by the negation', () => {
+    expect(fileMatchesAnyGlob('domain/services/users.controller.test.ts', patterns)).toBe(false)
+  })
+
+  it('returns false for a totally unrelated file in the module directory', () => {
+    expect(fileMatchesAnyGlob('README.md', patterns)).toBe(false)
+  })
+})

--- a/packages/cli/src/typegen/index.ts
+++ b/packages/cli/src/typegen/index.ts
@@ -213,6 +213,19 @@ export async function runTypegen(opts: RunTypegenOptions = {}): Promise<{
         }
       }
     }
+    if (scan.orphanedClasses.length > 0) {
+      // forinda/kick-js#235 §4 — decorated classes sitting inside a
+      // module directory whose globs don't pick them up. At runtime
+      // the decorator never fires; downstream code paths get
+      // confusing `MissingContributorError` or silent misroutes.
+      console.warn(
+        `  kick typegen: ${scan.orphanedClasses.length} decorated class(es) not matched by any module's import.meta.glob():`,
+      )
+      for (const orphan of scan.orphanedClasses) {
+        console.warn(`    @${orphan.decorator} ${orphan.className} (${orphan.relativePath})`)
+        console.warn(`      → not picked up by any glob in ${orphan.moduleFilePath}`)
+      }
+    }
   }
 
   return { scan, result, tokenWarnings }

--- a/packages/cli/src/typegen/scanner.ts
+++ b/packages/cli/src/typegen/scanner.ts
@@ -444,20 +444,6 @@ const PATH_FIELD_REGEX = /\bpath\s*:\s*['"`]([^'"`]*)['"`]/g
 const CONTROLLER_FIELD_REGEX = /\bcontroller\s*:\s*([A-Z]\w*)\b/g
 
 /**
- * Scan a module file's `routes()` body for `{ path, controller }` pairs.
- * A single return value or an array of return values both work — we
- * regex out every `path: '...'` and every `controller: Ident` and
- * zip them in order. Adopter writing wildly creative bodies won't be
- * matched; that's fine — the scanner falls back to no-mount behaviour
- * (per-route path only) which is the pre-fix behaviour.
- *
- * Returns a list of `{ controller, mountPath }` entries. A controller
- * that appears multiple times in `routes()` (rare; multi-mount
- * version-bundled controllers) gets multiple entries; the route
- * scanner uses the first one for path-param extraction since the
- * pattern usually shares the prefix.
- */
-/**
  * Match the start of an `import.meta.glob(...)` call. The first arg
  * (string or string array) gets parsed forward via balanced-paren
  * walking to handle whitespace + line breaks inside the array.
@@ -550,6 +536,20 @@ export interface ModuleMount {
   mountPath: string
 }
 
+/**
+ * Scan a module file's `routes()` body for `{ path, controller }` pairs.
+ * A single return value or an array of return values both work — we
+ * regex out every `path: '...'` and every `controller: Ident` and
+ * zip them in order. Adopter writing wildly creative bodies won't be
+ * matched; that's fine — the scanner falls back to no-mount behaviour
+ * (per-route path only) which is the pre-fix behaviour.
+ *
+ * Returns a list of `{ controller, mountPath }` entries. A controller
+ * that appears multiple times in `routes()` (rare; multi-mount
+ * version-bundled controllers) gets multiple entries; the route
+ * scanner uses the first one for path-param extraction since the
+ * pattern usually shares the prefix.
+ */
 export function extractModuleMounts(source: string): ModuleMount[] {
   const out: ModuleMount[] = []
   ROUTES_METHOD_START.lastIndex = 0

--- a/packages/cli/src/typegen/scanner.ts
+++ b/packages/cli/src/typegen/scanner.ts
@@ -186,6 +186,26 @@ export interface DiscoveredAugmentation {
   relativePath: string
 }
 
+/**
+ * A decorated class whose file sits inside a module directory but
+ * isn't picked up by any of the module's `import.meta.glob(...)`
+ * patterns. Surfaced as a typegen warning per forinda/kick-js#235 §4
+ * so adopters notice silent registration drift before it bites them
+ * at runtime with a `MissingContributorError` or wrong code path.
+ */
+export interface OrphanedClass {
+  /** The decorated class name */
+  className: string
+  /** Absolute path of the class file */
+  filePath: string
+  /** Path relative to scan root, with forward slashes */
+  relativePath: string
+  /** Absolute path of the module file whose globs didn't match */
+  moduleFilePath: string
+  /** The decorator name (`Service`, `Controller`, `Repository`, …) */
+  decorator: DecoratorName
+}
+
 /** Aggregated scanner output */
 export interface ScanResult {
   classes: DiscoveredClass[]
@@ -199,6 +219,12 @@ export interface ScanResult {
   pluginsAndAdapters: DiscoveredPluginOrAdapter[]
   /** Augmentation interfaces declared via `defineAugmentation('Name', meta)` */
   augmentations: DiscoveredAugmentation[]
+  /**
+   * Decorated classes that sit inside a module directory but aren't
+   * picked up by any of the module's `import.meta.glob(...)` patterns.
+   * Empty when every decorator file is matched. forinda/kick-js#235 §4.
+   */
+  orphanedClasses: OrphanedClass[]
 }
 
 /** Options for the scanner */
@@ -385,6 +411,170 @@ function readMethodAfterDecorators(
 function extractPathParams(path: string): string[] {
   const matches = path.match(/:([a-zA-Z_]\w*)/g) ?? []
   return matches.map((m) => m.slice(1))
+}
+
+/**
+ * Join a controller's mount-prefix path with a per-route path.
+ * Handles the slash edge cases so `'/orgs/:id'` + `'/'` becomes
+ * `'/orgs/:id'` (no trailing slash) and `'/orgs/:id'` + `'/:code'`
+ * becomes `'/orgs/:id/:code'`. forinda/kick-js#235 §3.
+ */
+function joinMountPath(mountPath: string, routePath: string): string {
+  const prefix = mountPath.endsWith('/') ? mountPath.slice(0, -1) : mountPath
+  if (!routePath || routePath === '/') return prefix || '/'
+  const suffix = routePath.startsWith('/') ? routePath : '/' + routePath
+  return prefix + suffix || '/'
+}
+
+/**
+ * Match the `routes()` method body on a class implementing `AppModule`.
+ * Captures the body region so we can scan it for `path:` + `controller:`
+ * pairs. Tolerates `routes(): ModuleRoutes` and stripped return type.
+ */
+const ROUTES_METHOD_START =
+  /\b(?:public\s+|private\s+|protected\s+)?routes\s*\([^)]*\)\s*(?::\s*[A-Za-z_][\w<>[\]\s,|]*\s*)?\{/g
+
+/**
+ * Match `path: '/...'` inside a routes-method body. Picks up both
+ * single-quoted and double-quoted / template literal forms.
+ */
+const PATH_FIELD_REGEX = /\bpath\s*:\s*['"`]([^'"`]*)['"`]/g
+
+/** Match `controller: SomeController` (bare identifier only). */
+const CONTROLLER_FIELD_REGEX = /\bcontroller\s*:\s*([A-Z]\w*)\b/g
+
+/**
+ * Scan a module file's `routes()` body for `{ path, controller }` pairs.
+ * A single return value or an array of return values both work — we
+ * regex out every `path: '...'` and every `controller: Ident` and
+ * zip them in order. Adopter writing wildly creative bodies won't be
+ * matched; that's fine — the scanner falls back to no-mount behaviour
+ * (per-route path only) which is the pre-fix behaviour.
+ *
+ * Returns a list of `{ controller, mountPath }` entries. A controller
+ * that appears multiple times in `routes()` (rare; multi-mount
+ * version-bundled controllers) gets multiple entries; the route
+ * scanner uses the first one for path-param extraction since the
+ * pattern usually shares the prefix.
+ */
+/**
+ * Match the start of an `import.meta.glob(...)` call. The first arg
+ * (string or string array) gets parsed forward via balanced-paren
+ * walking to handle whitespace + line breaks inside the array.
+ * forinda/kick-js#235 §4.
+ */
+const IMPORT_META_GLOB_START = /\bimport\.meta\.glob\s*\(/g
+
+/**
+ * Extract every glob pattern from `import.meta.glob([...patterns], ...)` calls
+ * in a module file. Single-string form (`import.meta.glob('./**\\/*.ts')`) and
+ * array form both supported. Negation patterns (`!./**\\/*.test.ts`)
+ * are returned with the leading `!` preserved so the caller can apply
+ * exclusion logic.
+ */
+export function extractGlobPatterns(source: string): string[] {
+  const patterns: string[] = []
+  IMPORT_META_GLOB_START.lastIndex = 0
+  while (IMPORT_META_GLOB_START.exec(source) !== null) {
+    const openParen = IMPORT_META_GLOB_START.lastIndex - 1
+    const closeParen = findBalancedClose(source, openParen)
+    if (closeParen < 0) continue
+    const args = source.slice(openParen + 1, closeParen)
+    // Pull out every string literal inside the first-arg region —
+    // we don't bother distinguishing the array form from the bare
+    // string; both end up as flat patterns.
+    const literalRe = /['"`]([^'"`]+)['"`]/g
+    let lit: RegExpExecArray | null
+    while ((lit = literalRe.exec(args)) !== null) {
+      patterns.push(lit[1] as string)
+    }
+  }
+  return patterns
+}
+
+/**
+ * Convert a Vite-style glob (e.g. `./**\\/*.controller.ts`) to a
+ * RegExp. Supports `**` (any path segments including `/`), `*` (any
+ * chars within one segment), `?` (single char). Brace alternation is
+ * intentionally not handled — none of the templated globs use it,
+ * and a false-negative on an unusual pattern is safer than a false-
+ * positive (better to skip the warning than to wrongly silence one).
+ */
+function globToRegex(pattern: string): RegExp {
+  // Process `?` before any of the substitutions that insert `?` into
+  // the output (e.g. the `(?:.+/)?` non-capture group for `**/`).
+  // If we left it for last, the `?` → `.` pass would mangle those
+  // groups into `(.:.+\/).` — broken regex.
+  const escaped = pattern
+    .replace(/[.+^$()|[\]\\]/g, '\\$&')
+    .replace(/\?/g, '.')
+    .replace(/\*\*\//g, '___DOUBLESTAR_SLASH___')
+    .replace(/\*\*/g, '___DOUBLESTAR___')
+    .replace(/\*/g, '[^/]*')
+    .replace(/___DOUBLESTAR_SLASH___/g, '(?:.+/)?')
+    .replace(/___DOUBLESTAR___/g, '.*')
+  return new RegExp('^' + escaped + '$')
+}
+
+/**
+ * Decide whether a file (relative to the module file's directory)
+ * matches any of the module's positive glob patterns. Negation
+ * patterns (`!./**\\/*.test.ts`) subtract; a file matched by both a
+ * positive and a negation is excluded.
+ */
+export function fileMatchesAnyGlob(
+  moduleRelativePath: string,
+  patterns: readonly string[],
+): boolean {
+  const normalised = moduleRelativePath.startsWith('./')
+    ? moduleRelativePath
+    : './' + moduleRelativePath
+  let matched = false
+  for (const pattern of patterns) {
+    const isNegation = pattern.startsWith('!')
+    const body = isNegation ? pattern.slice(1) : pattern
+    if (globToRegex(body).test(normalised)) {
+      matched = !isNegation
+    }
+  }
+  return matched
+}
+
+export function extractModuleMounts(
+  source: string,
+): Array<{ controller: string; mountPath: string }> {
+  const out: Array<{ controller: string; mountPath: string }> = []
+  ROUTES_METHOD_START.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = ROUTES_METHOD_START.exec(source)) !== null) {
+    const openBrace = source.indexOf('{', m.index + m[0].length - 1)
+    if (openBrace < 0) continue
+    const closeBrace = findBalancedBrace(source, openBrace)
+    if (closeBrace < 0) continue
+    const body = source.slice(openBrace + 1, closeBrace)
+
+    const paths: string[] = []
+    PATH_FIELD_REGEX.lastIndex = 0
+    let p: RegExpExecArray | null
+    while ((p = PATH_FIELD_REGEX.exec(body)) !== null) {
+      paths.push(p[1] ?? '')
+    }
+
+    const controllers: string[] = []
+    CONTROLLER_FIELD_REGEX.lastIndex = 0
+    let c: RegExpExecArray | null
+    while ((c = CONTROLLER_FIELD_REGEX.exec(body)) !== null) {
+      controllers.push(c[1] as string)
+    }
+
+    // Zip — if counts mismatch, take the shorter of the two so we
+    // never assign a wrong controller to a path.
+    const n = Math.min(paths.length, controllers.length)
+    for (let i = 0; i < n; i++) {
+      out.push({ controller: controllers[i] as string, mountPath: paths[i] as string })
+    }
+  }
+  return out
 }
 
 /**
@@ -646,6 +836,7 @@ export function extractRoutesFromSource(
   filePath: string,
   cwd: string,
   classesInFile: DiscoveredClass[],
+  mountPathByController: ReadonlyMap<string, string> = new Map(),
 ): DiscoveredRoute[] {
   const out: DiscoveredRoute[] = []
   if (classesInFile.length === 0) return out
@@ -700,12 +891,19 @@ export function extractRoutesFromSource(
       const queryId = extractObjectFieldIdentifier(routeArgs, 'query')
       const paramsId = extractObjectFieldIdentifier(routeArgs, 'params')
 
+      // forinda/kick-js#235 §3 — when the controller is mounted under a path
+      // with `:params` (e.g. `/orgs/:id/extensions`), surface those
+      // params in `pathParams` so the typegen widens `ctx.params`
+      // without adopters repeating `params: schema` on every route.
+      const mountPath = mountPathByController.get(cls.className) ?? ''
+      const fullPath = mountPath ? joinMountPath(mountPath, path) : path
+
       out.push({
         controller: cls.className,
         method: methodName,
         httpMethod: verb.toUpperCase() as DiscoveredRoute['httpMethod'],
         path,
-        pathParams: extractPathParams(path),
+        pathParams: extractPathParams(fullPath),
         queryFilterable: apiQp?.filterable ?? null,
         querySortable: apiQp?.sortable ?? null,
         querySearchable: apiQp?.searchable ?? null,
@@ -1033,9 +1231,52 @@ export async function scanProject(opts: ScanOptions): Promise<ScanResult> {
     augmentations.push(...extractAugmentationsFromSource(source, file, opts.cwd))
   }
 
+  // forinda/kick-js#235 §3 — build a `Controller → mountPath` map from every
+  // module file's `routes()` body so per-route `pathParams` can include
+  // the prefix params (e.g. `/orgs/:id`) without adopters re-declaring
+  // `params:` on every method. First mount wins on duplicates (rare
+  // multi-mount controllers — typically share the prefix shape).
+  const mountPathByController = new Map<string, string>()
+  for (const [, source] of sources) {
+    for (const { controller, mountPath } of extractModuleMounts(source)) {
+      if (!mountPathByController.has(controller)) {
+        mountPathByController.set(controller, mountPath)
+      }
+    }
+  }
+
   for (const [file, source] of sources) {
     const classesInFile = classes.filter((c) => c.filePath === file)
-    routes.push(...extractRoutesFromSource(source, file, opts.cwd, classesInFile))
+    routes.push(
+      ...extractRoutesFromSource(source, file, opts.cwd, classesInFile, mountPathByController),
+    )
+  }
+
+  // forinda/kick-js#235 §4 — for every module file, extract its
+  // `import.meta.glob([...])` patterns and flag any decorated class
+  // whose file sits inside the module directory but isn't matched by
+  // a positive pattern. Catches the "added a new file type, forgot to
+  // extend the glob" silent-degradation case.
+  const orphanedClasses: OrphanedClass[] = []
+  for (const [moduleFile, source] of sources) {
+    if (!/\.module\.[mc]?[tj]sx?$/.test(moduleFile)) continue
+    const patterns = extractGlobPatterns(source)
+    if (patterns.length === 0) continue
+    const moduleDir = moduleFile.slice(0, moduleFile.lastIndexOf('/'))
+    for (const cls of classes) {
+      if (!cls.filePath.startsWith(moduleDir + '/')) continue
+      if (cls.filePath === moduleFile) continue // skip the module file itself
+      const moduleRelative = cls.filePath.slice(moduleDir.length + 1)
+      if (!fileMatchesAnyGlob(moduleRelative, patterns)) {
+        orphanedClasses.push({
+          className: cls.className,
+          filePath: cls.filePath,
+          relativePath: cls.relativePath,
+          moduleFilePath: moduleFile,
+          decorator: cls.decorator,
+        })
+      }
+    }
   }
 
   // Deterministic ordering for stable .d.ts output
@@ -1062,6 +1303,11 @@ export async function scanProject(opts: ScanOptions): Promise<ScanResult> {
   const collisions = findCollisions(classes)
   const env = await detectEnvFile(opts.cwd, opts.envFile ?? 'src/env.ts')
 
+  orphanedClasses.sort(
+    (a, b) =>
+      a.relativePath.localeCompare(b.relativePath) || a.className.localeCompare(b.className),
+  )
+
   return {
     classes,
     routes,
@@ -1071,5 +1317,6 @@ export async function scanProject(opts: ScanOptions): Promise<ScanResult> {
     env,
     pluginsAndAdapters,
     augmentations,
+    orphanedClasses,
   }
 }

--- a/packages/cli/src/typegen/scanner.ts
+++ b/packages/cli/src/typegen/scanner.ts
@@ -540,10 +540,18 @@ export function fileMatchesAnyGlob(
   return matched
 }
 
-export function extractModuleMounts(
-  source: string,
-): Array<{ controller: string; mountPath: string }> {
-  const out: Array<{ controller: string; mountPath: string }> = []
+/**
+ * A `{ controller, mountPath }` pair extracted from a module's
+ * `routes()` body. Multiple entries appear when a module returns an
+ * array (multi-mount). forinda/kick-js#235 §3.
+ */
+export interface ModuleMount {
+  controller: string
+  mountPath: string
+}
+
+export function extractModuleMounts(source: string): ModuleMount[] {
+  const out: ModuleMount[] = []
   ROUTES_METHOD_START.lastIndex = 0
   let m: RegExpExecArray | null
   while ((m = ROUTES_METHOD_START.exec(source)) !== null) {
@@ -1257,16 +1265,25 @@ export async function scanProject(opts: ScanOptions): Promise<ScanResult> {
   // whose file sits inside the module directory but isn't matched by
   // a positive pattern. Catches the "added a new file type, forgot to
   // extend the glob" silent-degradation case.
+  // Normalize Windows backslashes to forward slashes before any
+  // slicing / startsWith / glob-matching — the rest of the scanner
+  // already speaks forward-slash relative paths, but absolute
+  // `filePath` values may carry the platform separator on Windows.
   const orphanedClasses: OrphanedClass[] = []
   for (const [moduleFile, source] of sources) {
     if (!/\.module\.[mc]?[tj]sx?$/.test(moduleFile)) continue
     const patterns = extractGlobPatterns(source)
     if (patterns.length === 0) continue
-    const moduleDir = moduleFile.slice(0, moduleFile.lastIndexOf('/'))
+    const moduleFilePosix = moduleFile.replaceAll(sep, '/')
+    const moduleDir = moduleFilePosix.slice(0, moduleFilePosix.lastIndexOf('/'))
     for (const cls of classes) {
-      if (!cls.filePath.startsWith(moduleDir + '/')) continue
-      if (cls.filePath === moduleFile) continue // skip the module file itself
-      const moduleRelative = cls.filePath.slice(moduleDir.length + 1)
+      // Skip module files themselves — they're scanner-synthesized
+      // `decorator: 'Module'` entries that aren't glob contributors.
+      if (cls.decorator === 'Module') continue
+      const classFilePosix = cls.filePath.replaceAll(sep, '/')
+      if (!classFilePosix.startsWith(moduleDir + '/')) continue
+      if (classFilePosix === moduleFilePosix) continue
+      const moduleRelative = classFilePosix.slice(moduleDir.length + 1)
       if (!fileMatchesAnyGlob(moduleRelative, patterns)) {
         orphanedClasses.push({
           className: cls.className,

--- a/packages/kickjs/__tests__/inject-autowired-positions.test.ts
+++ b/packages/kickjs/__tests__/inject-autowired-positions.test.ts
@@ -114,7 +114,10 @@ describe('forinda/kick-js#235 §2 — Autowired + Inject both work in property a
 
     @Service()
     class UsesNoTokenCtor {
-      constructor(@Inject(AnotherGreeterImpl) private readonly g: AnotherGreeterImpl) {}
+      // True no-token form — relies on TypeScript's emitted
+      // `design:paramtypes` reflection to find `AnotherGreeterImpl`.
+      // Symmetric with `@Autowired()` on a typed property.
+      constructor(@Inject() private readonly g: AnotherGreeterImpl) {}
       sayHi() {
         return this.g.hello()
       }

--- a/packages/kickjs/__tests__/inject-autowired-positions.test.ts
+++ b/packages/kickjs/__tests__/inject-autowired-positions.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { Autowired, Container, Inject, Service, createToken } from '../src'
+
+// forinda/kick-js#235 §2 — `@Autowired` and `@Inject` previously diverged at
+// the type level: one was property-only, the other parameter-only.
+// Adopters who picked the wrong name for the position got a cryptic
+// TS1240 error. Both now accept either position and route to the
+// correct metadata bucket at runtime — locked here so a regression
+// surfaces.
+
+interface Greeter {
+  hello(): string
+}
+
+const GREETER = createToken<Greeter>('test/greeter')
+const SECOND = createToken<Greeter>('test/greeter-2')
+
+beforeEach(() => {
+  Container.reset()
+})
+
+afterEach(() => {
+  Container.reset()
+})
+
+describe('forinda/kick-js#235 §2 — Autowired + Inject both work in property and parameter positions', () => {
+  it('Autowired works as a constructor-parameter decorator (the previously-rejected position)', () => {
+    @Service()
+    class UsesAutowiredInCtor {
+      constructor(@Autowired(GREETER) private readonly g: Greeter) {}
+      sayHi() {
+        return this.g.hello()
+      }
+    }
+
+    const container = Container.getInstance()
+    container.registerInstance(GREETER, { hello: () => 'hi' })
+
+    expect(container.resolve(UsesAutowiredInCtor).sayHi()).toBe('hi')
+  })
+
+  it('Inject works as a property decorator (the previously-rejected position)', () => {
+    @Service()
+    class UsesInjectOnProperty {
+      @Inject(GREETER) private readonly g!: Greeter
+      sayHi() {
+        return this.g.hello()
+      }
+    }
+
+    const container = Container.getInstance()
+    container.registerInstance(GREETER, { hello: () => 'hi' })
+
+    expect(container.resolve(UsesInjectOnProperty).sayHi()).toBe('hi')
+  })
+
+  it('Autowired in its traditional property position still works', () => {
+    @Service()
+    class UsesAutowiredOnProperty {
+      @Autowired(GREETER) private readonly g!: Greeter
+      sayHi() {
+        return this.g.hello()
+      }
+    }
+
+    const container = Container.getInstance()
+    container.registerInstance(GREETER, { hello: () => 'hi' })
+
+    expect(container.resolve(UsesAutowiredOnProperty).sayHi()).toBe('hi')
+  })
+
+  it('Inject in its traditional constructor-parameter position still works', () => {
+    @Service()
+    class UsesInjectInCtor {
+      constructor(@Inject(GREETER) private readonly g: Greeter) {}
+      sayHi() {
+        return this.g.hello()
+      }
+    }
+
+    const container = Container.getInstance()
+    container.registerInstance(GREETER, { hello: () => 'hi' })
+
+    expect(container.resolve(UsesInjectInCtor).sayHi()).toBe('hi')
+  })
+
+  it('no-token Autowired() on a property resolves via reflected design:type', () => {
+    @Service()
+    class GreeterImpl {
+      hello() {
+        return 'reflected-hi'
+      }
+    }
+
+    @Service()
+    class UsesNoTokenProperty {
+      @Autowired() private readonly g!: GreeterImpl
+      sayHi() {
+        return this.g.hello()
+      }
+    }
+
+    const container = Container.getInstance()
+    expect(container.resolve(UsesNoTokenProperty).sayHi()).toBe('reflected-hi')
+  })
+
+  it('no-token Inject() on a constructor parameter resolves via reflected design:paramtypes', () => {
+    @Service()
+    class AnotherGreeterImpl {
+      hello() {
+        return 'param-hi'
+      }
+    }
+
+    @Service()
+    class UsesNoTokenCtor {
+      constructor(@Inject(AnotherGreeterImpl) private readonly g: AnotherGreeterImpl) {}
+      sayHi() {
+        return this.g.hello()
+      }
+    }
+
+    const container = Container.getInstance()
+    expect(container.resolve(UsesNoTokenCtor).sayHi()).toBe('param-hi')
+  })
+
+  it('mixing both names within one class works — they share the runtime', () => {
+    @Service()
+    class Mixed {
+      @Inject(GREETER) private readonly g1!: Greeter
+      constructor(@Autowired(SECOND) private readonly g2: Greeter) {}
+      both() {
+        return `${this.g1.hello()}-${this.g2.hello()}`
+      }
+    }
+
+    const container = Container.getInstance()
+    container.registerInstance(GREETER, { hello: () => 'hi' })
+    container.registerInstance(SECOND, { hello: () => 'hola' })
+
+    expect(container.resolve(Mixed).both()).toBe('hi-hola')
+  })
+})

--- a/packages/kickjs/src/core/decorators.ts
+++ b/packages/kickjs/src/core/decorators.ts
@@ -131,20 +131,70 @@ export function PostConstruct(): MethodDecorator {
   }
 }
 
-// ── Property Decorators ─────────────────────────────────────────────────
+// ── Injection Decorators (property + constructor parameter) ─────────────
 
-/** Property injection — resolved lazily from the container */
-export function Autowired(token?: any): PropertyDecorator {
-  return (target, propertyKey) => {
+/**
+ * A decorator that's valid as either a property decorator OR a
+ * constructor-parameter decorator. forinda/kick-js#235 §2 — `@Autowired` and
+ * `@Inject` previously diverged at the type level (property-only vs
+ * parameter-only) and adopters who picked the wrong name for the
+ * position got a cryptic TS1240 error. Both names now accept either
+ * position and route to the correct metadata bucket at runtime.
+ */
+export interface PropertyOrParameterDecorator {
+  (target: object, propertyKey: string | symbol): void
+  (target: object, propertyKey: string | symbol | undefined, parameterIndex: number): void
+}
+
+function applyInjection(
+  token: unknown,
+  target: object,
+  propertyKey: string | symbol | undefined,
+  parameterIndex: number | undefined,
+): void {
+  // Legacy parameter decorators receive 3 args (target, propertyKey,
+  // parameterIndex); property decorators receive 2 (target, propertyKey).
+  // The 3rd-arg-number-vs-undefined check is the canonical position
+  // detection in TypeScript's legacy decorator runtime.
+  if (typeof parameterIndex === 'number') {
+    setInMetaRecord(METADATA.INJECT, target, parameterIndex, token)
+    return
+  }
+  if (propertyKey != null) {
+    // `target` for a property decorator on a non-static field is the
+    // class prototype; the AUTOWIRED bucket is keyed off the prototype
+    // identity at resolution time, so pass it through unchanged.
     setInMetaMap(METADATA.AUTOWIRED, target, propertyKey as string, token)
   }
 }
 
 /**
- * Constructor parameter injection with an explicit token.
+ * Inject a dependency. Works in two positions:
  *
- * **Constructor parameters only** — does not work as a property decorator.
- * For property injection with a token, use `@Autowired(token)` instead.
+ * - **Property decorator** — `@Autowired(TOKEN) private repo!: UserRepo`.
+ *   Resolved lazily from the container the first time the property is
+ *   read.
+ * - **Constructor parameter decorator** — `constructor(@Autowired(TOKEN) repo: UserRepo) {}`.
+ *   Resolved at instantiation; injected into the ctor call.
+ *
+ * `@Inject` is the same function under another name — they share
+ * runtime + types so the two names are interchangeable. Pick whichever
+ * reads better at the call site.
+ */
+export function Autowired(token?: unknown): PropertyOrParameterDecorator {
+  return ((
+    target: object,
+    propertyKey: string | symbol | undefined,
+    parameterIndex?: number,
+  ): void => {
+    applyInjection(token, target, propertyKey, parameterIndex)
+  }) as PropertyOrParameterDecorator
+}
+
+/**
+ * Inject a dependency by token. Same shape as {@link Autowired} —
+ * works as either a property decorator or a constructor-parameter
+ * decorator. See `@Autowired` for the long-form docstring.
  *
  * ## Typed string-literal overload (architecture.md §22.4 #3)
  *
@@ -162,6 +212,8 @@ export function Autowired(token?: any): PropertyDecorator {
  * `@Service()`
  * class UserRepo {
  *   constructor(@Inject('kick/prisma/Client') private db: PrismaClient) {}
+ *   // OR property form, same decorator:
+ *   @Inject('kick/prisma/Client') private db2!: PrismaClient
  * }
  * ```
  *
@@ -169,12 +221,18 @@ export function Autowired(token?: any): PropertyDecorator {
  * literal autocompletes from the registry, and a typo
  * (`@Inject('kick/prisma/Cleint')`) becomes a TS2345 error.
  */
-export function Inject<K extends keyof KickJsRegistry & string>(token: K): ParameterDecorator
-export function Inject(token: unknown): ParameterDecorator
-export function Inject(token: unknown): ParameterDecorator {
-  return (target, _propertyKey, parameterIndex) => {
-    setInMetaRecord(METADATA.INJECT, target as object, parameterIndex, token)
-  }
+export function Inject<K extends keyof KickJsRegistry & string>(
+  token: K,
+): PropertyOrParameterDecorator
+export function Inject(token: unknown): PropertyOrParameterDecorator
+export function Inject(token: unknown): PropertyOrParameterDecorator {
+  return ((
+    target: object,
+    propertyKey: string | symbol | undefined,
+    parameterIndex?: number,
+  ): void => {
+    applyInjection(token, target, propertyKey, parameterIndex)
+  }) as PropertyOrParameterDecorator
 }
 
 /**

--- a/packages/kickjs/src/core/decorators.ts
+++ b/packages/kickjs/src/core/decorators.ts
@@ -224,8 +224,8 @@ export function Autowired(token?: unknown): PropertyOrParameterDecorator {
 export function Inject<K extends keyof KickJsRegistry & string>(
   token: K,
 ): PropertyOrParameterDecorator
-export function Inject(token: unknown): PropertyOrParameterDecorator
-export function Inject(token: unknown): PropertyOrParameterDecorator {
+export function Inject(token?: unknown): PropertyOrParameterDecorator
+export function Inject(token?: unknown): PropertyOrParameterDecorator {
   return ((
     target: object,
     propertyKey: string | symbol | undefined,

--- a/packages/kickjs/src/core/decorators.ts
+++ b/packages/kickjs/src/core/decorators.ts
@@ -135,14 +135,16 @@ export function PostConstruct(): MethodDecorator {
 
 /**
  * A decorator that's valid as either a property decorator OR a
- * constructor-parameter decorator. forinda/kick-js#235 §2 — `@Autowired` and
- * `@Inject` previously diverged at the type level (property-only vs
- * parameter-only) and adopters who picked the wrong name for the
+ * constructor-parameter decorator. forinda/kick-js#235 §2 — `@Autowired`
+ * and `@Inject` previously diverged at the type level (property-only
+ * vs parameter-only) and adopters who picked the wrong name for the
  * position got a cryptic TS1240 error. Both names now accept either
  * position and route to the correct metadata bucket at runtime.
  */
 export interface PropertyOrParameterDecorator {
+  /** Property decorator form — `@Autowired(TOKEN) private foo!: Foo`. */
   (target: object, propertyKey: string | symbol): void
+  /** Constructor-parameter form — `constructor(@Inject(TOKEN) foo: Foo) {}`. */
   (target: object, propertyKey: string | symbol | undefined, parameterIndex: number): void
 }
 
@@ -194,9 +196,9 @@ export function Autowired(token?: unknown): PropertyOrParameterDecorator {
 /**
  * Inject a dependency by token. Same shape as {@link Autowired} —
  * works as either a property decorator or a constructor-parameter
- * decorator. See `@Autowired` for the long-form docstring.
+ * decorator. Pick whichever name reads better at the call site.
  *
- * ## Typed string-literal overload (architecture.md §22.4 #3)
+ * ## Typed string-literal overload
  *
  * When called with a string literal that matches a key of the
  * augmented `KickJsRegistry`, TypeScript narrows the parameter type
@@ -217,9 +219,9 @@ export function Autowired(token?: unknown): PropertyOrParameterDecorator {
  * }
  * ```
  *
- * After `kick typegen` populates `.kickjs/types/registry.d.ts` the
- * literal autocompletes from the registry, and a typo
- * (`@Inject('kick/prisma/Cleint')`) becomes a TS2345 error.
+ * After `kick typegen` runs, the literal autocompletes from the
+ * registry and a typo (`@Inject('kick/prisma/Cleint')`) becomes a
+ * TS2345 error.
  */
 export function Inject<K extends keyof KickJsRegistry & string>(
   token: K,

--- a/packages/kickjs/src/core/index.ts
+++ b/packages/kickjs/src/core/index.ts
@@ -169,6 +169,7 @@ export {
   type AnyContributorRegistration,
   type ContributorRegistrations,
   type ContextDecorator,
+  type ContextDecoratorTarget,
   type DepValue,
   type ResolvedDeps,
 } from './context-decorator'


### PR DESCRIPTION
Closes forinda/kick-js#235.

Bundles all four DX rough edges from the issue into one stacked PR per the request. Each fix lands independently — the failing surface for one didn't depend on any other — but the review + CHANGELOG entry stay coherent in a single landing.

## §1 — `ContextDecoratorTarget` is now publicly exported

Adopters wrapping `defineHttpContextDecorator(...)` in a public method-decorator factory hit **TS4058** under `declaration: true` builds because the inferred return type referenced an internal symbol. The interface was already exported from `core/context-decorator.ts`; it just wasn't re-exported from `core/index.ts`. One-line fix — adopters can now annotate their wrapper's return type as `ContextDecoratorTarget` instead of re-deriving the legacy `MethodDecorator` shape locally.

```ts
import {
  defineHttpContextDecorator,
  type ContextDecoratorTarget,
} from '@forinda/kickjs'

const RequirePermissionContext = defineHttpContextDecorator<...>({...})

export function RequirePermission(code: PermissionCode): ContextDecoratorTarget {
  return RequirePermissionContext({ permissionCode: code })
}
```

## §2 — `@Autowired` and `@Inject` work in either position

Both decorators previously diverged at the type level (`PropertyDecorator` vs `ParameterDecorator`). Adopters who picked the wrong name for the position got a cryptic **TS1240** error.

Both now accept either position and route to the correct metadata bucket at runtime via the standard "third arg is a number" position-detection (TypeScript's legacy parameter-decorator signature):

```ts
@Service()
class UserRepo {
  // Property position — both names work.
  @Autowired(DB) private db1!: KickDbClient
  @Inject(DB) private db2!: KickDbClient

  // Constructor parameter position — both names work.
  constructor(
    @Autowired(LOGGER) private logger: Logger,
    @Inject(CACHE) private cache: Cache,
  ) {}
}
```

The pre-existing **no-token reflection-based forms** (`@Autowired() private foo!: SomeClass`, `@Inject(SomeClass) foo: SomeClass`) keep working unchanged — `design:type` / `design:paramtypes` fallback fires when `token` is `undefined`. **7 new unit cases** in `inject-autowired-positions.test.ts` lock the full matrix (property + ctor × both names + no-token + mixed-in-one-class).

## §3 — Mount-prefix `:params` propagate into `ctx.params` types

Controllers mounted under a path with parameters (e.g. `/control/orgs/:id/extensions`) no longer need `params: orgIdParamsSchema` repeated on every route to type `ctx.params.id`. The typegen scanner now extracts each module's `routes()` body for `{ path, controller }` pairs and combines the mount path with the per-route path before extracting `:params`.

```ts
// In tasks.module.ts:
routes(): ModuleRoutes {
  return { path: '/control/orgs/:id/extensions', controller: ExtensionsController }
}

// In tasks.controller.ts — `id` is now typed on every route, no per-method schema needed.
@Controller()
export class ExtensionsController {
  @Get('/') list(ctx) { ctx.params.id }        // ✓ typed
  @Post('/') enable(ctx) { ctx.params.id }      // ✓ typed
  @Delete('/:code') disable(ctx) {              // ✓ both typed
    ctx.params.id
    ctx.params.code
  }
}
```

Per-route `params: schema` declarations still override (schema wins over the URL-pattern fallback, as before). Multi-mount controllers (rare versioned variants) take the first mount's prefix; the per-route `params: schema` escape hatch handles asymmetric cases. **6 new unit cases** in `scanner-mount-path-params.test.ts`.

## §4 — Typegen warns when a decorated file isn't picked up by any module glob

The default module template generates `import.meta.glob([patterns])` to side-effect-register decorated classes. Adopters who add a new file type (e.g. `context-decorators/*.ts`) and forget to extend the glob got silent registration drift — the decorator never fires, downstream hits a confusing `MissingContributorError` at request time.

The typegen scanner now extracts every module file's globs, matches each decorated class file in the module subtree against them, and emits a `console.warn` for orphans:

```text
  kick typegen: 1 decorated class(es) not matched by any module's import.meta.glob():
    @Service RequireExtensionEnabled (src/modules/ext/context-decorators/require-extension.ts)
      → not picked up by any glob in src/modules/ext/ext.module.ts
```

Surfaced at every `kick typegen` (and `kick dev` pre-typecheck) run. Doesn't fail the build — adopters who deliberately exclude files keep working — but the orphan is impossible to miss. **9 new unit cases** in `scanner-orphaned-classes.test.ts` lock the glob-to-regex translator (`**/` → `(?:.+/)?`, `*` → `[^/]*`, `?` → `.`, negation patterns subtract) and `fileMatchesAnyGlob` semantics.

## Numbers

| Package | Before | After |
|---|---|---|
| `@forinda/kickjs` | 408 tests | 415 tests (+7) |
| `@forinda/kickjs-cli` | 276 tests | 291 tests (+15) |

**Minor bumps on both packages.** Position widening on `@Autowired`/`@Inject` is technically minor (previously-rejected positions now accept); the rest are additive surface (`ContextDecoratorTarget` export, new typegen warning) or scanner internals.

## Pre-existing failures (NOT caused by this PR)

`pnpm test` on bare `main` shows 9 pre-existing failures in `config-service.test.ts` / `env-typing.test.ts` / `generator-extension.test.ts` (cli) and 2 in `assets.test.ts` (kickjs). Verified by stashing this branch and re-running the same files on `main` — same failures. Out of scope for this PR.

## Verification

```text
pnpm --filter @forinda/kickjs build          # green
pnpm --filter @forinda/kickjs-cli build      # green
pnpm exec vitest run __tests__/inject-autowired-positions.test.ts  # 7/7
pnpm exec vitest run __tests__/scanner-mount-path-params.test.ts   # 6/6
pnpm exec vitest run __tests__/scanner-orphaned-classes.test.ts    # 9/9
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `@Autowired` and `@Inject` now work as both property and constructor-parameter decorators
  * Controller mount-path `:params` are included in generated route parameter types
  * Type generation warns when decorated classes aren’t matched by module glob patterns
  * `ContextDecoratorTarget` is publicly exported

* **Tests**
  * Added coverage for decorator positions, mount-path param propagation, glob matching, and orphaned-class detection

* **Documentation**
  * Updated DI docs to reflect decorator interchangeability and no-token behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/236)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->