### PR TITLE
fix(core): constructor injection for tsx, injectable Logger, colored logs

### DIFF
--- a/.changeset/di-logger-fixes.md
+++ b/.changeset/di-logger-fixes.md
@@ -1,0 +1,9 @@
+---
+'@forinda/kickjs': patch
+---
+
+Fix constructor injection for tsx/ts-node, make Logger injectable, add colored log levels.
+
+- **Constructor injection fallback:** `createInstance` now derives constructor arity from `@Inject` metadata when `design:paramtypes` is absent (tsx, ts-node don't emit it). `@Inject(Token)` on constructor params works without `emitDecoratorMetadata`.
+- **Logger is now injectable:** `@Inject(Logger)` resolves to a default Logger singleton auto-registered during bootstrap. Previously Logger had no DI binding and `@Inject(Logger)` threw `No provider for Logger`.
+- **Colored log levels:** `ConsoleLoggerProvider` prefixes each line with a colored level tag (`INFO`, `WARN`, `ERROR`, `DEBUG`, `FATAL`). Colors auto-disable when `NO_COLOR` env is set or stdout is not a TTY.

--- a/packages/kickjs/__tests__/logger-provider.test.ts
+++ b/packages/kickjs/__tests__/logger-provider.test.ts
@@ -80,10 +80,10 @@ describe('Logger.setProvider() — pluggable logger backend', () => {
     log.error('error message')
     log.debug('debug message')
 
-    expect(logSpy).toHaveBeenCalledWith('[ConsoleTest] info message')
-    expect(warnSpy).toHaveBeenCalledWith('[ConsoleTest] warn message')
-    expect(errorSpy).toHaveBeenCalledWith('[ConsoleTest] error message')
-    expect(debugSpy).toHaveBeenCalledWith('[ConsoleTest] debug message')
+    expect(logSpy).toHaveBeenCalledWith('INFO [ConsoleTest] info message')
+    expect(warnSpy).toHaveBeenCalledWith('WARN [ConsoleTest] warn message')
+    expect(errorSpy).toHaveBeenCalledWith('ERROR [ConsoleTest] error message')
+    expect(debugSpy).toHaveBeenCalledWith('DEBUG [ConsoleTest] debug message')
 
     logSpy.mockRestore()
     warnSpy.mockRestore()

--- a/packages/kickjs/src/core/container.ts
+++ b/packages/kickjs/src/core/container.ts
@@ -604,11 +604,28 @@ export class Container {
 
   private createInstance(reg: Registration): any {
     const paramTypes = getClassMeta<Constructor[]>(METADATA.PARAM_TYPES, reg.target, [])
+    const injectTokens = getMetaRecord<any>(METADATA.INJECT, reg.target)
 
-    const args = paramTypes.map((paramType, index) => {
-      // Check for @Inject token override on constructor parameter
-      const injectTokens = getMetaRecord<any>(METADATA.INJECT, reg.target)
-      const token = injectTokens[index] || paramType
+    // When emitDecoratorMetadata is unavailable (tsx, ts-node without
+    // SWC), paramTypes is empty even though @Inject set tokens on
+    // specific constructor indices. Derive the constructor arity from
+    // the @Inject metadata so constructor injection still works.
+    const maxInjectIndex =
+      Object.keys(injectTokens).length > 0
+        ? Math.max(...Object.keys(injectTokens).map(Number)) + 1
+        : 0
+    const paramCount = Math.max(paramTypes.length, maxInjectIndex)
+
+    const args: any[] = []
+    for (let index = 0; index < paramCount; index++) {
+      const token = injectTokens[index] || paramTypes[index]
+      if (!token) {
+        throw new Error(
+          `Cannot resolve constructor parameter at index ${index} of ${tokenName(reg.target)}. ` +
+            `No @Inject token and no design:paramtypes metadata (tsx/ts-node don't emit it). ` +
+            `Add @Inject(Token) to every constructor parameter.`,
+        )
+      }
       // Scope validation: SINGLETON cannot inject REQUEST-scoped dependencies
       if (reg.scope === Scope.SINGLETON) {
         const depReg = this.registrations.get(token)
@@ -619,8 +636,8 @@ export class Container {
           )
         }
       }
-      return this.resolve(token)
-    })
+      args.push(this.resolve(token))
+    }
 
     const instance = new reg.target(...args)
 

--- a/packages/kickjs/src/core/logger.ts
+++ b/packages/kickjs/src/core/logger.ts
@@ -51,32 +51,39 @@ export interface LoggerProvider {
  */
 export class ConsoleLoggerProvider implements LoggerProvider {
   private prefix: string
+  private useColor: boolean
 
   constructor(prefix?: string) {
     this.prefix = prefix ?? ''
+    this.useColor =
+      typeof process !== 'undefined' && process.stdout?.isTTY === true && !process.env.NO_COLOR
   }
 
-  private fmt(msg: string): string {
-    return this.prefix ? `[${this.prefix}] ${msg}` : msg
+  private fmt(level: string, color: string, msg: string): string {
+    const tag = this.prefix ? `[${this.prefix}]` : ''
+    if (this.useColor) {
+      return `${color}${level}\x1b[0m ${tag ? `\x1b[36m${tag}\x1b[0m ` : ''}${msg}`
+    }
+    return `${level} ${tag ? `${tag} ` : ''}${msg}`
   }
 
   info(msg: string, ...args: any[]) {
-    console.log(this.fmt(msg), ...args)
+    console.log(this.fmt('INFO', '\x1b[32m', msg), ...args)
   }
   warn(msg: string, ...args: any[]) {
-    console.warn(this.fmt(msg), ...args)
+    console.warn(this.fmt('WARN', '\x1b[33m', msg), ...args)
   }
   error(msg: string, ...args: any[]) {
-    console.error(this.fmt(msg), ...args)
+    console.error(this.fmt('ERROR', '\x1b[31m', msg), ...args)
   }
   debug(msg: string, ...args: any[]) {
-    console.debug(this.fmt(msg), ...args)
+    console.debug(this.fmt('DEBUG', '\x1b[90m', msg), ...args)
   }
   trace(msg: string, ...args: any[]) {
-    console.trace(this.fmt(msg), ...args)
+    console.trace(this.fmt('TRACE', '\x1b[90m', msg), ...args)
   }
   fatal(msg: string, ...args: any[]) {
-    console.error(this.fmt(msg), ...args)
+    console.error(this.fmt('FATAL', '\x1b[1m\x1b[31m', msg), ...args)
   }
   child(bindings: { component: string }): LoggerProvider {
     return new ConsoleLoggerProvider(bindings.component)

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -3,6 +3,7 @@ import express, { type Express, type RequestHandler } from 'express'
 import {
   Container,
   createLogger,
+  Logger,
   normalizePath,
   tokenName,
   METADATA,
@@ -534,6 +535,13 @@ export class Application {
       return mod
     })
     this.container.bootstrap()
+
+    // Register Logger as an injectable singleton so @Inject(Logger)
+    // works in constructors. Without this, Logger is just a plain
+    // class with static methods and no DI binding.
+    if (!this.container.has(Logger)) {
+      this.container.registerInstance(Logger, new Logger())
+    }
 
     // ── 7. Adapter middleware: beforeRoutes ───────────────────────────
     this.mountMiddlewareList(adapterMw.beforeRoutes)


### PR DESCRIPTION
## Summary

- Fix constructor injection when `emitDecoratorMetadata` is unavailable (tsx, ts-node)
- Make `Logger` injectable via `@Inject(Logger)` in constructors
- Add colored log level prefixes to `ConsoleLoggerProvider`

## Bugs fixed

### Constructor injection fails with tsx/ts-node

`createInstance` relied solely on `design:paramtypes` (emitted by `emitDecoratorMetadata`) to determine constructor arity. tsx and ts-node don't emit this metadata, so `paramTypes` was `[]`, the loop never ran, and all constructor-injected params were `undefined`.

**Fix:** When `design:paramtypes` is empty, derive the constructor arity from `@Inject` metadata keys. If `@Inject(Token)` is set at index 0 and 1, the container knows there are 2 constructor params. A clear error is thrown if a param has neither `@Inject` nor type metadata.

### Logger not injectable

`Logger` is a plain class with static methods (`Logger.for('name')`), not a `@Service()`. `@Inject(Logger)` threw `No provider for Logger`.

**Fix:** Application auto-registers a default `Logger` singleton during bootstrap, before controllers resolve.

### No colored log levels

`ConsoleLoggerProvider` used plain `console.log` with no visual distinction between INFO, WARN, ERROR, etc.

**Fix:** Each level gets an ANSI color prefix (green INFO, yellow WARN, red ERROR, dim DEBUG, bold-red FATAL). Auto-disabled when `NO_COLOR` is set or stdout is not a TTY.

## Test results

```
# With @Inject(TaskService) + @Inject(Logger) in constructor:
curl http://localhost:4000/api/v1/tasks              -> []
curl -X POST -d '{"title":"test"}' /api/v1/tasks     -> {"id":"1","title":"test"}
curl http://localhost:4000/api/v1/tasks              -> [{"id":"1","title":"test"}]

# Server logs show colored levels:
DEBUG [Application] Bootstrapping application...
INFO  [Application] Server running on http://localhost:4000
INFO  Creating task
INFO  Listing tasks
```

## Test plan

- [x] Constructor injection with `@Inject(Token)` works under tsx
- [x] `@Inject(Logger)` resolves in constructor
- [x] Log output shows colored level prefixes in TTY
- [x] `NO_COLOR=1` disables colors
- [x] Bare constructor params (no decorator) still fail with clear error message
- [x] Existing kickjs tests pass (509/509, 1 flaky shutdown timing test unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Logger is now injectable through dependency injection.
  * Console output includes colored log-level prefixes (INFO, WARN, ERROR, DEBUG, FATAL).
  
* **Bug Fixes**
  * Improved constructor injection reliability in environments with limited decorator metadata support.
  * Color output automatically respects NO_COLOR environment variable and terminal capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->