### PR TITLE
feat(http): widen AdapterMiddleware.path + tighten handler type + clarify lifecycle docs

### DIFF
--- a/.changeset/adapter-middleware-path-patterns.md
+++ b/.changeset/adapter-middleware-path-patterns.md
@@ -1,0 +1,28 @@
+---
+'@forinda/kickjs': minor
+'@forinda/kickjs-cli': patch
+---
+
+feat(http): widen AdapterMiddleware.path + tighten handler typing + clarify lifecycle docs
+
+Three improvements to the adapter middleware contract, surfacing from a real-world bug-report investigation that found no bug — just sharp edges:
+
+**1. Widened path scope.** `AdapterMiddleware.path` now accepts `string | RegExp | (string | RegExp)[]` (new `MiddlewarePath` type, exported from `@forinda/kickjs`) instead of a bare `string`. Mirrors Express's native `app.use(path, …)` shape so adopters get the full range without learning a new mini-language:
+
+```ts
+middleware() {
+  return [
+    { handler: rateLimit(), phase: 'beforeRoutes', path: ['/api', '/admin'] },
+    { handler: csrf(), phase: 'afterGlobal', path: /^\/api\/v\d+\//, },
+    { handler: bodyLog({ region: 'eu' }), phase: 'afterGlobal', path: ['/api', /^\/internal\//] },
+  ]
+}
+```
+
+The framework copies readonly arrays before passing to Express (`PathParams` requires a mutable array), so adopters can declare paths with `as const` without any runtime workaround.
+
+**2. Tighter `handler` typing.** `AdapterMiddleware.handler` is now `RequestHandler | ErrorRequestHandler` instead of `any`. Adapters that ship error-handling middleware get type checking; the union resolves via Express's arity-based dispatch.
+
+**3. Lifecycle JSDoc clarified.** The `MiddlewarePhase` JSDoc spells out the `afterRoutes` semantics — fires **only on fall-through** (no route matched, or a handler called `next()` without ending the response). Controllers that respond with `ctx.json(…)` end the chain and skip this phase. For per-response work (logging, metrics) the doc points adopters at `res.on('finish', …)` from an earlier phase instead. The `kick g middleware` generator template now embeds the same guidance so freshly scaffolded middleware files explain phase trade-offs at the point of use.
+
+New tests in `__tests__/adapter-middleware-path-patterns.test.ts` exercise every path shape (string prefix, array of strings, single RegExp, mixed array, `as const` readonly array, omitted). The existing `lifecycle-mount-order.test.ts` continues to lock in the order semantics.

--- a/packages/cli/src/generators/middleware.ts
+++ b/packages/cli/src/generators/middleware.ts
@@ -66,7 +66,7 @@ export interface ${toPascalCase(name)}Options {
  *     return [{
  *       handler: ${camel}({ region: 'eu' }),
  *       phase: 'afterGlobal',
- *       path: ['/api', /^\\\\/admin/],
+ *       path: ['/api', /^\\/admin/],
  *     }]
  *   }
  *

--- a/packages/cli/src/generators/middleware.ts
+++ b/packages/cli/src/generators/middleware.ts
@@ -34,24 +34,50 @@ export async function generateMiddleware(options: GenerateMiddlewareOptions): Pr
     `import type { Request, Response, NextFunction } from 'express'
 
 export interface ${toPascalCase(name)}Options {
-  // Add configuration options here
+  // Add configuration options here. The factory below closes over the
+  // resolved options object; pass them at the call site —
+  // \`${camel}({ foo: 'bar' })\` — and the closure preserves them across
+  // every request.
 }
 
 /**
  * ${toPascalCase(name)} middleware.
  *
- * Usage in bootstrap:
+ * Usage in bootstrap (fires on every request):
  *   middleware: [${camel}()]
  *
- * Usage with adapter:
- *   middleware() { return [{ handler: ${camel}(), phase: 'afterGlobal' }] }
+ * Usage with adapter — phase controls *when* the handler runs:
+ *
+ *   middleware() {
+ *     return [{ handler: ${camel}(), phase: 'afterGlobal' }]
+ *   }
+ *
+ * Phase semantics (see \`MiddlewarePhase\` JSDoc for the full contract):
+ *   - 'beforeGlobal' / 'afterGlobal' / 'beforeRoutes' — fire on every
+ *     request, before module routes run.
+ *   - 'afterRoutes' — fires ONLY when no route matched (404 fall-through)
+ *     OR a route handler called \`next()\` without ending the response.
+ *     Controllers that call \`ctx.json(…)\` end the chain and skip this
+ *     phase. For per-response work (logging, metrics) attach to
+ *     \`res.on('finish', …)\` from an earlier-phase middleware instead.
+ *
+ * Optional path scope — string, RegExp, or array of either:
+ *   middleware() {
+ *     return [{
+ *       handler: ${camel}({ region: 'eu' }),
+ *       phase: 'afterGlobal',
+ *       path: ['/api', /^\\\\/admin/],
+ *     }]
+ *   }
  *
  * Usage with @Middleware decorator:
  *   @Middleware(${camel}())
  */
 export function ${camel}(options: ${toPascalCase(name)}Options = {}) {
   return (req: Request, res: Response, next: NextFunction) => {
-    // Implement your middleware logic here
+    // Implement your middleware logic here. \`options\` is captured by
+    // closure — log or read it anywhere in this handler body.
+    void options
     next()
   }
 }

--- a/packages/kickjs/__tests__/adapter-middleware-path-patterns.test.ts
+++ b/packages/kickjs/__tests__/adapter-middleware-path-patterns.test.ts
@@ -189,9 +189,7 @@ describe('AdapterMiddleware.path — widened pattern shapes', () => {
     const trace: string[] = []
     const adapter: AppAdapter = {
       name: 'A',
-      middleware: () => [
-        { handler: tap(trace, 'fired'), phase: 'beforeRoutes', path: PATHS },
-      ],
+      middleware: () => [{ handler: tap(trace, 'fired'), phase: 'beforeRoutes', path: PATHS }],
     }
     const app = new Application({
       modules: [new HelloModule(), new AdminModule()],

--- a/packages/kickjs/__tests__/adapter-middleware-path-patterns.test.ts
+++ b/packages/kickjs/__tests__/adapter-middleware-path-patterns.test.ts
@@ -1,0 +1,208 @@
+import 'reflect-metadata'
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import type { Request, Response, NextFunction } from 'express'
+import {
+  Application,
+  Container,
+  Controller,
+  Get,
+  RequestContext,
+  type AppAdapter,
+  type AppModule,
+  type ModuleRoutes,
+} from '../src/index'
+
+beforeEach(() => {
+  Container.reset()
+})
+
+/**
+ * Exercise the widened {@link MiddlewarePath} shape on `AdapterMiddleware`.
+ * Path scope now accepts the same set Express's `app.use(path, …)` takes:
+ *
+ *   string | RegExp | (string | RegExp)[]
+ *
+ * These tests pin the runtime behaviour for each shape so a future
+ * refactor of `mountMiddlewareList` (e.g. dropping the ReadonlyArray
+ * spread) shows up as a regression here.
+ */
+
+@Controller()
+class HelloController {
+  @Get('/ping')
+  ping(ctx: RequestContext) {
+    ctx.json({ ok: true })
+  }
+}
+
+@Controller()
+class AdminController {
+  @Get('/users')
+  users(ctx: RequestContext) {
+    ctx.json({ users: [] })
+  }
+}
+
+class HelloModule implements AppModule {
+  routes(): ModuleRoutes {
+    return { path: '/hello', controller: HelloController }
+  }
+}
+
+class AdminModule implements AppModule {
+  routes(): ModuleRoutes {
+    return { path: '/admin', controller: AdminController }
+  }
+}
+
+function tap(trace: string[], label: string) {
+  return (_req: Request, _res: Response, next: NextFunction) => {
+    trace.push(label)
+    next()
+  }
+}
+
+describe('AdapterMiddleware.path — widened pattern shapes', () => {
+  it('accepts a string prefix (existing behaviour, regression guard)', async () => {
+    const trace: string[] = []
+    const adapter: AppAdapter = {
+      name: 'A',
+      middleware: () => [
+        { handler: tap(trace, 'fired'), phase: 'beforeRoutes', path: '/api/v1/hello' },
+      ],
+    }
+    const app = new Application({
+      modules: [new HelloModule(), new AdminModule()],
+      adapters: [adapter],
+      apiPrefix: '/api',
+      defaultVersion: 1,
+    })
+    await app.setup()
+
+    await request(app.getExpressApp()).get('/api/v1/hello/ping').expect(200)
+    await request(app.getExpressApp()).get('/api/v1/admin/users').expect(200)
+    // Fires only for the hello path.
+    expect(trace).toEqual(['fired'])
+  })
+
+  it('accepts an array of string prefixes — fires for any matching prefix', async () => {
+    const trace: string[] = []
+    const adapter: AppAdapter = {
+      name: 'A',
+      middleware: () => [
+        {
+          handler: tap(trace, 'fired'),
+          phase: 'beforeRoutes',
+          path: ['/api/v1/hello', '/api/v1/admin'],
+        },
+      ],
+    }
+    const app = new Application({
+      modules: [new HelloModule(), new AdminModule()],
+      adapters: [adapter],
+      apiPrefix: '/api',
+      defaultVersion: 1,
+    })
+    await app.setup()
+
+    await request(app.getExpressApp()).get('/api/v1/hello/ping').expect(200)
+    await request(app.getExpressApp()).get('/api/v1/admin/users').expect(200)
+    expect(trace).toEqual(['fired', 'fired'])
+  })
+
+  it('accepts a RegExp — pattern-matches the request URL', async () => {
+    const trace: string[] = []
+    const adapter: AppAdapter = {
+      name: 'A',
+      middleware: () => [
+        {
+          handler: tap(trace, 'fired'),
+          phase: 'beforeRoutes',
+          path: /^\/api\/v\d+\/hello/,
+        },
+      ],
+    }
+    const app = new Application({
+      modules: [new HelloModule(), new AdminModule()],
+      adapters: [adapter],
+      apiPrefix: '/api',
+      defaultVersion: 1,
+    })
+    await app.setup()
+
+    await request(app.getExpressApp()).get('/api/v1/hello/ping').expect(200)
+    await request(app.getExpressApp()).get('/api/v1/admin/users').expect(200)
+    expect(trace).toEqual(['fired'])
+  })
+
+  it('accepts a mixed array of string + RegExp', async () => {
+    const trace: string[] = []
+    const adapter: AppAdapter = {
+      name: 'A',
+      middleware: () => [
+        {
+          handler: tap(trace, 'fired'),
+          phase: 'beforeRoutes',
+          path: ['/api/v1/admin', /^\/api\/v\d+\/hello/],
+        },
+      ],
+    }
+    const app = new Application({
+      modules: [new HelloModule(), new AdminModule()],
+      adapters: [adapter],
+      apiPrefix: '/api',
+      defaultVersion: 1,
+    })
+    await app.setup()
+
+    await request(app.getExpressApp()).get('/api/v1/hello/ping').expect(200)
+    await request(app.getExpressApp()).get('/api/v1/admin/users').expect(200)
+    expect(trace).toEqual(['fired', 'fired'])
+  })
+
+  it('omitting path applies the middleware unconditionally', async () => {
+    const trace: string[] = []
+    const adapter: AppAdapter = {
+      name: 'A',
+      middleware: () => [{ handler: tap(trace, 'fired'), phase: 'beforeRoutes' }],
+    }
+    const app = new Application({
+      modules: [new HelloModule()],
+      adapters: [adapter],
+      apiPrefix: '/api',
+      defaultVersion: 1,
+    })
+    await app.setup()
+
+    await request(app.getExpressApp()).get('/api/v1/hello/ping').expect(200)
+    await request(app.getExpressApp()).get('/no-such-path').expect(404)
+    // Fires for both, since no scope is declared.
+    expect(trace).toEqual(['fired', 'fired'])
+  })
+
+  it('readonly array typed at the spec site survives Express mount (does not throw on use)', async () => {
+    // Adopter declares the path as readonly (`as const`) — common
+    // ergonomic shape for sharing constants. The framework must copy
+    // it before handing to Express, which doesn't accept readonly arrays.
+    const PATHS = ['/api/v1/hello', '/api/v1/admin'] as const
+    const trace: string[] = []
+    const adapter: AppAdapter = {
+      name: 'A',
+      middleware: () => [
+        { handler: tap(trace, 'fired'), phase: 'beforeRoutes', path: PATHS },
+      ],
+    }
+    const app = new Application({
+      modules: [new HelloModule(), new AdminModule()],
+      adapters: [adapter],
+      apiPrefix: '/api',
+      defaultVersion: 1,
+    })
+    // Setup must NOT throw — internal copy handles the readonly → mutable
+    // boundary that Express's PathParams type requires.
+    await expect(app.setup()).resolves.not.toThrow()
+    await request(app.getExpressApp()).get('/api/v1/hello/ping').expect(200)
+    expect(trace).toEqual(['fired'])
+  })
+})

--- a/packages/kickjs/__tests__/adapter-middleware-path-patterns.test.ts
+++ b/packages/kickjs/__tests__/adapter-middleware-path-patterns.test.ts
@@ -197,9 +197,12 @@ describe('AdapterMiddleware.path — widened pattern shapes', () => {
       apiPrefix: '/api',
       defaultVersion: 1,
     })
-    // Setup must NOT throw — internal copy handles the readonly → mutable
-    // boundary that Express's PathParams type requires.
-    await expect(app.setup()).resolves.not.toThrow()
+    // Setup must resolve normally (not reject) — the internal copy
+    // handles the readonly → mutable boundary that Express's
+    // PathParams type requires. `.resolves.toBeUndefined()` checks the
+    // resolved-value side; if the promise rejected instead, vitest
+    // would surface the rejection as the test failure.
+    await expect(app.setup()).resolves.toBeUndefined()
     await request(app.getExpressApp()).get('/api/v1/hello/ping').expect(200)
     expect(trace).toEqual(['fired'])
   })

--- a/packages/kickjs/src/core/adapter.ts
+++ b/packages/kickjs/src/core/adapter.ts
@@ -1,5 +1,5 @@
 import type http from 'node:http'
-import type { Express } from 'express'
+import type { Express, RequestHandler, ErrorRequestHandler } from 'express'
 import type { Container } from './container'
 import type { ContributorRegistrations } from './context-decorator'
 import type { MaybePromise, Constructor } from './interfaces'
@@ -8,21 +8,57 @@ import type { KickJsPluginName } from './augmentation'
 /**
  * Where in the middleware pipeline an adapter's middleware should be inserted.
  *
- *   beforeGlobal  → runs before any user-defined global middleware
- *   afterGlobal   → runs after global middleware, before module routes
- *   beforeRoutes  → just before module routes are mounted
- *   afterRoutes   → after module routes but before error handlers
+ * - `beforeGlobal` — runs **before** any user-defined global middleware.
+ *   Suitable for transport-level concerns (request tagging, low-level
+ *   request rewriting). Fires on every request.
+ * - `afterGlobal` — runs **after** global middleware, **before** module
+ *   routes are matched. Default for most adapter middleware (auth pre-checks,
+ *   tenant resolution, body shaping). Fires on every request.
+ * - `beforeRoutes` — runs just before module routes are mounted. Functionally
+ *   equivalent to `afterGlobal` for most cases; the explicit phase exists so
+ *   adapters that *must* sit at the very end of the pre-route stack can
+ *   declare intent. Fires on every request.
+ * - `afterRoutes` — sits **after** module routes but **before** error
+ *   handlers. **Fires only on fall-through** — when no route matched (404
+ *   path) or a route handler called `next()` without ending the response.
+ *   Controllers that respond with `ctx.json(...)` end the chain and skip
+ *   this phase, so it is *not* a "post-response" hook. For per-response
+ *   work (logging, metrics) use `res.on('finish', ...)` from inside an
+ *   earlier-phase middleware instead.
  */
 export type MiddlewarePhase = 'beforeGlobal' | 'afterGlobal' | 'beforeRoutes' | 'afterRoutes'
 
+/**
+ * Path scope for an {@link AdapterMiddleware} entry. Mirrors what
+ * Express's `app.use(path, handler)` accepts so adapters get the full
+ * range without learning a new mini-language:
+ *
+ * - A `string` prefix — `'/api'` matches `/api`, `/api/v1`, `/api/v1/x`.
+ * - A `RegExp` — `/^\/api\/v\d+/` matches `/api/v1`, `/api/v42`.
+ * - An array of either — `['/api', '/admin']` matches either prefix;
+ *   `['/api', /^\/internal\//]` mixes shapes.
+ *
+ * Omit to apply the middleware unconditionally (Express `app.use(handler)`).
+ */
+export type MiddlewarePath = string | RegExp | ReadonlyArray<string | RegExp>
+
 /** A middleware entry contributed by an adapter */
 export interface AdapterMiddleware {
-  /** Express-compatible handler: (req, res, next) => void */
-  handler: any
+  /**
+   * Express handler: either a `RequestHandler` (`(req, res, next) => …`)
+   * or an `ErrorRequestHandler` (`(err, req, res, next) => …`).
+   * Express dispatches based on arity, so the same field accepts both
+   * without a discriminant.
+   */
+  handler: RequestHandler | ErrorRequestHandler
   /** Which phase to insert into (default: 'afterGlobal') */
   phase?: MiddlewarePhase
-  /** Optional path to scope the middleware to (e.g. '/api/v1/auth') */
-  path?: string
+  /**
+   * Optional path scope. See {@link MiddlewarePath} for the accepted
+   * shapes (string prefix, RegExp, or an array mixing both). Omit to
+   * apply the middleware to every request that reaches this phase.
+   */
+  path?: MiddlewarePath
 }
 
 /**

--- a/packages/kickjs/src/core/index.ts
+++ b/packages/kickjs/src/core/index.ts
@@ -82,6 +82,7 @@ export {
   type AdapterContext,
   type AdapterMiddleware,
   type MiddlewarePhase,
+  type MiddlewarePath,
 } from './adapter'
 
 // Plugin System

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -981,11 +981,17 @@ export class Application {
 
   private mountMiddlewareList(entries: AdapterMiddleware[]): void {
     for (const entry of entries) {
-      if (entry.path) {
-        this.app.use(entry.path, entry.handler)
-      } else {
+      if (entry.path === undefined) {
         this.app.use(entry.handler)
+        continue
       }
+      // Copy ReadonlyArray paths to a mutable array — Express's
+      // `PathParams` doesn't accept readonly arrays, even though the
+      // function never mutates them. Pass-through for non-array shapes.
+      const path: string | RegExp | (string | RegExp)[] = Array.isArray(entry.path)
+        ? [...entry.path]
+        : (entry.path as string | RegExp)
+      this.app.use(path, entry.handler)
     }
   }
 


### PR DESCRIPTION
## Summary

Three improvements to the adapter middleware contract. All surfaced from a real-world investigation that found **no underlying bug** — just sharp edges around what the API exposes and what the docs imply.

## Changes

### 1. Widened path scope (minor — new public type)

`AdapterMiddleware.path` was a bare `string`. Express's `app.use(path, …)` natively accepts `string | RegExp | (string | RegExp)[]`, so the framework was narrowing what Express already supports.

New `MiddlewarePath` type exported from `@forinda/kickjs`:

```ts
export type MiddlewarePath = string | RegExp | ReadonlyArray<string | RegExp>
```

Usage:

```ts
middleware() {
  return [
    { handler: rateLimit(), phase: 'beforeRoutes', path: ['/api', '/admin'] },
    { handler: csrf(), phase: 'afterGlobal', path: /^\/api\/v\d+\// },
    { handler: bodyLog({ region: 'eu' }), phase: 'afterGlobal', path: ['/api', /^\/internal\//] },
  ]
}
```

`mountMiddlewareList` copies readonly arrays before passing to Express's `PathParams` (which insists on a mutable array), so adopters can declare paths with `as const` without any runtime workaround.

### 2. Tighter `handler` typing (minor — type narrowing)

`AdapterMiddleware.handler` was `any`. Now:

```ts
handler: RequestHandler | ErrorRequestHandler
```

Adapters that ship error-handling middleware get real type checking. Express's arity-based dispatch (`4 args → error handler, 3 args → request handler`) resolves the union at runtime — same as today.

### 3. Lifecycle JSDoc clarified (patch — docs/UX)

The `MiddlewarePhase` JSDoc now spells out the `afterRoutes` semantics:

> Sits **after** module routes but **before** error handlers. **Fires only on fall-through** — when no route matched (404 path) or a route handler called `next()` without ending the response. Controllers that respond with `ctx.json(...)` end the chain and skip this phase, so it is *not* a "post-response" hook. For per-response work (logging, metrics) use `res.on('finish', ...)` from inside an earlier-phase middleware instead.

The `kick g middleware` generator template embeds the same guidance so freshly scaffolded middleware files explain phase trade-offs at the point of use. Also:

- Documents the path-pattern shapes alongside the phase explanation
- References `options` inside the body via `void options` so adopters can tell the closure captures their config (was easy to miss)

## Test plan

- [x] `pnpm vitest run __tests__/adapter-middleware-path-patterns.test.ts` — 6/6 passing, covers every path shape (string prefix, array of strings, single RegExp, mixed array, `as const` readonly array, omitted)
- [x] `__tests__/lifecycle-mount-order.test.ts` continues to pass (12 tests across the file)
- [x] `pnpm typecheck` clean (only the 3 pre-existing `@forinda/kickjs-ai` errors on `main`)
- [x] `pnpm lint` clean (0 errors, 1 unrelated pre-existing warning in `packages/db`)
- [x] Pre-commit hooks green

## Why this PR

A user reported `options` showing up empty inside their adapter middleware. After writing 4 reproduction tests (all green), the diagnosis turned out to be: they had **two `mws()` instances** mounted — one as global middleware (`mws({})`, empty params), one on the adapter (`mws({ key: 'value' })`). The "params lost" symptom was actually them seeing the global one fire. Closure semantics were never broken. But:

- They originally tried `phase: 'afterRoutes'` and saw no log at all → because matched routes don't reach `afterRoutes`. The docs didn't say that loudly enough.
- They wanted to apply the middleware to multiple paths and were limited by the `path: string` shape.
- The `handler: any` typing meant their IDE never warned them about the closure / arity mismatch they were chasing.

This PR doesn't fix a bug — it removes the three confusion sources that made the non-bug look like one.

## Follow-ups still pending

- `#13` — `kick g agents` → `.agents/` subfolder restructure
- `#14` — Audit `kick new` prompts for deprecated dep refs
- `#15` — Remove `auth-scaffold` generator + `auth` from `kick new` + scrub docs + delete `packages/auth/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Middleware paths now accept strings, regular expressions, or arrays mixing both.
  * CLI middleware generator produces richer templates with usage examples and guidance.

* **Improvements**
  * Stronger typing for middleware handlers for safer behavior.
  * Clarified middleware phase semantics, including fall-through vs. continuation behavior.
  * Middleware mounting now reliably handles readonly path arrays.

* **Tests**
  * Added tests covering all supported middleware path pattern shapes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->