### PR TITLE
feat(cli): plugin generators in kick g --help + defineTypegen helper

### DIFF
--- a/.changeset/cli-plugin-authoring-ergonomics.md
+++ b/.changeset/cli-plugin-authoring-ergonomics.md
@@ -1,0 +1,16 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+feat(cli): plugin generators register as Commander subcommands + `defineTypegen` helper
+
+Two related improvements to the CLI plugin authoring surface:
+
+**`defineTypegen` identity factory.** Mirrors the existing `defineGenerator` ergonomics — adopters can now write `defineTypegen({ id, inputs, generate })` and get full type inference on the `generate(ctx)` body without manually annotating `TypegenPlugin`. Exported alongside `defineGenerator` from `@forinda/kickjs-cli`.
+
+**Plugin generators surface in `kick g --help` and dispatch via Commander.** Previously, `KickCliPlugin.generators[]` entries were only discoverable through `kick g --list`, and a bare invocation like `kick g drizzle-typegen` (no item arg) silently fell through to the module generator — scaffolding a module called "drizzle-typegen" instead of running the plugin. Two changes fix this:
+
+1. `KickCliPluginContext` now carries the merged `generators[]` (threaded through by `mergeCliPlugins.register()`), so `register()` callbacks have access to plugin generators at command-registration time.
+2. The built-in `kick/generate` plugin now iterates over `ctx.generators` and registers each as a real Commander subcommand. The subcommand syntax honors the spec's first `args[]` entry (`<schema>` when required, `[schema]` when optional), and declared `flags[]` show up as `--flag` options. The bare-action dispatch is preserved as a safety net for late-discovered generators (e.g. package.json-resolved entries that didn't reach `mergeCliPlugins`).
+
+The previous `if (names.length >= 2)` gate in the bare action is gone — plugin generators dispatch via Commander whether the adopter passes 0, 1, or N positionals, with required-arg validation handled at the Commander layer.

--- a/packages/cli/__tests__/plugin-merge.test.ts
+++ b/packages/cli/__tests__/plugin-merge.test.ts
@@ -112,4 +112,70 @@ describe('mergeCliPlugins', () => {
     expect(r.generators[0].source).toBe('cqrs-plugin')
     expect(r.generators[0].spec).toBe(spec)
   })
+
+  it('threads merged generators into the register ctx', async () => {
+    const spec = {
+      name: 'drizzle-typegen',
+      description: 'Generate Drizzle types',
+      args: [{ name: 'schema', required: true }],
+      files: () => [],
+    }
+    const plugin = defineCliPlugin({ name: 'drizzle', generators: [spec] })
+    let seen: unknown
+    const consumer = defineCliPlugin({
+      name: 'consumer',
+      register: (_program, ctx) => {
+        seen = ctx?.generators
+      },
+    })
+    const r = mergeCliPlugins([plugin, consumer])
+    await r.register(new Command())
+    expect(Array.isArray(seen)).toBe(true)
+    expect((seen as { spec: { name: string } }[]).map((g) => g.spec.name)).toEqual([
+      'drizzle-typegen',
+    ])
+  })
+})
+
+describe('plugin generators registered as Commander subcommands', () => {
+  it('each plugin generator becomes a kick g <name> subcommand', async () => {
+    const { registerGenerateCommand } = await import('../src/commands/generate')
+    const spec = {
+      name: 'drizzle-typegen',
+      description: 'Generate Drizzle types',
+      args: [{ name: 'schema', required: true }],
+      flags: [{ name: 'output', description: 'Output path' }],
+      files: () => [],
+    }
+    const program = new Command()
+    registerGenerateCommand(program, {
+      cwd: process.cwd(),
+      config: null,
+      log: () => {},
+      generators: [{ source: 'test-plugin', spec }],
+    })
+    const gen = program.commands.find((c) => c.name() === 'generate')!
+    const sub = gen.commands.find((c) => c.name() === 'drizzle-typegen')
+    expect(sub).toBeDefined()
+    // Description includes the source plugin in brackets so adopters
+    // can tell at a glance which plugin shipped the generator.
+    expect(sub!.description()).toContain('Generate Drizzle types')
+    expect(sub!.description()).toContain('[test-plugin]')
+    // First positional honors required-ness from spec.args[0].
+    expect(sub!.usage()).toMatch(/<schema>/)
+    // Flags declared on the spec show up as --flags.
+    const outputFlag = sub!.options.find((o) => o.long === '--output')
+    expect(outputFlag).toBeDefined()
+  })
+
+  it('does not register plugin subcommands when ctx.generators is omitted', async () => {
+    const { registerGenerateCommand } = await import('../src/commands/generate')
+    const program = new Command()
+    registerGenerateCommand(program)
+    const gen = program.commands.find((c) => c.name() === 'generate')!
+    // Built-in subcommands still register (module, controller, etc.).
+    expect(gen.commands.length).toBeGreaterThan(0)
+    // But no plugin-shipped generator slipped in.
+    expect(gen.commands.find((c) => c.name() === 'drizzle-typegen')).toBeUndefined()
+  })
 })

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,7 +1,12 @@
 import { resolve } from 'node:path'
 import type { Command } from 'commander'
-import { listPluginGenerators, tryDispatchPluginGenerator } from '../generator-extension'
+import {
+  listPluginGenerators,
+  tryDispatchPluginGenerator,
+  type DiscoveredGenerator,
+} from '../generator-extension'
 import { mergeCliPlugins } from '../plugin'
+import type { KickCliPluginContext } from '../plugin/types'
 import { generateModule } from '../generators/module'
 import { resolveRepoType, type RepoType } from '../generators/module'
 import { generateAdapter } from '../generators/adapter'
@@ -269,7 +274,7 @@ async function runModuleGeneration(
   await runPostTypegen(dryRun)
 }
 
-export function registerGenerateCommand(program: Command): void {
+export function registerGenerateCommand(program: Command, ctx?: KickCliPluginContext): void {
   const gen = program
     .command('generate [names...]')
     .alias('g')
@@ -298,20 +303,21 @@ export function registerGenerateCommand(program: Command): void {
       const dryRun = isDryRun(cmd)
       setDryRun(dryRun)
 
-      // Try plugin generators first — `kick g <name> <itemName>` where
-      // `<name>` matches a discovered plugin generator wins over the
-      // bare-module shortcut. This lets `kick g command Order` route
-      // to a CQRS plugin without colliding with `kick g <module-name>`.
-      // Config-supplied generators (kick.config.ts > plugins[]) take
-      // priority over the legacy package.json discovery path.
-      if (names.length >= 2) {
-        const [generatorName, itemName, ...rest] = names
+      // Bare-form safety net — plugin generators are registered as real
+      // Commander subcommands further down, so Commander routes
+      // `kick g <plugin-gen> [item]` to its dedicated action before
+      // this bare action ever fires. This block only matters for the
+      // rare case where a plugin generator is discovered late (e.g.
+      // package.json-discovered, not config-supplied) and so didn't
+      // get a Commander subcommand at register time.
+      const [generatorName, itemName, ...rest] = names
+      if (generatorName) {
         const cfg = await loadKickConfig(process.cwd())
         const merged = mergeCliPlugins(cfg?.plugins ?? [], cfg?.commands ?? [])
         const result = await tryDispatchPluginGenerator(
           {
             generatorName,
-            itemName,
+            itemName: itemName ?? '',
             args: rest,
             flags: opts as unknown as Record<string, string | boolean>,
             cwd: process.cwd(),
@@ -717,4 +723,64 @@ export function registerGenerateCommand(program: Command): void {
       })
       printGenerated(files, dryRun)
     })
+
+  // ── Plugin-shipped generators ───────────────────────────────────────
+  // Surface each plugin's generators as real Commander subcommands so
+  // they appear in `kick g --help` and `kick g <name>` (bare form,
+  // no item arg) dispatches without falling through to the module
+  // generator. Without this loop a single-name invocation like
+  // `kick g drizzle-typegen` would silently scaffold a module called
+  // "drizzle-typegen".
+  //
+  // Positional syntax mirrors the spec's first `args[]` entry so the
+  // auto-generated help reads naturally (`drizzle-typegen <schema>`
+  // instead of `drizzle-typegen [itemName]`). The runtime still treats
+  // the first positional as `itemName` for dispatch — the spec entry
+  // is purely a documentation hint to Commander.
+  for (const entry of ctx?.generators ?? []) {
+    registerPluginGeneratorSubcommand(gen, entry)
+  }
+}
+
+function registerPluginGeneratorSubcommand(gen: Command, entry: DiscoveredGenerator): void {
+  const { source, spec } = entry
+  const firstArg = spec.args?.[0]
+  const firstArgName = firstArg?.name ?? 'itemName'
+  const firstArgSyntax = firstArg?.required ? `<${firstArgName}>` : `[${firstArgName}]`
+  // Variadic catch-all for any additional positionals; runtime forwards
+  // them to the generator as `ctx.args` for the generator's own parsing.
+  const cmdSyntax = `${spec.name} ${firstArgSyntax} [extraArgs...]`
+
+  const subCmd = gen.command(cmdSyntax).description(`${spec.description}  [${source}]`)
+  for (const flag of spec.flags ?? []) {
+    const flagBody = flag.takesValue ? `--${flag.name} <value>` : `--${flag.name}`
+    const flagWithAlias = flag.alias ? `-${flag.alias}, ${flagBody}` : flagBody
+    subCmd.option(flagWithAlias, flag.description ?? '')
+  }
+
+  // Commander invokes `.action` with one parameter per positional in
+  // declaration order, then opts, then the Command instance. Two
+  // positionals here (firstArg + variadic extraArgs) → 4-arg signature.
+  subCmd.action(
+    async (
+      firstValue: string | undefined,
+      extraArgs: string[],
+      opts: Record<string, unknown>,
+      command: Command,
+    ) => {
+      const dryRun = isDryRun(command)
+      setDryRun(dryRun)
+      const result = await tryDispatchPluginGenerator(
+        {
+          generatorName: spec.name,
+          itemName: firstValue ?? '',
+          args: extraArgs ?? [],
+          flags: opts as Record<string, string | boolean>,
+          cwd: process.cwd(),
+        },
+        [entry],
+      )
+      if (result) printGenerated(result.files, dryRun)
+    },
+  )
 }

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -742,6 +742,30 @@ export function registerGenerateCommand(program: Command, ctx?: KickCliPluginCon
   }
 }
 
+/**
+ * Wire a single {@link DiscoveredGenerator} entry into the `kick g`
+ * Commander tree as a dedicated subcommand. Called once per merged
+ * plugin generator at CLI bootstrap so the entry shows up in
+ * `kick g --help` and routes through Commander instead of falling
+ * through the bare-action dispatch.
+ *
+ * Behaviour:
+ *
+ * - Positional syntax mirrors `spec.args[0]` so the help reads
+ *   naturally (`drizzle-typegen <schema>` vs `drizzle-typegen
+ *   [itemName]`). Required-ness comes from `spec.args[0].required`;
+ *   additional positionals are bundled into a variadic catch-all and
+ *   forwarded to the generator as `ctx.args` for its own parsing.
+ * - Each `spec.flags[]` entry becomes a Commander `.option(...)`
+ *   with optional alias + value-taking shape preserved.
+ * - The action handler dispatches via {@link tryDispatchPluginGenerator}
+ *   restricted to the single matching entry — keeping the runtime path
+ *   identical to the bare-action fallback so behaviour stays consistent
+ *   whether Commander routes the call or the safety-net catches it.
+ *
+ * The source plugin name is appended to the description in `[brackets]`
+ * so adopters can see at a glance which plugin shipped each generator.
+ */
 function registerPluginGeneratorSubcommand(gen: Command, entry: DiscoveredGenerator): void {
   const { source, spec } = entry
   const firstArg = spec.args?.[0]

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,7 @@ export { defineCliPlugin, KickPluginConflictError } from './plugin/types'
 
 // Typegen plugin contract — passed via `KickCliPlugin.typegens`.
 export type { TypegenPlugin, TypegenContext, TypegenPluginResult } from './typegen/plugin'
+export { defineTypegen } from './typegen/plugin'
 
 // Plugin Generator Extension API (architecture.md §21.2.3)
 // Plugins ship `kick g <name>` generators via `kickjs.generators` in

--- a/packages/cli/src/plugin/merge.ts
+++ b/packages/cli/src/plugin/merge.ts
@@ -100,11 +100,14 @@ export function mergeCliPlugins(
   }
 
   const register = async (program: Command, ctx?: KickCliPluginContext): Promise<void> => {
-    const resolved: KickCliPluginContext = ctx ?? {
-      cwd: process.cwd(),
-      config: null,
-      log: () => {},
-    }
+    // Default ctx if caller didn't provide one (tests, scripts). Thread
+    // `generators` through so the `kick/generate` built-in can register
+    // each plugin generator as a real Commander subcommand. Caller-
+    // supplied ctx wins for every field — including `generators`, in
+    // case a test fixture wants to inject a different set.
+    const resolved: KickCliPluginContext = ctx
+      ? { generators, ...ctx }
+      : { cwd: process.cwd(), config: null, log: () => {}, generators }
     for (const p of plugins) {
       if (p.register) await p.register(program, resolved)
     }

--- a/packages/cli/src/plugin/types.ts
+++ b/packages/cli/src/plugin/types.ts
@@ -28,6 +28,7 @@ import type { Command } from 'commander'
 import type { TypegenPlugin } from '../typegen/plugin'
 import type { KickCommandDefinition, KickConfig } from '../config'
 import type { GeneratorSpec } from '../generator-extension/define'
+import type { DiscoveredGenerator } from '../generator-extension/discover'
 
 /**
  * Runtime context handed to `register()` — saves callbacks from
@@ -39,6 +40,18 @@ export interface KickCliPluginContext {
   /** Resolved kick.config.ts (null if the project has none). */
   config: KickConfig | null
   log: (msg: string) => void
+  /**
+   * Plugin-shipped generators merged from built-ins + adopter
+   * `kick.config.ts > plugins[]`. Populated by `mergeCliPlugins` and
+   * threaded through so `register()` callbacks (notably
+   * `kick/generate`) can register each plugin generator as a real
+   * Commander subcommand — without that, plugin generators only fire
+   * via the bare-action dispatch and are invisible to `kick g --help`.
+   *
+   * Optional so light test harnesses that call `plugin.register(program)`
+   * directly (no merge step) stay unaffected.
+   */
+  generators?: DiscoveredGenerator[]
 }
 
 export interface KickCliPlugin {

--- a/packages/cli/src/typegen/plugin.ts
+++ b/packages/cli/src/typegen/plugin.ts
@@ -76,3 +76,30 @@ export interface TypegenPluginResult {
   status: 'written' | 'unchanged' | 'skipped'
   outFile?: string
 }
+
+/**
+ * Identity factory for {@link TypegenPlugin}. Returns the spec verbatim.
+ * Exists for type inference and forward-compatibility — future
+ * fields can be added with defaults without breaking adopters.
+ *
+ * Mirrors {@link defineGenerator} ergonomics. Use at the call site so
+ * the plugin's `generate(ctx)` body gets a fully-typed `ctx` without
+ * an explicit annotation:
+ *
+ * @example
+ * ```ts
+ * import { defineTypegen } from '@forinda/kickjs-cli'
+ *
+ * export const drizzleTypegen = defineTypegen({
+ *   id: 'drizzle',
+ *   inputs: ['src/db/schema.ts'],
+ *   async generate(ctx) {
+ *     const schema = await ctx.importTs(`${ctx.cwd}/src/db/schema.ts`)
+ *     return `// declare module …`
+ *   },
+ * })
+ * ```
+ */
+export function defineTypegen(spec: TypegenPlugin): TypegenPlugin {
+  return spec
+}


### PR DESCRIPTION
## Summary

Closes two of the CLI plugin authoring gaps surfaced during the testing-app investigation that opened #241:

- **`kick g <plugin-gen>` (bare-name) silently scaffolds a module instead of dispatching to the plugin.**
- **Plugin-shipped generators are absent from `kick g --help`** — only `kick g --list` revealed them.

Plus an ergonomics helper to round out plugin authoring parity:

- **`defineTypegen({...})`** mirroring the existing `defineGenerator` factory.

## Changes

### `defineTypegen` — `packages/cli/src/typegen/plugin.ts`

Identity factory exported from `@forinda/kickjs-cli`. Same shape as `defineGenerator` — adopters get type inference on `generate(ctx)` without manually annotating `TypegenPlugin`.

```ts
import { defineTypegen } from '@forinda/kickjs-cli'

export const drizzleTypegen = defineTypegen({
  id: 'drizzle',
  inputs: ['src/db/schema.ts'],
  async generate(ctx) {
    const schema = await ctx.importTs(`${ctx.cwd}/src/db/schema.ts`)
    return `// declare module …`
  },
})
```

### Plugin generators → real Commander subcommands

`KickCliPluginContext` now carries `generators?: DiscoveredGenerator[]`. `mergeCliPlugins.register()` threads the merged generators into the ctx so `register()` callbacks see them at command-registration time (previously: the ctx had only `cwd`, `config`, `log`).

`registerGenerateCommand(program, ctx)` iterates over `ctx.generators` and calls `gen.command(...)` for each. The Commander subcommand syntax honors the spec's first `args[]` entry — `<schema>` when `required: true`, `[schema]` when optional — and declared `flags[]` become Commander `--option` instances.

```diff
-      if (names.length >= 2) {
-        const [generatorName, itemName, ...rest] = names
-        ...
-      }
-      await runModuleGeneration(names, opts, dryRun)
+      // Bare-form safety net — plugin generators are now real subcommands
+      const [generatorName, itemName, ...rest] = names
+      if (generatorName) {
+        ...dispatch attempt for late-discovered plugins...
+      }
+      await runModuleGeneration(names, opts, dryRun)
```

The bare-action plugin-dispatch is preserved as a safety net for late-discovered generators (e.g. `package.json` `kickjs.generators`-resolved entries that don't reach `mergeCliPlugins`).

## Test plan

- [x] `pnpm vitest run __tests__/plugin-merge.test.ts` — 13/13 passing including 3 new cases:
  - `threads merged generators into the register ctx`
  - `each plugin generator becomes a kick g <name> subcommand` (asserts description + `[source]` attribution + `<schema>` required-positional + `--output` flag)
  - `does not register plugin subcommands when ctx.generators is omitted` (light-harness opt-out)
- [x] `pnpm lint` clean (0 errors, 1 unrelated pre-existing warning in `packages/db`)
- [x] `pnpm typecheck` — only the 3 pre-existing `@forinda/kickjs-ai` errors that exist on `main`; no new errors from this PR
- [x] Manual smoke: built CLI loads testing-app's `kick.config.ts` and surfaces `findProjectRoot`, `loadKickConfig`, `defineTypegen`, `defineGenerator`, `defineCliPlugin` from the public index
- [ ] Manual: re-enable the `plugins: [drizzleCliPlugin(...)]` line in the testing-app `kick.config.ts`, run `kick g --help`, confirm `drizzle-typegen` appears under the `generate` subcommands
- [ ] Manual: run `kick g drizzle-typegen ./src/db/schema.ts` and confirm the plugin's `files()` runs (not the module generator fallback)

## Follow-ups still on the task list

- `#13` — `kick g agents` → `.agents/` subfolder (CLAUDE.md stays at root as a thin pointer)
- `#14` — Audit `kick new` prompts for deprecated dep refs
- `#15` — Migrate `auth-scaffold` off `@forinda/kickjs-auth` to context decorators
- `#17` — Test that adapter/plugin middleware mounts in the declared lifecycle order (separate request from this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `defineTypegen` helper API and re-exported it from the CLI package.
  * Plugin generators now register as real CLI subcommands and show in help.

* **Bug Fixes**
  * Corrected generator fallback so invoking the generate command without extra args dispatches as expected.

* **Tests**
  * Added tests for merged plugin generator registration and CLI subcommand behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->