### PR TITLE
feat(cli): `kick doctor` — pre-flight checks with extension API

### DIFF
--- a/.changeset/kick-doctor.md
+++ b/.changeset/kick-doctor.md
@@ -1,0 +1,81 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+feat(cli): `kick doctor` — pre-flight checks for dev environment
+
+New CLI command that catches common "doesn't work on my machine" misconfigs before they bite. Sibling to `kick check --deploy` (which scans for production-readiness); doctor is the dev-setup counterpart.
+
+```bash
+kick doctor
+```
+
+Sample output:
+
+```text
+KickJS Doctor
+
+✔  Node version  (v22.7.0)
+✔  @forinda/kickjs installed  (^5.12.0)
+✔  express installed  (^5.1.0)
+✔  reflect-metadata installed  (^0.2.2)
+✔  tsconfig: experimentalDecorators
+✔  tsconfig: emitDecoratorMetadata
+✔  env wiring
+✔  typegen freshness  (2m ago)
+
+8 passed, 0 warnings, 0 errors — your environment looks good
+```
+
+Exit code is `0` on pass-or-warn, `1` on any error.
+
+**Built-in checks (this first pass):**
+
+| Check                              | Severity     | Detects                                                                                                                                                                                   |
+| ---------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Node version                       | error        | Node < 20                                                                                                                                                                                 |
+| `@forinda/kickjs` installed        | error        | Wrong directory / fresh repo                                                                                                                                                              |
+| `express` installed                | error        | Required peer dep missing                                                                                                                                                                 |
+| `reflect-metadata` installed       | error        | Decorator polyfill missing                                                                                                                                                                |
+| tsconfig: `experimentalDecorators` | error        | Decorators won't compile                                                                                                                                                                  |
+| tsconfig: `emitDecoratorMetadata`  | error        | DI container can't read constructor types                                                                                                                                                 |
+| env wiring                         | error / warn | env-init file (`src/env.ts`, `src/env/index.ts`, `src/config/env.ts`, `src/config/index.ts`) calls `loadEnv(...)` but the app entry doesn't import it — or imports it AFTER `bootstrap()` |
+| typegen freshness                  | warn         | `.kickjs/types/` last touched > 60 min ago                                                                                                                                                |
+
+The env-wiring check handles common file-location variations and accepts both relative (`'./env'`, `'./config/env'`) and `@/`-aliased (`'@/env'`, `'@/config'`) imports. Detects the canonical "ConfigService.get() returns undefined while @Value() works" footgun.
+
+**No ORM-specific checks in core.** The framework stays stack-agnostic — Prisma / Drizzle / Mongoose checks belong in adopter config (or in adapter packages that ship doctor extensions).
+
+**Extensibility — `defineDoctorExtension`:**
+
+```ts
+// doctor-checks/prisma.ts (publishable as a package, or workspace-shared)
+import { defineDoctorExtension } from '@forinda/kickjs-cli'
+
+export const prismaDoctor = defineDoctorExtension({
+  checks: [
+    (ctx) => {
+      // adopter-defined check; same DoctorContext + DoctorResult shape
+      // as the built-ins. Return null to skip.
+    },
+  ],
+})
+
+// kick.config.ts
+import { defineConfig } from '@forinda/kickjs-cli'
+import { prismaDoctor } from './doctor-checks/prisma'
+
+export default defineConfig({ doctor: prismaDoctor })
+```
+
+Extra checks run after the built-ins, support async, and merge into the same summary output.
+
+**New exports from `@forinda/kickjs-cli`:**
+
+- `defineDoctorExtension(ext)` — identity helper for an extension bundle (mirrors `defineConfig`)
+- `defineDoctorCheck(check)` — identity helper for a single check
+- `DoctorExtension`, `DoctorCheck`, `DoctorContext`, `DoctorResult` — type contracts
+
+**Tests:** 29 new in `doctor.test.ts` covering all built-in checks, env-wiring variations (4 file locations × relative/alias imports × before/after bootstrap()), the extensibility hook (sync + async + null-skip), and both identity helpers.
+
+Closes B.4 from the roadmap.

--- a/docs/guide/cli-commands.md
+++ b/docs/guide/cli-commands.md
@@ -192,6 +192,143 @@ kick start -p 8080
 
 Sets `NODE_ENV=production` automatically.
 
+## kick doctor
+
+Pre-flight checks for your KickJS project's dev environment. Catches the common "doesn't work on my machine" misconfigs before they bite — missing decorator flags, env-wiring footguns, stale typegen, wrong Node version.
+
+```bash
+kick doctor
+```
+
+Sibling to `kick check --deploy` (which scans for production-readiness — JWT secrets, CORS, rate limits, etc.). Doctor is the dev-setup counterpart.
+
+Sample output:
+
+```text
+KickJS Doctor
+
+✔  Node version  (v22.7.0)
+✔  @forinda/kickjs installed  (^5.12.0)
+✔  express installed  (^5.1.0)
+✔  reflect-metadata installed  (^0.2.2)
+✔  tsconfig: experimentalDecorators
+✔  tsconfig: emitDecoratorMetadata
+⚠  env wiring  (env-init imported AFTER bootstrap() — should be before)
+   → Move the env import above the bootstrap() call so the schema
+   → runs before any service reads from ConfigService.
+✔  typegen freshness  (2m ago)
+
+8 passed, 1 warning, 0 errors — review the warnings
+```
+
+Exit code is `0` on pass-or-warn, `1` on any error.
+
+### What it checks
+
+| Check                              | Severity if failing | Detects                                                                                                    |
+| ---------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Node version                       | error               | Node version below the framework's minimum (20+)                                                           |
+| `@forinda/kickjs` installed        | error               | Wrong directory, or fresh repo without `kick new`                                                          |
+| `express` installed                | error               | Required peer dep missing (`@forinda/kickjs`'s peer)                                                       |
+| `reflect-metadata` installed       | error               | Decorator runtime polyfill missing                                                                         |
+| tsconfig: `experimentalDecorators` | error               | Decorators won't compile                                                                                   |
+| tsconfig: `emitDecoratorMetadata`  | error               | DI container can't read constructor types                                                                  |
+| env wiring                         | error / warn        | env-init file calls `loadEnv(...)` but the app entry doesn't import it (or imports it AFTER `bootstrap()`) |
+| typegen freshness                  | warn                | `.kickjs/types/` last touched > 60 minutes ago                                                             |
+
+The env-wiring check looks at multiple common locations — `src/env.ts`, `src/env/index.ts`, `src/config/env.ts`, `src/config/index.ts` — and accepts both relative and `@/` aliased imports.
+
+### Extending with custom checks
+
+Add your own checks via `kick.config.ts`. Adopter-supplied checks run after the built-ins and use the same `DoctorContext` / `DoctorResult` shape. The CLI exports `defineDoctorExtension` and `defineDoctorCheck` as identity helpers — they give you type inference and autocomplete without an explicit type annotation, mirroring the `defineConfig` pattern.
+
+#### Inline — quickest path
+
+```ts
+// kick.config.ts
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { defineConfig, defineDoctorExtension } from '@forinda/kickjs-cli'
+
+export default defineConfig({
+  doctor: defineDoctorExtension({
+    checks: [
+      // ORM-specific: only emits a result when this project actually uses Prisma
+      (ctx) => {
+        if (!existsSync(join(ctx.cwd, 'prisma/schema.prisma'))) return null
+        const generated = join(ctx.cwd, 'node_modules/@prisma/client/default.js')
+        return existsSync(generated)
+          ? { name: 'Prisma client generated', status: 'pass' }
+          : {
+              name: 'Prisma client generated',
+              status: 'fail',
+              fix: 'Run: pnpm exec prisma generate',
+            }
+      },
+    ],
+  }),
+})
+```
+
+#### Shared extension — published or workspace-shared
+
+When you want the same extension across multiple projects in a monorepo (or want to publish it as a package), put the extension in its own module:
+
+```ts
+// doctor-checks/prisma.ts
+import { defineDoctorExtension } from '@forinda/kickjs-cli'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const prismaDoctor = defineDoctorExtension({
+  checks: [
+    (ctx) => {
+      if (!existsSync(join(ctx.cwd, 'prisma/schema.prisma'))) return null
+      const generated = join(ctx.cwd, 'node_modules/@prisma/client/default.js')
+      return existsSync(generated)
+        ? { name: 'Prisma client generated', status: 'pass' }
+        : {
+            name: 'Prisma client generated',
+            status: 'fail',
+            fix: 'Run: pnpm exec prisma generate',
+          }
+    },
+  ],
+})
+```
+
+```ts
+// kick.config.ts
+import { defineConfig } from '@forinda/kickjs-cli'
+import { prismaDoctor } from './doctor-checks/prisma'
+
+export default defineConfig({
+  doctor: prismaDoctor,
+})
+```
+
+#### Single-check helper
+
+For one-off checks scattered across modules, `defineDoctorCheck` provides the same type-inference convenience:
+
+```ts
+import { defineDoctorCheck } from '@forinda/kickjs-cli'
+
+export const checkJwtSecretLength = defineDoctorCheck((ctx) => {
+  const v = process.env.JWT_SECRET
+  if (!v || v.length < 32) {
+    return {
+      name: 'JWT_SECRET ≥ 32 chars',
+      status: 'warn',
+      fix: 'Generate a strong secret: openssl rand -hex 32',
+    }
+  }
+  return { name: 'JWT_SECRET ≥ 32 chars', status: 'pass' }
+})
+```
+
+The framework stays ORM-agnostic on purpose — Prisma / Drizzle / Mongoose-specific checks belong in adopter config (or in adapter packages that ship doctor extensions), never in core.
+
 ## kick info
 
 Print system and framework information:

--- a/packages/cli/__tests__/doctor.test.ts
+++ b/packages/cli/__tests__/doctor.test.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -17,8 +17,18 @@ import {
 
 // ── helpers ───────────────────────────────────────────────────────────
 
+/**
+ * Temp-dir tracking with afterEach cleanup. Earlier revisions called
+ * `cleanup(dir)` at the tail of each `it` block, but any failing
+ * assertion short-circuits and leaks the directory in the OS temp
+ * folder. Tracking + global afterEach guarantees cleanup regardless
+ * of test outcome.
+ */
+const trackedDirs: string[] = []
+
 function tempProject(files: Record<string, string>): string {
   const dir = mkdtempSync(join(tmpdir(), 'kick-doctor-'))
+  trackedDirs.push(dir)
   for (const [path, contents] of Object.entries(files)) {
     const full = join(dir, path)
     mkdirSync(dirname(full), { recursive: true })
@@ -27,13 +37,16 @@ function tempProject(files: Record<string, string>): string {
   return dir
 }
 
-function cleanup(dir: string): void {
-  try {
-    rmSync(dir, { recursive: true, force: true })
-  } catch {
-    // Windows sometimes holds the lock briefly; tolerate.
+afterEach(() => {
+  while (trackedDirs.length > 0) {
+    const dir = trackedDirs.pop()!
+    try {
+      rmSync(dir, { recursive: true, force: true })
+    } catch {
+      // Windows sometimes holds the lock briefly; tolerate.
+    }
   }
-}
+})
 
 function ctx(cwd: string, overrides: Partial<DoctorContext> = {}): DoctorContext {
   const pkgPath = join(cwd, 'package.json')
@@ -54,7 +67,6 @@ describe('checkKickJsInstalled', () => {
     const r = checkKickJsInstalled(ctx(dir))
     expect(r.status).toBe('pass')
     expect(r.message).toBe('^5.0.0')
-    cleanup(dir)
   })
 
   it('fails when @forinda/kickjs is missing', () => {
@@ -62,14 +74,12 @@ describe('checkKickJsInstalled', () => {
     const r = checkKickJsInstalled(ctx(dir))
     expect(r.status).toBe('fail')
     expect(r.fix).toContain('kick new')
-    cleanup(dir)
   })
 
   it('warns when package.json is missing', () => {
     const dir = tempProject({})
     const r = checkKickJsInstalled(ctx(dir))
     expect(r.status).toBe('warn')
-    cleanup(dir)
   })
 })
 
@@ -83,7 +93,6 @@ describe('checkReflectMetadata', () => {
       }),
     })
     expect(checkReflectMetadata(ctx(dir)).status).toBe('pass')
-    cleanup(dir)
   })
 
   it('fails when reflect-metadata is missing', () => {
@@ -93,7 +102,6 @@ describe('checkReflectMetadata', () => {
     const r = checkReflectMetadata(ctx(dir))
     expect(r.status).toBe('fail')
     expect(r.fix).toContain('reflect-metadata')
-    cleanup(dir)
   })
 })
 
@@ -109,7 +117,6 @@ describe('checkExpressInstalled', () => {
     const r = checkExpressInstalled(ctx(dir))
     expect(r?.status).toBe('fail')
     expect(r?.fix).toContain('express')
-    cleanup(dir)
   })
 
   it('passes when both kickjs and express are installed', () => {
@@ -119,13 +126,11 @@ describe('checkExpressInstalled', () => {
       }),
     })
     expect(checkExpressInstalled(ctx(dir))?.status).toBe('pass')
-    cleanup(dir)
   })
 
   it('skips (returns null) when there is no kickjs and no express', () => {
     const dir = tempProject({ 'package.json': JSON.stringify({ dependencies: {} }) })
     expect(checkExpressInstalled(ctx(dir))).toBeNull()
-    cleanup(dir)
   })
 })
 
@@ -164,7 +169,6 @@ describe('checkEnvWiring', () => {
   it('skips when no env-init file exists', () => {
     const dir = tempProject({ 'src/index.ts': 'export {}\n' })
     expect(checkEnvWiring(ctx(dir))).toBeNull()
-    cleanup(dir)
   })
 
   it("skips when an env file exists but doesn't call loadEnv()", () => {
@@ -175,7 +179,6 @@ describe('checkEnvWiring', () => {
       'src/index.ts': 'export {}',
     })
     expect(checkEnvWiring(ctx(dir))).toBeNull()
-    cleanup(dir)
   })
 
   it("fails when src/env.ts has loadEnv but src/index.ts doesn't import it", () => {
@@ -186,7 +189,6 @@ describe('checkEnvWiring', () => {
     const r = checkEnvWiring(ctx(dir))
     expect(r?.status).toBe('fail')
     expect(r?.fix).toContain("import './env'")
-    cleanup(dir)
   })
 
   it('passes when src/env.ts is imported before bootstrap()', () => {
@@ -199,7 +201,6 @@ bootstrap({})
 `,
     })
     expect(checkEnvWiring(ctx(dir))?.status).toBe('pass')
-    cleanup(dir)
   })
 
   it('warns when env import lands AFTER bootstrap()', () => {
@@ -214,7 +215,6 @@ import './env'
     const r = checkEnvWiring(ctx(dir))
     expect(r?.status).toBe('warn')
     expect(r?.message).toContain('AFTER bootstrap')
-    cleanup(dir)
   })
 
   it('handles src/config/env.ts variation', () => {
@@ -227,7 +227,6 @@ bootstrap({})
 `,
     })
     expect(checkEnvWiring(ctx(dir))?.status).toBe('pass')
-    cleanup(dir)
   })
 
   it('handles src/config/index.ts variation', () => {
@@ -240,7 +239,6 @@ bootstrap({})
 `,
     })
     expect(checkEnvWiring(ctx(dir))?.status).toBe('pass')
-    cleanup(dir)
   })
 
   it('handles the @/ alias import form', () => {
@@ -253,7 +251,6 @@ bootstrap({})
 `,
     })
     expect(checkEnvWiring(ctx(dir))?.status).toBe('pass')
-    cleanup(dir)
   })
 
   it("fails when src/config/env.ts has loadEnv but src/index.ts doesn't import it", () => {
@@ -264,7 +261,6 @@ bootstrap({})
     const r = checkEnvWiring(ctx(dir))
     expect(r?.status).toBe('fail')
     expect(r?.message).toContain('config/env.ts')
-    cleanup(dir)
   })
 
   it('falls back to src/main.ts when src/index.ts is absent', () => {
@@ -273,7 +269,6 @@ bootstrap({})
       'src/main.ts': `import './env'\nimport { bootstrap } from '@forinda/kickjs'\nbootstrap({})\n`,
     })
     expect(checkEnvWiring(ctx(dir))?.status).toBe('pass')
-    cleanup(dir)
   })
 })
 
@@ -297,7 +292,6 @@ describe('runChecks', () => {
     const kickjsCheck = results.find((r) => r.name === '@forinda/kickjs installed')
     expect(kickjsCheck?.status).toBe('pass')
     expect(results.find((r) => r.name === 'tsconfig.json present')?.status).toBe('fail')
-    cleanup(dir)
   })
 
   it('runs caller-supplied extra checks after the built-ins', async () => {
@@ -310,18 +304,45 @@ describe('runChecks', () => {
       extraChecks: [() => ({ name: 'My custom check', status: 'pass' })],
     })
     expect(results.find((r) => r.name === 'My custom check')?.status).toBe('pass')
-    cleanup(dir)
   })
 
-  it('skips extra checks that return null', async () => {
+  it('skips extra checks that return null — no null entries pollute the result array', async () => {
+    const dir = tempProject({
+      'package.json': JSON.stringify({ dependencies: {} }),
+    })
+    // Bracket the built-in checks with two null-returning extras AND a
+    // real one. The real one MUST appear; the nulls MUST be skipped (no
+    // null/undefined entries, no extra slots in the array).
+    const results = await runChecks(dir, {
+      extraChecks: [() => null, () => ({ name: 'Real check', status: 'pass' }), () => null],
+    })
+    expect(results.every((r) => r != null)).toBe(true)
+    expect(results.some((r) => r.name === 'Real check')).toBe(true)
+    // Exactly one entry per non-null check — the two nulls add nothing.
+    const realIdx = results.findIndex((r) => r.name === 'Real check')
+    expect(realIdx).toBeGreaterThanOrEqual(0)
+    expect(results.filter((r) => r.name === 'Real check').length).toBe(1)
+  })
+
+  it('isolates failing checks so one extension cannot abort the whole report', async () => {
     const dir = tempProject({
       'package.json': JSON.stringify({ dependencies: {} }),
     })
     const results = await runChecks(dir, {
-      extraChecks: [() => null],
+      extraChecks: [
+        () => {
+          throw new Error('Boom from a buggy extension')
+        },
+        () => ({ name: 'After the boom', status: 'pass' }),
+      ],
     })
-    expect(results.find((r) => r.name === 'My custom check')).toBeUndefined()
-    cleanup(dir)
+    // Built-ins still ran
+    expect(results.find((r) => r.name === 'Node version')).toBeDefined()
+    // The throwing check produced a synthetic fail with the error message
+    const synthetic = results.find((r) => r.status === 'fail' && r.message?.includes('Boom'))
+    expect(synthetic).toBeDefined()
+    // The check AFTER the thrower still ran — the loop didn't abort
+    expect(results.find((r) => r.name === 'After the boom')?.status).toBe('pass')
   })
 
   it('awaits async extra checks', async () => {
@@ -337,7 +358,6 @@ describe('runChecks', () => {
       ],
     })
     expect(results.find((r) => r.name === 'Async check')?.status).toBe('pass')
-    cleanup(dir)
   })
 })
 
@@ -358,7 +378,6 @@ describe('defineDoctorExtension', () => {
     })
     const results = await runChecks(dir, { extraChecks: ext.checks })
     expect(results.find((r) => r.name === 'Custom from extension')?.status).toBe('pass')
-    cleanup(dir)
   })
 })
 
@@ -376,6 +395,5 @@ describe('defineDoctorCheck', () => {
     }))
     const results = await runChecks(dir, { extraChecks: [myCheck] })
     expect(results.find((r) => r.name === 'Bound check')?.status).toBe('pass')
-    cleanup(dir)
   })
 })

--- a/packages/cli/__tests__/doctor.test.ts
+++ b/packages/cli/__tests__/doctor.test.ts
@@ -1,0 +1,381 @@
+import 'reflect-metadata'
+import { describe, it, expect } from 'vitest'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import {
+  checkDecoratorTsConfig,
+  checkEnvWiring,
+  checkExpressInstalled,
+  checkKickJsInstalled,
+  checkReflectMetadata,
+  defineDoctorCheck,
+  defineDoctorExtension,
+  runChecks,
+  type DoctorContext,
+} from '../src/commands/doctor'
+
+// ── helpers ───────────────────────────────────────────────────────────
+
+function tempProject(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kick-doctor-'))
+  for (const [path, contents] of Object.entries(files)) {
+    const full = join(dir, path)
+    mkdirSync(dirname(full), { recursive: true })
+    writeFileSync(full, contents)
+  }
+  return dir
+}
+
+function cleanup(dir: string): void {
+  try {
+    rmSync(dir, { recursive: true, force: true })
+  } catch {
+    // Windows sometimes holds the lock briefly; tolerate.
+  }
+}
+
+function ctx(cwd: string, overrides: Partial<DoctorContext> = {}): DoctorContext {
+  const pkgPath = join(cwd, 'package.json')
+  const pkg = existsSync(pkgPath) ? JSON.parse(readFileSync(pkgPath, 'utf-8')) : null
+  return { cwd, pkg, tsconfig: null, ...overrides }
+}
+
+// ── checkKickJsInstalled ──────────────────────────────────────────────
+
+describe('checkKickJsInstalled', () => {
+  it('passes when @forinda/kickjs is in dependencies', () => {
+    const dir = tempProject({
+      'package.json': JSON.stringify({
+        name: 'x',
+        dependencies: { '@forinda/kickjs': '^5.0.0' },
+      }),
+    })
+    const r = checkKickJsInstalled(ctx(dir))
+    expect(r.status).toBe('pass')
+    expect(r.message).toBe('^5.0.0')
+    cleanup(dir)
+  })
+
+  it('fails when @forinda/kickjs is missing', () => {
+    const dir = tempProject({ 'package.json': JSON.stringify({ name: 'x', dependencies: {} }) })
+    const r = checkKickJsInstalled(ctx(dir))
+    expect(r.status).toBe('fail')
+    expect(r.fix).toContain('kick new')
+    cleanup(dir)
+  })
+
+  it('warns when package.json is missing', () => {
+    const dir = tempProject({})
+    const r = checkKickJsInstalled(ctx(dir))
+    expect(r.status).toBe('warn')
+    cleanup(dir)
+  })
+})
+
+// ── checkReflectMetadata ──────────────────────────────────────────────
+
+describe('checkReflectMetadata', () => {
+  it('passes when reflect-metadata is in any dep section', () => {
+    const dir = tempProject({
+      'package.json': JSON.stringify({
+        dependencies: { 'reflect-metadata': '^0.2.0' },
+      }),
+    })
+    expect(checkReflectMetadata(ctx(dir)).status).toBe('pass')
+    cleanup(dir)
+  })
+
+  it('fails when reflect-metadata is missing', () => {
+    const dir = tempProject({
+      'package.json': JSON.stringify({ dependencies: { express: '^5.0.0' } }),
+    })
+    const r = checkReflectMetadata(ctx(dir))
+    expect(r.status).toBe('fail')
+    expect(r.fix).toContain('reflect-metadata')
+    cleanup(dir)
+  })
+})
+
+// ── checkExpressInstalled ─────────────────────────────────────────────
+
+describe('checkExpressInstalled', () => {
+  it('fails when @forinda/kickjs is present but express is not', () => {
+    const dir = tempProject({
+      'package.json': JSON.stringify({
+        dependencies: { '@forinda/kickjs': '^5.0.0' },
+      }),
+    })
+    const r = checkExpressInstalled(ctx(dir))
+    expect(r?.status).toBe('fail')
+    expect(r?.fix).toContain('express')
+    cleanup(dir)
+  })
+
+  it('passes when both kickjs and express are installed', () => {
+    const dir = tempProject({
+      'package.json': JSON.stringify({
+        dependencies: { '@forinda/kickjs': '^5.0.0', express: '^5.1.0' },
+      }),
+    })
+    expect(checkExpressInstalled(ctx(dir))?.status).toBe('pass')
+    cleanup(dir)
+  })
+
+  it('skips (returns null) when there is no kickjs and no express', () => {
+    const dir = tempProject({ 'package.json': JSON.stringify({ dependencies: {} }) })
+    expect(checkExpressInstalled(ctx(dir))).toBeNull()
+    cleanup(dir)
+  })
+})
+
+// ── checkDecoratorTsConfig ────────────────────────────────────────────
+
+describe('checkDecoratorTsConfig', () => {
+  it('passes when both decorator flags are enabled', () => {
+    const c = ctx('/x', {
+      tsconfig: {
+        compilerOptions: { experimentalDecorators: true, emitDecoratorMetadata: true },
+      },
+    })
+    const rs = checkDecoratorTsConfig(c)
+    expect(rs.every((r) => r.status === 'pass')).toBe(true)
+  })
+
+  it('fails when experimentalDecorators is missing', () => {
+    const c = ctx('/x', {
+      tsconfig: { compilerOptions: { emitDecoratorMetadata: true } },
+    })
+    const rs = checkDecoratorTsConfig(c)
+    const exp = rs.find((r) => r.name.includes('experimentalDecorators'))
+    expect(exp?.status).toBe('fail')
+  })
+
+  it('fails when tsconfig.json is missing entirely', () => {
+    const rs = checkDecoratorTsConfig(ctx('/x', { tsconfig: null }))
+    expect(rs[0]?.status).toBe('fail')
+    expect(rs[0]?.fix).toContain('tsconfig.json')
+  })
+})
+
+// ── checkEnvWiring (the canonical footgun check) ──────────────────────
+
+describe('checkEnvWiring', () => {
+  it('skips when no env-init file exists', () => {
+    const dir = tempProject({ 'src/index.ts': 'export {}\n' })
+    expect(checkEnvWiring(ctx(dir))).toBeNull()
+    cleanup(dir)
+  })
+
+  it("skips when an env file exists but doesn't call loadEnv()", () => {
+    // Just having `src/env.ts` isn't proof of env wiring — it has to
+    // actually call loadEnv() for the check to apply.
+    const dir = tempProject({
+      'src/env.ts': 'export const foo = 1',
+      'src/index.ts': 'export {}',
+    })
+    expect(checkEnvWiring(ctx(dir))).toBeNull()
+    cleanup(dir)
+  })
+
+  it("fails when src/env.ts has loadEnv but src/index.ts doesn't import it", () => {
+    const dir = tempProject({
+      'src/env.ts': 'import { loadEnv } from "@forinda/kickjs"\nloadEnv({})',
+      'src/index.ts': "import 'reflect-metadata'\nimport { bootstrap } from '@forinda/kickjs'\n",
+    })
+    const r = checkEnvWiring(ctx(dir))
+    expect(r?.status).toBe('fail')
+    expect(r?.fix).toContain("import './env'")
+    cleanup(dir)
+  })
+
+  it('passes when src/env.ts is imported before bootstrap()', () => {
+    const dir = tempProject({
+      'src/env.ts': 'import { loadEnv } from "@forinda/kickjs"\nloadEnv({})',
+      'src/index.ts': `import 'reflect-metadata'
+import './env'
+import { bootstrap } from '@forinda/kickjs'
+bootstrap({})
+`,
+    })
+    expect(checkEnvWiring(ctx(dir))?.status).toBe('pass')
+    cleanup(dir)
+  })
+
+  it('warns when env import lands AFTER bootstrap()', () => {
+    const dir = tempProject({
+      'src/env.ts': 'import { loadEnv } from "@forinda/kickjs"\nloadEnv({})',
+      'src/index.ts': `import 'reflect-metadata'
+import { bootstrap } from '@forinda/kickjs'
+bootstrap({})
+import './env'
+`,
+    })
+    const r = checkEnvWiring(ctx(dir))
+    expect(r?.status).toBe('warn')
+    expect(r?.message).toContain('AFTER bootstrap')
+    cleanup(dir)
+  })
+
+  it('handles src/config/env.ts variation', () => {
+    const dir = tempProject({
+      'src/config/env.ts': 'import { loadEnv } from "@forinda/kickjs"\nloadEnv({})',
+      'src/index.ts': `import 'reflect-metadata'
+import './config/env'
+import { bootstrap } from '@forinda/kickjs'
+bootstrap({})
+`,
+    })
+    expect(checkEnvWiring(ctx(dir))?.status).toBe('pass')
+    cleanup(dir)
+  })
+
+  it('handles src/config/index.ts variation', () => {
+    const dir = tempProject({
+      'src/config/index.ts': 'import { loadEnv } from "@forinda/kickjs"\nloadEnv({})',
+      'src/index.ts': `import 'reflect-metadata'
+import './config'
+import { bootstrap } from '@forinda/kickjs'
+bootstrap({})
+`,
+    })
+    expect(checkEnvWiring(ctx(dir))?.status).toBe('pass')
+    cleanup(dir)
+  })
+
+  it('handles the @/ alias import form', () => {
+    const dir = tempProject({
+      'src/config/env.ts': 'import { loadEnv } from "@forinda/kickjs"\nloadEnv({})',
+      'src/index.ts': `import 'reflect-metadata'
+import '@/config/env'
+import { bootstrap } from '@forinda/kickjs'
+bootstrap({})
+`,
+    })
+    expect(checkEnvWiring(ctx(dir))?.status).toBe('pass')
+    cleanup(dir)
+  })
+
+  it("fails when src/config/env.ts has loadEnv but src/index.ts doesn't import it", () => {
+    const dir = tempProject({
+      'src/config/env.ts': 'import { loadEnv } from "@forinda/kickjs"\nloadEnv({})',
+      'src/index.ts': "import { bootstrap } from '@forinda/kickjs'\n",
+    })
+    const r = checkEnvWiring(ctx(dir))
+    expect(r?.status).toBe('fail')
+    expect(r?.message).toContain('config/env.ts')
+    cleanup(dir)
+  })
+
+  it('falls back to src/main.ts when src/index.ts is absent', () => {
+    const dir = tempProject({
+      'src/env.ts': 'import { loadEnv } from "@forinda/kickjs"\nloadEnv({})',
+      'src/main.ts': `import './env'\nimport { bootstrap } from '@forinda/kickjs'\nbootstrap({})\n`,
+    })
+    expect(checkEnvWiring(ctx(dir))?.status).toBe('pass')
+    cleanup(dir)
+  })
+})
+
+// ── runChecks integration + extensibility ─────────────────────────────
+
+describe('runChecks', () => {
+  it('aggregates pass + fail + skipped checks into a single results array', async () => {
+    const dir = tempProject({
+      'package.json': JSON.stringify({
+        dependencies: {
+          '@forinda/kickjs': '^5.0.0',
+          'reflect-metadata': '^0.2.0',
+          express: '^5.0.0',
+        },
+      }),
+      // no tsconfig → both decorator checks fail; no env.ts → env-wiring skipped
+    })
+    const results = await runChecks(dir)
+    expect(results.length).toBeGreaterThan(0)
+    expect(results.find((r) => r.name === 'Node version')).toBeDefined()
+    const kickjsCheck = results.find((r) => r.name === '@forinda/kickjs installed')
+    expect(kickjsCheck?.status).toBe('pass')
+    expect(results.find((r) => r.name === 'tsconfig.json present')?.status).toBe('fail')
+    cleanup(dir)
+  })
+
+  it('runs caller-supplied extra checks after the built-ins', async () => {
+    const dir = tempProject({
+      'package.json': JSON.stringify({
+        dependencies: { '@forinda/kickjs': '^5.0.0' },
+      }),
+    })
+    const results = await runChecks(dir, {
+      extraChecks: [() => ({ name: 'My custom check', status: 'pass' })],
+    })
+    expect(results.find((r) => r.name === 'My custom check')?.status).toBe('pass')
+    cleanup(dir)
+  })
+
+  it('skips extra checks that return null', async () => {
+    const dir = tempProject({
+      'package.json': JSON.stringify({ dependencies: {} }),
+    })
+    const results = await runChecks(dir, {
+      extraChecks: [() => null],
+    })
+    expect(results.find((r) => r.name === 'My custom check')).toBeUndefined()
+    cleanup(dir)
+  })
+
+  it('awaits async extra checks', async () => {
+    const dir = tempProject({
+      'package.json': JSON.stringify({ dependencies: {} }),
+    })
+    const results = await runChecks(dir, {
+      extraChecks: [
+        async () => {
+          await new Promise((r) => setTimeout(r, 1))
+          return { name: 'Async check', status: 'pass' }
+        },
+      ],
+    })
+    expect(results.find((r) => r.name === 'Async check')?.status).toBe('pass')
+    cleanup(dir)
+  })
+})
+
+// ── defineDoctorExtension / defineDoctorCheck identity helpers ────────
+
+describe('defineDoctorExtension', () => {
+  it('returns the same object it received (identity for inference)', () => {
+    const input = {
+      checks: [() => ({ name: 'X', status: 'pass' as const })],
+    }
+    expect(defineDoctorExtension(input)).toBe(input)
+  })
+
+  it('extensions plug into runChecks unchanged', async () => {
+    const dir = tempProject({ 'package.json': JSON.stringify({ dependencies: {} }) })
+    const ext = defineDoctorExtension({
+      checks: [() => ({ name: 'Custom from extension', status: 'pass' })],
+    })
+    const results = await runChecks(dir, { extraChecks: ext.checks })
+    expect(results.find((r) => r.name === 'Custom from extension')?.status).toBe('pass')
+    cleanup(dir)
+  })
+})
+
+describe('defineDoctorCheck', () => {
+  it('returns the same function it received', () => {
+    const fn = () => ({ name: 'X', status: 'pass' as const })
+    expect(defineDoctorCheck(fn)).toBe(fn)
+  })
+
+  it('a check authored with defineDoctorCheck plugs into runChecks', async () => {
+    const dir = tempProject({ 'package.json': JSON.stringify({ dependencies: {} }) })
+    const myCheck = defineDoctorCheck((ctx) => ({
+      name: 'Bound check',
+      status: ctx.pkg ? 'pass' : 'fail',
+    }))
+    const results = await runChecks(dir, { extraChecks: [myCheck] })
+    expect(results.find((r) => r.name === 'Bound check')?.status).toBe('pass')
+    cleanup(dir)
+  })
+})

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, statSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import type { Command } from 'commander'
 import { loadKickConfig, type KickConfig } from '../config'
@@ -380,28 +380,69 @@ export function checkEnvWiring(ctx: DoctorContext): DoctorResult | null {
   return { name: 'env wiring', status: 'pass' }
 }
 
+/**
+ * Find the newest file mtime under a directory tree, recursively.
+ * Returns `0` when the tree is empty or unreadable. Walks at most
+ * {@link MAX_TYPEGEN_FILES} entries to bound the cost on large
+ * generated trees.
+ *
+ * Necessary because the directory's own `mtimeMs` does not update
+ * when existing files inside are rewritten — `kick typegen` can run
+ * successfully and the directory stat still looks stale. The newest
+ * file mtime is the honest measure.
+ */
+function newestFileMtime(dir: string, budget = MAX_TYPEGEN_FILES): number {
+  let newest = 0
+  let visited = 0
+  const stack = [dir]
+  while (stack.length > 0 && visited < budget) {
+    const current = stack.pop()!
+    let entries
+    try {
+      entries = readdirSync(current, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      if (visited >= budget) break
+      visited++
+      const full = join(current, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(full)
+        continue
+      }
+      try {
+        const m = statSync(full).mtimeMs
+        if (m > newest) newest = m
+      } catch {
+        // skip unreadable files
+      }
+    }
+  }
+  return newest
+}
+
+const MAX_TYPEGEN_FILES = 2000
+
 export function checkTypegenFreshness(ctx: DoctorContext): DoctorResult | null {
   const typegenDir = join(ctx.cwd, '.kickjs', 'types')
   if (!existsSync(typegenDir)) return null
-  try {
-    const stat = statSync(typegenDir)
-    const ageMs = Date.now() - stat.mtimeMs
-    const ageMin = Math.floor(ageMs / 60_000)
-    if (ageMin > 60) {
-      return {
-        name: 'typegen freshness',
-        status: 'warn',
-        message: `last updated ${ageMin} minutes ago`,
-        fix: 'Re-run `kick typegen` (or `kick dev`, which runs it on every reload) so generated types match the current code.',
-      }
-    }
+  const newest = newestFileMtime(typegenDir)
+  if (newest === 0) return null
+  const ageMs = Date.now() - newest
+  const ageMin = Math.floor(ageMs / 60_000)
+  if (ageMin > 60) {
     return {
       name: 'typegen freshness',
-      status: 'pass',
-      message: ageMin === 0 ? 'just now' : `${ageMin}m ago`,
+      status: 'warn',
+      message: `last updated ${ageMin} minutes ago`,
+      fix: 'Re-run `kick typegen` (or `kick dev`, which runs it on every reload) so generated types match the current code.',
     }
-  } catch {
-    return null
+  }
+  return {
+    name: 'typegen freshness',
+    status: 'pass',
+    message: ageMin === 0 ? 'just now' : `${ageMin}m ago`,
   }
 }
 
@@ -429,7 +470,20 @@ export async function runChecks(
   const checks = [...BUILT_IN_CHECKS, ...(options.extraChecks ?? [])]
   const out: DoctorResult[] = []
   for (const check of checks) {
-    const r = await check(ctx)
+    // Per-check try/catch so one buggy extension can't abort the whole
+    // report. A throwing check produces a synthetic `fail` result with
+    // the error message; the loop continues to the next check.
+    let r: DoctorResult | DoctorResult[] | null
+    try {
+      r = await check(ctx)
+    } catch (err) {
+      out.push({
+        name: check.name || 'doctor check',
+        status: 'fail',
+        message: err instanceof Error ? err.message : String(err),
+      })
+      continue
+    }
     if (r == null) continue
     if (Array.isArray(r)) out.push(...r)
     else out.push(r)

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,512 @@
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import type { Command } from 'commander'
+import { loadKickConfig, type KickConfig } from '../config'
+import { colors } from '../utils/colors'
+import { intro, outro, log } from '../utils/prompts'
+
+/**
+ * `kick doctor` — pre-flight checks for a KickJS project's dev
+ * environment. Detects common misconfigs before they bite, with an
+ * actionable fix hint for each problem.
+ *
+ * Sibling command to `kick check --deploy`, which scans for production
+ * readiness (JWT, CORS, helmet, etc.). Doctor is the dev-setup
+ * counterpart — "is my environment correctly wired?"
+ *
+ * Extending: adopters can ship their own checks by exporting a
+ * `doctor.checks` array from `kick.config.ts`. Each {@link DoctorCheck}
+ * receives the same {@link DoctorContext} the built-ins use and
+ * returns one or more {@link DoctorResult}s. The framework stays
+ * ORM-agnostic — Prisma / Drizzle / Mongoose-specific checks belong
+ * in their respective adapters or in adopter config, not in core.
+ */
+
+// ── Public types ──────────────────────────────────────────────────────
+
+export interface DoctorContext {
+  cwd: string
+  pkg: any | null
+  tsconfig: any | null
+}
+
+export interface DoctorResult {
+  /** Short label for the check (printed first). */
+  name: string
+  status: 'pass' | 'warn' | 'fail'
+  /** Optional extra context after the label (e.g. resolved version). */
+  message?: string
+  /** Multi-line actionable fix shown when status is `warn` or `fail`. */
+  fix?: string
+}
+
+export type DoctorCheck = (
+  ctx: DoctorContext,
+) => DoctorResult | DoctorResult[] | null | Promise<DoctorResult | DoctorResult[] | null>
+
+/**
+ * Shape of a doctor extension — the `doctor` block on `KickConfig`,
+ * also the publishable unit that plugins and shared modules use to
+ * ship a bundle of related checks.
+ */
+export interface DoctorExtension {
+  /** Extra checks merged after the built-ins. */
+  checks?: DoctorCheck[]
+}
+
+/**
+ * Identity helper for adopters / plugins authoring a doctor extension.
+ *
+ * Provides type inference + autocomplete on the `checks` array without
+ * requiring an explicit `: DoctorExtension` annotation. Mirrors the
+ * `defineConfig` pattern.
+ *
+ * @example
+ * ```ts
+ * // doctor-checks/prisma.ts (shared across projects, or shipped as a
+ * // standalone package)
+ * import { defineDoctorExtension } from '@forinda/kickjs-cli'
+ * import { existsSync } from 'node:fs'
+ * import { join } from 'node:path'
+ *
+ * export const prismaDoctor = defineDoctorExtension({
+ *   checks: [
+ *     (ctx) => {
+ *       if (!existsSync(join(ctx.cwd, 'prisma/schema.prisma'))) return null
+ *       const generated = join(ctx.cwd, 'node_modules/@prisma/client/default.js')
+ *       return existsSync(generated)
+ *         ? { name: 'Prisma client generated', status: 'pass' }
+ *         : { name: 'Prisma client generated', status: 'fail', fix: 'pnpm exec prisma generate' }
+ *     },
+ *   ],
+ * })
+ *
+ * // kick.config.ts
+ * import { defineConfig } from '@forinda/kickjs-cli'
+ * import { prismaDoctor } from './doctor-checks/prisma'
+ *
+ * export default defineConfig({ doctor: prismaDoctor })
+ * ```
+ */
+export function defineDoctorExtension(ext: DoctorExtension): DoctorExtension {
+  return ext
+}
+
+/**
+ * Identity helper for a single doctor check. Pairs with
+ * `defineDoctorExtension` when assembling an extension from separate
+ * per-check files, and gives the same type-inference win for one-offs.
+ *
+ * @example
+ * ```ts
+ * import { defineDoctorCheck } from '@forinda/kickjs-cli'
+ *
+ * export const checkJwtSecretLength = defineDoctorCheck((ctx) => {
+ *   const v = process.env.JWT_SECRET
+ *   if (!v || v.length < 32) {
+ *     return {
+ *       name: 'JWT_SECRET ≥ 32 chars',
+ *       status: 'warn',
+ *       fix: 'Generate a strong secret: openssl rand -hex 32',
+ *     }
+ *   }
+ *   return { name: 'JWT_SECRET ≥ 32 chars', status: 'pass' }
+ * })
+ * ```
+ */
+export function defineDoctorCheck(check: DoctorCheck): DoctorCheck {
+  return check
+}
+
+// ── File helpers ──────────────────────────────────────────────────────
+
+function safeReadJson(filepath: string): any | null {
+  try {
+    return JSON.parse(readFileSync(filepath, 'utf-8'))
+  } catch {
+    return null
+  }
+}
+
+function safeRead(filepath: string): string | null {
+  try {
+    return readFileSync(filepath, 'utf-8')
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Read tsconfig.json with `extends` followed one level. Most adopters
+ * use a single config; for those that extend kickjs-cli's preset, we
+ * pick up the inherited `compilerOptions`. Avoids pulling in `tsc` just
+ * to resolve the chain.
+ */
+function loadTsConfig(cwd: string): any | null {
+  const tsconfigPath = join(cwd, 'tsconfig.json')
+  const raw = safeRead(tsconfigPath)
+  if (!raw) return null
+  // tsconfig files often contain comments; strip them before parsing.
+  const stripped = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
+  let cfg: any
+  try {
+    cfg = JSON.parse(stripped)
+  } catch {
+    return null
+  }
+  if (typeof cfg?.extends === 'string') {
+    const extendsPath = resolveExtends(cwd, cfg.extends)
+    if (extendsPath) {
+      const parent = safeReadJson(extendsPath) ?? {}
+      cfg.compilerOptions = {
+        ...parent.compilerOptions,
+        ...cfg.compilerOptions,
+      }
+    }
+  }
+  return cfg
+}
+
+function resolveExtends(cwd: string, ext: string): string | null {
+  if (ext.startsWith('.')) {
+    const resolved = resolve(cwd, ext)
+    return existsSync(resolved) ? resolved : null
+  }
+  const mod = join(cwd, 'node_modules', ext)
+  if (existsSync(mod)) return mod
+  return null
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// ── Individual checks ─────────────────────────────────────────────────
+
+const MIN_NODE_MAJOR = 20
+
+export function checkNodeVersion(): DoctorResult {
+  const v = process.version
+  const major = Number.parseInt(v.replace(/^v/, '').split('.')[0]!, 10)
+  if (Number.isNaN(major) || major < MIN_NODE_MAJOR) {
+    return {
+      name: 'Node version',
+      status: 'fail',
+      message: v,
+      fix: `KickJS requires Node ${MIN_NODE_MAJOR} or newer.\nInstall a supported version via nvm / fnm / volta.`,
+    }
+  }
+  return { name: 'Node version', status: 'pass', message: v }
+}
+
+export function checkKickJsInstalled(ctx: DoctorContext): DoctorResult {
+  if (!ctx.pkg) {
+    return { name: '@forinda/kickjs installed', status: 'warn', message: 'no package.json' }
+  }
+  const deps = {
+    ...ctx.pkg.dependencies,
+    ...ctx.pkg.peerDependencies,
+  }
+  if (!deps['@forinda/kickjs']) {
+    return {
+      name: '@forinda/kickjs installed',
+      status: 'fail',
+      fix: 'This directory does not look like a KickJS project — `@forinda/kickjs` is not in your package.json. Run `kick doctor` from the project root, or scaffold a fresh project with `kick new <name>`.',
+    }
+  }
+  return { name: '@forinda/kickjs installed', status: 'pass', message: deps['@forinda/kickjs'] }
+}
+
+export function checkExpressInstalled(ctx: DoctorContext): DoctorResult | null {
+  if (!ctx.pkg) return null
+  const deps = {
+    ...ctx.pkg.dependencies,
+    ...ctx.pkg.peerDependencies,
+  }
+  if (deps['@forinda/kickjs'] && !deps.express) {
+    return {
+      name: 'express installed',
+      status: 'fail',
+      fix: '`@forinda/kickjs` declares `express` as a required peer dependency, but your package.json does not include it. Install: pnpm add express',
+    }
+  }
+  return deps.express ? { name: 'express installed', status: 'pass', message: deps.express } : null
+}
+
+export function checkReflectMetadata(ctx: DoctorContext): DoctorResult {
+  if (!ctx.pkg)
+    return { name: 'reflect-metadata installed', status: 'warn', message: 'no package.json' }
+  const deps = {
+    ...ctx.pkg.dependencies,
+    ...ctx.pkg.peerDependencies,
+    ...ctx.pkg.devDependencies,
+  }
+  if (!deps['reflect-metadata']) {
+    return {
+      name: 'reflect-metadata installed',
+      status: 'fail',
+      fix: `KickJS decorators require the reflect-metadata polyfill.\nInstall it: pnpm add reflect-metadata\nThen import it at the top of src/index.ts:\n\n  import 'reflect-metadata'\n  // ... rest of bootstrap`,
+    }
+  }
+  return { name: 'reflect-metadata installed', status: 'pass', message: deps['reflect-metadata'] }
+}
+
+export function checkDecoratorTsConfig(ctx: DoctorContext): DoctorResult[] {
+  if (!ctx.tsconfig) {
+    return [
+      {
+        name: 'tsconfig.json present',
+        status: 'fail',
+        fix: 'Create a tsconfig.json with `experimentalDecorators: true` and `emitDecoratorMetadata: true`. `kick new` scaffolds one automatically.',
+      },
+    ]
+  }
+  const co = ctx.tsconfig.compilerOptions ?? {}
+  const results: DoctorResult[] = []
+  results.push(
+    co.experimentalDecorators === true
+      ? { name: 'tsconfig: experimentalDecorators', status: 'pass' }
+      : {
+          name: 'tsconfig: experimentalDecorators',
+          status: 'fail',
+          fix: 'Add `"experimentalDecorators": true` to compilerOptions in tsconfig.json. Without it, @Service / @Controller / @Get etc. don\'t register any metadata at compile time.',
+        },
+  )
+  results.push(
+    co.emitDecoratorMetadata === true
+      ? { name: 'tsconfig: emitDecoratorMetadata', status: 'pass' }
+      : {
+          name: 'tsconfig: emitDecoratorMetadata',
+          status: 'fail',
+          fix: 'Add `"emitDecoratorMetadata": true` to compilerOptions in tsconfig.json. The DI container uses this metadata for constructor-parameter injection.',
+        },
+  )
+  return results
+}
+
+/**
+ * The canonical "you forgot to wire env" footgun: an env-init file
+ * (e.g. `src/env.ts`, `src/config/env.ts`, `src/config/index.ts`)
+ * calls `loadEnv(envSchema)` as a side effect, but the app entry
+ * (`src/index.ts` / `src/main.ts`) doesn't import it. Result:
+ * `ConfigService.get('X')` returns undefined while `@Value('X')`
+ * works via process.env fallback, so adopters get half-broken config
+ * without seeing an error.
+ *
+ * Detection walks the common env-file locations, identifies the ones
+ * that actually call `loadEnv(`, then verifies the app entry imports
+ * one of them (via relative path or `@/` alias) BEFORE `bootstrap(`.
+ */
+export function checkEnvWiring(ctx: DoctorContext): DoctorResult | null {
+  const envCandidates = [
+    'src/env.ts',
+    'src/env/index.ts',
+    'src/config/env.ts',
+    'src/config/index.ts',
+  ]
+  const envFiles = envCandidates
+    .map((p) => join(ctx.cwd, p))
+    .filter((p) => existsSync(p))
+    .filter((p) => /\bloadEnv\s*\(/.test(safeRead(p) ?? ''))
+
+  if (envFiles.length === 0) return null
+
+  const indexPath = ['src/index.ts', 'src/main.ts']
+    .map((p) => join(ctx.cwd, p))
+    .find((p) => existsSync(p))
+  if (!indexPath) {
+    return {
+      name: 'env wiring',
+      status: 'warn',
+      message: 'env-init file exists but no src/index.ts or src/main.ts found',
+    }
+  }
+  const indexContent = safeRead(indexPath) ?? ''
+  const indexDir = dirname(indexPath)
+
+  // Build the set of import specifiers that would wire any of these
+  // env files — relative paths (`./env`, `./config/env`, …) and the
+  // `@/` alias variant (`@/env`, `@/config/env`, …). For each file we
+  // accept both the with-`/index` suffix and the bare-directory form,
+  // since both resolve to the same module under TypeScript.
+  const importSpecs: string[] = []
+  for (const envFile of envFiles) {
+    const relPath = relative(indexDir, envFile).replace(/\\/g, '/').replace(/\.ts$/, '')
+    const relImport = relPath.startsWith('.') ? relPath : './' + relPath
+    const relImportNoIndex = relImport.replace(/\/index$/, '')
+    importSpecs.push(relImport, relImportNoIndex)
+
+    // `@/` is the standard alias the scaffold and most adopters use;
+    // it points at `src/`. Derive the @/-prefixed path from the file's
+    // location under src/.
+    const srcRel = envFile.replace(/\\/g, '/').match(/\/src\/(.+?)(?:\.ts)?$/)
+    if (srcRel) {
+      const aliasImport = '@/' + srcRel[1]
+      const aliasNoIndex = aliasImport.replace(/\/index$/, '')
+      importSpecs.push(aliasImport, aliasNoIndex)
+    }
+  }
+
+  let earliestImportIdx = -1
+  for (const spec of new Set(importSpecs)) {
+    const re = new RegExp(`^import\\s+(?:.*?from\\s+)?['"]${escapeRegExp(spec)}['"]`, 'm')
+    const m = indexContent.match(re)
+    if (m && m.index !== undefined) {
+      if (earliestImportIdx === -1 || m.index < earliestImportIdx) {
+        earliestImportIdx = m.index
+      }
+    }
+  }
+
+  const bootstrapIdx = indexContent.search(/\bbootstrap\s*\(/)
+  const sample = envFiles.map((p) => relative(ctx.cwd, p).replace(/\\/g, '/')).join(', ')
+
+  if (earliestImportIdx === -1) {
+    return {
+      name: 'env wiring',
+      status: 'fail',
+      message: sample,
+      fix: `An env-init file (${sample}) calls \`loadEnv(...)\` but \`${relative(ctx.cwd, indexPath).replace(/\\/g, '/')}\` doesn't import it.\nWithout this, ConfigService.get('X') returns undefined while @Value('X') works via process.env fallback — a half-broken config you won't notice until something is missing.\n\nFix: add a side-effect import at the top of ${relative(ctx.cwd, indexPath).replace(/\\/g, '/')} (above bootstrap()), pointing at one of the detected files. For example:\n\n  import './env'\n  // or\n  import './config'\n  // or, with the @/ alias:\n  import '@/config/env'`,
+    }
+  }
+  if (bootstrapIdx !== -1 && earliestImportIdx > bootstrapIdx) {
+    return {
+      name: 'env wiring',
+      status: 'warn',
+      message: 'env-init imported AFTER bootstrap() — should be before',
+      fix: `Move the env import above the bootstrap() call so the schema runs before any service reads from ConfigService.`,
+    }
+  }
+  return { name: 'env wiring', status: 'pass' }
+}
+
+export function checkTypegenFreshness(ctx: DoctorContext): DoctorResult | null {
+  const typegenDir = join(ctx.cwd, '.kickjs', 'types')
+  if (!existsSync(typegenDir)) return null
+  try {
+    const stat = statSync(typegenDir)
+    const ageMs = Date.now() - stat.mtimeMs
+    const ageMin = Math.floor(ageMs / 60_000)
+    if (ageMin > 60) {
+      return {
+        name: 'typegen freshness',
+        status: 'warn',
+        message: `last updated ${ageMin} minutes ago`,
+        fix: 'Re-run `kick typegen` (or `kick dev`, which runs it on every reload) so generated types match the current code.',
+      }
+    }
+    return {
+      name: 'typegen freshness',
+      status: 'pass',
+      message: ageMin === 0 ? 'just now' : `${ageMin}m ago`,
+    }
+  } catch {
+    return null
+  }
+}
+
+// ── Runner ────────────────────────────────────────────────────────────
+
+const BUILT_IN_CHECKS: DoctorCheck[] = [
+  () => checkNodeVersion(),
+  checkKickJsInstalled,
+  checkExpressInstalled,
+  checkReflectMetadata,
+  checkDecoratorTsConfig,
+  checkEnvWiring,
+  checkTypegenFreshness,
+]
+
+export async function runChecks(
+  cwd: string,
+  options: { extraChecks?: DoctorCheck[] } = {},
+): Promise<DoctorResult[]> {
+  const ctx: DoctorContext = {
+    cwd,
+    pkg: safeReadJson(join(cwd, 'package.json')),
+    tsconfig: loadTsConfig(cwd),
+  }
+  const checks = [...BUILT_IN_CHECKS, ...(options.extraChecks ?? [])]
+  const out: DoctorResult[] = []
+  for (const check of checks) {
+    const r = await check(ctx)
+    if (r == null) continue
+    if (Array.isArray(r)) out.push(...r)
+    else out.push(r)
+  }
+  return out
+}
+
+// ── Output ────────────────────────────────────────────────────────────
+
+function statusTag(status: DoctorResult['status']): string {
+  switch (status) {
+    case 'pass':
+      return colors.green('✔')
+    case 'warn':
+      return colors.yellow('⚠')
+    case 'fail':
+      return colors.red('✖')
+  }
+}
+
+function formatResult(r: DoctorResult): string {
+  const tag = statusTag(r.status)
+  const tail = r.message ? `  ${colors.dim(`(${r.message})`)}` : ''
+  return `${tag}  ${r.name}${tail}`
+}
+
+function formatFix(fix: string): string {
+  return fix
+    .split('\n')
+    .map((line) => `   ${colors.dim('→')} ${line}`)
+    .join('\n')
+}
+
+// ── Command registration ──────────────────────────────────────────────
+
+function extractDoctorChecks(config: KickConfig | null): DoctorCheck[] {
+  return config?.doctor?.checks ?? []
+}
+
+export function registerDoctorCommand(program: Command): void {
+  program
+    .command('doctor')
+    .description('Pre-flight checks for your KickJS project (dev environment health)')
+    .action(async () => {
+      const cwd = process.cwd()
+      const config = await loadKickConfig(cwd)
+      const extraChecks = extractDoctorChecks(config)
+
+      intro('KickJS Doctor')
+
+      const results = await runChecks(cwd, { extraChecks })
+
+      for (const r of results) {
+        log.message(formatResult(r))
+        if (r.fix && r.status !== 'pass') {
+          log.message(formatFix(r.fix))
+        }
+      }
+
+      const passed = results.filter((r) => r.status === 'pass').length
+      const warns = results.filter((r) => r.status === 'warn').length
+      const fails = results.filter((r) => r.status === 'fail').length
+
+      const passText = colors.green(`${passed} passed`)
+      const warnText =
+        warns > 0 ? colors.yellow(`${warns} warning${warns === 1 ? '' : 's'}`) : `${warns} warnings`
+      const failText =
+        fails > 0 ? colors.red(`${fails} error${fails === 1 ? '' : 's'}`) : `${fails} errors`
+      const summary = [passText, warnText, failText].join(', ')
+
+      if (fails > 0) {
+        outro(`${summary} — fix the errors above before running the app`)
+        process.exit(1)
+      } else if (warns > 0) {
+        outro(`${summary} — review the warnings`)
+      } else {
+        outro(colors.green(`${summary} — your environment looks good`))
+      }
+    })
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -423,6 +423,44 @@ export interface KickConfig {
     trailingComma?: 'all' | 'es5' | 'none'
     indent?: number
   }
+
+  /**
+   * Extensibility hook for `kick doctor`. Adopters add their own
+   * environment / project-shape checks here; each function receives
+   * the same context the built-in checks see and returns a result (or
+   * `null` to skip).
+   *
+   * The framework stays ORM- and stack-agnostic — Prisma-specific,
+   * Drizzle-specific, deploy-target-specific checks belong in adopter
+   * config (or in adapter packages that ship doctor extensions),
+   * never in core.
+   *
+   * @example
+   * ```ts
+   * import { existsSync } from 'node:fs'
+   * import { join } from 'node:path'
+   * import { defineConfig } from '@forinda/kickjs-cli'
+   *
+   * export default defineConfig({
+   *   doctor: {
+   *     checks: [
+   *       (ctx) => {
+   *         if (!existsSync(join(ctx.cwd, 'prisma/schema.prisma'))) return null
+   *         const generated = join(ctx.cwd, 'node_modules/@prisma/client/default.js')
+   *         return existsSync(generated)
+   *           ? { name: 'Prisma client generated', status: 'pass' }
+   *           : {
+   *               name: 'Prisma client generated',
+   *               status: 'fail',
+   *               fix: 'Run: pnpm exec prisma generate',
+   *             }
+   *       },
+   *     ],
+   *   },
+   * })
+   * ```
+   */
+  doctor?: import('./commands/doctor').DoctorExtension
 }
 
 /** Helper to define a type-safe kick.config.ts */

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,5 +38,17 @@ export {
   type DiscoveryResult,
 } from './generator-extension'
 
+// Doctor extension API — adopters and plugins ship custom dev-environment
+// checks via `defineDoctorExtension({...})` and plug them through the
+// `doctor.checks` block of kick.config.ts.
+export {
+  defineDoctorCheck,
+  defineDoctorExtension,
+  type DoctorCheck,
+  type DoctorContext,
+  type DoctorExtension,
+  type DoctorResult,
+} from './commands/doctor'
+
 // Utilities
 export { toPascalCase, toCamelCase, toKebabCase, pluralize } from './utils/naming'

--- a/packages/cli/src/plugin/builtins.ts
+++ b/packages/cli/src/plugin/builtins.ts
@@ -20,6 +20,7 @@ import { registerTinkerCommand } from '../commands/tinker'
 import { registerRemoveCommand } from '../commands/remove'
 import { registerTypegenCommand } from '../commands/typegen'
 import { registerCheckCommand } from '../commands/check'
+import { registerDoctorCommand } from '../commands/doctor'
 import { registerDbCommands } from '../commands/db'
 import { registerCodemodCommands } from '../commands/codemod'
 import { kickDbTypegen } from '../typegen/builtin/db'
@@ -43,6 +44,7 @@ export const builtinCliPlugins: readonly KickCliPlugin[] = [
   defineCliPlugin({ name: 'kick/remove', register: registerRemoveCommand }),
   defineCliPlugin({ name: 'kick/typegen', register: registerTypegenCommand }),
   defineCliPlugin({ name: 'kick/check', register: registerCheckCommand }),
+  defineCliPlugin({ name: 'kick/doctor', register: registerDoctorCommand }),
   defineCliPlugin({ name: 'kick/db', register: registerDbCommands, typegens: [kickDbTypegen()] }),
   defineCliPlugin({ name: 'kick/codemod', register: registerCodemodCommands }),
   // kick/assets, kick/routes are typegen-only — the asset manager


### PR DESCRIPTION
Closes B.4 from the roadmap.

## What this does

New `kick doctor` CLI command — pre-flight checks for a KickJS project's dev environment. Catches "doesn't work on my machine" misconfigs before they bite.

Sibling to `kick check --deploy` (which scans for production-readiness — JWT secrets, CORS, rate limits). Doctor is the dev-setup counterpart.

```text
$ kick doctor

KickJS Doctor

✔  Node version  (v22.7.0)
✔  @forinda/kickjs installed  (^5.12.0)
✔  express installed  (^5.1.0)
✔  reflect-metadata installed  (^0.2.2)
✔  tsconfig: experimentalDecorators
✔  tsconfig: emitDecoratorMetadata
⚠  env wiring  (env-init imported AFTER bootstrap() — should be before)
   → Move the env import above the bootstrap() call so the schema
   → runs before any service reads from ConfigService.
✔  typegen freshness  (2m ago)

8 passed, 1 warning, 0 errors — review the warnings
```

Exit code is `0` on pass-or-warn, `1` on any error.

## Built-in checks

| Check | Severity | Detects |
|---|---|---|
| Node version | error | Node < 20 |
| `@forinda/kickjs` installed | error | Wrong directory / fresh repo |
| `express` installed | error | Required peer dep missing |
| `reflect-metadata` installed | error | Decorator polyfill missing |
| tsconfig: `experimentalDecorators` | error | Decorators won't compile |
| tsconfig: `emitDecoratorMetadata` | error | DI container can't read constructor types |
| env wiring | error / warn | env-init file calls `loadEnv(...)` but app entry doesn't import it, or imports it AFTER `bootstrap()` |
| typegen freshness | warn | `.kickjs/types/` last touched > 60 min ago |

The env-wiring check is the most logic-heavy one — it handles **multiple file-location variations** (`src/env.ts`, `src/env/index.ts`, `src/config/env.ts`, `src/config/index.ts`) and accepts both relative (`'./env'`, `'./config/env'`) and `@/`-aliased (`'@/env'`, `'@/config'`) imports. Detects the canonical "ConfigService.get() returns undefined while @Value() works" footgun documented in CLAUDE.md.

## What's deliberately NOT in core

No ORM-specific checks (Prisma client generated, Drizzle migration table exists, Mongoose connection string, etc.). The framework stays stack-agnostic — those checks belong in adopter config, or in adapter packages that ship doctor extensions.

## Extensibility — `defineDoctorExtension`

Two new identity helpers exported from `@forinda/kickjs-cli`:

```ts
// doctor-checks/prisma.ts (publishable as a package, or workspace-shared)
import { defineDoctorExtension } from '@forinda/kickjs-cli'

export const prismaDoctor = defineDoctorExtension({
  checks: [
    (ctx) => {
      if (!existsSync(join(ctx.cwd, 'prisma/schema.prisma'))) return null
      const generated = join(ctx.cwd, 'node_modules/@prisma/client/default.js')
      return existsSync(generated)
        ? { name: 'Prisma client generated', status: 'pass' }
        : { name: 'Prisma client generated', status: 'fail', fix: 'pnpm exec prisma generate' }
    },
  ],
})

// kick.config.ts
import { defineConfig } from '@forinda/kickjs-cli'
import { prismaDoctor } from './doctor-checks/prisma'

export default defineConfig({ doctor: prismaDoctor })
```

Both helpers are identity functions (return their input) — they exist purely for type inference + autocomplete, mirroring the `defineConfig` pattern. `defineDoctorCheck(fn)` is the single-check sibling for one-offs.

## New exports from `@forinda/kickjs-cli`

- `defineDoctorExtension(ext)` — identity helper for an extension bundle
- `defineDoctorCheck(check)` — identity helper for a single check
- `DoctorExtension`, `DoctorCheck`, `DoctorContext`, `DoctorResult` — type contracts

## Test plan

- [x] `pnpm --filter @forinda/kickjs-cli exec vitest run __tests__/doctor.test.ts` — **29/29 pass**
  - 11 tests across built-in checks (`checkKickJsInstalled`, `checkReflectMetadata`, `checkExpressInstalled`, `checkDecoratorTsConfig`, `checkEnvWiring`)
  - 8 env-wiring variation tests (4 file locations × relative/alias imports, plus before/after bootstrap, plus `src/main.ts` fallback)
  - 4 `runChecks` integration tests (built-in aggregation, extra checks, null-skip, async)
  - 4 helper tests (`defineDoctorExtension` + `defineDoctorCheck` identity + plug-through)
- [x] Lint clean (oxlint)
- [x] Format clean (oxfmt)
- [x] Build clean

**Note on pre-existing CI failures:** `__tests__/config-service.test.ts` and `__tests__/typegen-token-conventions.test.ts` have flaky `tsc` failures on `main` (verified by checking out main and running them in isolation). Not introduced by this PR.

## Files

| File | Change |
|---|---|
| `packages/cli/src/commands/doctor.ts` | new — built-in checks + runner + `defineDoctorExtension` + `defineDoctorCheck` |
| `packages/cli/src/plugin/builtins.ts` | register `kick/doctor` plugin |
| `packages/cli/src/index.ts` | re-export `defineDoctorExtension`, `defineDoctorCheck`, types |
| `packages/cli/src/config.ts` | add `KickConfig.doctor?: DoctorExtension` |
| `packages/cli/__tests__/doctor.test.ts` | new — 29 tests |
| `docs/guide/cli-commands.md` | new "kick doctor" section + extensibility recipes |
| `.changeset/kick-doctor.md` | minor bump for `@forinda/kickjs-cli` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `kick doctor` CLI command that validates your development environment, checking Node version, required dependencies, TypeScript settings, and project setup.
  * Added extensibility mechanism to register custom project checks via configuration.

* **Documentation**
  * Added comprehensive `kick doctor` guide with usage examples and patterns for adding custom checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->