### PR TITLE
feat(cli): propagate projectRoot through GeneratorContext + KickCliPluginContext

### DIFF
--- a/.changeset/cli-context-project-root.md
+++ b/.changeset/cli-context-project-root.md
@@ -1,0 +1,54 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+feat(cli): propagate `projectRoot` through `GeneratorContext` and `KickCliPluginContext`
+
+Both CLI contexts now carry a resolved `projectRoot` field alongside the existing `cwd`. Plugin authors and generator authors no longer need to call `findProjectRoot(cwd)` themselves to find the directory that owns `kick.config.*` — the value is resolved once at CLI startup and threaded through.
+
+**`GeneratorContext` (`packages/cli/src/generator-extension/define.ts`)**
+
+```ts
+export interface GeneratorContext {
+  // ...existing fields
+  cwd: string // where the CLI was invoked
+  projectRoot: string // resolved root via findProjectRoot()
+}
+```
+
+`buildGeneratorContext` now accepts an optional `projectRoot`. When omitted it derives one from `cwd` via `findProjectRoot()` — zero-config for ad-hoc callers, free for the CLI entry which already resolved it.
+
+**`KickCliPluginContext` (`packages/cli/src/plugin/types.ts`)**
+
+```ts
+export interface KickCliPluginContext {
+  cwd: string // invocation directory
+  projectRoot: string // resolved root
+  config: KickConfig | null
+  log: (msg: string) => void
+  generators?: DiscoveredGenerator[]
+}
+```
+
+`mergeCliPlugins.register()` now populates `projectRoot` automatically:
+
+- When the caller supplies a ctx, that field wins (test harnesses can inject a different workspace boundary).
+- When no ctx is supplied (lightweight test path), the default is `findProjectRoot(process.cwd())`.
+
+**Dispatch threading**
+
+`tryDispatchPluginGenerator` accepts a `projectRoot` field in `DispatchInput` so both the bare-action dispatch and `kick g <subcommand>` Commander dispatch propagate the resolved root from `cli.ts` down to plugin generator `files()` factories.
+
+**Why both contexts?**
+
+`cwd` and `projectRoot` are semantically distinct:
+
+- `cwd` = where the adopter typed the command (could be any subdirectory)
+- `projectRoot` = the resolved base that owns `kick.config.*` (or `package.json` as fallback)
+
+Generators that emit "files relative to the project" should now use `ctx.projectRoot` instead of `ctx.cwd`. Existing code that treats `ctx.cwd` as the project root keeps working — the CLI entry point sets `cwd` to the resolved root for back-compat, so the two fields hold the same value at the top of the chain.
+
+**Tests**
+
+- `buildGeneratorContext`: caller-supplied `projectRoot` wins; derived from `cwd` via `findProjectRoot()` when omitted; falls back to `cwd` when no marker file exists anywhere.
+- `mergeCliPlugins`: caller `projectRoot` flows through to `ctx`; default ctx populates it from `process.cwd()`.

--- a/packages/cli/__tests__/generator-extension.test.ts
+++ b/packages/cli/__tests__/generator-extension.test.ts
@@ -103,6 +103,50 @@ describe('buildGeneratorContext', () => {
     expect(fromSnake.pascal).toBe(fromPascal.pascal)
     expect(fromKebab.pascal).toBe(fromPascal.pascal)
   })
+
+  it('exposes projectRoot — caller-supplied value wins over derived', () => {
+    const ctx = buildGeneratorContext({
+      name: 'task',
+      cwd: '/some/nested/dir',
+      projectRoot: '/some',
+    })
+    expect(ctx.projectRoot).toBe('/some')
+  })
+
+  it('derives projectRoot from cwd via findProjectRoot when not supplied', () => {
+    // Create a fixture: a temp dir containing a kick.config.json marker
+    // and a nested src/modules/foo/ subdir. buildGeneratorContext should
+    // walk up from the nested cwd and land on the temp dir.
+    const root = mkdtempSync(join(tmpdir(), 'kick-gen-root-'))
+    const nested = join(root, 'src', 'modules', 'foo')
+    mkdirSync(nested, { recursive: true })
+    writeFileSync(join(root, 'kick.config.json'), '{}')
+    try {
+      const ctx = buildGeneratorContext({ name: 'task', cwd: nested })
+      expect(ctx.projectRoot).toBe(root)
+      // cwd remains where the caller said — only projectRoot walks up
+      expect(ctx.cwd).toBe(nested)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('projectRoot falls back to cwd when no marker file is found anywhere', () => {
+    // Walk up will hit the filesystem root without finding a marker;
+    // findProjectRoot returns the startDir in that case so the field
+    // is always a usable absolute path.
+    const orphan = mkdtempSync(join(tmpdir(), 'kick-gen-orphan-'))
+    try {
+      const ctx = buildGeneratorContext({ name: 'task', cwd: orphan })
+      // On most systems no kick.config.* or package.json sits between
+      // /tmp and /. Either the orphan dir itself OR a parent with a
+      // package.json — but it must be an absolute path, not undefined.
+      expect(typeof ctx.projectRoot).toBe('string')
+      expect(ctx.projectRoot.length).toBeGreaterThan(0)
+    } finally {
+      rmSync(orphan, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('discoverPluginGenerators', () => {

--- a/packages/cli/__tests__/plugin-merge.test.ts
+++ b/packages/cli/__tests__/plugin-merge.test.ts
@@ -135,6 +135,41 @@ describe('mergeCliPlugins', () => {
       'drizzle-typegen',
     ])
   })
+
+  it('threads caller-supplied projectRoot into the register ctx', async () => {
+    let seen: string | undefined
+    const consumer = defineCliPlugin({
+      name: 'consumer',
+      register: (_program, ctx) => {
+        seen = ctx?.projectRoot
+      },
+    })
+    const r = mergeCliPlugins([consumer])
+    await r.register(new Command(), {
+      cwd: '/foo/bar',
+      projectRoot: '/foo',
+      config: null,
+      log: () => {},
+    })
+    expect(seen).toBe('/foo')
+  })
+
+  it('defaults projectRoot from process.cwd() when no ctx is supplied', async () => {
+    let seen: string | undefined
+    const consumer = defineCliPlugin({
+      name: 'consumer',
+      register: (_program, ctx) => {
+        seen = ctx?.projectRoot
+      },
+    })
+    const r = mergeCliPlugins([consumer])
+    await r.register(new Command())
+    // findProjectRoot(process.cwd()) returns an absolute path. We can't
+    // assert the exact value (it depends on where the test runs from),
+    // but it must be a non-empty absolute path.
+    expect(typeof seen).toBe('string')
+    expect((seen ?? '').length).toBeGreaterThan(0)
+  })
 })
 
 describe('plugin generators registered as Commander subcommands', () => {

--- a/packages/cli/__tests__/plugin-merge.test.ts
+++ b/packages/cli/__tests__/plugin-merge.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { Command } from 'commander'
+import { isAbsolute } from 'node:path'
 
 import { defineCliPlugin, mergeCliPlugins, KickPluginConflictError } from '../src/plugin'
 
@@ -166,9 +167,11 @@ describe('mergeCliPlugins', () => {
     await r.register(new Command())
     // findProjectRoot(process.cwd()) returns an absolute path. We can't
     // assert the exact value (it depends on where the test runs from),
-    // but it must be a non-empty absolute path.
+    // but it must be a non-empty absolute path — assert both since the
+    // contract on KickCliPluginContext.projectRoot says "usable absolute".
     expect(typeof seen).toBe('string')
     expect((seen ?? '').length).toBeGreaterThan(0)
+    expect(isAbsolute(seen ?? '')).toBe(true)
   })
 })
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -23,8 +23,12 @@ async function main() {
   // Walk up to find the project root — `kick` invoked from any
   // subdirectory (e.g. `src/modules/users/`) still resolves the
   // adopter's kick.config.* + plugins instead of silently falling
-  // back to defaults.
-  const cwd = findProjectRoot(process.cwd())
+  // back to defaults. `cwd` shadows the resolved root for back-compat
+  // with existing command code that reads `ctx.cwd` as the project
+  // base; `projectRoot` is the same value exposed under a name that
+  // matches what the field actually carries.
+  const projectRoot = findProjectRoot(process.cwd())
+  const cwd = projectRoot
 
   // Default to {} so spreads + the `commands`/`plugins` reads stay
   // safe when the adopter has no kick.config.ts. The cast keeps the
@@ -41,6 +45,7 @@ async function main() {
 
   await merged.register(program, {
     cwd,
+    projectRoot,
     config,
     log: (msg) => console.log(msg),
   })

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -321,6 +321,7 @@ export function registerGenerateCommand(program: Command, ctx?: KickCliPluginCon
             args: rest,
             flags: opts as unknown as Record<string, string | boolean>,
             cwd: process.cwd(),
+            projectRoot: ctx?.projectRoot,
           },
           merged.generators,
         )
@@ -695,7 +696,7 @@ export function registerGenerateCommand(program: Command, ctx?: KickCliPluginCon
   // the first positional as `itemName` for dispatch — the spec entry
   // is purely a documentation hint to Commander.
   for (const entry of ctx?.generators ?? []) {
-    registerPluginGeneratorSubcommand(gen, entry)
+    registerPluginGeneratorSubcommand(gen, entry, ctx?.projectRoot)
   }
 }
 
@@ -723,7 +724,11 @@ export function registerGenerateCommand(program: Command, ctx?: KickCliPluginCon
  * The source plugin name is appended to the description in `[brackets]`
  * so adopters can see at a glance which plugin shipped each generator.
  */
-function registerPluginGeneratorSubcommand(gen: Command, entry: DiscoveredGenerator): void {
+function registerPluginGeneratorSubcommand(
+  gen: Command,
+  entry: DiscoveredGenerator,
+  projectRoot?: string,
+): void {
   const { source, spec } = entry
   const firstArg = spec.args?.[0]
   const firstArgName = firstArg?.name ?? 'itemName'
@@ -758,6 +763,7 @@ function registerPluginGeneratorSubcommand(gen: Command, entry: DiscoveredGenera
           args: extraArgs ?? [],
           flags: opts as Record<string, string | boolean>,
           cwd: process.cwd(),
+          projectRoot,
         },
         [entry],
       )

--- a/packages/cli/src/generator-extension/context.ts
+++ b/packages/cli/src/generator-extension/context.ts
@@ -1,6 +1,7 @@
 import { pathToFileURL } from 'node:url'
 import { resolve } from 'node:path'
 import { toPascalCase, toCamelCase, toKebabCase, pluralize } from '../utils/naming'
+import { findProjectRoot } from '../utils/project-root'
 import type { GeneratorContext } from './define'
 
 /** Convert any string to snake_case (`UserPost` / `user-post` → `user_post`). */
@@ -20,9 +21,17 @@ export function buildGeneratorContext(input: {
   flags?: Record<string, string | boolean>
   modulesDir?: string
   cwd?: string
+  /**
+   * Resolved project root. When omitted, derived from {@link cwd} via
+   * `findProjectRoot()` so adopter-facing call sites stay zero-config.
+   * Callers that already know the root (e.g. `cli.ts` after one upfront
+   * resolution) should pass it through to avoid redundant fs walks.
+   */
+  projectRoot?: string
   pluralize?: boolean
 }): GeneratorContext {
   const cwd = input.cwd ?? process.cwd()
+  const projectRoot = input.projectRoot ?? findProjectRoot(cwd)
   const usePlural = input.pluralize ?? true
 
   const pascal = toPascalCase(input.name)
@@ -38,6 +47,7 @@ export function buildGeneratorContext(input: {
     snake,
     modulesDir: input.modulesDir ?? 'src/modules',
     cwd,
+    projectRoot,
     args: input.args ?? [],
     flags: input.flags ?? {},
   }

--- a/packages/cli/src/generator-extension/define.ts
+++ b/packages/cli/src/generator-extension/define.ts
@@ -61,8 +61,23 @@ export interface GeneratorContext {
   pluralCamel?: string
   /** Modules directory from `kick.config.ts` (default `'src/modules'`). */
   modulesDir: string
-  /** Working directory for the generator — usually `process.cwd()`. */
+  /**
+   * Working directory the CLI was invoked from. May be a nested subdirectory
+   * if the adopter ran `kick g ...` from `src/modules/foo/` — for "write
+   * files relative to the project" use {@link projectRoot} instead.
+   */
   cwd: string
+  /**
+   * Resolved project root — the nearest ancestor directory of {@link cwd}
+   * containing `kick.config.{ts,js,mjs,json}` (or `package.json` as a
+   * fallback). Always set; falls back to `cwd` when no marker is found.
+   *
+   * Use this when writing files that must land at a known location
+   * regardless of where the adopter typed the command. `kick g ...` from
+   * inside `src/modules/foo/` will still see `projectRoot` pointing at
+   * the directory that owns `kick.config.ts`.
+   */
+  projectRoot: string
   /** Positional arguments passed AFTER the name (e.g. `kick g command Order extra1 extra2` → `['extra1', 'extra2']`). */
   args: string[]
   /** Flag values from the command line — booleans for switches, strings for `--key value`. */

--- a/packages/cli/src/generator-extension/dispatch.ts
+++ b/packages/cli/src/generator-extension/dispatch.ts
@@ -95,6 +95,17 @@ function findGenerator(discovery: DiscoveryResult, name: string): DiscoveredGene
   return discovery.generators.find((g) => g.spec.name === name)
 }
 
+/**
+ * Invoke a {@link GeneratorSpec.files} factory with a fully-populated
+ * {@link GeneratorContext}, write every returned file under the context's
+ * cwd, and return the absolute paths along with the source plugin name.
+ *
+ * Threads `input.projectRoot` through to `buildGeneratorContext` so
+ * callers that already resolved the project root (the CLI entry does
+ * this once at startup) avoid a redundant filesystem walk. When omitted,
+ * `buildGeneratorContext` derives `projectRoot` from `cwd` via
+ * `findProjectRoot()` — keeping ad-hoc callers zero-config.
+ */
 async function runGenerator(
   spec: GeneratorSpec,
   source: string,

--- a/packages/cli/src/generator-extension/dispatch.ts
+++ b/packages/cli/src/generator-extension/dispatch.ts
@@ -18,6 +18,13 @@ export interface DispatchInput {
   flags?: Record<string, string | boolean>
   /** Project context — usually `process.cwd()`. */
   cwd?: string
+  /**
+   * Resolved project root. When omitted, `buildGeneratorContext` derives
+   * it from `cwd` via `findProjectRoot()`. Pass through when the caller
+   * has already resolved it (the CLI entry point does this once at
+   * startup) to avoid re-walking the filesystem on every generator call.
+   */
+  projectRoot?: string
   /** Modules dir from `kick.config.ts`. */
   modulesDir?: string
   /** Whether the project enables auto-pluralization. */
@@ -101,6 +108,7 @@ async function runGenerator(
     modulesDir: input.modulesDir,
     pluralize: input.pluralize,
     cwd,
+    projectRoot: input.projectRoot,
   })
 
   const files = await spec.files(ctx)

--- a/packages/cli/src/plugin/merge.ts
+++ b/packages/cli/src/plugin/merge.ts
@@ -103,11 +103,25 @@ export function mergeCliPlugins(
     // Default ctx if caller didn't provide one (tests, scripts). Thread
     // `generators` through so the `kick/generate` built-in can register
     // each plugin generator as a real Commander subcommand. Caller-
-    // supplied ctx wins for every field — including `generators`, in
-    // case a test fixture wants to inject a different set.
-    const resolved: KickCliPluginContext = ctx
-      ? { generators, ...ctx }
-      : { cwd: process.cwd(), config: null, log: () => {}, generators }
+    // supplied ctx wins for every field — including `generators` and
+    // `projectRoot`, in case a test fixture wants to inject a different
+    // workspace boundary. Lazy-resolve `findProjectRoot` only when no
+    // caller-provided ctx supplies a projectRoot — keeps the no-op
+    // fast path zero-cost.
+    let resolved: KickCliPluginContext
+    if (ctx) {
+      resolved = { generators, ...ctx }
+    } else {
+      const { findProjectRoot } = await import('../utils/project-root')
+      const cwd = process.cwd()
+      resolved = {
+        cwd,
+        projectRoot: findProjectRoot(cwd),
+        config: null,
+        log: () => {},
+        generators,
+      }
+    }
     for (const p of plugins) {
       if (p.register) await p.register(program, resolved)
     }

--- a/packages/cli/src/plugin/merge.ts
+++ b/packages/cli/src/plugin/merge.ts
@@ -99,15 +99,18 @@ export function mergeCliPlugins(
     }
   }
 
+  /**
+   * Apply every plugin's `register()` callback in input order against the
+   * given Commander program. Each callback receives a {@link KickCliPluginContext}:
+   * caller-supplied ctx wins (test fixtures can inject a different
+   * workspace boundary); otherwise a default ctx is built with
+   * `findProjectRoot(process.cwd())` as the project root, `cwd` matching
+   * `process.cwd()`, null config, no-op log, and the merged generator set
+   * threaded through so the `kick/generate` built-in can surface each as
+   * a Commander subcommand. The dynamic import of `findProjectRoot` keeps
+   * the caller-supplied fast path zero-cost.
+   */
   const register = async (program: Command, ctx?: KickCliPluginContext): Promise<void> => {
-    // Default ctx if caller didn't provide one (tests, scripts). Thread
-    // `generators` through so the `kick/generate` built-in can register
-    // each plugin generator as a real Commander subcommand. Caller-
-    // supplied ctx wins for every field — including `generators` and
-    // `projectRoot`, in case a test fixture wants to inject a different
-    // workspace boundary. Lazy-resolve `findProjectRoot` only when no
-    // caller-provided ctx supplies a projectRoot — keeps the no-op
-    // fast path zero-cost.
     let resolved: KickCliPluginContext
     if (ctx) {
       resolved = { generators, ...ctx }

--- a/packages/cli/src/plugin/types.ts
+++ b/packages/cli/src/plugin/types.ts
@@ -36,7 +36,25 @@ import type { DiscoveredGenerator } from '../generator-extension/discover'
  * land here without changing the callback signature.
  */
 export interface KickCliPluginContext {
+  /**
+   * Working directory the CLI was invoked from. Plugin authors that need
+   * a stable "project base" location (e.g. to write artifacts, resolve
+   * config-relative paths) should prefer {@link projectRoot} over `cwd`
+   * — `cwd` is whatever the adopter typed the command from, including
+   * arbitrary subdirectories.
+   */
   cwd: string
+  /**
+   * Resolved project root — the directory `loadKickConfig` walked up to
+   * via `findProjectRoot()`. Always set to a usable absolute path: when
+   * a `kick.config.{ts,js,mjs,json}` is found, that directory; otherwise
+   * the nearest ancestor with a `package.json`; otherwise `cwd` itself.
+   *
+   * Populated by `mergeCliPlugins.register()` from the same resolution
+   * that `cli.ts` performs at startup, so plugin authors get a coherent
+   * view of the project root without re-walking the filesystem.
+   */
+  projectRoot: string
   /** Resolved kick.config.ts (null if the project has none). */
   config: KickConfig | null
   log: (msg: string) => void


### PR DESCRIPTION
## Summary

Both CLI contexts now carry a resolved `projectRoot` field alongside the existing `cwd`. Plugin authors and generator authors no longer need to call `findProjectRoot(cwd)` themselves to find the directory that owns `kick.config.*` — the value is resolved once at CLI startup and threaded through.

## Why

`cwd` was overloaded. The CLI entry resolved the project root via `findProjectRoot(process.cwd())` and stored it as `cwd` — that worked but lied about what the field carried. Adopters (and reviewers) had to track two meanings of `cwd` depending on context:
- Sometimes "where the adopter typed the command" (raw invocation dir, possibly nested)
- Sometimes "the resolved project base" (what `cli.ts` actually stored)

Adding a dedicated `projectRoot` makes the distinction explicit and frees `cwd` to mean what its name says.

## Changes

### `GeneratorContext` — `packages/cli/src/generator-extension/define.ts`

```diff
 export interface GeneratorContext {
   // ...existing fields
   cwd: string
+  projectRoot: string
 }
```

`buildGeneratorContext` accepts an optional `projectRoot`. When omitted it derives one from `cwd` via `findProjectRoot()` — zero-config for ad-hoc callers, free for the CLI entry which already resolved it once at startup.

### `KickCliPluginContext` — `packages/cli/src/plugin/types.ts`

```diff
 export interface KickCliPluginContext {
   cwd: string
+  projectRoot: string
   config: KickConfig | null
   log: (msg: string) => void
   generators?: DiscoveredGenerator[]
 }
```

`mergeCliPlugins.register()` populates `projectRoot` automatically:
- Caller-supplied ctx wins (test harnesses can inject a different workspace boundary).
- Default ctx (no caller) uses `findProjectRoot(process.cwd())`.

### Dispatch threading — `packages/cli/src/generator-extension/dispatch.ts` + `packages/cli/src/commands/generate.ts`

`tryDispatchPluginGenerator` accepts `projectRoot` in `DispatchInput`. Both call sites (bare-action dispatch + Commander subcommand dispatch) propagate it from `cli.ts` down to plugin generator `files()` factories.

## Semantics

| Field | Meaning |
|-------|---------|
| `cwd` | Where the adopter typed the command (could be any subdirectory) |
| `projectRoot` | Resolved base that owns `kick.config.*` (or `package.json` as fallback) |

Generators that emit "files relative to the project" should now use `ctx.projectRoot` instead of `ctx.cwd`. **Existing code that treats `ctx.cwd` as the project root keeps working** — `cli.ts` sets `cwd` to the resolved root for back-compat, so the two fields hold the same value at the top of the chain.

## Test plan

- [x] `buildGeneratorContext` — 3 new cases:
  - Caller-supplied `projectRoot` wins over derived
  - Derived from `cwd` via `findProjectRoot()` when omitted (verified with a temp dir + `kick.config.json` marker)
  - Falls back to `cwd` when no marker file exists anywhere
- [x] `mergeCliPlugins.register` — 2 new cases:
  - Caller-supplied `projectRoot` threads through to ctx
  - Default ctx populates from `process.cwd()` when no ctx supplied
- [x] All 6 new tests + 39 existing tests passing in the impacted suites
- [x] `pnpm lint` clean (0 errors, same 1 pre-existing unrelated warning)
- [x] `pnpm typecheck` — only the 3 pre-existing `@forinda/kickjs-ai` errors on `main`; no new errors

## Follow-ups

DevTools audit task on the list (raised mid-PR):
- Adapter `introspect()` snapshot not surfaced on the DevTools dashboard
- Context contributor `dependsOn` not propagated to DevTools — contributor dependency graph shows empty deps

Will tackle in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * CLI now resolves the project root once at startup (via marker detection) and consistently propagates it through plugin and generator contexts, improving behavior when running from nested directories.

* **Documentation**
  * Guidance updated: plugin and generator authors should use ctx.projectRoot for project-relative paths instead of ctx.cwd.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->