### PR TITLE
feat(reactivity): ref() and computed() auto-unwrap on JSON.stringify

### DIFF
--- a/.changeset/ref-tojson.md
+++ b/.changeset/ref-tojson.md
@@ -1,0 +1,39 @@
+---
+'@forinda/kickjs': minor
+---
+
+feat(reactivity): `ref()` and `computed()` auto-unwrap on `JSON.stringify`
+
+Both `ref()` and `computed()` now implement `toJSON()` returning their current `value`. This means refs serialise transparently inside larger JSON payloads — adopters who keep adapter / plugin state in refs and surface it via `introspect()` no longer need to `.value`-unwrap manually at every call site:
+
+```ts
+// Before — manual unwrap:
+introspect() {
+  return {
+    state: {
+      connectedAt: this.connectedAt.value, // .value everywhere
+      activeConnections: this.activeConnections.value,
+    },
+  }
+}
+
+// After — refs serialise as their value:
+introspect() {
+  return {
+    state: {
+      connectedAt: this.connectedAt,        // JSON.stringify unwraps
+      activeConnections: this.activeConnections,
+    },
+  }
+}
+```
+
+`computed()` recomputes when stale on `toJSON` access — same cost as reading `.value`.
+
+The `Ref<T>` and `ComputedRef<T>` interfaces gain a `toJSON(): T` method to match.
+
+**`reactive()` is unchanged** — JSON.stringify walks its enumerable keys via the existing Proxy get-trap, already producing the correct shape. Test pins that behaviour as a regression guard.
+
+**One-shot semantics**: `JSON.stringify` calls `toJSON` exactly once per value chain. `ref(ref(x))` serialises to `{"value": x}` rather than `x` because the inner ref's `toJSON` is reached via property walking, not a fresh substitution. The test suite documents this so a future "recursive unwrap" refactor doesn't land silently.
+
+Backward-compatible — `toJSON` is additive, and existing code that read `.value` continues to work unchanged.

--- a/.changeset/ref-tojson.md
+++ b/.changeset/ref-tojson.md
@@ -4,7 +4,7 @@
 
 feat(reactivity): `ref()` and `computed()` auto-unwrap on `JSON.stringify`
 
-Both `ref()` and `computed()` now implement `toJSON()` returning their current `value`. This means refs serialise transparently inside larger JSON payloads — adopters who keep adapter / plugin state in refs and surface it via `introspect()` no longer need to `.value`-unwrap manually at every call site:
+Both `ref()` and `computed()` now implement `toJSON()` returning their current `value`. This means refs serialize transparently inside larger JSON payloads — adopters who keep adapter / plugin state in refs and surface it via `introspect()` no longer need to `.value`-unwrap manually at every call site:
 
 ```ts
 // Before — manual unwrap:
@@ -17,7 +17,7 @@ introspect() {
   }
 }
 
-// After — refs serialise as their value:
+// After — refs serialize as their value:
 introspect() {
   return {
     state: {
@@ -32,8 +32,8 @@ introspect() {
 
 The `Ref<T>` and `ComputedRef<T>` interfaces gain a `toJSON(): T` method to match.
 
-**`reactive()` is unchanged** — JSON.stringify walks its enumerable keys via the existing Proxy get-trap, already producing the correct shape. Test pins that behaviour as a regression guard.
+**`reactive()` is unchanged** — JSON.stringify walks its enumerable keys via the existing Proxy get-trap, already producing the correct shape. Test pins that behavior as a regression guard.
 
-**One-shot semantics**: `JSON.stringify` calls `toJSON` exactly once per value chain. `ref(ref(x))` serialises to `{"value": x}` rather than `x` because the inner ref's `toJSON` is reached via property walking, not a fresh substitution. The test suite documents this so a future "recursive unwrap" refactor doesn't land silently.
+**One-shot semantics**: `JSON.stringify` calls `toJSON` exactly once per value chain. `ref(ref(x))` serializes to `{"value": x}` rather than `x` because the inner ref's `toJSON` is reached via property walking, not a fresh substitution. The test suite documents this so a future "recursive unwrap" refactor doesn't land silently.
 
 Backward-compatible — `toJSON` is additive, and existing code that read `.value` continues to work unchanged.

--- a/packages/kickjs/__tests__/reactivity-tojson.test.ts
+++ b/packages/kickjs/__tests__/reactivity-tojson.test.ts
@@ -1,0 +1,91 @@
+import 'reflect-metadata'
+import { describe, it, expect } from 'vitest'
+
+import { ref, computed, reactive } from '../src/core/reactivity'
+
+/**
+ * Locks in the `toJSON` auto-unwrap on ref / computed — added so
+ * adapter/plugin authors can return refs from `introspect()` and have
+ * JSON.stringify unwrap them transparently. Without this, the wrapper
+ * shape leaks (`{"value":…,"subscribe":…}` instead of the underlying
+ * value), and adopters had to `.value`-unwrap by hand on every site.
+ */
+describe('ref().toJSON — auto-unwrap on JSON.stringify', () => {
+  it('serialises a primitive ref as its value, not the wrapper', () => {
+    const count = ref(42)
+    expect(JSON.stringify(count)).toBe('42')
+  })
+
+  it('serialises an object ref as its value', () => {
+    const user = ref({ id: 1, name: 'alice' })
+    expect(JSON.parse(JSON.stringify(user))).toEqual({ id: 1, name: 'alice' })
+  })
+
+  it('unwraps refs nested inside a plain object', () => {
+    // Real-world shape: an introspect() snapshot whose `state` field
+    // contains refs from the adapter's internal reactive state.
+    const snapshot = {
+      protocolVersion: 1 as const,
+      name: 'RedisAdapter',
+      kind: 'adapter' as const,
+      state: {
+        connectedAt: ref(1_700_000_000_000),
+        activeConnections: ref(3),
+      },
+      metrics: {
+        cacheHits: ref(120),
+      },
+    }
+    const json = JSON.parse(JSON.stringify(snapshot))
+    expect(json.state.connectedAt).toBe(1_700_000_000_000)
+    expect(json.state.activeConnections).toBe(3)
+    expect(json.metrics.cacheHits).toBe(120)
+  })
+
+  it('reflects the current value when serialised after a write', () => {
+    const flag = ref(false)
+    flag.value = true
+    expect(JSON.stringify(flag)).toBe('true')
+  })
+
+  it('one-shot unwrap — JSON.stringify calls toJSON exactly once per chain (nested refs preserved as wrapper)', () => {
+    // Document the one-shot behaviour: `JSON.stringify`'s toJSON
+    // substitution fires once per value, so `ref(ref(x))` serialises
+    // to the inner ref's enumerable shape (`{"value":x}`), NOT to `x`.
+    // Adopters shouldn't wrap a ref in another ref deliberately;
+    // assert here so a future "recursive unwrap" refactor doesn't
+    // land silently.
+    const inner = ref(7)
+    const outer = ref(inner)
+    expect(JSON.parse(JSON.stringify(outer))).toEqual({ value: 7 })
+  })
+})
+
+describe('computed().toJSON — auto-unwrap with stale-cache recompute', () => {
+  it('serialises a computed value as its current cached result', () => {
+    const base = ref(10)
+    const doubled = computed(() => base.value * 2)
+    expect(JSON.stringify(doubled)).toBe('20')
+  })
+
+  it('recomputes if the dependency changed since last read', () => {
+    const base = ref(5)
+    const doubled = computed(() => base.value * 2)
+    // Read once to fill the cache.
+    void doubled.value
+    base.value = 8
+    // toJSON triggers a recompute when stale; identical to reading .value.
+    expect(JSON.stringify(doubled)).toBe('16')
+  })
+})
+
+describe('reactive().toJSON — plain serialisation through the Proxy', () => {
+  it('serialises a reactive object by walking its enumerable keys', () => {
+    // No explicit toJSON on the Proxy — JSON.stringify enumerates
+    // the underlying target's keys via the get trap, which returns
+    // the raw value for primitives. This test pins existing behaviour
+    // so a future Proxy refactor doesn't accidentally break it.
+    const state = reactive({ users: 10, errors: 0 })
+    expect(JSON.parse(JSON.stringify(state))).toEqual({ users: 10, errors: 0 })
+  })
+})

--- a/packages/kickjs/__tests__/reactivity-tojson.test.ts
+++ b/packages/kickjs/__tests__/reactivity-tojson.test.ts
@@ -11,12 +11,12 @@ import { ref, computed, reactive } from '../src/core/reactivity'
  * value), and adopters had to `.value`-unwrap by hand on every site.
  */
 describe('ref().toJSON — auto-unwrap on JSON.stringify', () => {
-  it('serialises a primitive ref as its value, not the wrapper', () => {
+  it('serializes a primitive ref as its value, not the wrapper', () => {
     const count = ref(42)
     expect(JSON.stringify(count)).toBe('42')
   })
 
-  it('serialises an object ref as its value', () => {
+  it('serializes an object ref as its value', () => {
     const user = ref({ id: 1, name: 'alice' })
     expect(JSON.parse(JSON.stringify(user))).toEqual({ id: 1, name: 'alice' })
   })
@@ -42,15 +42,15 @@ describe('ref().toJSON — auto-unwrap on JSON.stringify', () => {
     expect(json.metrics.cacheHits).toBe(120)
   })
 
-  it('reflects the current value when serialised after a write', () => {
+  it('reflects the current value when serialized after a write', () => {
     const flag = ref(false)
     flag.value = true
     expect(JSON.stringify(flag)).toBe('true')
   })
 
   it('one-shot unwrap — JSON.stringify calls toJSON exactly once per chain (nested refs preserved as wrapper)', () => {
-    // Document the one-shot behaviour: `JSON.stringify`'s toJSON
-    // substitution fires once per value, so `ref(ref(x))` serialises
+    // Document the one-shot behavior: `JSON.stringify`'s toJSON
+    // substitution fires once per value, so `ref(ref(x))` serializes
     // to the inner ref's enumerable shape (`{"value":x}`), NOT to `x`.
     // Adopters shouldn't wrap a ref in another ref deliberately;
     // assert here so a future "recursive unwrap" refactor doesn't
@@ -62,7 +62,7 @@ describe('ref().toJSON — auto-unwrap on JSON.stringify', () => {
 })
 
 describe('computed().toJSON — auto-unwrap with stale-cache recompute', () => {
-  it('serialises a computed value as its current cached result', () => {
+  it('serializes a computed value as its current cached result', () => {
     const base = ref(10)
     const doubled = computed(() => base.value * 2)
     expect(JSON.stringify(doubled)).toBe('20')
@@ -79,11 +79,11 @@ describe('computed().toJSON — auto-unwrap with stale-cache recompute', () => {
   })
 })
 
-describe('reactive().toJSON — plain serialisation through the Proxy', () => {
-  it('serialises a reactive object by walking its enumerable keys', () => {
+describe('reactive().toJSON — plain serialization through the Proxy', () => {
+  it('serializes a reactive object by walking its enumerable keys', () => {
     // No explicit toJSON on the Proxy — JSON.stringify enumerates
     // the underlying target's keys via the get trap, which returns
-    // the raw value for primitives. This test pins existing behaviour
+    // the raw value for primitives. This test pins existing behavior
     // so a future Proxy refactor doesn't accidentally break it.
     const state = reactive({ users: 10, errors: 0 })
     expect(JSON.parse(JSON.stringify(state))).toEqual({ users: 10, errors: 0 })

--- a/packages/kickjs/src/core/reactivity.ts
+++ b/packages/kickjs/src/core/reactivity.ts
@@ -43,7 +43,7 @@ export interface Ref<T = any> {
   subscribe(fn: (newValue: T, oldValue: T) => void): () => void
   /**
    * Auto-unwrap on `JSON.stringify` — returns the underlying value
-   * so refs serialise transparently inside larger payloads (introspect
+   * so refs serialize transparently inside larger payloads (introspect
    * snapshots, devtools state, request responses). Equivalent to
    * `unref(ref)` but invoked implicitly by the JSON pipeline.
    */
@@ -83,7 +83,7 @@ export function ref<T>(initialValue: T): Ref<T> {
       return () => subscribers.delete(fn)
     },
     /**
-     * Auto-unwrap on `JSON.stringify`. Without this, serialising a ref
+     * Auto-unwrap on `JSON.stringify`. Without this, serializing a ref
      * leaks the wrapper shape (`{"value": …, "subscribe": …}`) instead
      * of the underlying value — particularly painful for adopters who
      * keep adapter / plugin state in refs and surface it through
@@ -152,7 +152,7 @@ export function computed<T>(getter: () => T): ComputedRef<T> {
       return recompute()
     },
     /**
-     * Auto-unwrap on `JSON.stringify`, matching {@link ref}'s behaviour
+     * Auto-unwrap on `JSON.stringify`, matching {@link ref}'s behavior
      * so adopters can drop a computed straight into a JSON-bound
      * payload (introspect snapshot, devtools state) and get the value
      * rather than the wrapper shape.

--- a/packages/kickjs/src/core/reactivity.ts
+++ b/packages/kickjs/src/core/reactivity.ts
@@ -41,6 +41,13 @@ export interface Ref<T = any> {
   value: T
   /** Subscribe to changes. Returns unsubscribe function. */
   subscribe(fn: (newValue: T, oldValue: T) => void): () => void
+  /**
+   * Auto-unwrap on `JSON.stringify` — returns the underlying value
+   * so refs serialise transparently inside larger payloads (introspect
+   * snapshots, devtools state, request responses). Equivalent to
+   * `unref(ref)` but invoked implicitly by the JSON pipeline.
+   */
+  toJSON(): T
 }
 
 /**
@@ -75,6 +82,18 @@ export function ref<T>(initialValue: T): Ref<T> {
       subscribers.add(fn)
       return () => subscribers.delete(fn)
     },
+    /**
+     * Auto-unwrap on `JSON.stringify`. Without this, serialising a ref
+     * leaks the wrapper shape (`{"value": …, "subscribe": …}`) instead
+     * of the underlying value — particularly painful for adopters who
+     * keep adapter / plugin state in refs and surface it through
+     * `introspect()`. Returning `value` here means
+     * `JSON.stringify({ count: ref(0) })` produces `{"count":0}` as
+     * expected, without callers having to `.value`-unwrap by hand.
+     */
+    toJSON(): T {
+      return wrapper._value
+    },
   }
 }
 
@@ -82,6 +101,12 @@ export function ref<T>(initialValue: T): Ref<T> {
 
 export interface ComputedRef<T = any> {
   readonly value: T
+  /**
+   * Auto-unwrap on `JSON.stringify` — see {@link Ref.toJSON} for the
+   * motivation. Triggers a recompute when the cached value is stale,
+   * same as reading `.value`.
+   */
+  toJSON(): T
 }
 
 /**
@@ -106,21 +131,38 @@ export function computed<T>(getter: () => T): ComputedRef<T> {
     trigger(wrapper, '_value')
   }
 
+  const recompute = (): T => {
+    if (dirty) {
+      const prev = activeEffect
+      activeEffect = effect
+      try {
+        cached = getter()
+      } finally {
+        activeEffect = prev
+      }
+      wrapper._value = cached
+      dirty = false
+    }
+    return cached
+  }
+
   return {
     get value(): T {
       track(wrapper, '_value')
-      if (dirty) {
-        const prev = activeEffect
-        activeEffect = effect
-        try {
-          cached = getter()
-        } finally {
-          activeEffect = prev
-        }
-        wrapper._value = cached
-        dirty = false
-      }
-      return cached
+      return recompute()
+    },
+    /**
+     * Auto-unwrap on `JSON.stringify`, matching {@link ref}'s behaviour
+     * so adopters can drop a computed straight into a JSON-bound
+     * payload (introspect snapshot, devtools state) and get the value
+     * rather than the wrapper shape.
+     *
+     * Computed values cache through the same dirty-flag the getter
+     * uses, so calling `toJSON` is at worst one recompute when stale —
+     * identical cost to reading `.value`.
+     */
+    toJSON(): T {
+      return recompute()
     },
   }
 }


### PR DESCRIPTION
## Summary

Both `ref()` and `computed()` now implement `toJSON()` returning their current `value`. Refs serialise transparently inside JSON payloads — `JSON.stringify({ count: ref(0) })` now produces `{"count":0}` instead of `{"count":{"value":0,"subscribe":…}}`.

## Why

Came out of the `introspect()` design discussion on #252. Adopters who use refs for adapter / plugin internal state had to `.value`-unwrap every field by hand when surfacing them through `introspect()`:

```ts
// Before — manual unwrap at every site
introspect() {
  return {
    state: {
      connectedAt: this.connectedAt.value,
      activeConnections: this.activeConnections.value,
    },
    metrics: { cacheHits: this.cacheHits.value },
  }
}

// After — refs serialise as their value, no .value churn
introspect() {
  return {
    state: {
      connectedAt: this.connectedAt,
      activeConnections: this.activeConnections,
    },
    metrics: { cacheHits: this.cacheHits },
  }
}
```

`computed()` recomputes when stale on `toJSON` access — same cost as reading `.value`.

## Changes

- `packages/kickjs/src/core/reactivity.ts`:
  - `ref()` returns object now includes `toJSON(): T => wrapper._value`
  - `computed()` extracts the cache-check logic into a `recompute()` helper used by both the `value` getter and the new `toJSON()`
  - `Ref<T>` and `ComputedRef<T>` interfaces gain a `toJSON(): T` method
- `packages/kickjs/__tests__/reactivity-tojson.test.ts`: 8 new tests covering primitive ref, object ref, ref inside an object, write-then-stringify, computed read, computed stale-recompute on stringify, reactive() proxy untouched, and the one-shot semantics for nested refs.

## One-shot semantics

`JSON.stringify` calls `toJSON` exactly once per value chain. `ref(ref(x))` therefore serialises to `{"value": x}` rather than `x` — the inner ref's `toJSON` is reached via property walking, not a fresh substitution.

The test suite documents this so a future "recursive unwrap" refactor doesn't land silently. Adopters shouldn't wrap a ref in another ref deliberately; if it ever shows up as a real adopter request, the right fix is to assign-to-reactive (which auto-unwraps in the assignment) rather than recursive `toJSON`.

## Test plan

- [x] `packages/kickjs/__tests__/reactivity-tojson.test.ts` — 8/8 passing
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors, same pre-existing unrelated warning)
- [x] Pre-commit hooks green

## Backward compatibility

Fully additive. `toJSON` is a new method on existing objects; nothing that read `.value` previously changes behaviour. Adopters who hand-unwrap can keep doing so — the new behaviour just makes that unnecessary.

## Related

Follows-up on the design discussion in #252. Independent of that PR — touches different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reactive references and computed values now serialize to their underlying values with JSON.stringify; computed values recompute when stale during serialization.

* **Tests**
  * Added test coverage verifying serialization behavior, nested unwrapping rules, recomputation semantics, and reactive object serialization.

* **Documentation**
  * Release notes updated describing toJSON behavior and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->