### PR TITLE
deps(db-adapters): declare `kysely` as peer at matching range

### DIFF
--- a/.changeset/db-adapters-kysely-peer.md
+++ b/.changeset/db-adapters-kysely-peer.md
@@ -1,0 +1,13 @@
+---
+'@forinda/kickjs-db-pg': patch
+'@forinda/kickjs-db-mysql': patch
+'@forinda/kickjs-db-sqlite': patch
+---
+
+deps: declare `kysely` as a peer dependency instead of a direct dependency
+
+`@forinda/kickjs-db-pg`, `@forinda/kickjs-db-mysql`, and `@forinda/kickjs-db-sqlite` each used to declare `kysely: 0.29.2` as a direct `dependency`. `@forinda/kickjs-db` (which all three depend on as a peer) also declares the same exact version. With four separate exact pins, pnpm dedupes to a single copy today — but the moment one adapter bumps independently of the others, you get two copies of kysely in `node_modules`. Kysely is dialect-sensitive (the `PostgresDialect` / `MysqlDialect` / `SqliteDialect` classes carry module-augmented types) so two copies break `instanceof` checks and confuse downstream type inference.
+
+Each adapter now declares `kysely: 0.29.2` as a `peerDependencies` entry pointing at the **same range** as `@forinda/kickjs-db`. The kickjs-db package keeps `kysely` as a `dependency` (it's the query-engine of that package, not a swappable choice). Adapters import `PostgresDialect`/`MysqlDialect`/`SqliteDialect` from kysely directly, so the peer declaration is required — without it, adopters using strict resolution wouldn't find kysely from the adapter's import path.
+
+No version change for adopters: pnpm 8+ and npm 7+ auto-install peers, so the resolved tree is the same — except now there's a hard guarantee that the adapter and kickjs-db agree on the kysely version.

--- a/packages/db-mysql/package.json
+++ b/packages/db-mysql/package.json
@@ -53,11 +53,10 @@
       "dependencies": []
     }
   },
-  "dependencies": {
-    "kysely": "0.29.2"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@forinda/kickjs-db": "workspace:^",
+    "kysely": "0.29.2",
     "mysql2": ">=3.0.0"
   },
   "devDependencies": {

--- a/packages/db-pg/package.json
+++ b/packages/db-pg/package.json
@@ -51,11 +51,10 @@
       "dependencies": []
     }
   },
-  "dependencies": {
-    "kysely": "0.29.2"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@forinda/kickjs-db": "workspace:^",
+    "kysely": "0.29.2",
     "pg": ">=8.11.0"
   },
   "devDependencies": {

--- a/packages/db-sqlite/package.json
+++ b/packages/db-sqlite/package.json
@@ -53,11 +53,10 @@
       "dependencies": []
     }
   },
-  "dependencies": {
-    "kysely": "0.29.2"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@forinda/kickjs-db": "workspace:^",
+    "kysely": "0.29.2",
     "better-sqlite3": ">=12.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -921,10 +921,6 @@ importers:
         version: 6.0.3
 
   packages/db-mysql:
-    dependencies:
-      kysely:
-        specifier: 0.29.2
-        version: 0.29.2
     devDependencies:
       '@forinda/kickjs':
         specifier: workspace:*
@@ -935,6 +931,9 @@ importers:
       '@types/node':
         specifier: ^25.8.0
         version: 25.8.0
+      kysely:
+        specifier: ^0.29.2
+        version: 0.29.2
       mysql2:
         specifier: ^3.22.3
         version: 3.22.3(@types/node@25.8.0)
@@ -943,10 +942,6 @@ importers:
         version: 6.0.3
 
   packages/db-pg:
-    dependencies:
-      kysely:
-        specifier: 0.29.2
-        version: 0.29.2
     devDependencies:
       '@forinda/kickjs':
         specifier: workspace:*
@@ -963,6 +958,9 @@ importers:
       '@types/pg':
         specifier: ^8.11.10
         version: 8.20.0
+      kysely:
+        specifier: ^0.29.2
+        version: 0.29.2
       pg:
         specifier: ^8.21.0
         version: 8.21.0
@@ -971,10 +969,6 @@ importers:
         version: 6.0.3
 
   packages/db-sqlite:
-    dependencies:
-      kysely:
-        specifier: 0.29.2
-        version: 0.29.2
     devDependencies:
       '@forinda/kickjs':
         specifier: workspace:*
@@ -991,6 +985,9 @@ importers:
       better-sqlite3:
         specifier: ^12.10.0
         version: 12.10.0
+      kysely:
+        specifier: ^0.29.2
+        version: 0.29.2
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Why

`@forinda/kickjs-db-pg`, `@forinda/kickjs-db-mysql`, and `@forinda/kickjs-db-sqlite` each declared `kysely: 0.29.2` as a direct `dependency`. `@forinda/kickjs-db` (which all three depend on as a peer) also declared the same exact version. **Four separate exact pins** meant pnpm currently dedupes to a single copy — but the moment one adapter bumps its kysely pin independently of the others, you get two copies of kysely in `node_modules`.

Kysely is dialect-sensitive: `PostgresDialect`, `MysqlDialect`, and `SqliteDialect` carry module-augmented types and singleton-like behavior in some areas. Two copies in `node_modules` would break `instanceof` checks and confuse downstream type inference where adopter code does `import { Kysely } from 'kysely'` and tries to feed a dialect from a kickjs adapter into it.

## What

`@forinda/kickjs-db-pg` / `-db-mysql` / `-db-sqlite` each move `kysely` from `dependencies` to `peerDependencies` at the same exact version (`0.29.2`) that `@forinda/kickjs-db` already declares.

| Package | Before | After |
|---|---|---|
| `@forinda/kickjs-db-pg` | `dependencies: kysely 0.29.2` | `peerDependencies: kysely 0.29.2` |
| `@forinda/kickjs-db-mysql` | `dependencies: kysely 0.29.2` | `peerDependencies: kysely 0.29.2` |
| `@forinda/kickjs-db-sqlite` | `dependencies: kysely 0.29.2` | `peerDependencies: kysely 0.29.2` |
| `@forinda/kickjs-db` | `dependencies: kysely 0.29.2` | **unchanged** — it's the query engine |

The adapter source code is unchanged — each `dialect.ts` still does `import { PostgresDialect } from 'kysely'` (etc.); kysely now resolves transitively through `@forinda/kickjs-db`'s own `dependencies` entry, plus the peer declaration documents the requirement explicitly.

## Verification

```
$ pnpm --filter "@forinda/kickjs-db*" exec pnpm why kysely

@forinda/kickjs-db@5.9.0       → kysely 0.29.2
@forinda/kickjs-db-pg@9.0.4    → @forinda/kickjs-db (link) → kysely 0.29.2
@forinda/kickjs-db-mysql@2.0.1 → @forinda/kickjs-db (link) → kysely 0.29.2
@forinda/kickjs-db-sqlite@2.0.1 → @forinda/kickjs-db (link) → kysely 0.29.2
```

Single kysely 0.29.2 copy across the workspace.

## Install-contract impact

- **pnpm 8+ (`auto-install-peers=true` default)**: zero action required
- **npm 7+**: zero action required (auto-installs peers)
- **pnpm strict mode**: surfaces a warning and adopters add `kysely` explicitly — they already had it transitively through `@forinda/kickjs-db`, so the install tree is unchanged
- **Future-proofing**: any independent version bump of one adapter no longer risks introducing a second kysely copy. The peer declaration is the contract that says "this adapter and kickjs-db must agree on kysely's version"

## Test plan

- [x] `pnpm --filter @forinda/kickjs-db-mysql test` — **34/34 pass**
- [x] `pnpm --filter @forinda/kickjs-db-sqlite test` — **13/13 pass**
- [x] `pnpm --filter @forinda/kickjs-db-pg exec vitest run __tests__/integration/abort-signal-pg.test.ts` — **3/3 pass** (one flaky testcontainer timeout on first parallel run; passes cleanly in isolation, unrelated to this change)
- [x] `pnpm install` clean
- [x] `pnpm why kysely` shows single 0.29.2 across all four packages

## Note on stacking

Branch is cut from `main`, independent of [#265](https://github.com/forinda/kick-js/pull/265) (logger), [#266](https://github.com/forinda/kick-js/pull/266) (multer peer), and [#267](https://github.com/forinda/kick-js/pull/267) (ws peer). All four touch disjoint files and can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
