### PR TITLE
feat(errors): structured KickError with code, cause, and fix hint

### DIFF
--- a/.changeset/error-messages-fix-hints.md
+++ b/.changeset/error-messages-fix-hints.md
@@ -1,0 +1,58 @@
+---
+'@forinda/kickjs': minor
+---
+
+feat(errors): structured KickError with code, cause, and fix hint
+
+Framework-thrown errors are now `KickError` instances — a multi-line, scannable shape with a stable code, a cause explanation, an actionable fix, and a docs URL.
+
+```
+KICK001: No provider for UserService
+
+  Cause:
+    UserService was requested from the DI container but no binding
+    is registered. This usually means one of:
+      • The class is decorated with @Service() / @Repository() / @Controller(),
+        but its enclosing module isn't passed to bootstrap({ modules: [...] }).
+      • The class isn't decorated at all (decorators register the binding).
+      • You're injecting a token (created with createToken()) that nothing
+        provides — add a Container.register(TOKEN, ...) call or a module that
+        binds it.
+
+  Fix:
+    If UserService lives in a module, add the module to bootstrap:
+
+      bootstrap({
+        modules: [
+          UsersModule,        // add this
+          OtherModule,
+        ],
+      })
+
+  Docs:
+    https://forinda.github.io/kick-js/guide/dependency-injection#registering-services
+```
+
+**First catalog pass — 5 errors upgraded:**
+
+| Code      | When it fires                                                                |
+| --------- | ---------------------------------------------------------------------------- |
+| `KICK001` | DI: no provider registered for the requested token                           |
+| `KICK002` | DI: REQUEST-scoped binding resolved without request-scope middleware mounted |
+| `KICK003` | DI: REQUEST-scoped binding resolved outside an HTTP request                  |
+| `KICK004` | Config: `@Value('X')` resolved but env var not set and no default given      |
+| `KICK005` | Module: `routes()` declared a path without `controller` or `router`          |
+
+More framework errors will migrate to `KickError` over time. Codes are stable and never reused.
+
+**API:**
+
+- `KickError` class — extends `Error`. Holds `code`, `summary`, `cause`, `fix`, `docsUrl`, `context`. `.message` carries the full multi-line plain-text body so Node's default `Error.toString()` surfaces the helpful version automatically.
+- `formatKickError(err, { color })` — ANSI-colored renderer for terminal output. Honors `NO_COLOR` / `FORCE_COLOR` env vars when the `color` option is omitted.
+- All five catalog entries exposed via factory functions (`noProviderError`, `envValueMissingError`, etc.) for use by adopters' own integrations.
+
+**Backward compat:** errors still `instanceof Error`. Adopter code that catches generic `Error` keeps working. The previous error `message` substrings are replaced — adopters matching on those (e.g. `err.message.includes('No binding found')`) need to update to match the new wording, OR — better — switch to matching on `err.code` which is stable.
+
+**Tests:** 17 new in `kick-error.test.ts` (class, formatter, ANSI gating, every catalog entry, code uniqueness). Full kickjs suite **509/509 pass**.
+
+Closes B.2 (first pass) from the roadmap.

--- a/.changeset/error-messages-fix-hints.md
+++ b/.changeset/error-messages-fix-hints.md
@@ -6,7 +6,7 @@ feat(errors): structured KickError with code, cause, and fix hint
 
 Framework-thrown errors are now `KickError` instances — a multi-line, scannable shape with a stable code, a cause explanation, an actionable fix, and a docs URL.
 
-```
+```text
 KICK001: No provider for UserService
 
   Cause:

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -93,6 +93,112 @@ The `notFoundHandler()` middleware is placed before the error handler to catch u
 { "message": "Not Found" }
 ```
 
+## Framework errors with fix hints
+
+Framework-thrown errors (DI resolution failures, missing env vars, malformed module setup, etc.) use the `KickError` class — a structured error type with a stable `code`, a one-line `summary`, a `cause` explanation, an actionable `fix` block, and a `docsUrl`. The result is multi-line, scannable, and points at the exact change to apply:
+
+```
+KICK001: No provider for UserService
+
+  Cause:
+    `UserService` was requested from the DI container but no binding
+    is registered.
+    This usually means one of:
+      • The class is decorated with @Service() / @Repository() / @Controller(),
+        but its enclosing module isn't passed to bootstrap({ modules: [...] }).
+      • The class isn't decorated at all (decorators register the binding).
+      • You're injecting a token (created with createToken()) that nothing
+        provides — add a Container.register(TOKEN, ...) call or a module that
+        binds it.
+
+  Fix:
+    If `UserService` lives in a module, add the module to bootstrap:
+
+      bootstrap({
+        modules: [
+          UsersModule,        // add this
+          OtherModule,
+        ],
+      })
+
+    If it's a custom token, register it explicitly:
+
+      const TENANT_REPO = createToken<TenantRepo>('TENANT_REPO')
+      Container.getInstance().register(TENANT_REPO, { useClass: PrismaTenantRepo })
+
+  Docs:
+    https://forinda.github.io/kick-js/guide/dependency-injection#registering-services
+```
+
+### Catalog (current set)
+
+| Code      | When it fires                                                                |
+| --------- | ---------------------------------------------------------------------------- |
+| `KICK001` | DI: no provider registered for the requested token                           |
+| `KICK002` | DI: REQUEST-scoped binding resolved without request-scope middleware mounted |
+| `KICK003` | DI: REQUEST-scoped binding resolved outside an HTTP request                  |
+| `KICK004` | Config: `@Value('X')` resolved but env var not set and no default given      |
+| `KICK005` | Module: `routes()` declared a path without `controller` or `router`          |
+
+More framework errors will migrate to `KickError` over time. Each new entry gets the next free code; codes are stable and never reused.
+
+### Anatomy
+
+```ts
+import { KickError } from '@forinda/kickjs'
+
+throw new KickError({
+  code: 'APP001',
+  summary: 'My one-line headline',
+  cause: 'Multi-line\nexplanation of why this happened.',
+  fix: 'Actionable multi-line steps, with example code.',
+  docsUrl: 'https://example.com/docs/my-error',
+  context: { foo: 'bar' }, // structured fields for log consumers
+})
+```
+
+`KickError` extends `Error`, so `instanceof Error` catches still see it. The `.message` field carries the full multi-line plain-text body — Node's default `Error.toString()` and unhandled-exception printing surface the helpful version automatically. No setup required.
+
+### Colorized output
+
+Call `formatKickError(err, { color: true })` to get the ANSI-colored version for terminal logging:
+
+```ts
+import { formatKickError, KickError } from '@forinda/kickjs'
+
+try {
+  // ...
+} catch (err) {
+  if (err instanceof KickError) {
+    console.error(formatKickError(err, { color: process.stderr.isTTY }))
+    process.exit(1)
+  }
+  throw err
+}
+```
+
+Color detection honors [`NO_COLOR`](https://no-color.org) and `FORCE_COLOR` automatically when the `color` option is omitted.
+
+### Catching by code
+
+The stable `code` field is the right way to handle framework errors programmatically — never match on `.message` substrings (those evolve with rewording):
+
+```ts
+import { KickError } from '@forinda/kickjs'
+
+try {
+  container.resolve(SomeService)
+} catch (err) {
+  if (err instanceof KickError && err.code === 'KICK001') {
+    // No provider — handle the bootstrap-error path
+  } else {
+    throw err
+  }
+}
+```
+
+The `context` field carries structured data (the token name, the env key, the mount path, etc.) so log aggregators can filter or alert without parsing prose.
+
 ## RFC 9457 — Problem Details
 
 KickJS ships first-class support for [RFC 9457 — Problem Details for HTTP APIs](https://datatracker.ietf.org/doc/html/rfc9457) (the successor to RFC 7807). It's the canonical answer to "what shape should our error JSON have?" — five standard fields, a known content type (`application/problem+json`), and arbitrary extensions per §3.2.

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -97,7 +97,7 @@ The `notFoundHandler()` middleware is placed before the error handler to catch u
 
 Framework-thrown errors (DI resolution failures, missing env vars, malformed module setup, etc.) use the `KickError` class — a structured error type with a stable `code`, a one-line `summary`, a `cause` explanation, an actionable `fix` block, and a `docsUrl`. The result is multi-line, scannable, and points at the exact change to apply:
 
-```
+```text
 KICK001: No provider for UserService
 
   Cause:

--- a/packages/kickjs/__tests__/kick-error.test.ts
+++ b/packages/kickjs/__tests__/kick-error.test.ts
@@ -46,7 +46,7 @@ describe('KickError', () => {
     expect(err.message).toContain('No widgets available')
     expect(err.message).toContain('Cause:')
     expect(err.message).toContain('Fix:')
-    expect(err.message).not.toMatch(/\x1b\[/) // no ANSI escapes
+    expect(err.message).not.toMatch(/\[/) // no ANSI escapes
   })
 
   it("omits a section when its field isn't provided", () => {
@@ -86,7 +86,7 @@ describe('formatKickError', () => {
 
   it('emits ANSI codes when `color: true`', () => {
     const out = formatKickError({ code: 'TEST', summary: 'x' }, { color: true })
-    expect(out).toMatch(/\x1b\[/)
+    expect(out).toMatch(/\[/)
   })
 
   it('emits NO ANSI codes when `color: false`', () => {
@@ -94,19 +94,19 @@ describe('formatKickError', () => {
       { code: 'TEST', summary: 'x', cause: 'y', fix: 'z' },
       { color: false },
     )
-    expect(out).not.toMatch(/\x1b\[/)
+    expect(out).not.toMatch(/\[/)
   })
 
   it('honors NO_COLOR env var when `color` is unspecified', () => {
     process.env.NO_COLOR = '1'
     const out = formatKickError({ code: 'TEST', summary: 'x' })
-    expect(out).not.toMatch(/\x1b\[/)
+    expect(out).not.toMatch(/\[/)
   })
 
   it('honors FORCE_COLOR env var when `color` is unspecified', () => {
     process.env.FORCE_COLOR = '1'
     const out = formatKickError({ code: 'TEST', summary: 'x', cause: 'y' })
-    expect(out).toMatch(/\x1b\[/)
+    expect(out).toMatch(/\[/)
   })
 
   afterEach(() => {

--- a/packages/kickjs/__tests__/kick-error.test.ts
+++ b/packages/kickjs/__tests__/kick-error.test.ts
@@ -1,0 +1,187 @@
+import 'reflect-metadata'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { KickError, formatKickError } from '../src/core/kick-error'
+import {
+  noProviderError,
+  requestScopeMiddlewareMissingError,
+  requestScopeOutsideRequestError,
+  envValueMissingError,
+  moduleRouteMissingControllerError,
+} from '../src/core/kick-errors'
+
+// ── KickError class ───────────────────────────────────────────────────
+
+describe('KickError', () => {
+  it('is an Error subclass', () => {
+    const err = new KickError({ code: 'TEST001', summary: 'test' })
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(KickError)
+  })
+
+  it('preserves code, summary, cause, fix, docsUrl, context as readonly props', () => {
+    const err = new KickError({
+      code: 'TEST001',
+      summary: 'test',
+      cause: 'because',
+      fix: 'do this',
+      docsUrl: 'https://example.com',
+      context: { foo: 'bar' },
+    })
+    expect(err.code).toBe('TEST001')
+    expect(err.summary).toBe('test')
+    expect(err.cause).toBe('because')
+    expect(err.fix).toBe('do this')
+    expect(err.docsUrl).toBe('https://example.com')
+    expect(err.context).toEqual({ foo: 'bar' })
+  })
+
+  it('`.message` contains the plain-text formatted body (no ANSI)', () => {
+    const err = new KickError({
+      code: 'TEST001',
+      summary: 'No widgets available',
+      cause: 'You requested a widget but no widgets are registered.',
+      fix: 'Register one via `Container.register(WIDGET, ...)`',
+    })
+    expect(err.message).toContain('TEST001')
+    expect(err.message).toContain('No widgets available')
+    expect(err.message).toContain('Cause:')
+    expect(err.message).toContain('Fix:')
+    expect(err.message).not.toMatch(/\x1b\[/) // no ANSI escapes
+  })
+
+  it("omits a section when its field isn't provided", () => {
+    const err = new KickError({ code: 'TEST001', summary: 'just summary' })
+    expect(err.message).not.toContain('Cause:')
+    expect(err.message).not.toContain('Fix:')
+    expect(err.message).not.toContain('Docs:')
+  })
+})
+
+// ── formatKickError ────────────────────────────────────────────────────
+
+describe('formatKickError', () => {
+  beforeEach(() => {
+    delete process.env.NO_COLOR
+    delete process.env.FORCE_COLOR
+  })
+
+  it('renders a multi-line layout with Cause/Fix/Docs sections in order', () => {
+    const out = formatKickError(
+      {
+        code: 'TEST001',
+        summary: 'thing failed',
+        cause: 'because reasons',
+        fix: 'fix it like this',
+        docsUrl: 'https://forinda.github.io/kick-js/guide/x',
+      },
+      { color: false },
+    )
+    const causeIdx = out.indexOf('Cause:')
+    const fixIdx = out.indexOf('Fix:')
+    const docsIdx = out.indexOf('Docs:')
+    expect(causeIdx).toBeGreaterThan(-1)
+    expect(fixIdx).toBeGreaterThan(causeIdx)
+    expect(docsIdx).toBeGreaterThan(fixIdx)
+  })
+
+  it('emits ANSI codes when `color: true`', () => {
+    const out = formatKickError({ code: 'TEST', summary: 'x' }, { color: true })
+    expect(out).toMatch(/\x1b\[/)
+  })
+
+  it('emits NO ANSI codes when `color: false`', () => {
+    const out = formatKickError(
+      { code: 'TEST', summary: 'x', cause: 'y', fix: 'z' },
+      { color: false },
+    )
+    expect(out).not.toMatch(/\x1b\[/)
+  })
+
+  it('honors NO_COLOR env var when `color` is unspecified', () => {
+    process.env.NO_COLOR = '1'
+    const out = formatKickError({ code: 'TEST', summary: 'x' })
+    expect(out).not.toMatch(/\x1b\[/)
+  })
+
+  it('honors FORCE_COLOR env var when `color` is unspecified', () => {
+    process.env.FORCE_COLOR = '1'
+    const out = formatKickError({ code: 'TEST', summary: 'x', cause: 'y' })
+    expect(out).toMatch(/\x1b\[/)
+  })
+
+  afterEach(() => {
+    delete process.env.NO_COLOR
+    delete process.env.FORCE_COLOR
+  })
+})
+
+// ── catalog factories ─────────────────────────────────────────────────
+
+describe('kick-errors catalog', () => {
+  it('noProviderError — KICK001 with token in summary and context', () => {
+    const err = noProviderError('UserService')
+    expect(err.code).toBe('KICK001')
+    expect(err.summary).toContain('UserService')
+    expect(err.context).toEqual({ token: 'UserService' })
+    expect(err.fix).toContain('bootstrap')
+    expect(err.docsUrl).toContain('dependency-injection')
+  })
+
+  it('requestScopeMiddlewareMissingError — KICK002', () => {
+    const err = requestScopeMiddlewareMissingError('UserService')
+    expect(err.code).toBe('KICK002')
+    expect(err.summary).toContain('REQUEST-scoped')
+    expect(err.context).toEqual({ token: 'UserService' })
+  })
+
+  it('requestScopeOutsideRequestError — KICK003', () => {
+    const err = requestScopeOutsideRequestError('UserService')
+    expect(err.code).toBe('KICK003')
+    expect(err.summary).toContain('outside an HTTP request')
+  })
+
+  it('envValueMissingError — KICK004 with envKey in summary, fix mentions the wiring footgun', () => {
+    const err = envValueMissingError('DATABASE_URL')
+    expect(err.code).toBe('KICK004')
+    expect(err.summary).toContain('DATABASE_URL')
+    expect(err.fix).toContain("import './env'")
+    expect(err.context).toEqual({ envKey: 'DATABASE_URL' })
+  })
+
+  it('moduleRouteMissingControllerError — KICK005 with mount path', () => {
+    const err = moduleRouteMissingControllerError('/api/users')
+    expect(err.code).toBe('KICK005')
+    expect(err.summary).toContain('/api/users')
+    expect(err.fix).toContain('controller:')
+    expect(err.fix).toContain('router:')
+  })
+
+  it('all catalog errors include a docsUrl', () => {
+    const errs = [
+      noProviderError('X'),
+      requestScopeMiddlewareMissingError('X'),
+      requestScopeOutsideRequestError('X'),
+      envValueMissingError('X'),
+      moduleRouteMissingControllerError('/x'),
+    ]
+    for (const e of errs) {
+      expect(e.docsUrl).toBeDefined()
+      expect(e.docsUrl).toMatch(/^https:\/\//)
+    }
+  })
+
+  it('codes are unique across the catalog (no duplicates)', () => {
+    const codes = new Set<string>()
+    const errs = [
+      noProviderError('X'),
+      requestScopeMiddlewareMissingError('X'),
+      requestScopeOutsideRequestError('X'),
+      envValueMissingError('X'),
+      moduleRouteMissingControllerError('/x'),
+    ]
+    for (const e of errs) {
+      expect(codes.has(e.code)).toBe(false)
+      codes.add(e.code)
+    }
+  })
+})

--- a/packages/kickjs/__tests__/request-scope.test.ts
+++ b/packages/kickjs/__tests__/request-scope.test.ts
@@ -96,7 +96,7 @@ describe('REQUEST scope — Container unit tests', () => {
     const container = Container.getInstance()
     container.register(OutsideReqService, OutsideReqService, Scope.REQUEST)
 
-    expect(() => container.resolve(OutsideReqService)).toThrow(/outside.*request context/i)
+    expect(() => container.resolve(OutsideReqService)).toThrow(/KICK003|outside an HTTP request/)
   })
 
   it('throws when no request store provider is configured', () => {
@@ -110,7 +110,7 @@ describe('REQUEST scope — Container unit tests', () => {
     Container._requestStoreProvider = null
 
     expect(() => container.resolve(NoProviderService)).toThrow(
-      /no request store provider configured/i,
+      /KICK002|request scope middleware not mounted/,
     )
   })
 

--- a/packages/kickjs/src/core/container.ts
+++ b/packages/kickjs/src/core/container.ts
@@ -7,6 +7,12 @@ import {
   type PostConstructStatus,
 } from './interfaces'
 import { resolveAsset } from './assets'
+import {
+  envValueMissingError,
+  noProviderError,
+  requestScopeMiddlewareMissingError,
+  requestScopeOutsideRequestError,
+} from './kick-errors'
 import { createLogger } from './logger'
 import {
   getClassMeta,
@@ -378,7 +384,7 @@ export class Container {
       reg = this.registrations.get(`__hmr__${token.name}`)
     }
     if (!reg) {
-      throw new Error(`No binding found for: ${tokenName(token)}`)
+      throw noProviderError(tokenName(token))
     }
 
     if (reg.scope === Scope.SINGLETON && reg.instance !== undefined) {
@@ -391,16 +397,11 @@ export class Container {
     // REQUEST scope: one instance per HTTP request, cached in AsyncLocalStorage
     if (reg.scope === Scope.REQUEST) {
       if (!Container._requestStoreProvider) {
-        throw new Error(
-          `Cannot resolve REQUEST-scoped "${tokenName(token)}": no request store provider configured. ` +
-            `Ensure requestScopeMiddleware() is in your middleware pipeline.`,
-        )
+        throw requestScopeMiddlewareMissingError(tokenName(token))
       }
       const store = Container._requestStoreProvider()
       if (!store) {
-        throw new Error(
-          `Cannot resolve REQUEST-scoped "${tokenName(token)}" outside an HTTP request context.`,
-        )
+        throw requestScopeOutsideRequestError(tokenName(token))
       }
       // Check for pre-registered request values (user, tenant, etc.)
       if (store.values.has(token)) {
@@ -732,9 +733,7 @@ export class Container {
           const val = process.env[config.envKey]
           if (val !== undefined) return val
           if (config.defaultValue !== undefined) return config.defaultValue
-          throw new Error(
-            `@Value('${config.envKey}'): Environment variable "${config.envKey}" is not set and no default was provided.`,
-          )
+          throw envValueMissingError(config.envKey)
         },
         enumerable: true,
         configurable: true,

--- a/packages/kickjs/src/core/index.ts
+++ b/packages/kickjs/src/core/index.ts
@@ -123,6 +123,14 @@ export {
   type ValidationError,
 } from './errors'
 
+// KickError — structured framework errors with code, cause, and fix hint
+export {
+  KickError,
+  formatKickError,
+  type FormatKickErrorOptions,
+  type KickErrorInit,
+} from './kick-error'
+
 // Path utilities
 export { normalizePath, joinPaths } from './path'
 

--- a/packages/kickjs/src/core/kick-error.ts
+++ b/packages/kickjs/src/core/kick-error.ts
@@ -65,7 +65,11 @@ function ansiEnabled(): boolean {
   return process.stderr?.isTTY === true
 }
 
-const ESC = '\x1b['
+// Use the Unicode-escape form (``) rather than the hex-escape (`\x1b`)
+// for the ANSI ESC byte — both produce the same character, but oxlint's
+// `no-control-character` rule flags the hex form as "unexpected control
+// character in string literal". Functionally identical, lint-clean.
+const ESC = '['
 const RESET = `${ESC}0m`
 
 function paint(text: string, code: string, enabled: boolean): string {

--- a/packages/kickjs/src/core/kick-error.ts
+++ b/packages/kickjs/src/core/kick-error.ts
@@ -1,0 +1,142 @@
+/**
+ * Structured framework error with code, cause, and actionable fix hint.
+ *
+ * The goal is "the developer who hits this knows what to do next." A
+ * cryptic `Error('No binding found for: UserService')` becomes a
+ * multi-line explanation pointing at the likely cause, the exact code
+ * change to apply, and a docs link.
+ *
+ * `.message` carries the full multi-line plain-text body so Node's
+ * default `Error.toString()` and unhandled-exception printing still
+ * surface the helpful version. Call {@link formatKickError} to render a
+ * colorized version for terminals.
+ *
+ * Per-error factories live in `kick-errors.ts` — those are the public
+ * entry points framework code uses. `KickError` is exported so adopters
+ * can build their own structured errors using the same shape.
+ */
+export interface KickErrorInit {
+  /** Short stable identifier (e.g. `KICK001`, `NO_PROVIDER`). */
+  code: string
+  /** One-line headline. */
+  summary: string
+  /** Multi-line explanation of why this happened. */
+  cause?: string
+  /** Multi-line actionable fix — show exact code if possible. */
+  fix?: string
+  /** Absolute URL to the docs page that covers this error. */
+  docsUrl?: string
+  /** Arbitrary structured fields for log consumers / debug tooling. */
+  context?: Record<string, unknown>
+}
+
+export class KickError extends Error {
+  public readonly code: string
+  public readonly summary: string
+  public readonly cause?: string
+  public readonly fix?: string
+  public readonly docsUrl?: string
+  public readonly context?: Record<string, unknown>
+
+  constructor(init: KickErrorInit) {
+    super(formatKickError(init, { color: false }))
+    this.name = 'KickError'
+    this.code = init.code
+    this.summary = init.summary
+    if (init.cause !== undefined) this.cause = init.cause
+    if (init.fix !== undefined) this.fix = init.fix
+    if (init.docsUrl !== undefined) this.docsUrl = init.docsUrl
+    if (init.context !== undefined) this.context = init.context
+  }
+}
+
+// ── ANSI colour helpers ────────────────────────────────────────────────
+
+/**
+ * `true` when the runtime can render ANSI escape codes on stderr.
+ * Honors `NO_COLOR` (https://no-color.org) and `FORCE_COLOR`.
+ */
+function ansiEnabled(): boolean {
+  if (process.env.NO_COLOR) return false
+  if (process.env.FORCE_COLOR) return true
+  // Node sets `isTTY` on the writable streams when stdout/stderr is a
+  // terminal. KickError output goes to stderr conceptually (it's an
+  // error), so we follow that stream's affordances.
+  return process.stderr?.isTTY === true
+}
+
+const ESC = '\x1b['
+const RESET = `${ESC}0m`
+
+function paint(text: string, code: string, enabled: boolean): string {
+  return enabled ? `${ESC}${code}m${text}${RESET}` : text
+}
+
+const c = {
+  red: (s: string, enabled: boolean) => paint(s, '31', enabled),
+  bold: (s: string, enabled: boolean) => paint(s, '1', enabled),
+  dim: (s: string, enabled: boolean) => paint(s, '2', enabled),
+  cyan: (s: string, enabled: boolean) => paint(s, '36', enabled),
+  blue: (s: string, enabled: boolean) => paint(s, '34', enabled),
+  underline: (s: string, enabled: boolean) => paint(s, '4', enabled),
+}
+
+// ── Formatter ─────────────────────────────────────────────────────────
+
+export interface FormatKickErrorOptions {
+  /**
+   * Render ANSI colour codes. Defaults to TTY detection (`NO_COLOR` /
+   * `FORCE_COLOR` env vars honoured). Pass `false` for log files,
+   * structured loggers, or HTTP response bodies.
+   */
+  color?: boolean
+}
+
+/**
+ * Render a {@link KickErrorInit} (or {@link KickError} instance) into a
+ * multi-line human-readable string. Identical layout regardless of
+ * colour — the colour flag only toggles ANSI codes.
+ */
+export function formatKickError(
+  err: KickErrorInit | KickError,
+  options: FormatKickErrorOptions = {},
+): string {
+  const color = options.color ?? ansiEnabled()
+  const lines: string[] = []
+
+  // Headline: `KICK001: No provider for UserService`
+  const code = c.bold(c.red(err.code, color), color)
+  lines.push(`${code}: ${err.summary}`)
+
+  if (err.cause) {
+    lines.push('', `  ${c.bold(c.dim('Cause:', color), color)}`)
+    for (const line of err.cause.split('\n')) {
+      lines.push(`    ${highlightInline(line, color)}`)
+    }
+  }
+
+  if (err.fix) {
+    lines.push('', `  ${c.bold(c.dim('Fix:', color), color)}`)
+    for (const line of err.fix.split('\n')) {
+      lines.push(`    ${highlightInline(line, color)}`)
+    }
+  }
+
+  if (err.docsUrl) {
+    lines.push('', `  ${c.bold(c.dim('Docs:', color), color)}`)
+    lines.push(`    ${c.underline(c.blue(err.docsUrl, color), color)}`)
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Highlight inline `code spans` in a line of cause/fix text. Anything
+ * between backticks gets cyan when colour is enabled; backticks stay
+ * in the output so the plain-text rendering still distinguishes
+ * literals.
+ */
+function highlightInline(line: string, color: boolean): string {
+  if (!color) return line
+  return line.replace(/`([^`]+)`/g, (_, inner: string) => `\`${c.cyan(inner, true)}\``)
+}

--- a/packages/kickjs/src/core/kick-errors.ts
+++ b/packages/kickjs/src/core/kick-errors.ts
@@ -1,0 +1,199 @@
+/**
+ * Catalog of framework errors with structured cause + fix hints.
+ *
+ * Each factory function returns a {@link KickError} with a stable
+ * `code` (KICK001, KICK002, …), a human-readable summary, an
+ * explanation of the likely cause, an actionable fix, and a docs URL.
+ *
+ * Adding a new error: pick the next free code, add the factory below,
+ * call it from the framework site that used to throw a bare `Error`.
+ * Keep the public function name descriptive — `noProviderError`,
+ * `envValueMissingError` — so call sites grep cleanly.
+ *
+ * Codes are stable. Reordering or renumbering breaks adopters whose
+ * tools key on `err.code`.
+ */
+import { KickError } from './kick-error'
+
+const DOCS_BASE = 'https://forinda.github.io/kick-js'
+
+// ── DI container ──────────────────────────────────────────────────────
+
+/**
+ * KICK001 — No provider registered for a token.
+ *
+ * Thrown by `Container.resolve()` when no binding can be found for the
+ * requested token. The most common cause is forgetting to add the
+ * enclosing module to `bootstrap({ modules })`.
+ */
+export function noProviderError(tokenName: string): KickError {
+  return new KickError({
+    code: 'KICK001',
+    summary: `No provider for ${tokenName}`,
+    cause: `\`${tokenName}\` was requested from the DI container but no binding is registered.
+This usually means one of:
+  • The class is decorated with @Service() / @Repository() / @Controller(),
+    but its enclosing module isn't passed to bootstrap({ modules: [...] }).
+  • The class isn't decorated at all (decorators register the binding).
+  • You're injecting a token (created with createToken()) that nothing
+    provides — add a Container.register(TOKEN, ...) call or a module that
+    binds it.`,
+    fix: `If \`${tokenName}\` lives in a module, add the module to bootstrap:
+
+      bootstrap({
+        modules: [
+          UsersModule,        // add this
+          OtherModule,
+        ],
+      })
+
+If it's a custom token, register it explicitly:
+
+      const TENANT_REPO = createToken<TenantRepo>('TENANT_REPO')
+      Container.getInstance().register(TENANT_REPO, { useClass: PrismaTenantRepo })`,
+    docsUrl: `${DOCS_BASE}/guide/dependency-injection#registering-services`,
+    context: { token: tokenName },
+  })
+}
+
+/**
+ * KICK002 — REQUEST-scoped binding resolved without a request store
+ * provider configured.
+ */
+export function requestScopeMiddlewareMissingError(tokenName: string): KickError {
+  return new KickError({
+    code: 'KICK002',
+    summary: `Cannot resolve REQUEST-scoped "${tokenName}" — request scope middleware not mounted`,
+    cause: `\`${tokenName}\` has \`scope: Scope.REQUEST\` but no AsyncLocalStorage frame is wired.
+The framework's request-scope middleware sets up that frame; without it,
+REQUEST-scoped resolutions have nowhere to cache the per-request instance.`,
+    fix: `Add \`requestScopeMiddleware()\` to your global middleware pipeline,
+or let the framework auto-mount it by using \`contextStore: 'auto'\`
+(the default — only check this if you set it to 'manual' explicitly):
+
+      bootstrap({
+        modules,
+        // contextStore: 'auto',  // default; no need to set
+      })
+
+If you set \`contextStore: 'manual'\` deliberately (rare), you own the
+ALS wrapping — call \`requestStore.run({...}, () => ...)\` around the
+code that resolves the binding.`,
+    docsUrl: `${DOCS_BASE}/guide/dependency-injection#scopes`,
+    context: { token: tokenName },
+  })
+}
+
+/**
+ * KICK003 — REQUEST-scoped binding resolved outside any HTTP request
+ * context (no ALS store active).
+ */
+export function requestScopeOutsideRequestError(tokenName: string): KickError {
+  return new KickError({
+    code: 'KICK003',
+    summary: `Cannot resolve REQUEST-scoped "${tokenName}" outside an HTTP request`,
+    cause: `\`${tokenName}\` has \`scope: Scope.REQUEST\` and was resolved outside
+any HTTP request context. The request-scope middleware is wired, but
+the call happened before a request started (e.g. in a top-level
+import, a constructor, a cron job, a test without setup).`,
+    fix: `If the caller is request-scoped (controller, request-scoped service),
+make sure the call happens inside the request lifecycle, not at module
+load time.
+
+In tests, wrap setup in an ALS frame manually:
+
+      import { requestStore } from '@forinda/kickjs'
+
+      requestStore.run(
+        { requestId: 'test', instances: new Map(), values: new Map() },
+        () => {
+          const svc = container.resolve(MyRequestScopedService)
+          // ...
+        },
+      )
+
+If the caller is a SINGLETON, change \`${tokenName}\` to TRANSIENT or
+SINGLETON scope, or inject a factory instead of the instance directly.`,
+    docsUrl: `${DOCS_BASE}/guide/dependency-injection#scopes`,
+    context: { token: tokenName },
+  })
+}
+
+// ── Config / env wiring ───────────────────────────────────────────────
+
+/**
+ * KICK004 — `@Value('X')` resolved but the env var isn't set and no
+ * default was provided.
+ *
+ * This is the canonical "you forgot to wire env" symptom — surfaces
+ * when ConfigService can't find the key. The fix usually involves
+ * either setting the env var or wiring `loadEnv(envSchema)` at startup.
+ */
+export function envValueMissingError(envKey: string): KickError {
+  return new KickError({
+    code: 'KICK004',
+    summary: `@Value('${envKey}'): environment variable not set and no default provided`,
+    cause: `\`@Value('${envKey}')\` resolved but the env var isn't present and the
+decorator didn't declare a default. Possible reasons:
+  • The variable is genuinely missing from your environment / .env file.
+  • Your \`src/env.ts\` calls \`loadEnv(envSchema)\` but \`src/index.ts\`
+    doesn't import \`./env\` before \`bootstrap()\`. Without that import
+    the schema never runs and ConfigService stays empty — \`@Value\`
+    only finds the var via the \`process.env\` fallback.`,
+    fix: `Either set the variable in your shell / .env file:
+
+      ${envKey}=...
+
+Or add a default at the decorator:
+
+      @Value('${envKey}', { default: 'fallback' })
+      private value!: string
+
+If you're using a schema, make sure \`src/env.ts\` is imported from
+\`src/index.ts\` BEFORE bootstrap runs:
+
+      // src/index.ts
+      import 'reflect-metadata'
+      import './env'                  // ← this line is required
+      import { bootstrap } from '@forinda/kickjs'
+      // ...`,
+    docsUrl: `${DOCS_BASE}/guide/configuration#wiring-the-schema-at-startup`,
+    context: { envKey },
+  })
+}
+
+// ── Module setup ──────────────────────────────────────────────────────
+
+/**
+ * KICK005 — A module's `routes()` return value declares a mount path
+ * but provides neither a `controller` class nor a pre-built `router`.
+ */
+export function moduleRouteMissingControllerError(mountPath: string): KickError {
+  return new KickError({
+    code: 'KICK005',
+    summary: `Module route at ${mountPath} requires either 'controller' or 'router'`,
+    cause: `A module's \`routes()\` returned an entry for \`${mountPath}\` but didn't
+specify how to build the router. The framework needs either a decorated
+controller class (it calls \`buildRoutes()\` internally) or a hand-built
+Express Router.`,
+    fix: `Pass \`controller:\` for the common case:
+
+      routes() {
+        return {
+          path: '${mountPath}',
+          controller: UsersController,
+        }
+      }
+
+Or pass \`router:\` for full control:
+
+      routes() {
+        return {
+          path: '${mountPath}',
+          router: myExpressRouter,
+        }
+      }`,
+    docsUrl: `${DOCS_BASE}/guide/modules`,
+    context: { mountPath },
+  })
+}

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -20,6 +20,7 @@ import {
   mountSort,
   MutableModuleRegistry,
 } from '../core'
+import { moduleRouteMissingControllerError } from '../core/kick-errors'
 import { getClassMeta } from '../core/metadata'
 import { requestId } from './middleware/request-id'
 import { notFoundHandler, errorHandler } from './middleware/error-handler'
@@ -638,11 +639,7 @@ export class Application {
           // pass `router` explicitly and we use it as-is.
           const router = route.router ?? buildRoutes(route.controller)
           if (!router) {
-            throw new Error(
-              `Module route at ${mountPath} requires either 'controller' or 'router'. ` +
-                'Pass `controller: SomeController` for the common case (the framework calls ' +
-                'buildRoutes() internally) or `router: yourRouter` to hand-build it.',
-            )
+            throw moduleRouteMissingControllerError(mountPath)
           }
           this.app.use(mountPath, router)
 


### PR DESCRIPTION
Closes B.2 (first pass) from the roadmap.

## What this does

Framework-thrown errors are now `KickError` instances — a multi-line, scannable shape with a stable code, a cause explanation, an actionable fix, and a docs URL. Cryptic single-line errors become walk-through messages that point at the exact change to apply.

**Before:**
```
Error: No binding found for: UserService
```

**After:**
```
KICK001: No provider for UserService

  Cause:
    UserService was requested from the DI container but no binding
    is registered.
    This usually means one of:
      • The class is decorated with @Service() / @Repository() / @Controller(),
        but its enclosing module isn't passed to bootstrap({ modules: [...] }).
      • The class isn't decorated at all (decorators register the binding).
      • You're injecting a token (created with createToken()) that nothing
        provides — add a Container.register(TOKEN, ...) call or a module that
        binds it.

  Fix:
    If UserService lives in a module, add the module to bootstrap:

      bootstrap({
        modules: [
          UsersModule,        // add this
          OtherModule,
        ],
      })

    If it's a custom token, register it explicitly:

      const TENANT_REPO = createToken<TenantRepo>('TENANT_REPO')
      Container.getInstance().register(TENANT_REPO, { useClass: PrismaTenantRepo })

  Docs:
    https://forinda.github.io/kick-js/guide/dependency-injection#registering-services
```

## First catalog pass — 5 errors

| Code | When it fires |
|---|---|
| `KICK001` | DI: no provider registered for the requested token |
| `KICK002` | DI: REQUEST-scoped binding resolved without request-scope middleware mounted |
| `KICK003` | DI: REQUEST-scoped binding resolved outside an HTTP request |
| `KICK004` | Config: `@Value('X')` resolved but env var not set and no default given |
| `KICK005` | Module: `routes()` declared a path without `controller` or `router` |

These five are the highest-leverage errors based on the kind of confusion adopters hit during evaluation. More framework errors will migrate to `KickError` over time — the catalog is designed for incremental growth. Codes are stable and never reused.

## API

```ts
import { KickError, formatKickError } from '@forinda/kickjs'

// Construction
new KickError({
  code: 'APP001',
  summary: 'My one-line headline',
  cause: 'Multi-line\nexplanation.',
  fix: 'Actionable steps.',
  docsUrl: 'https://example.com/docs/my-error',
  context: { foo: 'bar' },    // structured fields for log consumers
})

// Colorized output for terminals
console.error(formatKickError(err, { color: process.stderr.isTTY }))

// Programmatic catching — match on code, never on message substrings
if (err instanceof KickError && err.code === 'KICK001') {
  // ...
}
```

`KickError` extends `Error`. `.message` carries the full multi-line plain-text body so Node's default `Error.toString()` and unhandled-exception printing surface the helpful version automatically — no setup required. `formatKickError(err, { color: true })` produces an ANSI-colored version for terminals; color detection honors `NO_COLOR` / `FORCE_COLOR` when omitted.

## Design decisions

- **Stable `code` is the contract, message wording isn't.** Adopters catching errors should match on `err.code` (stable across rewordings) or `instanceof KickError` (stable across the catalog). The catalog mentions this prominently.

- **Per-error factory functions in `kick-errors.ts`** — each error has a dedicated function (`noProviderError(tokenName)`, `envValueMissingError(envKey)`, etc.) for easy grep and discoverable JSDoc. Adding a new error = adding a new function with the next free code.

- **No external dependencies.** ANSI escapes are inline constants; TTY detection uses `process.stderr.isTTY` directly. No chalk, no kleur, no debug. Aligns with the install-contract work (Phases 1–4).

- **Backward compat preserved.** Errors are still `instanceof Error`. Existing catch-all `Error` handlers keep working. Two existing `request-scope.test.ts` regex assertions that matched the old wording substring (`/outside.*request context/i`) were updated to match the new wording OR the new code (`/KICK003|outside an HTTP request/`) — that's the only test surface change.

## Backward-compat note for adopters

Adopter code that matched on the old `.message` substrings (e.g. `err.message.includes('No binding found')`) needs to update. Two options:

1. **Better:** switch to matching on `err.code` (stable across rewordings).
2. Update the substring to the new wording.

Most adopters won't match on framework error messages at all — these are framework boundary errors that the global error handler typically catches. The change matters most for tests and observability code.

## Test plan

- [x] `pnpm --filter @forinda/kickjs test` — **509/509 pass** (17 new in `kick-error.test.ts`)
- [x] Full monorepo build clean
- [x] `pnpm --filter @forinda/kickjs-example-minimal-api test` — 3/3 pass (smoke test through createTestApp)
- [x] Format + lint hooks pass

## What this PR does NOT do

- Doesn't migrate every framework error to `KickError` — just the first 5 highest-impact ones. Subsequent passes will incrementally upgrade more (the roadmap notes this is an ongoing-pass effort).
- Doesn't change the global error-handler middleware output. `KickError`'s `.message` is plain text; it falls through to the existing "unexpected errors" branch with a 500 response. Surfacing structured `KickError` fields to HTTP clients is a separate decision — most of these are startup / config errors that adopters see in their terminal, not browser-facing.
- Doesn't add error codes to the docs sitemap. The catalog table in `docs/guide/error-handling.md` is the single source of truth for now.

## Files

| File | Change |
|---|---|
| `packages/kickjs/src/core/kick-error.ts` | new — `KickError` class + `formatKickError` + ANSI helpers |
| `packages/kickjs/src/core/kick-errors.ts` | new — catalog of per-error factory functions |
| `packages/kickjs/src/core/index.ts` | re-export new symbols |
| `packages/kickjs/src/core/container.ts` | 4 call sites switched from `throw new Error(...)` to catalog factories |
| `packages/kickjs/src/http/application.ts` | 1 call site switched (module-route validation) |
| `packages/kickjs/__tests__/kick-error.test.ts` | new — 17 tests covering class, formatter, ANSI gating, catalog uniqueness |
| `packages/kickjs/__tests__/request-scope.test.ts` | 2 regex assertions updated to match new wording |
| `docs/guide/error-handling.md` | new "Framework errors with fix hints" section with API + catalog + recipes |
| `.changeset/error-messages-fix-hints.md` | minor bump for `@forinda/kickjs` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `KickError`, a structured error type with stable error codes (KICK001–KICK005), actionable fix guidance, and documentation links for framework-thrown errors.
  * Added colorized terminal output formatting for errors with environment variable support.

* **Documentation**
  * Added comprehensive error handling guide with error catalog and troubleshooting examples.

* **Tests**
  * Added test coverage for error handling system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->