### PR TITLE
fix: typed @Autowired overload + DevTools peer-adapter visibility

### DIFF
--- a/.changeset/autowired-typed-keys-overload.md
+++ b/.changeset/autowired-typed-keys-overload.md
@@ -1,0 +1,16 @@
+---
+'@forinda/kickjs': patch
+---
+
+fix(core): restore typed `KickJsRegistry` overload on `@Autowired`
+
+The first overload — `<K extends keyof KickJsRegistry & string>(token: K)` —
+already exists on `@Inject` but was lost on `@Autowired` during the
+dual-position unification in forinda/kick-js#236. Without it, adopters lose
+string-literal narrowing + typo detection when reaching for `@Autowired`
+instead of `@Inject`, even though the two are interchangeable everywhere
+else.
+
+After `kick typegen` populates the registry, `@Autowired('kick/prisma/Client')`
+now autocompletes the key and typo'd literals become TS2345 errors, matching
+`@Inject` exactly. No runtime behaviour change.

--- a/.changeset/devtools-adapter-visibility.md
+++ b/.changeset/devtools-adapter-visibility.md
@@ -1,0 +1,22 @@
+---
+'@forinda/kickjs-devtools': patch
+---
+
+fix(devtools): surface every peer adapter on `/_debug/health` + Overview
+
+Two related bugs caused the DevTools Overview > Health card to list
+**only** `DevToolsAdapter` even when the app booted with several
+adapters:
+
+- `adapterStatuses` was only ever written in `beforeMount`/`shutdown`
+  for the DevTools adapter itself — peers were never added, so the
+  `/_debug/health` JSON returned `adapters: { DevToolsAdapter: 'running' }`
+  regardless of how many other adapters were registered.
+- The Overview > Health card's Adapters accordion defaulted to
+  collapsed, hiding the list further.
+
+The fix seeds `adapterStatuses` from `getPeerAdapters()` in `afterStart`
+(every mounted peer appears as `running`), refreshes each entry from
+`peer.onHealthCheck()` when present at request time so the status is
+live rather than a frozen boot snapshot, and defaults the Overview
+accordion to open. No public-API change.

--- a/packages/devtools/spa/src/tabs/OverviewTab.tsx
+++ b/packages/devtools/spa/src/tabs/OverviewTab.tsx
@@ -23,7 +23,11 @@ export const OverviewTab: Component = () => {
 }
 
 const HealthCard: Component = () => {
-  const [adaptersOpen, setAdaptersOpen] = createSignal(false)
+  // Default-open so the registered adapter list is visible on first
+  // load — the previous collapsed default made adapters easy to miss
+  // entirely (especially when only `DevToolsAdapter` ever populated the
+  // dict; see adapter.ts `afterStart` peer-seeding).
+  const [adaptersOpen, setAdaptersOpen] = createSignal(true)
   return (
     <div class="bg-surface-1 rounded-xl border border-border p-5">
       <h2 class="text-xs font-semibold uppercase tracking-wider text-text-muted mb-3">Health</h2>

--- a/packages/devtools/src/adapter.ts
+++ b/packages/devtools/src/adapter.ts
@@ -476,15 +476,38 @@ export const DevToolsAdapter = defineAdapter<DevToolsOptions, DevToolsAdapterExt
           })
         })
 
-        router.get('/health', (_req: Request, res: Response) => {
+        router.get('/health', async (_req: Request, res: Response) => {
           const healthy = errorRate.value < errorRateThreshold
           const status = healthy ? 'healthy' : 'degraded'
+
+          // Refresh peer statuses from `onHealthCheck()` when present.
+          // The static `adapterStatuses` dict (seeded in `afterStart`)
+          // proves a peer was mounted; calling `onHealthCheck()` here
+          // upgrades that to a live `up`/`down`/`degraded` reading so
+          // the Overview > Health card reflects actual adapter state,
+          // not just "registered at boot".
+          const live: Record<string, string> = { ...adapterStatuses }
+          await Promise.all(
+            getPeerAdapters().map(async (peer) => {
+              if (typeof peer?.onHealthCheck !== 'function') return
+              const name: unknown = peer?.name
+              if (typeof name !== 'string' || name === 'DevToolsAdapter') return
+              try {
+                const result = await peer.onHealthCheck()
+                if (result && typeof result.status === 'string') {
+                  live[name] = result.status
+                }
+              } catch {
+                live[name] = 'down'
+              }
+            }),
+          )
 
           res.status(healthy ? 200 : 503).json({
             status,
             errorRate: errorRate.value,
             uptime: uptimeSeconds.value,
-            adapters: adapterStatuses,
+            adapters: live,
           })
         })
 
@@ -947,6 +970,20 @@ export const DevToolsAdapter = defineAdapter<DevToolsOptions, DevToolsAdapterExt
         // any other adapter sharing the same listener stays
         // unaffected — only `${basePath}/_bus` is claimed.
         if (server) bus?.attachUpgrade(server)
+
+        // Seed `/_debug/health.adapters` with every peer the framework
+        // mounted alongside us. Before this, only `DevToolsAdapter`
+        // appeared in the Overview > Health card because the dict was
+        // only ever written in `beforeMount` (self) and `shutdown`
+        // (self). Peers with `onHealthCheck` get their live status;
+        // anything else is reported as `running` since reaching
+        // `afterStart` means the framework already mounted them.
+        for (const peer of getPeerAdapters()) {
+          const name = peer?.name
+          if (typeof name !== 'string' || name === 'DevToolsAdapter') continue
+          adapterStatuses[name] = 'running'
+        }
+
         log.info(
           `DevTools ready — ${routes.length} routes tracked, ` +
             `${container?.getRegistrations().length ?? 0} DI bindings, ` +

--- a/packages/devtools/src/adapter.ts
+++ b/packages/devtools/src/adapter.ts
@@ -97,6 +97,30 @@ function writeSseEvent(res: Response, payload: unknown): void {
 }
 
 /**
+ * Race a promise against a timeout. Clears the timer when the inner
+ * promise wins so we don't leak handles every time a peer responds
+ * quickly. Used to bound peer `onHealthCheck()` calls inside the
+ * `/_debug/health` handler — one slow peer must not be able to stall
+ * the dashboard request.
+ */
+function raceWithTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+  })
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer)
+  })
+}
+
+/**
+ * Per-peer budget for `onHealthCheck()` inside `/_debug/health`.
+ * Long enough for a typical DB ping or remote check, short enough that
+ * one misbehaving adapter can't stall the dashboard endpoint.
+ */
+const PEER_HEALTHCHECK_TIMEOUT_MS = 1500
+
+/**
  * Module-scoped guard for `POST /_debug/memory/snapshot`. `writeHeapSnapshot()`
  * blocks the event loop for the duration of the capture (multi-second
  * for large heaps); two concurrent captures would compound the pause.
@@ -486,6 +510,12 @@ export const DevToolsAdapter = defineAdapter<DevToolsOptions, DevToolsAdapterExt
           // upgrades that to a live `up`/`down`/`degraded` reading so
           // the Overview > Health card reflects actual adapter state,
           // not just "registered at boot".
+          //
+          // Each peer call is bounded by `PEER_HEALTHCHECK_TIMEOUT_MS` —
+          // an adapter whose check hangs (network DB ping, remote
+          // service, etc.) must not be able to stall the entire
+          // dashboard request. Timed-out peers fall through to the
+          // catch arm and are reported as `down`.
           const live: Record<string, string> = { ...adapterStatuses }
           await Promise.all(
             getPeerAdapters().map(async (peer) => {
@@ -493,7 +523,11 @@ export const DevToolsAdapter = defineAdapter<DevToolsOptions, DevToolsAdapterExt
               const name: unknown = peer?.name
               if (typeof name !== 'string' || name === 'DevToolsAdapter') return
               try {
-                const result = await peer.onHealthCheck()
+                const result = await raceWithTimeout(
+                  Promise.resolve(peer.onHealthCheck()),
+                  PEER_HEALTHCHECK_TIMEOUT_MS,
+                  `onHealthCheck(${name})`,
+                )
                 if (result && typeof result.status === 'string') {
                   live[name] = result.status
                 }

--- a/packages/kickjs/src/core/decorators.ts
+++ b/packages/kickjs/src/core/decorators.ts
@@ -182,7 +182,16 @@ function applyInjection(
  * `@Inject` is the same function under another name — they share
  * runtime + types so the two names are interchangeable. Pick whichever
  * reads better at the call site.
+ *
+ * Like `@Inject`, the typed string-literal overload narrows the token
+ * to a key of the augmented `KickJsRegistry`. After `kick typegen`
+ * populates the registry, `@Autowired('kick/prisma/Client')` auto-
+ * completes the key and typo'd literals become TS2345 errors.
  */
+export function Autowired<K extends keyof KickJsRegistry & string>(
+  token: K,
+): PropertyOrParameterDecorator
+export function Autowired(token?: unknown): PropertyOrParameterDecorator
 export function Autowired(token?: unknown): PropertyOrParameterDecorator {
   return ((
     target: object,


### PR DESCRIPTION
## Why

Two small, unrelated post-#236 DX fixes batched into one PR:

### 1. `@Autowired` lost its typed `KickJsRegistry` overload

The first overload — `<K extends keyof KickJsRegistry & string>(token: K)` —
already exists on `@Inject` but was lost on `@Autowired` during the
dual-position unification in forinda/kick-js#236. Without it, adopters lose
string-literal narrowing + typo detection when reaching for `@Autowired`
instead of `@Inject`, even though the two are interchangeable everywhere
else.

After `kick typegen` populates the registry, `@Autowired('kick/prisma/Client')`
now autocompletes the key and typo'd literals become `TS2345` errors,
matching `@Inject` exactly. No runtime behaviour change.

### 2. DevTools Overview only listed `DevToolsAdapter`

Two bugs hid every adapter except `DevToolsAdapter` from the Overview >
Health card:

- `adapterStatuses` was only ever written by `DevToolsAdapter` for
  itself in `beforeMount`/`shutdown` — peers (`WsAdapter`,
  `QueueAdapter`, etc.) were never added, so `/_debug/health` returned
  `adapters: { DevToolsAdapter: 'running' }` regardless of how many
  other adapters were registered.
- The Overview > Health card's Adapters accordion defaulted to
  collapsed, hiding the list further (so clicking through still
  revealed only `DevToolsAdapter` — doubly invisible).

Fix:

- `afterStart` seeds `adapterStatuses` from `getPeerAdapters()` —
  every mounted peer appears as `running`.
- `/_debug/health` refreshes each entry from `peer.onHealthCheck()`
  when present at request time so the dict reflects live status
  (`up`/`down`/`degraded`) rather than a frozen boot snapshot.
- Overview tab defaults the Adapters accordion to open.

## Changesets

- `@forinda/kickjs` — patch (restore typed-keys overload on `@Autowired`)
- `@forinda/kickjs-devtools` — patch (peer-adapter visibility on `/_debug/health` + Overview)

## Test plan

- [x] `pnpm --filter @forinda/kickjs build` clean
- [x] `pnpm --filter @forinda/kickjs-devtools build` clean
- [x] `pnpm --filter @forinda/kickjs test` — `inject-typed.test.ts` + `inject-autowired-positions.test.ts` (13 pass)
- [x] `pnpm --filter @forinda/kickjs-devtools test` — 93 pass (no regressions)
- [ ] Manual: boot an example app with `WsAdapter` + `QueueAdapter` and confirm both surface on `/_debug/health`
- [ ] Manual: confirm Overview > Health card shows the Adapters list open by default


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `@Autowired` decorator type checking to match `@Inject` behavior, improving string-literal narrowing and typo detection.
  * DevTools Health now reports all peer adapters with live, per-request status checks instead of a static snapshot.
  * DevTools Overview tab now defaults the adapters section to expanded for easier visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/238)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->