### PR TITLE
test(http): lock in Application middleware lifecycle mount order

### DIFF
--- a/.changeset/test-lifecycle-mount-order.md
+++ b/.changeset/test-lifecycle-mount-order.md
@@ -1,0 +1,16 @@
+---
+'@forinda/kickjs': patch
+---
+
+test(http): lock in Application middleware lifecycle mount order
+
+Adds a dedicated test file (`__tests__/lifecycle-mount-order.test.ts`) that exercises every documented step of `Application.setup()` and asserts the runtime mount order through the real Express stack. Six cases:
+
+- `beforeMount` → `register()` → `beforeStart` hooks fire during `setup()` in adapter / plugin declaration order
+- `afterStart` only fires under `start()`, never `setup()` (the documented contract for `createTestApp` compatibility)
+- Per-request middleware fires in phase order: `beforeGlobal` (adapter) → plugin → user-declared global → `afterGlobal` (adapter) → `beforeRoutes` (adapter) → route handler
+- `afterRoutes` middleware does fire when a request falls through to the 404 handler — guards against accidentally short-circuiting the chain
+- Multiple adapters within the same phase fire in `dependsOn`-topological order at runtime (cascading from the existing construction-time sort to per-phase execution)
+- Plugin middleware fires before user-declared global middleware (§3c precedes §4)
+
+No production behaviour change — pure regression coverage for previously untested lifecycle contracts.

--- a/packages/kickjs/__tests__/lifecycle-mount-order.test.ts
+++ b/packages/kickjs/__tests__/lifecycle-mount-order.test.ts
@@ -1,0 +1,278 @@
+import 'reflect-metadata'
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import type { Request, Response, NextFunction } from 'express'
+import {
+  Application,
+  Container,
+  Controller,
+  Get,
+  RequestContext,
+  type AppAdapter,
+  type AppModule,
+  type KickPlugin,
+  type ModuleRoutes,
+  type MiddlewareEntry,
+} from '../src/index'
+
+beforeEach(() => {
+  Container.reset()
+})
+
+/**
+ * Locks in the documented Application.setup() lifecycle order
+ * (application.ts §373-385):
+ *
+ *   Hooks fired during setup():
+ *     1. adapter.beforeMount()
+ *     2. plugin.register()                 (DI binding only)
+ *     3. (request-time middleware installed but not yet running)
+ *    11. adapter.beforeStart()
+ *
+ *   Per-request middleware chain (declaration order within each phase):
+ *     1. adapter.middleware() phase=beforeGlobal
+ *     2. plugin.middleware()
+ *     3. user-declared global middleware (options.middleware)
+ *     4. adapter.middleware() phase=afterGlobal
+ *     5. adapter.middleware() phase=beforeRoutes
+ *     6. module route handler
+ *     7. adapter.middleware() phase=afterRoutes   (only if route called next())
+ *
+ *   Only fires under start(), not setup():
+ *     adapter.afterStart()
+ *
+ * Multiple adapters within the same phase fire in dependsOn-sorted
+ * order; the existing application-mount-sort.test.ts covers the sort,
+ * this file covers the per-phase RUNTIME order through the actual
+ * Express middleware stack.
+ */
+
+type Trace = string[]
+
+/** Pluck a tagged adapter with the full set of lifecycle hooks. */
+function buildTracingAdapter(trace: Trace, name: string): AppAdapter {
+  return {
+    name,
+    beforeMount: () => {
+      trace.push(`${name}:beforeMount`)
+    },
+    middleware: () => [
+      {
+        phase: 'beforeGlobal',
+        handler: (_req: Request, _res: Response, next: NextFunction) => {
+          trace.push(`${name}:beforeGlobal-mw`)
+          next()
+        },
+      },
+      {
+        phase: 'afterGlobal',
+        handler: (_req: Request, _res: Response, next: NextFunction) => {
+          trace.push(`${name}:afterGlobal-mw`)
+          next()
+        },
+      },
+      {
+        phase: 'beforeRoutes',
+        handler: (_req: Request, _res: Response, next: NextFunction) => {
+          trace.push(`${name}:beforeRoutes-mw`)
+          next()
+        },
+      },
+      {
+        phase: 'afterRoutes',
+        handler: (_req: Request, _res: Response, next: NextFunction) => {
+          trace.push(`${name}:afterRoutes-mw`)
+          next()
+        },
+      },
+    ],
+    beforeStart: () => {
+      trace.push(`${name}:beforeStart`)
+    },
+    afterStart: () => {
+      trace.push(`${name}:afterStart`)
+    },
+  }
+}
+
+function buildTracingPlugin(trace: Trace, name: string): KickPlugin {
+  return {
+    name,
+    register: () => {
+      trace.push(`${name}:register`)
+    },
+    middleware: () => [
+      (_req: Request, _res: Response, next: NextFunction) => {
+        trace.push(`${name}:middleware`)
+        next()
+      },
+    ],
+  }
+}
+
+function buildTracingModule(trace: Trace): AppModule {
+  @Controller()
+  class TraceController {
+    @Get('/ping')
+    ping(ctx: RequestContext) {
+      trace.push('route:handler')
+      ctx.json({ ok: true })
+    }
+  }
+  return {
+    routes(): ModuleRoutes {
+      return { path: '/trace', controller: TraceController }
+    },
+  }
+}
+
+function userMiddleware(trace: Trace, label: string): MiddlewareEntry {
+  return (_req: Request, _res: Response, next: NextFunction) => {
+    trace.push(label)
+    next()
+  }
+}
+
+describe('Application lifecycle mount order', () => {
+  it('adapter.beforeMount + plugin.register fire during setup() in declared order', async () => {
+    const trace: Trace = []
+    const app = new Application({
+      modules: [],
+      adapters: [buildTracingAdapter(trace, 'A1'), buildTracingAdapter(trace, 'A2')],
+      plugins: [buildTracingPlugin(trace, 'P1'), buildTracingPlugin(trace, 'P2')],
+      // No user middleware → uses framework defaults; doesn't affect lifecycle-hook ordering
+    })
+    await app.setup()
+    // beforeMount for every adapter fires before any plugin.register()
+    // (plugin.register() runs in §3b, beforeMount in §1). beforeStart
+    // for every adapter fires at the very end.
+    const idx = (label: string) => trace.indexOf(label)
+    expect(idx('A1:beforeMount')).toBeLessThan(idx('A2:beforeMount'))
+    expect(idx('A2:beforeMount')).toBeLessThan(idx('P1:register'))
+    expect(idx('P1:register')).toBeLessThan(idx('P2:register'))
+    expect(idx('P2:register')).toBeLessThan(idx('A1:beforeStart'))
+    expect(idx('A1:beforeStart')).toBeLessThan(idx('A2:beforeStart'))
+  })
+
+  it('afterStart does NOT fire under setup() — only start()', async () => {
+    const trace: Trace = []
+    const app = new Application({
+      modules: [],
+      adapters: [buildTracingAdapter(trace, 'Solo')],
+    })
+    await app.setup()
+    expect(trace).toContain('Solo:beforeMount')
+    expect(trace).toContain('Solo:beforeStart')
+    expect(trace).not.toContain('Solo:afterStart')
+  })
+
+  it('per-request middleware fires in documented phase order for a matched route', async () => {
+    const trace: Trace = []
+    const app = new Application({
+      modules: [buildTracingModule(trace)],
+      adapters: [buildTracingAdapter(trace, 'A')],
+      plugins: [buildTracingPlugin(trace, 'P')],
+      middleware: [userMiddleware(trace, 'user-global-mw')],
+      apiPrefix: '/api',
+      defaultVersion: 1,
+    })
+    await app.setup()
+
+    // Reset trace AFTER setup so we only assert on the per-request slice.
+    trace.length = 0
+
+    await request(app.getExpressApp()).get('/api/v1/trace/ping').expect(200)
+
+    // Phases per application.ts §3 → §7:
+    //   beforeGlobal (adapter) → plugin middleware → user global →
+    //   afterGlobal (adapter) → beforeRoutes (adapter) → route handler
+    // afterRoutes does NOT fire here because the route handler ended
+    // the response without calling next() — see the next test for that.
+    expect(trace).toEqual([
+      'A:beforeGlobal-mw',
+      'P:middleware',
+      'user-global-mw',
+      'A:afterGlobal-mw',
+      'A:beforeRoutes-mw',
+      'route:handler',
+    ])
+  })
+
+  it('afterRoutes middleware fires for an unmatched path that falls through to 404', async () => {
+    const trace: Trace = []
+    const app = new Application({
+      modules: [buildTracingModule(trace)],
+      adapters: [buildTracingAdapter(trace, 'A')],
+      middleware: [],
+      apiPrefix: '/api',
+      defaultVersion: 1,
+    })
+    await app.setup()
+    trace.length = 0
+
+    await request(app.getExpressApp()).get('/no-such-path').expect(404)
+
+    // Same chain as the matched-route case, but instead of the route
+    // handler firing, the request falls past the route mount and hits
+    // afterRoutes before the 404 handler responds.
+    expect(trace).toEqual([
+      'A:beforeGlobal-mw',
+      'A:afterGlobal-mw',
+      'A:beforeRoutes-mw',
+      'A:afterRoutes-mw',
+    ])
+  })
+
+  it('multiple adapters fire each phase in dependsOn-topological order', async () => {
+    const trace: Trace = []
+    // AuthAdapter depends on TenantAdapter — sort must put Tenant first
+    // in every phase. Each adapter's hook tags itself, so an out-of-order
+    // run shows up as a flipped pair in the assertion.
+    const tenant = buildTracingAdapter(trace, 'Tenant')
+    const auth = { ...buildTracingAdapter(trace, 'Auth'), dependsOn: ['Tenant' as const] }
+    const app = new Application({
+      modules: [buildTracingModule(trace)],
+      adapters: [auth, tenant], // declared out of order intentionally
+      apiPrefix: '/api',
+      defaultVersion: 1,
+    })
+    await app.setup()
+    trace.length = 0
+    await request(app.getExpressApp()).get('/api/v1/trace/ping').expect(200)
+
+    // Within each phase, Tenant's middleware runs before Auth's because
+    // the constructor topo-sorted Tenant ahead of Auth.
+    const seen = trace.filter((s) => s.endsWith('-mw'))
+    const tenantIdx = seen.findIndex((s) => s.startsWith('Tenant'))
+    const authIdx = seen.findIndex((s) => s.startsWith('Auth'))
+    expect(tenantIdx).toBeGreaterThanOrEqual(0)
+    expect(authIdx).toBeGreaterThanOrEqual(0)
+    expect(tenantIdx).toBeLessThan(authIdx)
+    // Spot-check every phase: Tenant's variant must precede Auth's variant.
+    for (const phase of [
+      'beforeGlobal-mw',
+      'afterGlobal-mw',
+      'beforeRoutes-mw',
+    ] as const) {
+      expect(trace.indexOf(`Tenant:${phase}`)).toBeLessThan(trace.indexOf(`Auth:${phase}`))
+    }
+  })
+
+  it('plugin middleware fires BEFORE user-declared global middleware', async () => {
+    // The framework mounts plugin.middleware() in §3c, before §4 (user
+    // global). Test guards against accidentally swapping those phases —
+    // adopters write middleware expecting plugin context to be ready.
+    const trace: Trace = []
+    const app = new Application({
+      modules: [buildTracingModule(trace)],
+      plugins: [buildTracingPlugin(trace, 'P')],
+      middleware: [userMiddleware(trace, 'user-mw')],
+      apiPrefix: '/api',
+      defaultVersion: 1,
+    })
+    await app.setup()
+    trace.length = 0
+    await request(app.getExpressApp()).get('/api/v1/trace/ping').expect(200)
+    expect(trace.indexOf('P:middleware')).toBeLessThan(trace.indexOf('user-mw'))
+  })
+})

--- a/packages/kickjs/__tests__/lifecycle-mount-order.test.ts
+++ b/packages/kickjs/__tests__/lifecycle-mount-order.test.ts
@@ -133,6 +133,23 @@ function userMiddleware(trace: Trace, label: string): MiddlewareEntry {
   }
 }
 
+/**
+ * Assert `earlier` precedes `later` in trace AND both are present.
+ * Plain `indexOf(...) < indexOf(...)` passes vacuously when either
+ * entry is missing (`-1 < anyPositive`), so a regression that drops
+ * a hook entirely would slip through. Use this helper for ordering
+ * assertions whenever a full-array `toEqual` would be too rigid.
+ */
+function expectOrder(trace: readonly string[], earlier: string, later: string): void {
+  const earlierIdx = trace.indexOf(earlier)
+  const laterIdx = trace.indexOf(later)
+  expect(earlierIdx, `expected '${earlier}' in trace [${trace.join(', ')}]`).toBeGreaterThanOrEqual(
+    0,
+  )
+  expect(laterIdx, `expected '${later}' in trace [${trace.join(', ')}]`).toBeGreaterThanOrEqual(0)
+  expect(earlierIdx, `'${earlier}' should precede '${later}'`).toBeLessThan(laterIdx)
+}
+
 describe('Application lifecycle mount order', () => {
   it('adapter.beforeMount + plugin.register fire during setup() in declared order', async () => {
     const trace: Trace = []
@@ -143,15 +160,22 @@ describe('Application lifecycle mount order', () => {
       // No user middleware → uses framework defaults; doesn't affect lifecycle-hook ordering
     })
     await app.setup()
-    // beforeMount for every adapter fires before any plugin.register()
-    // (plugin.register() runs in §3b, beforeMount in §1). beforeStart
-    // for every adapter fires at the very end.
-    const idx = (label: string) => trace.indexOf(label)
-    expect(idx('A1:beforeMount')).toBeLessThan(idx('A2:beforeMount'))
-    expect(idx('A2:beforeMount')).toBeLessThan(idx('P1:register'))
-    expect(idx('P1:register')).toBeLessThan(idx('P2:register'))
-    expect(idx('P2:register')).toBeLessThan(idx('A1:beforeStart'))
-    expect(idx('A1:beforeStart')).toBeLessThan(idx('A2:beforeStart'))
+    // Strict full-trace equality so a missing hook fails the test —
+    // indexOf-only ordering passes vacuously when an entry is missing
+    // (-1 < anything). The expected sequence is:
+    //   §1  every adapter.beforeMount fires in declaration order
+    //   §3b every plugin.register fires (DI bindings only — no middleware
+    //       handler runs because no request has been sent)
+    //   §11 every adapter.beforeStart fires
+    // No `afterStart` here — covered by the next test.
+    expect(trace).toEqual([
+      'A1:beforeMount',
+      'A2:beforeMount',
+      'P1:register',
+      'P2:register',
+      'A1:beforeStart',
+      'A2:beforeStart',
+    ])
   })
 
   it('afterStart does NOT fire under setup() — only start()', async () => {
@@ -248,13 +272,11 @@ describe('Application lifecycle mount order', () => {
     expect(tenantIdx).toBeGreaterThanOrEqual(0)
     expect(authIdx).toBeGreaterThanOrEqual(0)
     expect(tenantIdx).toBeLessThan(authIdx)
-    // Spot-check every phase: Tenant's variant must precede Auth's variant.
-    for (const phase of [
-      'beforeGlobal-mw',
-      'afterGlobal-mw',
-      'beforeRoutes-mw',
-    ] as const) {
-      expect(trace.indexOf(`Tenant:${phase}`)).toBeLessThan(trace.indexOf(`Auth:${phase}`))
+    // Spot-check every phase: Tenant's variant must precede Auth's
+    // variant AND both must be present (a missing entry would let
+    // bare `indexOf < indexOf` pass vacuously).
+    for (const phase of ['beforeGlobal-mw', 'afterGlobal-mw', 'beforeRoutes-mw'] as const) {
+      expectOrder(trace, `Tenant:${phase}`, `Auth:${phase}`)
     }
   })
 
@@ -273,6 +295,6 @@ describe('Application lifecycle mount order', () => {
     await app.setup()
     trace.length = 0
     await request(app.getExpressApp()).get('/api/v1/trace/ping').expect(200)
-    expect(trace.indexOf('P:middleware')).toBeLessThan(trace.indexOf('user-mw'))
+    expectOrder(trace, 'P:middleware', 'user-mw')
   })
 })


### PR DESCRIPTION
## Summary

Locks in `Application.setup()`'s lifecycle mount order with a dedicated test file. The contract was prose-only (laid out in the `setup()` JSDoc), so swapping two §-numbered phases would land silently.

**Result of the investigation:** no ordering bug — all 6 tests pass against the current implementation on first run. This PR is pure regression coverage.

## What the tests assert

`packages/kickjs/__tests__/lifecycle-mount-order.test.ts` — 6 cases:

1. **Hooks during `setup()` fire in declared order:**
   `adapter.beforeMount` → `plugin.register()` → `adapter.beforeStart`
2. **`afterStart` only fires under `start()`, never `setup()`.** Preserves the documented `createTestApp` compatibility — adapters that use `beforeStart` for DI binding still run under unit tests; `afterStart` is reserved for work that genuinely needs a listening server.
3. **Per-request middleware fires in documented phase order through the real Express stack:**
   `beforeGlobal` (adapter) → plugin middleware → user-declared global → `afterGlobal` (adapter) → `beforeRoutes` (adapter) → route handler
4. **`afterRoutes` middleware DOES fire when a request falls through to 404** — guards against accidentally short-circuiting the chain at route-mount.
5. **Multiple adapters within the same phase fire in `dependsOn`-topological order at runtime.** The construction-time topo-sort (already covered by `application-mount-sort.test.ts`) cascades into per-phase execution.
6. **Plugin middleware fires before user-declared global middleware** (§3c precedes §4 in `Application.setup()`).

The test wires up an actual Express app via `Application` + a stamped `AppAdapter` + stamped `KickPlugin` + a tracing `AppModule` + user middleware, then asserts the resulting trace through `supertest` requests. Real stack, no mocking the middleware pipeline.

## Why now

Asked during the testing-app investigation that opened #241, #243, #244 — the user wanted to know whether middleware actually mounts in the lifecycle order the JSDoc claims. Answer: yes. This PR makes that answer durable.

## Test plan

- [x] `pnpm vitest run __tests__/lifecycle-mount-order.test.ts` — 6/6 passing
- [x] `pnpm lint` — 0 errors (1 unrelated pre-existing warning in `packages/db`)
- [x] Pre-commit hooks (lint / lint-tokens / format) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression tests validating lifecycle hook sequencing during setup and startup, per-request middleware ordering across adapters, plugins and user globals, adapter phase behavior for matched vs unmatched routes, topological ordering when multiple adapters declare dependencies, and plugin precedence over user globals. No production behavior changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->