### PR TITLE
feat(devtools): render full introspect snapshot + surface module-level contributors with intact dependsOn

### DIFF
--- a/.changeset/devtools-introspect-and-module-contributors.md
+++ b/.changeset/devtools-introspect-and-module-contributors.md
@@ -1,0 +1,56 @@
+---
+'@forinda/kickjs': minor
+'@forinda/kickjs-devtools': minor
+'@forinda/kickjs-devtools-kit': minor
+---
+
+feat(devtools): render full introspect snapshot + surface module-level contributors with intact dependsOn
+
+Three related fixes addressing two adopter reports: the DevTools dashboard wasn't surfacing data that `introspect()` and context-contributor `dependsOn` were already providing.
+
+**1. PrimitiveRow renders all `IntrospectionSnapshot` fields**
+
+The server side has been collecting `introspect()` snapshots correctly for every adapter / plugin in `/_debug/topology`. The SPA's `PrimitiveRow` in `TopologyTab.tsx` only rendered `name`, `version`, `tokens.provides`, and `metrics` — silently dropping `state`, `tokens.requires`, `memoryBytes`, and `kind`. Adopters whose `introspect()` returned (say) `{ state, memoryBytes, tokens: { requires } }` saw a row with just the name.
+
+PrimitiveRow now renders all six fields, with `memoryBytes` formatted as B/KB/MB/GB and `state` rendered as key/value pairs (JSON-stringified for nested objects).
+
+**2. Module-level contributors surface via `Application.getContributors()`**
+
+The framework's `getContributors()` deliberately skipped module-level registrations because module instances aren't retained on the `Application` instance post-bootstrap. Adopters who declared `AppModule.contributors?()` returning a typed `dependsOn` saw the contributor missing entirely from the DevTools Contributors table, which read as "empty deps."
+
+`Application.setup()` now retains a snapshot of every module-level registration (just the frozen `{ key, dependsOn }` view — no `resolve` closures kept), and `getContributors()` returns those entries with `source: 'module'`. The snapshot is cleared at the start of each `setup()` pass so test harnesses and dev-server restarts don't accumulate stale entries.
+
+Per-route (method/class decorator) contributors still aren't enumerated — they live on the route registry and warrant a separate RPC; flagged as a follow-up.
+
+**3. `TopologyContributorEntry.source` widens to the full union**
+
+The kit's `source` field was typed as bare `string` with a JSDoc-documented enum; the server collapsed `'plugin' | 'global'` → `'adapter'` because of an earlier narrower mapping. Both are now removed: kit ships a proper `TopologyContributorSource` union (`'method' | 'class' | 'module' | 'adapter' | 'plugin' | 'global'`), and the server passes `source` through unchanged. Dashboards can now badge / filter by the real origin. Wire-format change is backward-compatible (new enum value added to an existing string field).
+
+**4. `IntrospectionSnapshot` reachable from `@forinda/kickjs` directly**
+
+`AppAdapter.introspect?()` and `KickPlugin.introspect?()` were typed as `unknown` — the JSDoc told adopters to import `IntrospectionSnapshot` from `@forinda/kickjs-devtools-kit` to satisfy the contract, taking on a dep just for the type. The snapshot type now lives canonically in `@forinda/kickjs` (`core/introspect.ts`); the kit's existing `IntrospectionSnapshot` stays structurally identical for back-compat. Adopters who don't already use the kit can write `introspect()` with full inference, no extra import:
+
+```ts
+export const MyAdapter = defineAdapter({
+  name: 'MyAdapter',
+  build: () => ({
+    introspect() {
+      // Return-type fully inferred — no `import type` needed.
+      return {
+        protocolVersion: 1,
+        name: 'MyAdapter',
+        kind: 'adapter',
+        state: { connectedAt: Date.now() },
+        memoryBytes: 12_345,
+        tokens: { provides: ['REDIS'], requires: [] },
+        version: '1.0',
+        metrics: { activeConnections: 3 },
+      }
+    },
+  }),
+})
+```
+
+**Tests**
+
+`application-get-contributors.test.ts` adds three cases: `dependsOn` survives `getContributors()` (regression guard); module-level contributors appear after `setup()` with `source: 'module'` and intact `dependsOn`; re-setup doesn't accumulate stale module entries.

--- a/packages/devtools-kit/src/index.ts
+++ b/packages/devtools-kit/src/index.ts
@@ -22,6 +22,7 @@ export {
   type RpcSuccess,
   type RuntimeSnapshot,
   type TopologyContributorEntry,
+  type TopologyContributorSource,
   type TopologyError,
   type TopologySnapshot,
   type TopologyTokenEntry,

--- a/packages/devtools-kit/src/types.ts
+++ b/packages/devtools-kit/src/types.ts
@@ -153,11 +153,31 @@ export interface TopologyTokenEntry {
  * `architecture.md` §20; this surface is just enough for the panel to
  * draw the Module → Contributor edge.
  */
+/**
+ * Origin of a contributor registration. Mirrors the precedence union
+ * from the framework's `ContributorSource` (method > class > module >
+ * adapter > global) plus `'plugin'` which the topology aggregator
+ * surfaces as a distinct label even though plugins land at adapter
+ * precedence on the per-route pipeline.
+ *
+ * Typed as a union so dashboards can render distinct badges / filters
+ * per source. Adding a new value here is a backward-compatible wire
+ * change (existing consumers happily ignore unknown values); removing
+ * one is breaking.
+ */
+export type TopologyContributorSource =
+  | 'method'
+  | 'class'
+  | 'module'
+  | 'adapter'
+  | 'plugin'
+  | 'global'
+
 export interface TopologyContributorEntry {
   /** Contributor key — what it sets on `ctx.set(...)`. */
   key: string
-  /** Source layer — `'method' | 'class' | 'module' | 'adapter' | 'global'`. */
-  source: string
+  /** Source layer — see {@link TopologyContributorSource}. */
+  source: TopologyContributorSource
   /** Other contributor keys this one depends on. */
   dependsOn: readonly string[]
 }

--- a/packages/devtools/spa/src/tabs/TopologyTab.tsx
+++ b/packages/devtools/spa/src/tabs/TopologyTab.tsx
@@ -196,6 +196,23 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
 }
 
+/**
+ * Render a single `state` value as a string for the topology row.
+ * `JSON.stringify` throws on circular structures and on objects with
+ * unserializable members (functions, bigints in older runtimes); falling
+ * back to `'[unserializable]'` keeps the dashboard from blanking out
+ * on a single malformed introspect snapshot. Same defensive pattern
+ * used by `summarisePayload()` elsewhere in the SPA.
+ */
+function formatStateValue(value: unknown): string {
+  if (typeof value !== 'object' || value === null) return String(value)
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return '[unserializable]'
+  }
+}
+
 const PrimitiveRow: Component<{ item: IntrospectionSnapshot }> = (props) => (
   <div class="tree-node">
     <span class="tree-key">{props.item.name}</span>
@@ -219,10 +236,7 @@ const PrimitiveRow: Component<{ item: IntrospectionSnapshot }> = (props) => (
         <For each={Object.entries(props.item.state ?? {})}>
           {([key, value]) => (
             <span style="margin-right:12px">
-              {key}:{' '}
-              <strong style="color:var(--text)">
-                {typeof value === 'object' ? JSON.stringify(value) : String(value)}
-              </strong>
+              {key}: <strong style="color:var(--text)">{formatStateValue(value)}</strong>
             </span>
           )}
         </For>

--- a/packages/devtools/spa/src/tabs/TopologyTab.tsx
+++ b/packages/devtools/spa/src/tabs/TopologyTab.tsx
@@ -188,14 +188,45 @@ const Section: Component<{
   </div>
 )
 
+/** Human-friendly byte formatter — bytes / KB / MB / GB with one decimal. */
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+}
+
 const PrimitiveRow: Component<{ item: IntrospectionSnapshot }> = (props) => (
   <div class="tree-node">
     <span class="tree-key">{props.item.name}</span>
+    <Show when={props.item.kind}>
+      <span class="tree-meta">[{props.item.kind}]</span>
+    </Show>
     <Show when={props.item.version}>
       <span class="tree-meta">v{props.item.version}</span>
     </Show>
+    <Show when={typeof props.item.memoryBytes === 'number'}>
+      <span class="tree-meta">{formatBytes(props.item.memoryBytes as number)}</span>
+    </Show>
     <Show when={props.item.tokens?.provides.length}>
       <div class="tree-meta">provides: {props.item.tokens?.provides.join(', ')}</div>
+    </Show>
+    <Show when={props.item.tokens?.requires.length}>
+      <div class="tree-meta">requires: {props.item.tokens?.requires.join(', ')}</div>
+    </Show>
+    <Show when={props.item.state && Object.keys(props.item.state).length > 0}>
+      <div class="tree-meta">
+        <For each={Object.entries(props.item.state ?? {})}>
+          {([key, value]) => (
+            <span style="margin-right:12px">
+              {key}:{' '}
+              <strong style="color:var(--text)">
+                {typeof value === 'object' ? JSON.stringify(value) : String(value)}
+              </strong>
+            </span>
+          )}
+        </For>
+      </div>
     </Show>
     <Show when={props.item.metrics}>
       {(m) => (

--- a/packages/devtools/src/topology.ts
+++ b/packages/devtools/src/topology.ts
@@ -175,15 +175,14 @@ function collectContributors(app: TopologyApplicationLike): TopologyContributorE
   if (typeof app.getContributors === 'function') {
     for (const c of app.getContributors()) {
       if (seen.has(c.key)) continue
-      // The kit's source enum currently only allows 'adapter' | 'module';
-      // 'plugin' + 'global' both map to 'adapter' provenance for now —
-      // the Topology UI labels them by `label` so the source field is
-      // mainly a coarse category. Future kit version can widen.
-      const mapped: TopologyContributorEntry['source'] =
-        c.source === 'module' ? 'module' : 'adapter'
+      // Pass `source` through unchanged — the kit's
+      // `TopologyContributorSource` union accepts every value the
+      // framework's `getContributors()` returns. Earlier versions
+      // collapsed `'plugin' | 'global'` → `'adapter'` because the kit
+      // type was narrower; that's no longer needed.
       seen.set(c.key, {
         key: c.key,
-        source: mapped,
+        source: c.source as TopologyContributorEntry['source'],
         dependsOn: c.dependsOn as string[],
       })
     }

--- a/packages/kickjs/__tests__/application-get-contributors.test.ts
+++ b/packages/kickjs/__tests__/application-get-contributors.test.ts
@@ -1,7 +1,13 @@
 import 'reflect-metadata'
 import { describe, it, expect } from 'vitest'
 
-import { Application, defineAdapter, definePlugin, defineContextDecorator } from '../src/index'
+import {
+  Application,
+  defineAdapter,
+  defineModule,
+  definePlugin,
+  defineContextDecorator,
+} from '../src/index'
 
 const tenantContrib = defineContextDecorator({
   key: 'tenant',
@@ -78,5 +84,90 @@ describe('Application.getContributors() — devtools introspection', () => {
   it('returns empty array when no contributors are registered', () => {
     const app = new Application({ modules: [] })
     expect(app.getContributors()).toEqual([])
+  })
+
+  it('preserves dependsOn through getContributors() (regression — empty deps in devtools)', () => {
+    // A contributor with declared dependsOn must keep that list when
+    // it round-trips through getContributors. Adopters reported the
+    // devtools Contributors table showing empty deps — silent drop
+    // here would mask the bug; assert the array survives.
+    const TENANT_CONTRIB = defineContextDecorator({
+      key: 'tenant',
+      resolve: () => ({ id: 't1' }),
+    })
+    const PROJECT_CONTRIB = defineContextDecorator({
+      key: 'project',
+      dependsOn: ['tenant'] as const,
+      resolve: () => ({ id: 'p1' }),
+    })
+    const A = defineAdapter({
+      name: 'TenantAdapter',
+      build: () => ({ contributors: () => [TENANT_CONTRIB.registration] }),
+    })
+    const P = definePlugin({
+      name: 'ProjectsPlugin',
+      build: () => ({ contributors: () => [PROJECT_CONTRIB.registration] }),
+    })
+    const app = new Application({ modules: [], adapters: [A()], plugins: [P()] })
+    const list = app.getContributors()
+    const project = list.find((c) => c.key === 'project')
+    expect(project).toBeDefined()
+    expect(project?.dependsOn).toEqual(['tenant'])
+  })
+
+  it('surfaces module-level contributors after setup() with source="module"', async () => {
+    // Module-level contributors live on AppModule instances that the
+    // Application discards post-bootstrap. Application.setup() retains
+    // them in an internal snapshot so devtools can render them — assert
+    // the snapshot survives and shows up with source: 'module'.
+    const FEATURE_CONTRIB = defineContextDecorator({
+      key: 'feature-flag',
+      dependsOn: ['tenant'] as const,
+      resolve: () => ({ enabled: true }),
+    })
+    const TENANT_CONTRIB = defineContextDecorator({
+      key: 'tenant',
+      resolve: () => ({ id: 't1' }),
+    })
+    const FeatureModule = defineModule({
+      name: 'FeatureModule',
+      build: () => ({
+        contributors: () => [FEATURE_CONTRIB.registration],
+        routes: () => null,
+      }),
+    })
+    const TenantSeed = defineAdapter({
+      name: 'TenantSeed',
+      build: () => ({ contributors: () => [TENANT_CONTRIB.registration] }),
+    })
+    const app = new Application({ modules: [FeatureModule()], adapters: [TenantSeed()] })
+    // Pre-setup: module contributors aren't captured yet.
+    expect(app.getContributors().some((c) => c.key === 'feature-flag')).toBe(false)
+    await app.setup()
+    // Post-setup: feature-flag appears with source='module' and intact deps.
+    const list = app.getContributors()
+    const featureFlag = list.find((c) => c.key === 'feature-flag')
+    expect(featureFlag).toBeDefined()
+    expect(featureFlag?.source).toBe('module')
+    expect(featureFlag?.dependsOn).toEqual(['tenant'])
+  })
+
+  it('clears module contributors on re-setup so re-runs do not accumulate', async () => {
+    const CONTRIB = defineContextDecorator({
+      key: 'audit',
+      resolve: () => ({ on: true }),
+    })
+    const AuditModule = defineModule({
+      name: 'AuditModule',
+      build: () => ({
+        contributors: () => [CONTRIB.registration],
+        routes: () => null,
+      }),
+    })
+    const app = new Application({ modules: [AuditModule()] })
+    await app.setup()
+    await app.setup()
+    // Two setup() calls = one module-level entry, not two.
+    expect(app.getContributors().filter((c) => c.key === 'audit')).toHaveLength(1)
   })
 })

--- a/packages/kickjs/__tests__/application-get-contributors.test.ts
+++ b/packages/kickjs/__tests__/application-get-contributors.test.ts
@@ -1,13 +1,21 @@
 import 'reflect-metadata'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 
 import {
   Application,
+  Container,
   defineAdapter,
   defineModule,
   definePlugin,
   defineContextDecorator,
 } from '../src/index'
+
+beforeEach(() => {
+  // Reset the singleton container between tests so adapter / plugin
+  // factory registrations from one case don't bleed into the next —
+  // standard pattern in this codebase per CLAUDE.md.
+  Container.reset()
+})
 
 const tenantContrib = defineContextDecorator({
   key: 'tenant',

--- a/packages/kickjs/src/core/adapter.ts
+++ b/packages/kickjs/src/core/adapter.ts
@@ -2,6 +2,7 @@ import type http from 'node:http'
 import type { Express, RequestHandler, ErrorRequestHandler } from 'express'
 import type { Container } from './container'
 import type { ContributorRegistrations } from './context-decorator'
+import type { IntrospectionSnapshot } from './introspect'
 import type { MaybePromise, Constructor } from './interfaces'
 import type { KickJsPluginName } from './augmentation'
 
@@ -219,12 +220,12 @@ export interface AppAdapter {
    * the implementation cheap (counters + flags, no DB round trips) since
    * the topology endpoint polls on a short interval.
    *
-   * The return type is intentionally untyped at this layer to avoid
-   * `@forinda/kickjs` taking on a runtime dep on `@forinda/kickjs-devtools-kit`.
-   * Adapter authors should import and return `IntrospectionSnapshot`
-   * from `@forinda/kickjs-devtools-kit` directly.
+   * The return type lives in `@forinda/kickjs` itself ({@link IntrospectionSnapshot})
+   * so adopters can author `introspect()` without importing the kit just
+   * to satisfy the contract. The kit's own `IntrospectionSnapshot` type
+   * stays structurally identical; either import works.
    */
-  introspect?(): unknown | Promise<unknown>
+  introspect?(): IntrospectionSnapshot | Promise<IntrospectionSnapshot>
 
   /**
    * Optional DevTools tabs this adapter contributes (architecture.md §23).

--- a/packages/kickjs/src/core/index.ts
+++ b/packages/kickjs/src/core/index.ts
@@ -88,6 +88,11 @@ export {
 // Plugin System
 export { type KickPlugin } from './plugin'
 
+// Introspection (DevTools hook contract — type-only; the kit re-exports
+// for back-compat but adopters can import from `@forinda/kickjs` directly
+// and skip the kit dep when they only need to type `introspect()`).
+export { type IntrospectionSnapshot, type IntrospectionKind, type IntrospectFn } from './introspect'
+
 // Cron
 export { Cron, getCronJobs, type CronJobMeta, CRON_META } from './cron'
 

--- a/packages/kickjs/src/core/introspect.ts
+++ b/packages/kickjs/src/core/introspect.ts
@@ -19,11 +19,14 @@
 export interface IntrospectionSnapshot {
   /**
    * Wire-protocol version this snapshot conforms to. The kit ships a
-   * `PROTOCOL_VERSION` constant — adopters can set this field to
-   * `1` directly without importing the constant; bumping it is a
-   * coordinated kit + framework release.
+   * `PROTOCOL_VERSION` constant typed as the literal `1`; we mirror
+   * that literal here so structural parity is enforced both ways —
+   * an adopter who writes `protocolVersion: 1` satisfies both this
+   * type and the kit's `IntrospectionSnapshot`. Bumping is a
+   * coordinated kit + framework release; widen this literal in
+   * lockstep.
    */
-  protocolVersion: number
+  protocolVersion: 1
   /** Stable identity matching the `name` from `definePlugin` / `defineAdapter`. */
   name: string
   /** Discriminator for what kind of primitive this is. */

--- a/packages/kickjs/src/core/introspect.ts
+++ b/packages/kickjs/src/core/introspect.ts
@@ -1,0 +1,62 @@
+/**
+ * Per-primitive introspection snapshot — the JSON shape an adapter or
+ * plugin's optional `introspect()` hook returns for DevTools.
+ *
+ * Lives in `@forinda/kickjs` (not `@forinda/kickjs-devtools-kit`) so
+ * adopters can type their `introspect()` return without taking on a
+ * dep on the kit just to satisfy the contract. The kit's own
+ * `IntrospectionSnapshot` type is structurally identical and continues
+ * to be the canonical doc location for DevTools-side consumers; the
+ * two stay in lockstep — if a field is added on one side it MUST be
+ * added on the other (covered by the type-equivalence test in the
+ * devtools-kit package).
+ *
+ * Cheap-by-default principle: `state` and `metrics` should be O(1) to
+ * compute (counters, flags, recent samples). Anything that requires a
+ * DB round trip or a full DI graph walk belongs behind a separate
+ * explicit RPC — DevTools polls topology aggressively.
+ */
+export interface IntrospectionSnapshot {
+  /**
+   * Wire-protocol version this snapshot conforms to. The kit ships a
+   * `PROTOCOL_VERSION` constant — adopters can set this field to
+   * `1` directly without importing the constant; bumping it is a
+   * coordinated kit + framework release.
+   */
+  protocolVersion: number
+  /** Stable identity matching the `name` from `definePlugin` / `defineAdapter`. */
+  name: string
+  /** Discriminator for what kind of primitive this is. */
+  kind: IntrospectionKind
+  /** Optional version string from the plugin / adapter metadata. */
+  version?: string
+  /**
+   * Reactive state surface — JSON-serialisable snapshot. Keep small
+   * (under a few KB) so polling stays cheap.
+   */
+  state?: Record<string, unknown>
+  /** DI tokens this primitive registers (`provides`) or consumes (`requires`). */
+  tokens?: { provides: readonly string[]; requires: readonly string[] }
+  /**
+   * Per-instance counters — active connections, in-flight jobs, cached
+   * items, etc. Numbers only so the DevTools panel can chart trends.
+   */
+  metrics?: Record<string, number>
+  /** Self-reported memory footprint estimate, in bytes. Optional. */
+  memoryBytes?: number
+}
+
+/**
+ * What kind of primitive an introspection snapshot describes. Matches
+ * the kit's `IntrospectionKind` and the routing the topology aggregator
+ * does when bucketing adapters vs plugins vs middleware vs contributor
+ * primitives.
+ */
+export type IntrospectionKind = 'plugin' | 'adapter' | 'middleware' | 'contributor'
+
+/**
+ * Convenience function signature for adopter-side helpers that return
+ * a complete snapshot. Used by the optional `introspect?()` hook on
+ * `AppAdapter` and `KickPlugin`.
+ */
+export type IntrospectFn = () => IntrospectionSnapshot | Promise<IntrospectionSnapshot>

--- a/packages/kickjs/src/core/plugin.ts
+++ b/packages/kickjs/src/core/plugin.ts
@@ -2,6 +2,7 @@ import type { Container } from './container'
 import type { AppAdapter } from './adapter'
 import type { AppModuleEntry } from './app-module'
 import type { ContributorRegistrations } from './context-decorator'
+import type { IntrospectionSnapshot } from './introspect'
 import type { KickJsPluginName } from './augmentation'
 import type { ModuleRegistry } from './module-registry'
 
@@ -192,12 +193,13 @@ export interface KickPlugin {
    * the implementation cheap (counters + flags, no DB round trips) since
    * the topology endpoint polls on a short interval.
    *
-   * The return type is intentionally untyped at this layer to avoid
-   * `@forinda/kickjs` taking on a runtime dep on `@forinda/kickjs-devtools-kit`.
-   * Plugin authors should import and return `IntrospectionSnapshot`
-   * from `@forinda/kickjs-devtools-kit` directly.
+   * The return type lives in `@forinda/kickjs` itself
+   * ({@link IntrospectionSnapshot}) so adopters can author `introspect()`
+   * without importing the kit just to satisfy the contract. The kit's
+   * own `IntrospectionSnapshot` type stays structurally identical;
+   * either import works.
    */
-  introspect?(): unknown | Promise<unknown>
+  introspect?(): IntrospectionSnapshot | Promise<IntrospectionSnapshot>
 
   /**
    * Optional DevTools tabs this plugin contributes (architecture.md §23).

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -277,6 +277,23 @@ export class Application {
 
   private readonly plugins: KickPlugin[]
 
+  /**
+   * Snapshot of every module-level Context Contributor registration
+   * captured during `setup()`. The registrations themselves are
+   * frozen by `defineContextDecorator`, so storing references is
+   * safe — they outlive the module instances they came from.
+   *
+   * Used by {@link getContributors} so DevTools and adopter tooling
+   * can render the module-level contributors alongside the adapter /
+   * plugin / global ones. Populated once per `setup()` call; cleared
+   * at the start of each invocation so a re-setup (test harnesses,
+   * dev-server restarts) doesn't accumulate stale entries.
+   */
+  private _moduleContributors: Array<{
+    registration: { key: string; dependsOn: readonly string[] }
+    label: string
+  }> = []
+
   /** Number of HTTP requests currently being processed */
   private _inFlightRequests = 0
   /** Whether the application is draining (shutting down gracefully) */
@@ -565,14 +582,29 @@ export class Application {
       }),
     )
 
+    // Reset module-contributor snapshot at the start of each setup
+    // pass so re-running `setup()` (test harnesses, dev-server
+    // restarts) doesn't accumulate stale entries.
+    this._moduleContributors = []
+
     for (const mod of modules) {
+      const moduleLabel = mod.constructor?.name ?? 'module'
       const moduleSources: SourcedRegistration[] = (mod.contributors?.() ?? []).map(
         (registration): SourcedRegistration => ({
           source: 'module',
           registration,
-          label: mod.constructor?.name ?? 'module',
+          label: moduleLabel,
         }),
       )
+      // Retain registrations for `getContributors()` — these would
+      // otherwise be unreachable post-bootstrap (module instances
+      // are not kept on the Application).
+      for (const src of moduleSources) {
+        this._moduleContributors.push({
+          registration: src.registration as { key: string; dependsOn: readonly string[] },
+          label: moduleLabel,
+        })
+      }
 
       // Thread per-module + adapter + global sources to buildRoutes via the
       // module-scoped slot. Module setup is sequential, so the slot is
@@ -878,30 +910,37 @@ export class Application {
 
   /**
    * Snapshot of every Context Contributor reachable from this app —
-   * walks the four registration sites (adapters, plugins, global, and
-   * the bootstrap `contributors` option). Module-level contributors
-   * are NOT included; module instances aren't retained post-bootstrap.
-   * The devtools Topology tab consumes this for the Contributors
-   * panel; tests + adopters can call it for diagnostics.
+   * walks **four** registration sites: adapters, plugins, modules,
+   * and the bootstrap `contributors` option. The devtools Topology
+   * tab consumes this for the Contributors panel; tests + adopters
+   * can call it for diagnostics.
+   *
+   * Per-route (method/class-decorator) registrations are NOT included
+   * here — they live on the route registry rather than on any of
+   * the four collection sites this method walks. A future RPC will
+   * surface them separately.
    *
    * Result shape stays minimal — `{ key, source, label, dependsOn }`
    * — so we don't leak `resolve` closures or other internal fields.
+   * `source` matches the five-level precedence union from
+   * `ContributorSource` (minus `'method'` / `'class'` which require
+   * the per-route walk noted above).
    */
   getContributors(): ReadonlyArray<{
     key: string
-    source: 'adapter' | 'plugin' | 'global'
+    source: 'module' | 'adapter' | 'plugin' | 'global'
     label: string
     dependsOn: readonly string[]
   }> {
     const out: Array<{
       key: string
-      source: 'adapter' | 'plugin' | 'global'
+      source: 'module' | 'adapter' | 'plugin' | 'global'
       label: string
       dependsOn: readonly string[]
     }> = []
     const ingest = (
       list: ReadonlyArray<unknown> | null | undefined,
-      source: 'adapter' | 'plugin' | 'global',
+      source: 'module' | 'adapter' | 'plugin' | 'global',
       label: string,
     ): void => {
       if (!list) return
@@ -925,6 +964,12 @@ export class Application {
     }
     for (const plugin of this.plugins) {
       ingest(plugin.contributors?.(), 'plugin', plugin.name ?? 'plugin')
+    }
+    // Module-level registrations — captured during `setup()` because
+    // module instances are not retained on the Application. Walk the
+    // snapshot rather than calling `mod.contributors()` here.
+    for (const { registration, label } of this._moduleContributors) {
+      ingest([registration], 'module', label)
     }
     ingest(this.options.contributors, 'global', 'bootstrap')
     return out

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -431,6 +431,13 @@ export class Application {
   async setup(): Promise<void> {
     log.debug('Bootstrapping application...')
 
+    // Reset module-contributor snapshot at the very top of each
+    // setup pass — before anything that could throw — so a partial
+    // failure doesn't leave stale entries that getContributors()
+    // would surface on the next call. See _moduleContributors field
+    // declaration for the use case.
+    this._moduleContributors = []
+
     // Collect adapter middleware by phase
     const adapterMw = this.collectAdapterMiddleware()
 
@@ -588,7 +595,18 @@ export class Application {
     this._moduleContributors = []
 
     for (const mod of modules) {
-      const moduleLabel = mod.constructor?.name ?? 'module'
+      // Prefer the declared `name` field (set by `defineModule({ name: 'X', ... })`)
+      // over `constructor.name`. Factory-built modules are plain objects whose
+      // constructor is `Object` — falling straight to `constructor.name` would
+      // degrade every label in the DevTools Contributors table to "Object".
+      const declaredName = (mod as { name?: unknown }).name
+      const ctorName = mod.constructor?.name
+      const moduleLabel =
+        typeof declaredName === 'string' && declaredName.length > 0
+          ? declaredName
+          : ctorName && ctorName !== 'Object'
+            ? ctorName
+            : 'module'
       const moduleSources: SourcedRegistration[] = (mod.contributors?.() ?? []).map(
         (registration): SourcedRegistration => ({
           source: 'module',


### PR DESCRIPTION
## Summary

Three related fixes addressing two adopter reports: the DevTools dashboard wasn't surfacing data that `introspect()` and context-contributor `dependsOn` were already providing.

## Root-cause audit

Background agent did a focused investigation before any code changed. Findings:

- **Server side fully wired.** `/_debug/topology` collects every adapter's `introspect()` snapshot in parallel with 100ms timeouts; all six documented fields ship on the wire.
- **SPA drops half the snapshot.** `PrimitiveRow` in `TopologyTab.tsx` only rendered `name`, `version`, `tokens.provides`, `metrics` — silently ignoring `state`, `tokens.requires`, `memoryBytes`, `kind`.
- **`dependsOn` survives — but module-level contributors don't appear.** The wire-format passes `dependsOn` through correctly. The Contributors table just had nothing to display for module-level registrations because `Application.getContributors()` deliberately excluded them ("module instances aren't retained post-bootstrap").

## Changes

### 1. `packages/devtools/spa/src/tabs/TopologyTab.tsx` — render the full snapshot

`PrimitiveRow` now renders `kind`, `memoryBytes` (formatted as B/KB/MB/GB), `tokens.requires`, and `state` (key/value rows, JSON-stringified for nested values) alongside the existing `name` / `version` / `tokens.provides` / `metrics`.

### 2. `packages/kickjs/src/http/application.ts` — retain + expose module contributors

`Application` gains a private `_moduleContributors` field. `setup()` captures every `mod.contributors?.()` registration into it (cleared at start of each pass so re-setup doesn't accumulate stale entries). `getContributors()` returns those entries with `source: 'module'`, intact `dependsOn`, and the module's class name as `label`.

The return-type union widens from `'adapter' | 'plugin' | 'global'` to include `'module'`. Per-route registrations (method/class decorators on controllers) are still NOT included — they live on the route registry and warrant a separate RPC; flagged in the JSDoc as a follow-up.

### 3. `packages/devtools/src/topology.ts` + `packages/devtools-kit/src/types.ts` — widen source union

Kit was typed `source: string` with a JSDoc-documented enum. Server collapsed `'plugin' | 'global'` → `'adapter'` because of an earlier narrower type. Both removed:

```ts
export type TopologyContributorSource =
  | 'method' | 'class' | 'module' | 'adapter' | 'plugin' | 'global'
```

Server passes `c.source` through unchanged. Dashboards can now badge / filter by the real origin. Backward-compatible wire change (new enum value on an existing string field).

### 4. `packages/kickjs/src/core/introspect.ts` (NEW) — type contract lives in the framework

`AppAdapter.introspect?()` and `KickPlugin.introspect?()` were typed as `unknown` — the JSDoc told adopters to import `IntrospectionSnapshot` from `@forinda/kickjs-devtools-kit` just to satisfy the return-type contract, taking on a dep for the type alone.

The canonical `IntrospectionSnapshot` type now lives in `@forinda/kickjs` (`core/introspect.ts`). The kit's existing `IntrospectionSnapshot` stays structurally identical for back-compat. Adopters who don't already use the kit get full inference without an extra import:

```ts
export const MyAdapter = defineAdapter({
  name: 'MyAdapter',
  build: () => ({
    introspect() {
      // Return-type fully inferred — no `import type` needed.
      return {
        protocolVersion: 1,
        name: 'MyAdapter',
        kind: 'adapter',
        state: { connectedAt: Date.now() },
        memoryBytes: 12_345,
        tokens: { provides: ['REDIS'], requires: [] },
        version: '1.0',
        metrics: { activeConnections: 3 },
      }
    },
  }),
})
```

## Test plan

- [x] `application-get-contributors.test.ts` — 8 tests, 3 new:
  - `dependsOn` survives `getContributors()` (regression guard against silent drop)
  - Module-level contributors appear after `setup()` with `source: 'module'` and intact `dependsOn`
  - Re-setup doesn't accumulate stale module entries
- [x] `packages/devtools/__tests__/topology.test.ts` — 8/8 still passing
- [x] `pnpm typecheck` clean across `kickjs`, `kickjs-devtools-kit`, `kickjs-devtools`
- [x] `pnpm lint` clean (0 errors, same 1 pre-existing unrelated warning)
- [x] Pre-commit hooks green
- [ ] Manual: run a project with an adapter implementing all six snapshot fields, open `/_debug/topology`, confirm every field renders
- [ ] Manual: declare a `defineModule({ build: () => ({ contributors: () => [...] }) })` with `dependsOn`, confirm it appears in the Contributors table with the deps populated

## Follow-up

- **Per-route contributors** — `@LoadX` on controllers stamps the registration onto the route metadata, not on any of the four collection sites `getContributors()` walks. Surfacing those would either need a new RPC (e.g. `/_debug/contributors/per-route`) or extending `/routes` to include per-handler contributor keys. Worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Topology UI now shows additional introspection details: component kind, memory usage, token requirements, and state values
  * Module-level contributors are now surfaced in contributor lists
  * Contributor provenance labels refined for clearer source attribution
  * Introspection snapshot types are now exposed for adopters and plugin authors

* **Tests**
  * Added regression tests for contributor metadata preservation and module-contributor visibility and re-setup behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->