### PR TITLE
fix(assets): normalise resolveAsset output to posix paths on every platform

### DIFF
--- a/.changeset/assets-posix-paths.md
+++ b/.changeset/assets-posix-paths.md
@@ -1,0 +1,15 @@
+---
+'@forinda/kickjs': patch
+---
+
+fix(assets): always return posix paths from `resolveAsset` / `assets.x.y()` / `useAssets()`
+
+`resolveAsset` now normalises returned paths to forward slashes on every platform. On Windows, it previously emitted native paths (`C:\Users\foo\dist\mails\welcome.ejs`), which broke:
+
+- splicing the result into URLs (`href` / `src` / CDN keys) — backslashes are invalid in URLs and silently corrupt the link
+- cross-host equality comparisons (a path produced on Windows vs. one on Linux)
+- substring assertions in adopters' tests
+
+Node's `fs.*` and Express's path-handling APIs accept either separator on Windows, so this change is safe for the common consumers — `express.static`, `res.sendFile`, `ejs.renderFile`, etc. The only adopter code it could break is something explicitly parsing Windows backslashes back out of the result, which would already be brittle.
+
+The internal manifest stays unchanged on disk; normalisation happens at the public-API boundary in `resolveAsset` only. The same value is then surfaced through `assets.x.y()`, `useAssets()`, and the `@Asset()` decorator.

--- a/packages/kickjs/__tests__/assets.test.ts
+++ b/packages/kickjs/__tests__/assets.test.ts
@@ -10,6 +10,15 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+
+/**
+ * `resolveAsset` normalises returned paths to posix (forward slashes)
+ * on every platform so adopters can splice them into URLs and compare
+ * them across hosts. Tests construct expected paths via `join(cwd,
+ * 'rel/path')` which yields backslashes on Windows — wrap with
+ * `toPosix()` so assertions hold on both Windows and posix CI.
+ */
+const toPosix = (p: string): string => p.replaceAll('\\', '/')
 import {
   ASSET_MANIFEST_VERSION,
   ASSETS,
@@ -78,20 +87,20 @@ describe('resolveAsset — built manifest path (prod)', () => {
     writeManifest('dist', { 'mails/welcome': 'mails/welcome.ejs' })
     writeFile('dist/mails/welcome.ejs', 'hi')
     const path = resolveAsset('mails', 'welcome')
-    expect(path).toBe(join(cwd, 'dist/mails/welcome.ejs'))
+    expect(path).toBe(toPosix(join(cwd, 'dist/mails/welcome.ejs')))
   })
 
   it('honours absolute manifest entries verbatim', () => {
     const abs = join(cwd, 'somewhere/else/file.txt')
     writeFile('somewhere/else/file.txt')
     writeManifest('dist', { 'x/y': abs })
-    expect(resolveAsset('x', 'y')).toBe(abs)
+    expect(resolveAsset('x', 'y')).toBe(toPosix(abs))
   })
 
   it('also probes build/ + out/ for the manifest', () => {
     writeManifest('out', { 'reports/monthly': 'reports/monthly.ejs' })
     writeFile('out/reports/monthly.ejs')
-    expect(resolveAsset('reports', 'monthly')).toBe(join(cwd, 'out/reports/monthly.ejs'))
+    expect(resolveAsset('reports', 'monthly')).toBe(toPosix(join(cwd, 'out/reports/monthly.ejs')))
   })
 
   it('skips a future-version manifest + falls through', () => {
@@ -110,7 +119,7 @@ describe('resolveAsset — KICK_ASSETS_ROOT env override', () => {
     writeFile('custom/mails/welcome.ejs')
     process.env.KICK_ASSETS_ROOT = join(cwd, 'custom')
     clearAssetCache()
-    expect(resolveAsset('mails', 'welcome')).toBe(join(cwd, 'custom/mails/welcome.ejs'))
+    expect(resolveAsset('mails', 'welcome')).toBe(toPosix(join(cwd, 'custom/mails/welcome.ejs')))
   })
 
   it('falls back to dist when the env path has no manifest', () => {
@@ -118,7 +127,7 @@ describe('resolveAsset — KICK_ASSETS_ROOT env override', () => {
     writeFile('dist/mails/welcome.ejs')
     process.env.KICK_ASSETS_ROOT = join(cwd, 'nonexistent')
     clearAssetCache()
-    expect(resolveAsset('mails', 'welcome')).toBe(join(cwd, 'dist/mails/welcome.ejs'))
+    expect(resolveAsset('mails', 'welcome')).toBe(toPosix(join(cwd, 'dist/mails/welcome.ejs')))
   })
 })
 
@@ -131,9 +140,11 @@ describe('resolveAsset — dev fallback (no manifest)', () => {
     writeFile('src/templates/mails/welcome.ejs', 'hi')
     writeFile('src/templates/mails/orders/confirmation.ejs', 'order')
 
-    expect(resolveAsset('mails', 'welcome')).toBe(join(cwd, 'src/templates/mails/welcome.ejs'))
+    expect(resolveAsset('mails', 'welcome')).toBe(
+      toPosix(join(cwd, 'src/templates/mails/welcome.ejs')),
+    )
     expect(resolveAsset('mails', 'orders/confirmation')).toBe(
-      join(cwd, 'src/templates/mails/orders/confirmation.ejs'),
+      toPosix(join(cwd, 'src/templates/mails/orders/confirmation.ejs')),
     )
   })
 
@@ -147,7 +158,7 @@ describe('resolveAsset — dev fallback (no manifest)', () => {
     writeFile('src/x/keep.ejs', 'keep')
     writeFile('src/x/skip.txt', 'skip')
 
-    expect(resolveAsset('x', 'keep')).toBe(join(cwd, 'src/x/keep.ejs'))
+    expect(resolveAsset('x', 'keep')).toBe(toPosix(join(cwd, 'src/x/keep.ejs')))
     expect(() => resolveAsset('x', 'skip')).toThrow(UnknownAssetError)
   })
 
@@ -196,14 +207,14 @@ describe('Variant A — assets Proxy ambient', () => {
     // would narrow this in real adopter code, but at runtime the
     // shape works without it.
     const path = (assets as any).mails.welcome()
-    expect(path).toBe(join(cwd, 'dist/mails/welcome.ejs'))
+    expect(path).toBe(toPosix(join(cwd, 'dist/mails/welcome.ejs')))
   })
 
   it('resolves nested access (assets.mails.orders.confirmation())', () => {
     writeManifest('dist', { 'mails/orders/confirmation': 'mails/orders/confirmation.ejs' })
     writeFile('dist/mails/orders/confirmation.ejs')
     const path = (assets as any).mails.orders.confirmation()
-    expect(path).toBe(join(cwd, 'dist/mails/orders/confirmation.ejs'))
+    expect(path).toBe(toPosix(join(cwd, 'dist/mails/orders/confirmation.ejs')))
   })
 
   it('returns undefined for thenable detection (Promise.resolve unwrap)', () => {
@@ -229,7 +240,7 @@ describe('Variant A — assets Proxy ambient', () => {
     const ns = 'reports'
     const key = 'monthly'
     const path = (assets as any)[ns][key]()
-    expect(path).toBe(join(cwd, 'dist/reports/monthly.ejs'))
+    expect(path).toBe(toPosix(join(cwd, 'dist/reports/monthly.ejs')))
   })
 })
 
@@ -247,7 +258,7 @@ describe('Variant B — useAssets hook', () => {
         return (this.assetsRef as any).mails.welcome()
       }
     }
-    expect(new MailService().welcome()).toBe(join(cwd, 'dist/mails/welcome.ejs'))
+    expect(new MailService().welcome()).toBe(toPosix(join(cwd, 'dist/mails/welcome.ejs')))
   })
 })
 
@@ -272,7 +283,7 @@ describe('@Asset decorator', () => {
 
     Container.getInstance().register(MailService, MailService)
     const svc = Container.getInstance().resolve(MailService)
-    expect(svc.welcomeTemplate).toBe(join(cwd, 'dist/mails/welcome.ejs'))
+    expect(svc.welcomeTemplate).toBe(toPosix(join(cwd, 'dist/mails/welcome.ejs')))
   })
 
   it('resolves nested-path assets (mails/orders/confirmation)', async () => {
@@ -289,7 +300,7 @@ describe('@Asset decorator', () => {
 
     Container.getInstance().register(MailService, MailService)
     const svc = Container.getInstance().resolve(MailService)
-    expect(svc.orderConfirmation).toBe(join(cwd, 'dist/mails/orders/confirmation.ejs'))
+    expect(svc.orderConfirmation).toBe(toPosix(join(cwd, 'dist/mails/orders/confirmation.ejs')))
   })
 
   it('is lazy — resolves on access, not at instantiation', async () => {
@@ -311,7 +322,7 @@ describe('@Asset decorator', () => {
     writeFile('dist/mails/welcome.ejs')
     clearAssetCache()
 
-    expect(inst.template).toBe(join(cwd, 'dist/mails/welcome.ejs'))
+    expect(inst.template).toBe(toPosix(join(cwd, 'dist/mails/welcome.ejs')))
   })
 
   it('throws UnknownAssetError on access for missing assets', async () => {

--- a/packages/kickjs/src/core/assets.ts
+++ b/packages/kickjs/src/core/assets.ts
@@ -72,6 +72,28 @@ export class UnknownAssetError extends Error {
 
 let manifestCache: ResolvedManifest | null | undefined = undefined
 
+/**
+ * Convert a filesystem path to its posix (forward-slash) form. The
+ * asset manifest and the public `resolveAsset` / `assets.x.y()` /
+ * `useAssets()` contract returns posix paths on every platform so
+ * adopters can:
+ *
+ * - pass the result to `express.static` / `res.sendFile` / `ejs.renderFile`
+ *   without worrying about Windows vs. posix separators
+ * - splice the path into URLs (`href`, `src`, CDN keys) without
+ *   replacing `\` with `/` by hand
+ * - compare two paths from `resolveAsset` for equality on any host
+ *
+ * Node's `fs.*` and Express's path-handling APIs accept either
+ * separator on Windows, so this normalisation is safe — the only
+ * adopter code it could break is something explicitly parsing
+ * Windows backslashes back out of the result, which would already be
+ * brittle.
+ */
+function toPosixPath(p: string): string {
+  return p.replaceAll('\\', '/')
+}
+
 export function resolveAsset(namespace: string, key: string): string {
   const resolved = loadManifest()
   if (!resolved) {
@@ -81,7 +103,8 @@ export function resolveAsset(namespace: string, key: string): string {
   if (!entry) {
     throw new UnknownAssetError(namespace, key)
   }
-  return isAbsolute(entry) ? entry : resolve(resolved.root, entry)
+  const abs = isAbsolute(entry) ? entry : resolve(resolved.root, entry)
+  return toPosixPath(abs)
 }
 
 /** Reset the manifest cache. Tests use this; production code shouldn't need it. */


### PR DESCRIPTION
## Why

`resolveAsset()` (and by extension `assets.x.y()`, `useAssets()`, `@Asset()`) returned native-separator paths on Windows: `C:\Users\foo\dist\mails\welcome.ejs`. That broke:

- splicing the result into URLs (`href` / `src` / CDN keys) — backslashes are invalid in URLs and silently corrupt the link
- cross-host string equality (a path emitted on Windows isn't `===` to the same path emitted on Linux)
- the two long-standing `assets.test.ts` failures on Windows CI (the `.toContain('mails/welcome.ejs')` assertions) that were authored assuming posix output

## What

Added a `toPosixPath()` helper in `packages/kickjs/src/core/assets.ts` and applied it at the public-API boundary in `resolveAsset()`. The manifest on disk stays untouched; only the return value is normalised. Node's `fs.*` and Express path handlers accept either separator on Windows, so the common consumers (`express.static`, `res.sendFile`, `ejs.renderFile`) keep working.

Updated all `toBe(join(cwd, '...'))` assertions in `assets.test.ts` to wrap with a local `toPosix()` helper so they hold on both Windows and posix CI.

## Test plan

- [x] `pnpm exec vitest run __tests__/assets.test.ts` — **26/26 pass on Windows** (was 24/26)
- [x] `pnpm exec vitest run` (full kickjs suite) — **452/452 pass** (was 450/452)
- [x] No downstream consumers grep-broken — only the CLI's typegen/scaffold templates reference these symbols, and they generate types rather than consuming the path string at runtime

## Compat note

If any adopter code is explicitly parsing Windows backslashes back out of the result (e.g. `path.split('\\')`), it'll need updating to `path.split('/')`. That code was already brittle and platform-locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Asset path resolution now consistently returns forward-slash paths on all platforms, fixing issues with URL construction and equality comparisons that previously failed on Windows.

* **Tests**
  * Updated asset resolution tests to verify consistent path formatting across all platforms and access patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->