### PR TITLE
chore(cli): drop @forinda/kickjs-auth from every user-facing CLI surface

### DIFF
--- a/.changeset/cli-remove-auth-options.md
+++ b/.changeset/cli-remove-auth-options.md
@@ -1,0 +1,17 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+chore(cli): drop @forinda/kickjs-auth from every user-facing CLI surface
+
+`@forinda/kickjs-auth` is no longer offered through the CLI. Adopters who already depend on it keep working — the package itself stays on disk and is unaffected. Only the prompts / scaffolds / registries that proactively suggested it have been pruned. Five surfaces touched:
+
+1. **`kick new` multi-select** — `Auth` removed from the optional-packages prompt (`init.ts`). New projects no longer see it offered.
+2. **`kick g auth-scaffold`** subcommand removed (`generate.ts`). The `kick g` Commander tree no longer registers the `auth-scaffold` subcommand. Underlying generator file (`generators/auth-scaffold.ts`) kept on disk for now — orphaned code, can be deleted in a follow-up.
+3. **`kick add auth`** registry entry removed (`commands/add.ts`). `kick add --list` no longer surfaces it.
+4. **`SIBLING_PACKAGES`** version-lookup list (`generators/project.ts`) — `@forinda/kickjs-auth` removed so `npm view <name> version` isn't queried at scaffold time for a package the CLI no longer offers.
+5. **`PACKAGE_DEPS`** alias map (`templates/project-config.ts`) — `auth` key removed.
+
+Imports cleaned up alongside: `generateAuthScaffold`, the local `AuthScaffoldOpts` interface, and the now-unused `select` / `promptConfirm` imports (the only callers were the removed auth-scaffold action).
+
+Documentation references in `project-docs.ts` template (recipes mentioning `@Public()`, `AuthAdapter`, `JwtStrategy`) intentionally kept — those are example prose, not CLI surfaces, and adopters who explicitly install `@forinda/kickjs-auth` still benefit from the recipes.

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -84,13 +84,6 @@ const PACKAGE_REGISTRY: Record<string, PackageEntry> = {
     dev: true,
   },
 
-  // Auth
-  auth: {
-    pkg: '@forinda/kickjs-auth',
-    peers: ['jsonwebtoken'],
-    description: 'Authentication — JWT, API key, and custom strategies',
-  },
-
   // Queue
   queue: {
     pkg: '@forinda/kickjs-queue',

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -20,7 +20,6 @@ import { generateConfig } from '../generators/config'
 import { generateAgentDocs } from '../generators/agent-docs'
 import { findStyleDriftModules } from '../generators/migrate-modules'
 import { colors } from '../utils/colors'
-import { generateAuthScaffold } from '../generators/auth-scaffold'
 import { generateJob } from '../generators/job'
 import { generateScaffold, parseFields } from '../generators/scaffold'
 import { generateTest } from '../generators/test'
@@ -32,7 +31,6 @@ import {
 } from '../config'
 import { setDryRun } from '../utils/fs'
 import { runTypegen } from '../typegen'
-import { select, confirm as promptConfirm } from '../utils/prompts'
 
 /** Options accepted by `kick g module` and the bare `kick g <name>` shortcut. */
 interface ModuleGenOpts {
@@ -72,12 +70,6 @@ interface ScaffoldOpts {
   tests?: boolean
   pluralize?: boolean
   modulesDir?: string
-}
-
-interface AuthScaffoldOpts {
-  strategy?: 'jwt' | 'session'
-  roleGuards?: boolean
-  out: string
 }
 
 interface ConfigOpts {
@@ -616,49 +608,6 @@ export function registerGenerateCommand(program: Command, ctx?: KickCliPluginCon
       }
       printGenerated(files, dryRun)
       await runPostTypegen(dryRun)
-    })
-
-  // ── kick g auth-scaffold ─────────────────────────────────────────────
-  gen
-    .command('auth-scaffold')
-    .description(
-      'Generate a complete auth module (register, login, logout, password hashing)\n' +
-        '  Includes controller, service, DTOs, and test stubs.',
-    )
-    .option('-s, --strategy <type>', 'Auth strategy: jwt | session')
-    .option('--role-guards', 'Generate role-based guards (default: true)')
-    .option('--no-role-guards', 'Skip role-based guard generation')
-    .option('-o, --out <dir>', 'Output directory', 'src/modules/auth')
-    .action(async (opts: AuthScaffoldOpts, cmd: Command) => {
-      const dryRun = isDryRun(cmd)
-      setDryRun(dryRun)
-
-      // Interactive prompts when flags not provided
-      let strategy = opts.strategy
-      if (!strategy) {
-        strategy = await select({
-          message: 'Auth strategy',
-          options: [
-            { value: 'jwt', label: 'JWT', hint: 'stateless token-based auth' },
-            { value: 'session', label: 'Session', hint: 'server-side session with cookies' },
-          ],
-        })
-      }
-
-      let roleGuards = opts.roleGuards
-      if (roleGuards === undefined) {
-        roleGuards = await promptConfirm({
-          message: 'Generate role-based guards?',
-          initialValue: true,
-        })
-      }
-
-      const files = await generateAuthScaffold({
-        strategy,
-        outDir: opts.out,
-        roleGuards,
-      })
-      printGenerated(files, dryRun)
     })
 
   // ── kick g config ────────────────────────────────────────────────────

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -8,7 +8,6 @@ import { resolvePackageManager } from './add'
 
 /** All optional packages available for selection */
 const OPTIONAL_PACKAGES = [
-  { value: 'auth', label: 'Auth', hint: 'JWT, OAuth, API keys' },
   { value: 'swagger', label: 'Swagger', hint: 'OpenAPI docs' },
   { value: 'ws', label: 'WebSocket', hint: 'rooms, heartbeat' },
   { value: 'queue', label: 'Queue', hint: 'BullMQ/RabbitMQ/Kafka' },

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -51,7 +51,6 @@ const SIBLING_PACKAGES = [
   '@forinda/kickjs',
   '@forinda/kickjs-cli',
   '@forinda/kickjs-vite',
-  '@forinda/kickjs-auth',
   '@forinda/kickjs-swagger',
   '@forinda/kickjs-ws',
   '@forinda/kickjs-queue',

--- a/packages/cli/src/generators/templates/project-config.ts
+++ b/packages/cli/src/generators/templates/project-config.ts
@@ -2,7 +2,6 @@ type ProjectTemplate = 'rest' | 'ddd' | 'cqrs' | 'minimal'
 
 /** Map of optional package names to their npm package identifiers */
 const PACKAGE_DEPS: Record<string, string> = {
-  auth: '@forinda/kickjs-auth',
   swagger: '@forinda/kickjs-swagger',
   ws: '@forinda/kickjs-ws',
   queue: '@forinda/kickjs-queue',


### PR DESCRIPTION
## Summary

Removes `@forinda/kickjs-auth` from every user-facing CLI surface. Per scope confirmed in the session: keep `packages/auth/` on disk, leave examples and framework code untouched, don't touch documentation prose. Only prune the prompts / scaffolds / registries that proactively suggested it.

## Surfaces touched

1. **`kick new` multi-select** (`commands/init.ts`) — `Auth` option removed from the optional-packages prompt.
2. **`kick g auth-scaffold`** (`commands/generate.ts`) — subcommand removed from the Commander tree. Underlying generator file (`generators/auth-scaffold.ts`) **kept on disk** for now — orphaned code can be deleted in a follow-up.
3. **`kick add auth`** (`commands/add.ts`) — registry entry removed. `kick add --list` no longer surfaces it.
4. **`SIBLING_PACKAGES`** (`generators/project.ts`) — `@forinda/kickjs-auth` removed from the version-lookup list so the CLI doesn't query npm for a package it no longer offers.
5. **`PACKAGE_DEPS`** (`templates/project-config.ts`) — `auth` alias key removed.

Imports cleaned up alongside the dead code:
- `generateAuthScaffold` import dropped from `generate.ts`
- Local `AuthScaffoldOpts` interface dropped from `generate.ts`
- `select` / `promptConfirm` imports dropped — the only callers were the removed `auth-scaffold` action

## What's NOT in this PR (intentional, per scope discussion)

- `packages/auth/` source — **kept**. The package still exists; adopters who already depend on it keep working.
- Example apps under `examples/multi-tenant-*` and `examples/task-mongoose-api` — **kept**. They import from `@forinda/kickjs-auth` and remain functional because the package is still present.
- Framework references in `packages/swagger/src/openapi-builder.ts` and `packages/kickjs/src/http/context.ts` — **kept**. Those are JSDoc comments explaining how the framework's `AuthUser` augmentation point bridges with `@forinda/kickjs-auth`.
- Recipe prose in `templates/project-docs.ts` (mentioning `@Public()`, `AuthAdapter`, `JwtStrategy`) — **kept**. Adopters who explicitly install `@forinda/kickjs-auth` still benefit from the recipes.

## Test plan

- [x] `pnpm build` (cli) — clean
- [x] `pnpm vitest run __tests__/plugin-merge.test.ts __tests__/plugin-integration.test.ts __tests__/kick-new-yes.test.ts __tests__/misc.test.ts` — 25/25 passing (covers the kick new prompt flow + plugin merge + custom commands)
- [x] `pnpm lint` clean (0 errors, same 1 pre-existing unrelated warning)
- [x] `pnpm exec oxfmt --check` on all 5 changed files — clean
- [x] Pre-commit hooks green
- [ ] Manual: `node packages/cli/bin.js new my-app --yes --no-install --no-git` in a tmp dir — confirm no `auth` in the multi-select; no `@forinda/kickjs-auth` in the resulting package.json
- [ ] Manual: `node packages/cli/bin.js g --help` — confirm `auth-scaffold` is no longer listed
- [ ] Manual: `node packages/cli/bin.js add --list` — confirm `auth` is no longer listed

## Follow-ups parked

- `#13` — `kick g agents` → `.agents/` subfolder restructure (next up)
- Generator file deletion (`packages/cli/src/generators/auth-scaffold.ts` is now orphaned and can be removed in a separate cleanup PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Auth package is no longer available in the CLI.
  * Removed from `kick new` optional packages selection.
  * Removed from `kick add` package registry.
  * `kick g auth-scaffold` generator command no longer available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->