### PR TITLE
fix(http) + feat(cli): context-decorator pipeline + jiti-based config loader

### DIFF
--- a/.changeset/fix-cli-config-loader.md
+++ b/.changeset/fix-cli-config-loader.md
@@ -1,0 +1,11 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+feat(cli): load TypeScript configs with jiti + walk-up project root resolution
+
+`kick.config.ts` no longer needs `tsx` wrapping or a manual loader — the CLI now imports it through `jiti` directly. Previously, `loadKickConfig` did a bare `await import('kick.config.ts')` which throws `ERR_UNKNOWN_FILE_EXTENSION` on vanilla Node; the bare `catch` swallowed it and silently returned `null`, so adopters' `plugins[]`, `commands[]`, `modules{}`, and `typegen{}` blocks were all dropped without explanation. The new path uses `jiti` (already a transitive dep across the workspace), and the warning fires only when `jiti` itself can't be resolved.
+
+`loadKickConfig` and `kick typegen` now walk up from the invocation cwd to find `kick.config.*` (or `package.json` as a fallback). Running `kick typegen` from inside `src/` used to resolve `srcDir` and `outDir` against `src/`, producing `src/.kickjs/types/` instead of `<root>/.kickjs/types/`. The new `findProjectRoot()` helper (exported from `@forinda/kickjs-cli`) makes this deterministic: it returns the first ancestor with a `kick.config.*`, or — only as a fallback — the first ancestor with a `package.json`.
+
+Also drops a handful of stale `graphql` mentions: the CLI no longer advertises a `--template graphql` flag (never existed; valid set is `rest | ddd | cqrs | minimal`), the `kick g resolver` doc line and the GraphQLAdapter rows in the example `kick inspect` output were removed, and a stray comment in `resolve-out-dir.ts` was corrected. GraphQL remains documented as a BYO recipe via `defineAdapter()` / `definePlugin()` (`docs/guide/migration-v3-to-v4.md`) — that hasn't changed.

--- a/.changeset/fix-module-contributors-auto-derived-router.md
+++ b/.changeset/fix-module-contributors-auto-derived-router.md
@@ -1,0 +1,9 @@
+---
+'@forinda/kickjs': patch
+---
+
+fix(http): preserve module/adapter/global context contributors across auto-derived router builds
+
+When a module returns `{ path, controller }` (auto-derive shape) instead of `{ path, router: buildRoutes(...) }`, the framework calls `buildRoutes(controller)` after `mod.routes()` returns. The internal `_externalContributorSources` slot was being cleared in a `finally` immediately after `mod.routes()` — so by the time `buildRoutes` ran, module-level, adapter-level, and global contributors were dropped from the pipeline. Any class/method-level `dependsOn` against a module-level key surfaced at boot as `MissingContributorError: Missing context contributor '<key>' required by '<dependent>' on route ...`.
+
+The slot lifetime now spans both `mod.routes()` and the subsequent per-route `buildRoutes(controller)` calls, then clears in a single `finally`. Existing modules that pre-built routers inside `routes()` were unaffected (they ran while the slot was still set) — this fix closes the gap for the documented `{ path, controller }` shape and `defineModule({ build: () => ({ contributors, routes }) })` pattern.

--- a/docs/guide/cli-commands.md
+++ b/docs/guide/cli-commands.md
@@ -302,7 +302,6 @@ Generate code scaffolds. See the [Generators](./generators.md) page for full det
 kick g --list            # List all available generators
 kick g module user       # Structure depends on pattern in kick.config.ts
 kick g module user --pattern rest  # Force flat REST structure
-kick g resolver product  # GraphQL resolver with @Query/@Mutation/@Arg
 kick g job email         # Queue job processor with @Job/@Process
 kick g scaffold Post title:string body:text:optional  # CRUD from fields
 kick g controller auth
@@ -443,12 +442,9 @@ Example output:
     PUT     /api/users/:id
     DELETE  /api/users/:id
     GET     /api/posts
-    POST    /api/posts
-    GET     /graphql          [GraphQLAdapter]
     WS      /chat             [WsAdapter]
 
-  Adapters (3):
-    GraphQLAdapter     /graphql
+  Adapters (2):
     WsAdapter          /chat
     DevToolsAdapter    /_debug
 
@@ -458,7 +454,6 @@ Example output:
   DI Container:
     Services:    8
     Controllers: 4
-    Resolvers:   2
 ```
 
 ## Port Configuration

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -31,7 +31,7 @@ kick mcp start            # Run app as an MCP stdio server
 kick typegen              # Refresh KickRoutes / KickEnv type maps
 ```
 
-`kick new` is interactive (template, package manager, ORM, package multi-select, git init, install) — every prompt has a flag for CI: `--template rest|graphql|ddd|cqrs|minimal`, `--pm pnpm|npm|yarn`, `--repo prisma|drizzle|inmemory|custom`, `--no-git`, `--no-install`, `--force`.
+`kick new` is interactive (template, package manager, ORM, package multi-select, git init, install) — every prompt has a flag for CI: `--template rest|ddd|cqrs|minimal`, `--pm pnpm|npm|yarn`, `--repo prisma|drizzle|inmemory|custom`, `--no-git`, `--no-install`, `--force`.
 
 ## Documentation
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -77,6 +77,7 @@
     "@forinda/kickjs-db": "workspace:*",
     "commander": "^14.0.3",
     "glob": "^13.0.6",
+    "jiti": "^2.7.0",
     "oxfmt": "^0.49.0",
     "picocolors": "^1.1.1",
     "pluralize": "^8.0.0"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,6 +7,7 @@ import { registerCustomCommands } from './commands/custom'
 import { loadKickConfig, type KickConfig } from './config'
 import { mergeCliPlugins } from './plugin'
 import { builtinCliPlugins } from './plugin/builtins'
+import { findProjectRoot } from './utils/project-root'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
@@ -19,12 +20,18 @@ async function main() {
     .description('KickJS — A production-grade, decorator-driven Node.js framework')
     .version(pkg.version)
 
+  // Walk up to find the project root — `kick` invoked from any
+  // subdirectory (e.g. `src/modules/users/`) still resolves the
+  // adopter's kick.config.* + plugins instead of silently falling
+  // back to defaults.
+  const cwd = findProjectRoot(process.cwd())
+
   // Default to {} so spreads + the `commands`/`plugins` reads stay
   // safe when the adopter has no kick.config.ts. The cast keeps the
   // shape downstream — `loadKickConfig` returns `KickConfig | null`,
   // we just substitute an empty config object instead of branching at
   // every use site.
-  const config = (await loadKickConfig(process.cwd())) ?? ({} as KickConfig)
+  const config = (await loadKickConfig(cwd)) ?? ({} as KickConfig)
 
   // Compose built-ins + user plugins into a single pipeline. Conflict
   // detection on plugin name / command name / typegen id runs here —
@@ -33,7 +40,7 @@ async function main() {
   const merged = mergeCliPlugins(allPlugins, config.commands ?? [])
 
   await merged.register(program, {
-    cwd: process.cwd(),
+    cwd,
     config,
     log: (msg) => console.log(msg),
   })

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -13,6 +13,7 @@ import { resolve } from 'node:path'
 import { runTypegen, sweepStaleTypegen, TokenCollisionError, watchTypegen } from '../typegen'
 import { runAllPluginTypegens } from '../typegen/run-plugins'
 import { loadKickConfig } from '../config'
+import { findProjectRoot } from '../utils/project-root'
 
 interface TypegenCliOptions {
   watch?: boolean
@@ -76,7 +77,11 @@ export function registerTypegenCommand(program: Command): void {
     .option('--check', 'CI gate: fail on plugin-typegen drift instead of writing')
     .option('--list', 'List every registered typegen plugin id (use to populate `typegen.disable`)')
     .action(async (opts: TypegenCliOptions) => {
-      const cwd = process.cwd()
+      // Walk up from process.cwd() to the directory that owns kick.config.*
+      // (or package.json). Without this, running `kick typegen` from inside
+      // `src/` would resolve srcDir/outDir relative to `src/`, writing
+      // `.kickjs/types/` to `src/.kickjs/types/` instead of the project root.
+      const cwd = findProjectRoot(process.cwd())
 
       // CLI flag wins over kick.config.ts; the config sets the project default.
       const config = await loadKickConfig(cwd)

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -512,10 +512,29 @@ export function resolveModuleConfig(config: KickConfig | null): ModuleConfig {
 
 const CONFIG_FILES = ['kick.config.ts', 'kick.config.js', 'kick.config.mjs', 'kick.config.json']
 
-/** Load kick.config.* from the project root */
-export async function loadKickConfig(cwd: string): Promise<KickConfig | null> {
+/**
+ * Load `kick.config.*` starting from `startDir` and walking up toward
+ * the filesystem root until a config file is found. Returns `null`
+ * when no config exists anywhere on the way up.
+ *
+ * Walking up means adopters can run `kick <cmd>` from any subdirectory
+ * (e.g. `src/modules/users/`) and still pick up the project's config —
+ * before this change a nested-cwd invocation silently saw `null` and
+ * fell back to framework defaults.
+ *
+ * TypeScript configs (`.ts`) are loaded via `jiti` when available;
+ * `.js` / `.mjs` use native `import()`; `.json` uses `JSON.parse`. The
+ * jiti import is dynamic + best-effort: if the dep is missing we
+ * surface a warning telling the adopter how to install it, instead of
+ * silently dropping the config (which is what the previous bare-catch
+ * did).
+ */
+export async function loadKickConfig(startDir: string): Promise<KickConfig | null> {
+  const { findProjectRoot } = await import('./utils/project-root')
+  const root = findProjectRoot(startDir)
+
   for (const filename of CONFIG_FILES) {
-    const filepath = join(cwd, filename)
+    const filepath = join(root, filename)
     try {
       await access(filepath)
     } catch {
@@ -527,24 +546,41 @@ export async function loadKickConfig(cwd: string): Promise<KickConfig | null> {
       return JSON.parse(content)
     }
 
-    // For .ts/.js/.mjs — dynamic import (use file URL for cross-platform compat)
+    const isTs = filename.endsWith('.ts')
+
+    if (isTs) {
+      try {
+        const { createJiti } = await import('jiti')
+        const jiti = createJiti(root, { interopDefault: true, fsCache: false })
+        const config = (await jiti.import(filepath, { default: true })) as KickConfig
+        const warnings = validateAssetMap(config, root)
+        for (const warning of warnings) console.warn(`  Warning: ${warning}`)
+        return config
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        if (msg.includes("Cannot find package 'jiti'") || msg.includes('ERR_MODULE_NOT_FOUND')) {
+          console.warn(
+            `Warning: Failed to load ${filename} — 'jiti' is required for TypeScript configs. ` +
+              "Run `pnpm add -D jiti` (or your package manager's equivalent), or rename the file " +
+              'to kick.config.js / kick.config.mjs / kick.config.json.',
+          )
+        } else {
+          console.warn(`Warning: Failed to load ${filename}: ${msg}`)
+        }
+        continue
+      }
+    }
+
     try {
       const { pathToFileURL } = await import('node:url')
       const mod = await import(pathToFileURL(filepath).href)
       const config = (mod.default ?? mod) as KickConfig
-      // Surface assetMap mistakes at config-load time so they aren't
-      // hidden inside the build pipeline. Warnings only — a typo
-      // shouldn't block `kick g`, `kick typegen`, etc.
-      const warnings = validateAssetMap(config, cwd)
+      const warnings = validateAssetMap(config, root)
       for (const warning of warnings) console.warn(`  Warning: ${warning}`)
       return config
-    } catch {
-      if (filename.endsWith('.ts')) {
-        console.warn(
-          `Warning: Failed to load ${filename}. TypeScript config files require ` +
-            'a runtime loader (e.g. tsx, ts-node) or use kick.config.js/.mjs instead.',
-        )
-      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.warn(`Warning: Failed to load ${filename}: ${msg}`)
       continue
     }
   }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -549,13 +549,18 @@ export async function loadKickConfig(startDir: string): Promise<KickConfig | nul
     const isTs = filename.endsWith('.ts')
 
     if (isTs) {
+      // Split the import-jiti step from the load-user-config step so the
+      // diagnostic blames the right thing. Both surface as Node module-
+      // resolution errors with similar shapes (`Cannot find package …`,
+      // `ERR_MODULE_NOT_FOUND`), but the remedies differ:
+      //
+      // - Missing jiti  → adopter needs to install jiti.
+      // - Missing dep referenced from kick.config.ts → adopter needs to
+      //   install THAT package; telling them to install jiti would send
+      //   them to the wrong fix and bury the real missing module.
+      let jitiModule: typeof import('jiti')
       try {
-        const { createJiti } = await import('jiti')
-        const jiti = createJiti(root, { interopDefault: true, fsCache: false })
-        const config = (await jiti.import(filepath, { default: true })) as KickConfig
-        const warnings = validateAssetMap(config, root)
-        for (const warning of warnings) console.warn(`  Warning: ${warning}`)
-        return config
+        jitiModule = await import('jiti')
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         if (msg.includes("Cannot find package 'jiti'") || msg.includes('ERR_MODULE_NOT_FOUND')) {
@@ -565,8 +570,20 @@ export async function loadKickConfig(startDir: string): Promise<KickConfig | nul
               'to kick.config.js / kick.config.mjs / kick.config.json.',
           )
         } else {
-          console.warn(`Warning: Failed to load ${filename}: ${msg}`)
+          console.warn(`Warning: Failed to initialize jiti for ${filename}: ${msg}`)
         }
+        continue
+      }
+
+      try {
+        const jiti = jitiModule.createJiti(root, { interopDefault: true, fsCache: false })
+        const config = (await jiti.import(filepath, { default: true })) as KickConfig
+        const warnings = validateAssetMap(config, root)
+        for (const warning of warnings) console.warn(`  Warning: ${warning}`)
+        return config
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        console.warn(`Warning: Failed to load ${filename}: ${msg}`)
         continue
       }
     }

--- a/packages/cli/src/generator-extension/define.ts
+++ b/packages/cli/src/generator-extension/define.ts
@@ -43,7 +43,7 @@
  * generators without rewriting their templates.
  */
 export interface GeneratorContext {
-  /** Raw name passed on the command line (`kick g resolver UserPost` → `'UserPost'`). */
+  /** Raw name passed on the command line (`kick g drizzle-typegen UserPost` → `'UserPost'`). */
   name: string
   /** PascalCase form (`UserPost`). */
   pascal: string

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ export { initProject } from './generators/project'
 // Config
 export { defineConfig, loadKickConfig } from './config'
 export type { KickConfig, KickCommandDefinition, KickDbConfigBlock } from './config'
+export { findProjectRoot } from './utils/project-root'
 
 // CLI Plugin contract — adopters write `defineCliPlugin({...})` and add
 // it to `kick.config.ts > plugins[]`. Built-in commands use the same

--- a/packages/cli/src/utils/project-root.ts
+++ b/packages/cli/src/utils/project-root.ts
@@ -1,0 +1,41 @@
+import { existsSync } from 'node:fs'
+import { dirname, parse, resolve } from 'node:path'
+
+const CONFIG_FILENAMES = ['kick.config.ts', 'kick.config.js', 'kick.config.mjs', 'kick.config.json']
+
+/**
+ * Walk up from `startDir` looking for the project root. A directory
+ * counts as the root when it contains any of:
+ * - `kick.config.{ts,js,mjs,json}` (strongest signal)
+ * - `package.json` (fallback when no config file exists yet)
+ *
+ * Returns the absolute path of the first matching directory, or
+ * `startDir` itself when nothing was found (no surprises — callers
+ * that didn't find a config still get a reasonable cwd).
+ *
+ * `kick.config.*` wins over `package.json` when both appear at
+ * different levels, so adopters running `kick typegen` from `src/`
+ * land on the project root that owns the config, not on the nearest
+ * workspace package boundary in a monorepo.
+ */
+export function findProjectRoot(startDir: string = process.cwd()): string {
+  const start = resolve(startDir)
+  const { root: fsRoot } = parse(start)
+
+  let firstPackageJson: string | null = null
+  let cursor = start
+  while (true) {
+    for (const name of CONFIG_FILENAMES) {
+      if (existsSync(resolve(cursor, name))) return cursor
+    }
+    if (firstPackageJson === null && existsSync(resolve(cursor, 'package.json'))) {
+      firstPackageJson = cursor
+    }
+    if (cursor === fsRoot) break
+    const parent = dirname(cursor)
+    if (parent === cursor) break
+    cursor = parent
+  }
+
+  return firstPackageJson ?? start
+}

--- a/packages/cli/src/utils/resolve-out-dir.ts
+++ b/packages/cli/src/utils/resolve-out-dir.ts
@@ -14,7 +14,7 @@ const DDD_FOLDER_MAP: Record<string, string> = {
 }
 
 /**
- * Flat folder mapping — REST/GraphQL/minimal patterns.
+ * Flat folder mapping — REST and minimal patterns.
  * Files live at the module root or in minimal subdirectories.
  */
 const FLAT_FOLDER_MAP: Record<string, string> = {

--- a/packages/kickjs/__tests__/contributor-registration-sites.test.ts
+++ b/packages/kickjs/__tests__/contributor-registration-sites.test.ts
@@ -327,6 +327,66 @@ describe('contributor sources — Application threading + per-module isolation',
       b: 'B-value',
     })
   })
+
+  // Regression: when a module returns `{ path, controller }` (auto-derive shape)
+  // instead of `{ path, router: buildRoutes(...) }`, the framework calls
+  // buildRoutes() AFTER mod.routes() returns. The external-contributor slot must
+  // stay populated across that auto-derive call or the module-level registrations
+  // (and any class-level dependsOn against them) are silently dropped.
+  it('threads module/adapter/global contributors through the auto-derived router (controller-only shape)', async () => {
+    const LoadLocale: ContributorRegistration = defineContextDecorator({
+      key: 'locale',
+      resolve: () => ({ language: 'en', region: 'US' }),
+    }).registration
+
+    const CheckLocale: ContributorRegistration = defineContextDecorator({
+      key: 'check-locale',
+      dependsOn: ['locale'],
+      resolve: () => 'ok',
+    }).registration
+
+    @Controller()
+    class HelloController {
+      @Get('/')
+      probe(ctx: RequestContext) {
+        return ctx.json({
+          locale: ctx.get('locale'),
+          check: ctx.get('check-locale'),
+        })
+      }
+    }
+
+    // Apply class-level contributor by writing to the metadata directly so the
+    // test doesn't depend on the decorator factory's TS overloads.
+    const { METADATA } = await import('../src/index')
+    const { pushClassMeta } = await import('../src/core/metadata')
+    pushClassMeta(METADATA.CLASS_CONTRIBUTORS, HelloController, CheckLocale)
+
+    class HelloModule implements AppModule {
+      contributors() {
+        return [LoadLocale]
+      }
+      routes(): ModuleRoutes {
+        // Auto-derive shape: framework calls buildRoutes(HelloController) later.
+        return { path: '/hello', controller: HelloController }
+      }
+    }
+
+    const { Application } = await import('../src/index')
+    const app = new Application({
+      modules: [HelloModule],
+      apiPrefix: '/api',
+      defaultVersion: 1,
+    })
+    await app.setup()
+
+    const res = await request(app.getExpressApp()).get('/api/v1/hello/')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({
+      locale: { language: 'en', region: 'US' },
+      check: 'ok',
+    })
+  })
 })
 
 // ── Plugin-level contributors (#107) ────────────────────────────────────

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -576,50 +576,55 @@ export class Application {
 
       // Thread per-module + adapter + global sources to buildRoutes via the
       // module-scoped slot. Module setup is sequential, so the slot is
-      // race-free; the finally block clears it even if mod.routes() throws.
+      // race-free. The slot MUST stay populated across both `mod.routes()`
+      // AND any framework-driven `buildRoutes(controller)` calls below —
+      // when a module returns `{ path, controller }` (auto-derive shape),
+      // buildRoutes runs here, not inside routes(). Clearing the slot in
+      // the routes()-finally would drop module/adapter/global contributors
+      // on the floor and surface as `MissingContributorError` for any
+      // class/method-level dependsOn referencing a module-level key.
       _setExternalContributorSources([...moduleSources, ...adapterSources, ...globalSources])
-      let result: ReturnType<AppModule['routes']>
       try {
-        result = mod.routes()
-      } finally {
-        _setExternalContributorSources([])
-      }
-      if (!result) continue // Non-HTTP modules (queues, cron) may return null
+        const result = mod.routes()
+        if (!result) continue // Non-HTTP modules (queues, cron) may return null
 
-      const routeSets = Array.isArray(result) ? result : [result]
+        const routeSets = Array.isArray(result) ? result : [result]
 
-      for (const route of routeSets) {
-        const version = route.version ?? defaultVersion
-        const mountPath = `${apiPrefix}/v${version}${normalizePath(route.path)}`
-        // Derive the router from `controller` when one wasn't passed
-        // explicitly. The common-case shape is `{ path, controller }` —
-        // the framework owns `buildRoutes(controller)` so adopters don't
-        // import + call it themselves. Adopters who hand-build a router
-        // (composing multiple controllers, mounting third-party routers)
-        // pass `router` explicitly and we use it as-is.
-        const router = route.router ?? buildRoutes(route.controller)
-        if (!router) {
-          throw new Error(
-            `Module route at ${mountPath} requires either 'controller' or 'router'. ` +
-              'Pass `controller: SomeController` for the common case (the framework calls ' +
-              'buildRoutes() internally) or `router: yourRouter` to hand-build it.',
-          )
-        }
-        this.app.use(mountPath, router)
+        for (const route of routeSets) {
+          const version = route.version ?? defaultVersion
+          const mountPath = `${apiPrefix}/v${version}${normalizePath(route.path)}`
+          // Derive the router from `controller` when one wasn't passed
+          // explicitly. The common-case shape is `{ path, controller }` —
+          // the framework owns `buildRoutes(controller)` so adopters don't
+          // import + call it themselves. Adopters who hand-build a router
+          // (composing multiple controllers, mounting third-party routers)
+          // pass `router` explicitly and we use it as-is.
+          const router = route.router ?? buildRoutes(route.controller)
+          if (!router) {
+            throw new Error(
+              `Module route at ${mountPath} requires either 'controller' or 'router'. ` +
+                'Pass `controller: SomeController` for the common case (the framework calls ' +
+                'buildRoutes() internally) or `router: yourRouter` to hand-build it.',
+            )
+          }
+          this.app.use(mountPath, router)
 
-        // Notify adapters (e.g. SwaggerAdapter for OpenAPI spec generation)
-        if (route.controller) {
-          for (const adapter of this.adapters) {
-            try {
-              adapter.onRouteMount?.(route.controller, mountPath)
-            } catch (err) {
-              log.error(err, `adapter.onRouteMount() failed for ${mountPath}`)
+          // Notify adapters (e.g. SwaggerAdapter for OpenAPI spec generation)
+          if (route.controller) {
+            for (const adapter of this.adapters) {
+              try {
+                adapter.onRouteMount?.(route.controller, mountPath)
+              } catch (err) {
+                log.error(err, `adapter.onRouteMount() failed for ${mountPath}`)
+              }
+            }
+            if (shouldLogRoutes) {
+              mountedRoutes.push({ controller: route.controller, mountPath })
             }
           }
-          if (shouldLogRoutes) {
-            mountedRoutes.push({ controller: route.controller, mountPath })
-          }
         }
+      } finally {
+        _setExternalContributorSources([])
       }
     }
 

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -1,6 +1,6 @@
 /// <reference types="multer" />
 import type { Request, Response, NextFunction } from 'express'
-import { type ContextMeta, type ExecutionContext, type MetaValue } from '../core/execution-context'
+import { type ExecutionContext, type MetaValue } from '../core/execution-context'
 import { requestStore } from './request-store'
 import {
   parseQuery,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -848,6 +848,9 @@ importers:
       glob:
         specifier: ^13.0.6
         version: 13.0.6
+      jiti:
+        specifier: ^2.7.0
+        version: 2.7.0
       oxfmt:
         specifier: ^0.49.0
         version: 0.49.0


### PR DESCRIPTION
## Summary

Two foundational bugs surfaced from a `kickjs`-based project:

1. **Context decorators registered at module level were never reaching the per-route pipeline** when a module returned `{ path, controller }` (the documented auto-derive shape). Any class/method-level `dependsOn` referencing a module-level key surfaced at boot as `MissingContributorError`.
2. **`kick.config.ts` was silently failing to load** unless adopters wrapped the binary in `tsx`. The bare `await import('kick.config.ts')` threw `ERR_UNKNOWN_FILE_EXTENSION` and the bare `catch` swallowed it, leaving `plugins[]`, `commands[]`, `modules{}`, `typegen{}` all dropped without explanation. Compounding this, `kick typegen` from a nested folder wrote `.kickjs/types/` inside that folder instead of the project root.

## Changes

### `fix(http)` — `packages/kickjs`
- `Application.setup()` now keeps `_externalContributorSources` populated across both `mod.routes()` and the subsequent framework-driven `buildRoutes(controller)` calls, clearing in a single try/finally that wraps the whole module-mount iteration.
- Regression test in `contributor-registration-sites.test.ts` covers the `{ path, controller }` auto-derive shape with a class-level `dependsOn` against a module-level contributor.
- Patch changeset.

### `feat(cli)` — `packages/cli`
- `loadKickConfig` imports `.ts` configs through `jiti` (already a transitive workspace dep). The warning only fires when `jiti` itself is missing, instead of swallowing any throw silently.
- New `findProjectRoot()` walks up from the invocation cwd looking for `kick.config.*` or `package.json`. Exported from `@forinda/kickjs-cli`. Wired into `loadKickConfig` and `kick typegen`.
- Stale `graphql` references scrubbed from the CLI README (the never-existed `--template graphql` flag), the example `kick inspect` output in `docs/guide/cli-commands.md`, the `kick g resolver` doc line (that generator was never added), and a stray JSDoc / comment. GraphQL remains documented as a BYO recipe.
- Minor changeset.

## Why not bundle the CLI fix into a patch?

`findProjectRoot` is a new public export. That's an additive surface change, so the changeset is `minor` for `@forinda/kickjs-cli`. The framework fix in `@forinda/kickjs` is purely a behavior fix — `patch`.

## Test plan

- [x] New regression test passes (`pnpm vitest run __tests__/contributor-registration-sites.test.ts` — 12 / 12 green, including `threads module/adapter/global contributors through the auto-derived router (controller-only shape)`)
- [x] Existing `contributor-registration-sites.test.ts` + `contributor-http-integration.test.ts` + `parameterised-contributors-tenant-flow.test.ts` still pass
- [x] CLI package tests: 270 passing / 21 pre-existing failures cascade from a separate `@forinda/kickjs-ai` typecheck miss on `main` — unrelated to this PR (reproducible by stashing and re-running on `main`)
- [x] Smoke-tested jiti loading + walk-up resolution by pointing `loadKickConfig` at `testing-app/src/modules/hello/` and confirming it walked up to load `kick.config.ts` from project root with full keys (pattern, packageManager, modules, typegen, commands, plugins)
- [x] Pre-commit hooks (`lint`, `lint-tokens`, `format`) green on both commits
- [ ] Manual: run `kick typegen` from a nested folder in an adopter project; confirm `.kickjs/types/` lands at root
- [ ] Manual: re-enable a `plugins: [...]` entry in an adopter `kick.config.ts`; confirm it loads without `tsx` wrapping

## Follow-ups (out of scope for this PR)

Reported by the same user during this investigation, parked on a task list:
- Plugin generators don't show up in `kick g --help` and bare-name invocations fall through to the module generator
- `kick g agents` should emit into a `.agents/` subfolder, with `CLAUDE.md` becoming a thin pointer
- `kick new` interactive prompts still reference deprecated packages
- `kick g auth-scaffold` still emits `@forinda/kickjs-auth` code instead of the context-decorator pattern
- `defineTypegen` helper to mirror `defineGenerator` ergonomics

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now resolves the project root from any subdirectory so commands and type generation use correct project-scoped paths and outputs.
  * TypeScript config files are loaded more robustly via a runtime loader when available.

* **Bug Fixes**
  * Preserved module-level context contributors for auto-derived route handlers to prevent missing dependency errors.

* **Documentation**
  * Updated CLI docs and templates; removed outdated GraphQL examples.

* **Chores**
  * Added a runtime dependency to improve config loading.

* **Tests**
  * Added a regression test covering contributor preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->