### PR TITLE
fix(devtools): bound routeLatency under 404 probing + token doc drift

### DIFF
--- a/.changeset/devtools-audit-cleanups.md
+++ b/.changeset/devtools-audit-cleanups.md
@@ -1,0 +1,24 @@
+---
+'@forinda/kickjs-devtools': patch
+'@forinda/kickjs-devtools-kit': patch
+---
+
+fix(devtools): two audit-found correctness wins
+
+**`routeLatency` map no longer grows unboundedly under 404 probing**
+(`@forinda/kickjs-devtools`).
+
+The request-tracking middleware keyed `routeLatency` by
+`${req.method} ${req.route?.path ?? req.path}` — when no route matched,
+the fallback used the raw URL, so every probed 404 path became its own
+entry. The samples ring buffer was capped at 1000, but the map itself
+had no cap; an attacker hammering random paths could inflate
+`/_debug/metrics` payloads and leak memory indefinitely. Unmatched
+requests now collapse into a single `<unmatched>` bucket per HTTP
+method.
+
+**`DEVTOOLS_BUS` token doc drift** (`@forinda/kickjs-devtools-kit`).
+
+The JSDoc claimed the adapter registered the bus in `beforeStart`, but
+it actually registers in `beforeMount`. Doc-only fix — no runtime
+change.

--- a/packages/devtools-kit/src/bus/token.ts
+++ b/packages/devtools-kit/src/bus/token.ts
@@ -8,7 +8,7 @@
 // owns the WebSocket transport + ws server lifecycle).
 //
 // `@forinda/kickjs-devtools` registers an instance under this token in
-// its adapter's `beforeStart` so anything resolved during plugin boot
+// its adapter's `beforeMount` so anything resolved during plugin boot
 // can grab it. Plugins that resolve before devtools boots get
 // `undefined`; making the dep optional via `@Optional()` is the
 // idiomatic guard.

--- a/packages/devtools/__tests__/devtools.test.ts
+++ b/packages/devtools/__tests__/devtools.test.ts
@@ -301,16 +301,56 @@ describe('DevToolsAdapter', () => {
       expect(stats.totalMs).toBeGreaterThanOrEqual(0)
     })
 
-    it('should fall back to req.path when req.route is undefined', () => {
+    it('buckets requests with no matching route under a single <unmatched> key', () => {
+      // Regression: the previous fallback used `req.path` (the raw URL)
+      // as the latency key, so each probed 404 created a new entry —
+      // unbounded growth in the reactive map. The fix collapses every
+      // unmatched request for a given method into one bucket.
       const adapter = createAdapter()
       const mw = adapter.middleware()[0].handler
 
-      const req = mockReq({ method: 'GET', path: '/fallback', route: undefined } as any)
-      const res = mockRes(200)
-      mw(req, res, mockNext())
-      res._finishCb()
+      const probedPaths = ['/wp-admin', '/.env', '/api/v2/users/123', '/random-junk']
+      for (const path of probedPaths) {
+        const req = mockReq({ method: 'GET', path, route: undefined } as any)
+        const res = mockRes(404)
+        mw(req, res, mockNext())
+        res._finishCb()
+      }
 
-      expect(adapter.routeLatency['GET /fallback']).toBeDefined()
+      // All four distinct 404 paths land in the same bucket — none of
+      // the raw URLs become keys.
+      expect(adapter.routeLatency['GET <unmatched>']).toBeDefined()
+      expect(adapter.routeLatency['GET <unmatched>'].count).toBe(4)
+      for (const path of probedPaths) {
+        expect(adapter.routeLatency[`GET ${path}`]).toBeUndefined()
+      }
+    })
+
+    it('keeps matched and unmatched buckets separate per method', () => {
+      const adapter = createAdapter()
+      const mw = adapter.middleware()[0].handler
+
+      // Matched GET — uses the route pattern.
+      const matched = mockReq({ method: 'GET', route: { path: '/api/users' } } as any)
+      const resMatched = mockRes(200)
+      mw(matched, resMatched, mockNext())
+      resMatched._finishCb()
+
+      // Unmatched GET — different raw paths, same bucket.
+      const unmatchedGet = mockReq({ method: 'GET', path: '/junk-1', route: undefined } as any)
+      const resGet = mockRes(404)
+      mw(unmatchedGet, resGet, mockNext())
+      resGet._finishCb()
+
+      // Unmatched POST — separate bucket because the method differs.
+      const unmatchedPost = mockReq({ method: 'POST', path: '/junk-2', route: undefined } as any)
+      const resPost = mockRes(404)
+      mw(unmatchedPost, resPost, mockNext())
+      resPost._finishCb()
+
+      expect(adapter.routeLatency['GET /api/users']).toBeDefined()
+      expect(adapter.routeLatency['GET <unmatched>']).toBeDefined()
+      expect(adapter.routeLatency['POST <unmatched>']).toBeDefined()
     })
   })
 

--- a/packages/devtools/src/adapter.ts
+++ b/packages/devtools/src/adapter.ts
@@ -939,7 +939,14 @@ export const DevToolsAdapter = defineAdapter<DevToolsOptions, DevToolsAdapterExt
                 if (res.statusCode >= 500) errorCount.value++
                 else if (res.statusCode >= 400) clientErrorCount.value++
 
-                const routeKey = `${req.method} ${req.route?.path ?? req.path}`
+                // Bucket unmatched paths (404s) under a single key. The
+                // previous `?? req.path` fallback used the raw URL, which
+                // grows the reactive map unboundedly under 404 probing —
+                // each random path became its own entry, bloating
+                // `/_debug/metrics` and leaking memory.
+                const routeKey = req.route?.path
+                  ? `${req.method} ${req.route.path}`
+                  : `${req.method} <unmatched>`
                 const elapsed = Date.now() - start
 
                 if (!routeLatency[routeKey]) {


### PR DESCRIPTION
## Why

Two low-risk audit findings from inspecting the devtools wiring after forinda/kick-js#238 landed. Both are correctness wins with no behaviour change for adopters in the happy path.

### 1. `routeLatency` map grew unboundedly under 404 probing

`packages/devtools/src/adapter.ts:942` keyed `routeLatency` by `${req.method} ${req.route?.path ?? req.path}`. When no route matched, the fallback used the raw URL — so every probed 404 path became its own entry in the reactive map. The samples ring buffer was capped at 1000, but the map itself had no cap.

An attacker hammering random paths (`/wp-admin`, `/.env`, `/wp-login.php`, …) could inflate `/_debug/metrics` payloads and leak memory indefinitely. Unmatched requests now collapse into a single `<unmatched>` bucket per HTTP method — `GET <unmatched>`, `POST <unmatched>`, etc.

### 2. `DEVTOOLS_BUS` token doc drift

`packages/devtools-kit/src/bus/token.ts:11` claimed the adapter registers the bus in `beforeStart`. The actual registration happens in `beforeMount` (`adapter.ts:444`). Doc-only fix — no runtime change.

## Outstanding audit items (NOT in this PR)

Surfaced during the audit but deferred — both want design discussion before patching:

- **Stale `DEVTOOLS_BUS` after shutdown**: `shutdown()` calls `bus?.close()` but the container has no `unregister` method, so HMR rebuilds resolve the closed bus. Possible fixes: add `Container.unregister()`, skip `bus.close()` and create fresh on rebuild, or tag shutdowns as HMR-vs-real-exit. Tradeoffs differ — needs design.
- **`peerAdapters` constructor option is mostly dead**: typed `any[]` and only used as a fallback when `appRef.__kickApp` is absent (effectively never). Either narrow the type or remove the option — soft API break either way.

## Test plan

- [x] `pnpm --filter @forinda/kickjs-devtools build` clean
- [x] `pnpm --filter @forinda/kickjs-devtools-kit build` clean
- [x] `pnpm --filter @forinda/kickjs-devtools test` — 94 pass (was 93, +1 for matched/unmatched separation coverage; replaced the old "fall back to req.path" test that asserted the buggy behaviour)
- [ ] Manual: hit `/_debug/metrics` after probing several 404 paths, confirm only `<unmatched>` bucket exists

## Changesets

- `@forinda/kickjs-devtools` — patch (`routeLatency` bucketing)
- `@forinda/kickjs-devtools-kit` — patch (token JSDoc fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unbounded growth in devtools latency metrics during 404 probing by consolidating unmatched requests into a single bucket per HTTP method.

* **Documentation**
  * Corrected timing documentation for token registration.

* **Tests**
  * Added regression tests to verify unmatched request bucketing and prevent metric key explosion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/240)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->