### PR TITLE
deps(ws,devtools): move `ws` to peerDependencies

### DIFF
--- a/.changeset/ws-devtools-peer-ws.md
+++ b/.changeset/ws-devtools-peer-ws.md
@@ -1,0 +1,10 @@
+---
+'@forinda/kickjs-ws': patch
+'@forinda/kickjs-devtools': patch
+---
+
+deps: move `ws` from `dependencies` to `peerDependencies` in both packages
+
+Both `@forinda/kickjs-ws` and `@forinda/kickjs-devtools` shipped `ws@^8.20.1` as a hard `dependency`. Adopters who already had `ws` installed (very common — it's used directly, through `socket.io`, through `undici`, through tons of other libs) could end up with two copies in `node_modules`, which breaks `instanceof WebSocket` checks and confuses some bundlers.
+
+Both packages now declare `ws` as a `peerDependencies` entry at `^8.0.0`. `ws@^8.20.1` stays in `devDependencies` so the workspace install/build/test still resolves a copy. Modern package managers auto-install peers (pnpm 8+ with `auto-install-peers=true`, npm 7+), so most adopters need no action; pnpm strict-mode users add `ws` to their dependencies explicitly.

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -71,11 +71,11 @@
   },
   "dependencies": {
     "@forinda/kickjs-devtools-kit": "workspace:*",
-    "reflect-metadata": "^0.2.2",
-    "ws": "^8.20.1"
+    "reflect-metadata": "^0.2.2"
   },
   "peerDependencies": {
     "express": "^5.1.0",
+    "ws": "^8.0.0",
     "@forinda/kickjs": ">=2.3.0"
   },
   "devDependencies": {
@@ -88,7 +88,8 @@
     "typescript": "^6.0.3",
     "vite": "^8.0.13",
     "vite-plugin-solid": "^2.11.12",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.6",
+    "ws": "^8.20.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -68,8 +68,7 @@
     }
   },
   "dependencies": {
-    "reflect-metadata": "^0.2.2",
-    "ws": "^8.20.1"
+    "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
     "@forinda/kickjs": "workspace:*",
@@ -77,7 +76,8 @@
     "@types/node": "^25.8.0",
     "@types/ws": "^8.18.0",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.6",
+    "ws": "^8.20.1"
   },
   "publishConfig": {
     "access": "public"
@@ -97,7 +97,8 @@
     "url": "https://github.com/forinda/kick-js/issues"
   },
   "peerDependencies": {
-    "@forinda/kickjs": ">=2.3.0"
+    "@forinda/kickjs": ">=2.3.0",
+    "ws": "^8.0.0"
   },
   "peerDependenciesMeta": {}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1003,9 +1003,6 @@ importers:
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
-      ws:
-        specifier: ^8.20.1
-        version: 8.20.1
     devDependencies:
       '@forinda/kickjs':
         specifier: workspace:*
@@ -1037,6 +1034,9 @@ importers:
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+      ws:
+        specifier: ^8.20.1
+        version: 8.20.1
 
   packages/devtools-kit:
     devDependencies:
@@ -1365,9 +1365,6 @@ importers:
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
-      ws:
-        specifier: ^8.20.1
-        version: 8.20.1
     devDependencies:
       '@forinda/kickjs':
         specifier: workspace:*
@@ -1387,6 +1384,9 @@ importers:
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+      ws:
+        specifier: ^8.20.1
+        version: 8.20.1
 
 packages:
 


### PR DESCRIPTION
## Why

Both `@forinda/kickjs-ws` and `@forinda/kickjs-devtools` shipped `ws@^8.20.1` as a hard `dependency`. The `ws` package is ubiquitous — many adopters already have it installed (directly, or transitively via `socket.io`, `undici`, etc.). When two copies land in `node_modules` at different ranges, `instanceof WebSocket` checks fail across copies, and a few bundlers get confused about which export to use.

## What

`ws` moves from `dependencies` to `peerDependencies` at `^8.0.0` in both packages. The workspace itself still installs `ws@^8.20.1` via `devDependencies` so build/test/typecheck keep working.

| Package | Before | After |
|---|---|---|
| `@forinda/kickjs-ws` | `dependencies: ws ^8.20.1` | `peerDependencies: ws ^8.0.0` + `devDependencies: ws ^8.20.1` |
| `@forinda/kickjs-devtools` | `dependencies: ws ^8.20.1` | `peerDependencies: ws ^8.0.0` + `devDependencies: ws ^8.20.1` |

## Install-contract impact

- **pnpm 8+ (`auto-install-peers=true` default)**: zero action required
- **npm 7+**: zero action required (auto-installs peers)
- **pnpm strict mode (`strict-peer-dependencies=true`)**: surfaces a clear warning; adopters add `ws` to their own `dependencies`
- **yarn 3+ classic**: may need explicit declaration

Adopters who already have `ws` installed end up with **one canonical copy** instead of two.

## Test plan

- [x] `pnpm --filter @forinda/kickjs-ws test` — **7/7 pass**
- [x] `pnpm --filter @forinda/kickjs-devtools test` — **94/94 pass**
- [x] `pnpm --filter @forinda/kickjs-example-task-drizzle-api test` — **144/144 pass** (this example uses both ws and devtools — confirms peer-dep resolution works in a real consumer)
- [x] `pnpm install` clean after change

## Note on stacking

Branch cut from `main`, independent of [#265](https://github.com/forinda/kick-js/pull/265) (logger refactor) and [#266](https://github.com/forinda/kick-js/pull/266) (multer/cookie-parser peers). All three touch disjoint files and can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
