### PR TITLE
deps: make multer optional peer, remove unused cookie-parser

### DIFF
--- a/.changeset/kickjs-optional-peers.md
+++ b/.changeset/kickjs-optional-peers.md
@@ -1,0 +1,11 @@
+---
+'@forinda/kickjs': minor
+---
+
+deps: make `multer` an optional peer dependency; remove unused `cookie-parser`
+
+**multer** moves from `dependencies` to `peerDependencies` (range `^2.0.0`) with `peerDependenciesMeta.optional: true`. The package is now lazy-loaded via `createRequire(import.meta.url)` inside `upload.ts`, so importing `@forinda/kickjs` no longer touches `multer`. Adopters who never call `upload.single/array/none()` or use `@FileUpload` don't need it installed at all. If you do call those APIs without `multer` installed, you get a clear runtime error: `"@forinda/kickjs: file uploads require the 'multer' package, which is not installed. Install it: pnpm add multer"`.
+
+**cookie-parser** is removed entirely. It was never imported anywhere in the source — only mentioned in a `csrf.ts` JSDoc snippet as an example of middleware adopters should wire themselves. The `@types/cookie-parser` devDep is removed too.
+
+No breaking change for adopters who already have `multer` installed (pnpm/npm 7+ auto-install peers; pnpm strict mode surfaces a clear warning).

--- a/packages/kickjs/package.json
+++ b/packages/kickjs/package.json
@@ -131,26 +131,28 @@
     }
   },
   "dependencies": {
-    "cookie-parser": "^1.4.7",
-    "multer": "^2.1.1",
     "reflect-metadata": "^0.2.2"
   },
   "peerDependencies": {
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
+    "multer": "^2.0.0",
     "zod": "^4.0.0"
   },
   "peerDependenciesMeta": {
     "dotenv": {
       "optional": true
+    },
+    "multer": {
+      "optional": true
     }
   },
   "devDependencies": {
     "@swc/core": "^1.15.33",
-    "@types/cookie-parser": "^1.4.10",
     "@types/express": "^5.0.6",
     "@types/multer": "^2.1.0",
     "@types/node": "^25.8.0",
+    "multer": "^2.1.1",
     "typescript": "^6.0.3",
     "vite": "^8.0.13",
     "vitest": "^4.1.6",

--- a/packages/kickjs/src/http/middleware/upload.ts
+++ b/packages/kickjs/src/http/middleware/upload.ts
@@ -1,7 +1,31 @@
 import { unlink } from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import type { Request, Response, NextFunction, RequestHandler } from 'express'
-import multer, { type Options as MulterOptions } from 'multer'
+import type { Options as MulterOptions } from 'multer'
 import type { BaseUploadOptions, FileUploadConfig } from '../../core'
+
+// `multer` is an optional peer dependency. We load it lazily via
+// `createRequire` so importing this module never touches `multer` —
+// only constructing an upload middleware does. Adopters who never
+// call `upload.single/array/none()` or use `@FileUpload` don't need
+// `multer` installed at all.
+const requireFromHere = createRequire(import.meta.url)
+type MulterFactory = typeof import('multer').default
+let _multer: MulterFactory | undefined
+
+function loadMulter(): MulterFactory {
+  if (_multer) return _multer
+  try {
+    const mod = requireFromHere('multer')
+    _multer = (mod.default ?? mod) as MulterFactory
+    return _multer
+  } catch {
+    throw new Error(
+      "@forinda/kickjs: file uploads require the 'multer' package, which is not installed.\n" +
+        'Install it as a peer dependency: pnpm add multer (or npm i multer / yarn add multer).',
+    )
+  }
+}
 
 /**
  * Maps short file extensions to their MIME types.
@@ -134,7 +158,7 @@ function createMulter(options: UploadOptions) {
     ...(options.dest ? { dest: options.dest } : {}),
   }
 
-  return multer(multerOptions)
+  return loadMulter()(multerOptions)
 }
 
 /**

--- a/packages/kickjs/src/http/middleware/upload.ts
+++ b/packages/kickjs/src/http/middleware/upload.ts
@@ -9,15 +9,18 @@ import type { BaseUploadOptions, FileUploadConfig } from '../../core'
 // only constructing an upload middleware does. Adopters who never
 // call `upload.single/array/none()` or use `@FileUpload` don't need
 // `multer` installed at all.
+//
+// multer uses CJS `export = multer`, so the module is itself the
+// callable factory — no `.default` indirection on either the type
+// or the runtime side.
 const requireFromHere = createRequire(import.meta.url)
-type MulterFactory = typeof import('multer').default
+type MulterFactory = typeof import('multer')
 let _multer: MulterFactory | undefined
 
 function loadMulter(): MulterFactory {
   if (_multer) return _multer
   try {
-    const mod = requireFromHere('multer')
-    _multer = (mod.default ?? mod) as MulterFactory
+    _multer = requireFromHere('multer') as MulterFactory
     return _multer
   } catch {
     throw new Error(

--- a/packages/kickjs/tsdown.config.ts
+++ b/packages/kickjs/tsdown.config.ts
@@ -45,7 +45,6 @@ export default defineConfig({
     'express',
     'reflect-metadata',
     'multer',
-    'cookie-parser',
     'dotenv',
     'dotenv/config',
     'zod',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1092,18 +1092,12 @@ importers:
 
   packages/kickjs:
     dependencies:
-      cookie-parser:
-        specifier: ^1.4.7
-        version: 1.4.7
       dotenv:
         specifier: ^17.0.0
         version: 17.3.1
       express:
         specifier: ^5.1.0
         version: 5.2.1
-      multer:
-        specifier: ^2.1.1
-        version: 2.1.1
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1111,9 +1105,6 @@ importers:
       '@swc/core':
         specifier: ^1.15.33
         version: 1.15.33
-      '@types/cookie-parser':
-        specifier: ^1.4.10
-        version: 1.4.10(@types/express@5.0.6)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -1123,6 +1114,9 @@ importers:
       '@types/node':
         specifier: ^25.8.0
         version: 25.8.0
+      multer:
+        specifier: ^2.1.1
+        version: 2.1.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -3327,11 +3321,6 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
-  '@types/cookie-parser@1.4.10':
-    resolution: {integrity: sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==}
-    peerDependencies:
-      '@types/express': '*'
-
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
 
@@ -4090,13 +4079,6 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  cookie-parser@1.4.7:
-    resolution: {integrity: sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==}
-    engines: {node: '>= 0.8.0'}
-
-  cookie-signature@1.0.6:
-    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -8442,10 +8424,6 @@ snapshots:
     dependencies:
       '@types/node': 25.8.0
 
-  '@types/cookie-parser@1.4.10(@types/express@5.0.6)':
-    dependencies:
-      '@types/express': 5.0.6
-
   '@types/cookiejar@2.1.5': {}
 
   '@types/cors@2.8.19':
@@ -9267,13 +9245,6 @@ snapshots:
   content-type@1.0.5: {}
 
   convert-source-map@2.0.0: {}
-
-  cookie-parser@1.4.7:
-    dependencies:
-      cookie: 0.7.2
-      cookie-signature: 1.0.6
-
-  cookie-signature@1.0.6: {}
 
   cookie-signature@1.2.2: {}
 


### PR DESCRIPTION
## Why

Two small install-contract issues in `@forinda/kickjs`:

1. **`multer`** was a hard `dependency`, locking adopters to whatever multer version kickjs shipped — even adopters who never call any upload API still paid the install cost and got their multer version pinned for them.
2. **`cookie-parser`** was a hard `dependency` that the framework **never imports**. It only appeared in a JSDoc snippet in `csrf.ts` showing adopters how to wire it themselves. Pure dead weight.

## What

**multer → optional peer dependency**

- Moved from `dependencies` to `peerDependencies` at `^2.0.0` with `peerDependenciesMeta.optional: true`
- Replaced the top-level `import multer from 'multer'` in `packages/kickjs/src/http/middleware/upload.ts` with a lazy `createRequire(import.meta.url)` loader cached on first call
- `createMulter()` now invokes `loadMulter()(multerOptions)` instead of the static import
- Type-only import of `Options as MulterOptions` is preserved (types don't trigger a runtime resolve)
- If multer isn't installed and the upload API is called, the user sees a clear actionable error:
  ```
  @forinda/kickjs: file uploads require the 'multer' package, which is not installed.
  Install it as a peer dependency: pnpm add multer (or npm i multer / yarn add multer).
  ```
- `multer@^2.1.1` stays in `devDependencies` so workspace install/build/test still resolves a copy

**cookie-parser → deleted**

- Removed from `dependencies`
- `@types/cookie-parser` removed from `devDependencies`
- Removed from `tsdown.config.ts` `external` list (it was never imported, so this was just noise)
- The JSDoc snippet in `csrf.ts` still shows `cookieParser()` as part of the recommended middleware chain — that's user-owned wiring, kickjs never imported it directly

## Install-contract impact

- **Adopters using `upload.single/array/none()` or `@FileUpload`**: need `multer` in their dependencies. Most package managers auto-install peers — pnpm with `auto-install-peers=true` (default since pnpm 8), npm 7+ default behavior — so no action. pnpm strict mode users get a clear warning and add it themselves
- **Adopters not using uploads**: smaller install (drops `multer` + `busboy` + `append-field` + a few others)
- **`cookie-parser`**: anyone using `csrf()` or sessions already had to install and wire `cookieParser()` themselves (the framework never set it up). No change needed

## Test plan

- [x] `pnpm --filter @forinda/kickjs test` — **452/452 pass**
- [x] `pnpm --filter @forinda/kickjs-example-minimal-api test` — **3/3 pass**
- [x] Full monorepo build clean
- [x] `pnpm install` resolves cleanly with the new peer-meta layout

## Note on stacking

This branch is cut from `main`, not stacked on [#265](https://github.com/forinda/kick-js/pull/265) (the logger refactor). They touch disjoint files (`logger.ts` + `package.json:deps` for pino, `upload.ts` + `package.json:deps` for multer), so they can land in either order. If #265 merges first this PR rebases cleanly; if this PR merges first, #265 rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
