### PR TITLE
deps: move zod to peerDependencies; align swagger peer range

### DIFF
--- a/.changeset/zod-peer-dep.md
+++ b/.changeset/zod-peer-dep.md
@@ -1,0 +1,22 @@
+---
+'@forinda/kickjs': minor
+'@forinda/kickjs-swagger': patch
+---
+
+deps: move `zod` to `peerDependencies` in `@forinda/kickjs`; align `@forinda/kickjs-swagger` peer range
+
+**Why:** Pinning `zod` as a regular `dependency` of `@forinda/kickjs` meant adopters got whichever zod version kickjs happened to ship with — and couldn't upgrade to a newer zod release until kickjs cut a new version. Multiple zod copies in `node_modules` were also possible, with the well-known "schema built with copy A doesn't pass through `parse()` dispatched from copy B" failure mode on minor mismatches.
+
+Both packages now declare `zod: ^4.0.0` as a **peer dependency**, so the adopter picks the version. Within zod 4.x they can freely upgrade; for a future zod 5 they wait for kickjs to declare support (zod has historically had breaking majors).
+
+**`@forinda/kickjs`** — `zod` moved from `dependencies` to `peerDependencies` (required, not optional — `baseEnvSchema = z.object(...)` runs at module load when `@forinda/kickjs` is imported, so the framework can't load without zod present).
+
+**`@forinda/kickjs-swagger`** — peer range tightened from `>=4.0.0` to `^4.0.0` for consistency with kickjs. Stays optional: `schema-parser.ts` duck-types Zod schemas (no `import 'zod'` in `src/`) so adopters using non-Zod parsers (Joi, Valibot, Yup, ArkType) don't need zod at all.
+
+**Upgrade impact:**
+
+- Projects scaffolded with `kick new` already pin `zod: ^4.4.3` — no action required.
+- Projects on `npm install`, `yarn` (non-strict), or `pnpm install` without `--strict-peer-dependencies` will see a "missing peer dependency" warning if they don't have zod. Fix: `pnpm add zod` (or your package manager's equivalent).
+- Projects using pnpm with `strict-peer-dependencies=true` or npm 7+ with `--legacy-peer-deps=false` will hard-fail until they add zod themselves.
+
+No runtime API change. `import { z, baseEnvSchema, defineEnv, loadEnv, ... } from '@forinda/kickjs'` continues to work identically once zod is installed.

--- a/packages/kickjs/package.json
+++ b/packages/kickjs/package.json
@@ -135,12 +135,12 @@
     "multer": "^2.1.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
-    "reflect-metadata": "^0.2.2",
-    "zod": "^4.4.3"
+    "reflect-metadata": "^0.2.2"
   },
   "peerDependencies": {
     "dotenv": "^17.0.0",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "zod": "^4.0.0"
   },
   "peerDependenciesMeta": {
     "dotenv": {
@@ -155,7 +155,8 @@
     "@types/node": "^25.8.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.13",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.6",
+    "zod": "^4.4.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "express": "^5.1.0",
-    "zod": ">=4.0.0",
+    "zod": "^4.0.0",
     "@forinda/kickjs": ">=2.3.0"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1116,9 +1116,6 @@ importers:
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
-      zod:
-        specifier: ^4.4.3
-        version: 4.4.3
     devDependencies:
       '@swc/core':
         specifier: ^1.15.33
@@ -1144,6 +1141,9 @@ importers:
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   packages/lint:
     devDependencies:


### PR DESCRIPTION
## Why

Pinning `zod` as a regular `dependency` of `@forinda/kickjs` locked adopters to whichever zod version kickjs happened to ship with. Users on a newer zod 4.x couldn't upgrade until kickjs cut a release. The "two copies of zod in `node_modules`" failure mode (schema built with copy A doesn't pass through `parse()` from copy B) was also possible.

## What

**`@forinda/kickjs`** — `zod` moved from `dependencies` to `peerDependencies` at `^4.0.0`. **Required**, not optional: `baseEnvSchema = z.object(...)` runs at module load when `@forinda/kickjs` is imported, so the framework can't load without zod present. Added to `devDependencies` so workspace install/build/test still resolves a copy.

**`@forinda/kickjs-swagger`** — peer range tightened from `>=4.0.0` to `^4.0.0` for consistency. Stays optional: `schema-parser.ts` duck-types Zod schemas (no `import 'zod'` in `src/`), so adopters using Joi/Valibot/Yup/ArkType genuinely don't need zod at all.

## Install-contract impact

- Projects scaffolded with `kick new` already pin `zod: ^4.4.3` — no action required
- Projects on `pnpm install` with `strict-peer-dependencies=true` or `npm@7+` with `--legacy-peer-deps=false` need to add `zod: ^4.x` explicitly
- Build output is unchanged — `zod` was already in tsdown's `external` list (`packages/kickjs/tsdown.config.ts:51`)

## Test plan

- [x] `pnpm --filter @forinda/kickjs exec vitest run` — 450/452 pass (2 Windows-path tests in `assets.test.ts` pre-existing and unrelated, fixed in a separate PR)
- [x] `pnpm --filter @forinda/kickjs-swagger exec vitest run` — 49/49 pass
- [x] `pnpm install` clean with `pnpm-lock.yaml` updated
- [ ] Smoke-test an adopter project on each package manager (pnpm strict, npm, yarn) — left for CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Adjusted `zod` dependency structure: moved from bundled to peer dependency and tightened version constraints to `^4.0.0` for consistency across packages. No runtime API changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->