### PR TITLE
feat(schema): schema-agnostic validation abstraction (alpha)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,29 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@forinda/kickjs-ai": "5.2.2",
+    "@forinda/kickjs-auth": "5.2.3",
+    "@forinda/kickjs-cli": "5.9.1",
+    "@forinda/kickjs-db": "5.9.1",
+    "@forinda/kickjs-db-mysql": "2.0.3",
+    "@forinda/kickjs-db-pg": "9.0.6",
+    "@forinda/kickjs-db-sqlite": "2.0.3",
+    "@forinda/kickjs-devtools": "5.3.2",
+    "@forinda/kickjs-devtools-kit": "5.4.1",
+    "@forinda/kickjs-devtools-spa": "3.2.0",
+    "@forinda/kickjs-drizzle": "5.3.1",
+    "@forinda/kickjs": "5.13.1",
+    "@forinda/kickjs-lint": "5.2.3",
+    "@forinda/kickjs-mcp": "5.2.3",
+    "@forinda/kickjs-prisma": "5.2.2",
+    "@forinda/kickjs-queue": "5.2.6",
+    "@forinda/kickjs-schema": "0.0.0",
+    "@forinda/kickjs-swagger": "5.3.2",
+    "@forinda/kickjs-testing": "5.2.3",
+    "@forinda/kickjs-vite": "5.3.2",
+    "kickjs-devtools": "5.2.1",
+    "@forinda/kickjs-ws": "5.2.3"
+  },
+  "changesets": []
+}

--- a/.changeset/schema-abstraction.md
+++ b/.changeset/schema-abstraction.md
@@ -1,0 +1,36 @@
+---
+'@forinda/kickjs-schema': minor
+'@forinda/kickjs': minor
+'@forinda/kickjs-swagger': patch
+'@forinda/kickjs-mcp': patch
+'@forinda/kickjs-cli': minor
+---
+
+Schema-agnostic validation abstraction
+
+**New package: `@forinda/kickjs-schema`**
+
+- `KickSchema` interface — unified `safeParse()`, `toJsonSchema()`, `_raw`
+- `SchemaIssue` — normalized error format (path, message, code, expected, received)
+- `detectSchema()` — auto-detects KickSchema, Zod, Valibot, Yup, Standard Schema v1, functions, and duck-typed schemas
+- `registerAdapter()` — plug in custom schema libraries at runtime
+- `InferSchemaOutput<T>` — type-level inference for Zod, Valibot, Standard Schema, and KickSchema
+
+**Adapters (tree-shakable sub-exports):**
+
+- `@forinda/kickjs-schema/zod` — `fromZod()` with full issue normalization and JSON Schema via `.toJSONSchema()`
+- `@forinda/kickjs-schema/valibot` — `fromValibot()` with issue mapping and JSON Schema via `@valibot/to-json-schema`
+- `@forinda/kickjs-schema/yup` — `fromYup()` with `validateSync` error mapping and JSON Schema from `describe()` metadata
+
+**Framework integration:**
+
+- `validate()` middleware uses `detectSchema()` — accepts any supported schema library
+- Swagger `SchemaParser` uses `detectSchema().toJsonSchema()` instead of Zod-specific conversion
+- MCP adapter uses `detectSchema()` for tool input/output schema conversion
+- `loadEnvFromSchema()` — schema-agnostic env loader alongside existing Zod-only `loadEnv()`
+
+**Typegen:**
+
+- New `schemaValidator: 'kickjs-schema'` option emits `InferSchemaOutput<>` for route body/query/params and env types
+- Default `'zod'` unchanged — fully backward compatible
+- CLI: `kick typegen --schema-validator kickjs-schema`

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ superpowers/
 # Bundle-size harness scratch dir — written by scripts/bundle-size-check.ts.
 # `**/` so the rule fires inside any nested project, not just root.
 **/.kickjs/
+examples/

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -163,10 +163,24 @@ const examplesSidebar = [
   },
 ]
 
+const schemasSidebar = [
+  {
+    text: 'Schema Abstraction',
+    items: [
+      { text: 'Overview & RFC', link: '/schemas/' },
+      { text: 'Standard Schema v1', link: '/schemas/standard-schema' },
+      { text: 'Adapters', link: '/schemas/adapters' },
+      { text: 'Error Format', link: '/schemas/error-format' },
+      { text: 'Framework Integration', link: '/schemas/integration' },
+    ],
+  },
+]
+
 const sharedSidebar = {
   '/guide/': guideSidebar,
   '/api/': apiSidebar,
   '/examples/': examplesSidebar,
+  '/schemas/': schemasSidebar,
 }
 
 export default defineVersionedConfig(
@@ -201,6 +215,7 @@ export default defineVersionedConfig(
       nav: [
         { text: 'Guide', link: '/guide/getting-started' },
         { text: 'API', link: '/api/core' },
+        { text: 'Schemas', link: '/schemas/' },
         { text: 'Examples', link: '/examples/' },
         { component: 'VersionSwitcher' },
       ],

--- a/docs/schemas/adapters.md
+++ b/docs/schemas/adapters.md
@@ -1,0 +1,213 @@
+# Schema Adapters
+
+Each adapter wraps a specific validation library into the unified `KickSchema` interface. Adapters are tree-shakable -- unused libraries add zero bytes to the bundle.
+
+## Zod Adapter
+
+```ts
+import { fromZod } from '@forinda/kickjs-schema/zod'
+import { z } from 'zod'
+
+const CreateUser = fromZod(
+  z.object({
+    name: z.string().min(1),
+    email: z.string().email(),
+    age: z.number().int().min(18),
+  }),
+)
+
+// Type inference preserved
+type CreateUserInput = typeof CreateUser extends KickSchema<infer T> ? T : never
+// { name: string; email: string; age: number }
+```
+
+**Validation protocol**: Calls `schema.safeParse(data)`. Returns `{ success: true, data }` or maps `ZodError.issues` to `SchemaIssue[]`.
+
+**JSON Schema**: Uses Zod v4 native `.toJSONSchema()`. For Zod v3, falls back to `zod-to-json-schema`.
+
+**Error mapping**:
+
+```
+ZodIssue.path       → SchemaIssue.path (string[])
+ZodIssue.message    → SchemaIssue.message
+ZodIssue.code       → SchemaIssue.code ("invalid_type", "too_small", etc.)
+```
+
+## Valibot Adapter
+
+```ts
+import { fromValibot } from '@forinda/kickjs-schema/valibot'
+import * as v from 'valibot'
+
+const CreateUser = fromValibot(
+  v.object({
+    name: v.pipe(v.string(), v.minLength(1)),
+    email: v.pipe(v.string(), v.email()),
+    age: v.pipe(v.number(), v.integer(), v.minValue(18)),
+  }),
+)
+```
+
+**Validation protocol**: Calls `v.safeParse(schema, data)`. Maps `result.issues` to `SchemaIssue[]`.
+
+**JSON Schema**: Uses `@valibot/to-json-schema` with configurable target (`draft-2020-12`, `openapi-3.0`).
+
+**Error mapping**:
+
+```
+issue.path[].key    → SchemaIssue.path (string[])
+issue.message       → SchemaIssue.message
+issue.type          → SchemaIssue.code ("string", "min_length", etc.)
+issue.expected      → SchemaIssue.expected
+issue.received      → SchemaIssue.received
+```
+
+## Yup Adapter
+
+```ts
+import { fromYup } from '@forinda/kickjs-schema/yup'
+import * as yup from 'yup'
+
+const CreateUser = fromYup(
+  yup.object({
+    name: yup.string().required().min(1),
+    email: yup.string().required().email(),
+    age: yup.number().required().integer().min(18),
+  }),
+)
+```
+
+**Validation protocol**: Calls `schema.validate(data, { abortEarly: false })`. Catches `ValidationError` and maps `error.inner` to `SchemaIssue[]`.
+
+**JSON Schema**: Uses `@sodaru/yup-to-json-schema` or custom walker.
+
+**Error mapping**:
+
+```
+inner[].path        → SchemaIssue.path (split on '.')
+inner[].message     → SchemaIssue.message
+inner[].type        → SchemaIssue.code ("required", "min", "email", etc.)
+```
+
+## Joi Adapter
+
+```ts
+import { fromJoi } from '@forinda/kickjs-schema/joi'
+import Joi from 'joi'
+
+const CreateUser = fromJoi(
+  Joi.object({
+    name: Joi.string().required().min(1),
+    email: Joi.string().required().email(),
+    age: Joi.number().required().integer().min(18),
+  }),
+)
+```
+
+**Validation protocol**: Calls `schema.validate(data, { abortEarly: false })`. Maps `error.details` to `SchemaIssue[]`.
+
+**JSON Schema**: Uses `joi-to-json` for conversion.
+
+**Error mapping**:
+
+```
+details[].path      → SchemaIssue.path (already string[])
+details[].message   → SchemaIssue.message
+details[].type      → SchemaIssue.code ("string.min", "any.required", etc.)
+```
+
+## Standard Schema Adapter (Universal)
+
+```ts
+import { fromStandard } from '@forinda/kickjs-schema/standard'
+
+// Works with ANY library implementing Standard Schema v1
+const CreateUser = fromStandard(anyStandardSchemaV1Object)
+```
+
+**Validation protocol**: Calls `schema['~standard'].validate(data)`. Maps Standard Schema issues to `SchemaIssue[]`.
+
+**JSON Schema**: Checks for StandardJSONSchemaV1's `~standard.jsonSchema.input()` method. Falls back to empty schema if not available.
+
+**Error mapping**:
+
+```
+issue.path          → SchemaIssue.path (mapped from PropertyKey | PathSegment)
+issue.message       → SchemaIssue.message
+(no code in spec)   → SchemaIssue.code = "validation"
+```
+
+## Auto-Detection (Zero-Config)
+
+When a raw schema (not wrapped) is passed to `validate()` or a route decorator, KickJS auto-detects the library:
+
+```ts
+function detectSchema(schema: unknown): KickSchema {
+  // 1. Already a KickSchema? Return as-is.
+  if (isKickSchema(schema)) return schema
+
+  // 2. Standard Schema v1? (~standard property)
+  if (hasStandardSchema(schema)) return fromStandard(schema)
+
+  // 3. Zod? (.safeParse + ._def)
+  if (isZodLike(schema)) return fromZod(schema)
+
+  // 4. Yup? (.validateSync + .describe)
+  if (isYupLike(schema)) return fromYup(schema)
+
+  // 5. Joi? (.validate + .describe + .$_root)
+  if (isJoiLike(schema)) return fromJoi(schema)
+
+  // 6. Plain function? Treat as custom validator
+  if (typeof schema === 'function') return fromFunction(schema)
+
+  throw new Error('Unrecognized schema. Wrap it with an adapter or implement StandardSchemaV1.')
+}
+```
+
+Priority order ensures Standard Schema takes precedence (since Zod v4 also implements it, checking `~standard` first avoids double-wrapping).
+
+## Writing a Custom Adapter
+
+For libraries not listed above:
+
+```ts
+import type { KickSchema, SchemaResult, SchemaIssue } from '@forinda/kickjs-schema'
+
+function fromMyLibrary<T>(schema: MyLibrarySchema<T>): KickSchema<T> {
+  return {
+    safeParse(data: unknown): SchemaResult<T> {
+      const result = schema.check(data)
+      if (result.valid) {
+        return { success: true, data: result.value }
+      }
+      return {
+        success: false,
+        issues: result.errors.map((e) => ({
+          path: e.location.split('.'),
+          message: e.text,
+          code: e.rule,
+        })),
+      }
+    },
+
+    toJsonSchema(options) {
+      return schema.toJSON({ dialect: options?.target ?? 'draft-2020-12' })
+    },
+
+    _raw: schema,
+  }
+}
+```
+
+Register it globally so auto-detection picks it up:
+
+```ts
+import { registerAdapter } from '@forinda/kickjs-schema'
+
+registerAdapter({
+  name: 'my-library',
+  detect: (schema) => schema instanceof MyLibrarySchema,
+  wrap: (schema) => fromMyLibrary(schema),
+})
+```

--- a/docs/schemas/adapters.md
+++ b/docs/schemas/adapters.md
@@ -27,7 +27,7 @@ type CreateUserInput = typeof CreateUser extends KickSchema<infer T> ? T : never
 
 **Error mapping**:
 
-```
+```text
 ZodIssue.path       → SchemaIssue.path (string[])
 ZodIssue.message    → SchemaIssue.message
 ZodIssue.code       → SchemaIssue.code ("invalid_type", "too_small", etc.)
@@ -54,7 +54,7 @@ const CreateUser = fromValibot(
 
 **Error mapping**:
 
-```
+```text
 issue.path[].key    → SchemaIssue.path (string[])
 issue.message       → SchemaIssue.message
 issue.type          → SchemaIssue.code ("string", "min_length", etc.)
@@ -83,7 +83,7 @@ const CreateUser = fromYup(
 
 **Error mapping**:
 
-```
+```text
 inner[].path        → SchemaIssue.path (split on '.')
 inner[].message     → SchemaIssue.message
 inner[].type        → SchemaIssue.code ("required", "min", "email", etc.)
@@ -91,30 +91,7 @@ inner[].type        → SchemaIssue.code ("required", "min", "email", etc.)
 
 ## Joi Adapter
 
-```ts
-import { fromJoi } from '@forinda/kickjs-schema/joi'
-import Joi from 'joi'
-
-const CreateUser = fromJoi(
-  Joi.object({
-    name: Joi.string().required().min(1),
-    email: Joi.string().required().email(),
-    age: Joi.number().required().integer().min(18),
-  }),
-)
-```
-
-**Validation protocol**: Calls `schema.validate(data, { abortEarly: false })`. Maps `error.details` to `SchemaIssue[]`.
-
-**JSON Schema**: Uses `joi-to-json` for conversion.
-
-**Error mapping**:
-
-```
-details[].path      → SchemaIssue.path (already string[])
-details[].message   → SchemaIssue.message
-details[].type      → SchemaIssue.code ("string.min", "any.required", etc.)
-```
+> **Not implemented.** Joi lacks TypeScript type inference (`Joi.infer<>` does not exist), so `InferSchemaOutput<typeof joiSchema>` always resolves to `unknown`. Since the core goal of the schema abstraction is type-safe validation, Joi is not planned. Use Zod, Valibot, or Yup instead.
 
 ## Standard Schema Adapter (Universal)
 
@@ -131,7 +108,7 @@ const CreateUser = fromStandard(anyStandardSchemaV1Object)
 
 **Error mapping**:
 
-```
+```text
 issue.path          → SchemaIssue.path (mapped from PropertyKey | PathSegment)
 issue.message       → SchemaIssue.message
 (no code in spec)   → SchemaIssue.code = "validation"

--- a/docs/schemas/error-format.md
+++ b/docs/schemas/error-format.md
@@ -1,0 +1,205 @@
+# Error Format Standardization
+
+Every schema library has its own error structure. KickJS normalizes all validation errors into a single format regardless of which library produced them.
+
+## Unified SchemaIssue
+
+```ts
+interface SchemaIssue {
+  path: string[] // ["address", "zip"] — dotted path segments
+  message: string // "Must be at least 5 characters"
+  code: string // "min_length", "required", "invalid_type"
+  expected?: string // "string", ">=18"
+  received?: string // "undefined", "12"
+}
+```
+
+## HTTP Error Response (422)
+
+```json
+{
+  "status": 422,
+  "message": "Validation failed",
+  "errors": [
+    {
+      "field": "email",
+      "message": "Invalid email address",
+      "code": "email"
+    },
+    {
+      "field": "age",
+      "message": "Must be at least 18",
+      "code": "min",
+      "expected": ">=18",
+      "received": "12"
+    },
+    {
+      "field": "address.zip",
+      "message": "Required",
+      "code": "required"
+    }
+  ]
+}
+```
+
+The `field` value is `path.join('.')` — a dotted string for nested fields.
+
+## Library Error Comparison
+
+### Zod
+
+```ts
+// ZodError.issues[]
+{
+  code: "too_small",
+  minimum: 18,
+  type: "number",
+  inclusive: true,
+  exact: false,
+  message: "Number must be greater than or equal to 18",
+  path: ["age"]
+}
+// → SchemaIssue
+{
+  path: ["age"],
+  message: "Number must be greater than or equal to 18",
+  code: "too_small",
+  expected: ">=18",
+  received: undefined
+}
+```
+
+### Valibot
+
+```ts
+// Valibot issue
+{
+  kind: "validation",
+  type: "min_value",
+  input: 12,
+  expected: ">=18",
+  received: "12",
+  message: "Must be at least 18",
+  path: [{ type: "object", origin: "value", input: {...}, key: "age", value: 12 }]
+}
+// → SchemaIssue
+{
+  path: ["age"],
+  message: "Must be at least 18",
+  code: "min_value",
+  expected: ">=18",
+  received: "12"
+}
+```
+
+### Yup
+
+```ts
+// Yup ValidationError.inner[]
+{
+  path: "age",
+  message: "age must be greater than or equal to 18",
+  type: "min",
+  params: { min: 18 }
+}
+// → SchemaIssue
+{
+  path: ["age"],
+  message: "age must be greater than or equal to 18",
+  code: "min",
+  expected: ">=18"
+}
+```
+
+### Joi
+
+```ts
+// Joi error.details[]
+{
+  message: "\"age\" must be greater than or equal to 18",
+  path: ["age"],
+  type: "number.min",
+  context: { limit: 18, value: 12, label: "age", key: "age" }
+}
+// → SchemaIssue
+{
+  path: ["age"],
+  message: "\"age\" must be greater than or equal to 18",
+  code: "number.min",
+  expected: ">=18",
+  received: "12"
+}
+```
+
+### Standard Schema
+
+```ts
+// Standard Schema FailureResult.issues[]
+{
+  message: "Must be at least 18",
+  path: ["age"]
+}
+// → SchemaIssue
+{
+  path: ["age"],
+  message: "Must be at least 18",
+  code: "validation"   // Standard Schema has no code field
+}
+```
+
+## Custom Error Formatter
+
+Override the default 422 format globally:
+
+```ts
+import { bootstrap } from '@forinda/kickjs'
+
+bootstrap({
+  validation: {
+    formatError(issues: SchemaIssue[], ctx: RequestContext) {
+      // RFC 9457 Problem Details
+      return {
+        type: 'https://api.example.com/errors/validation',
+        title: 'Validation Error',
+        status: 422,
+        detail: `${issues.length} field(s) failed validation`,
+        violations: issues.map((i) => ({
+          property: i.path.join('.'),
+          constraint: i.code,
+          message: i.message,
+        })),
+      }
+    },
+  },
+})
+```
+
+## Per-Route Error Handling
+
+```ts
+@Post('/', {
+  body: createUserSchema,
+  onValidationError(issues, ctx) {
+    ctx.status(400).json({
+      ok: false,
+      fields: Object.fromEntries(issues.map((i) => [i.path.join('.'), i.message])),
+    })
+  },
+})
+async create(ctx: RequestContext) { /* ... */ }
+```
+
+## Error Codes Reference
+
+Common normalized codes across libraries:
+
+| Code           | Meaning                | Zod                  | Valibot                  | Yup         | Joi                   |
+| -------------- | ---------------------- | -------------------- | ------------------------ | ----------- | --------------------- |
+| `required`     | Missing required field | `invalid_type`       | `non_optional`           | `required`  | `any.required`        |
+| `invalid_type` | Wrong type             | `invalid_type`       | `*` (type name)          | `typeError` | `*.base`              |
+| `min`          | Below minimum          | `too_small`          | `min_value`/`min_length` | `min`       | `*.min`               |
+| `max`          | Above maximum          | `too_big`            | `max_value`/`max_length` | `max`       | `*.max`               |
+| `pattern`      | Regex mismatch         | `invalid_string`     | `regex`                  | `matches`   | `string.pattern.base` |
+| `email`        | Invalid email          | `invalid_string`     | `email`                  | `email`     | `string.email`        |
+| `enum`         | Not in allowed values  | `invalid_enum_value` | `enum_`                  | `oneOf`     | `any.only`            |
+| `custom`       | Custom validation      | `custom`             | `custom`                 | `test`      | `any.custom`          |

--- a/docs/schemas/index.md
+++ b/docs/schemas/index.md
@@ -1,0 +1,339 @@
+# Schema Abstraction (RFC)
+
+KickJS ships with Zod as the default validation library, but the framework is designed to be **schema-agnostic**. This reference documents the industry standards, the interfaces involved, and how KickJS will support any validation library going forward.
+
+## Why Schema-Agnostic?
+
+Tying a framework to a single schema library means:
+
+- Users inherit that library's bundle size, API style, and release cadence
+- Switching libraries requires rewriting every DTO, not just swapping an import
+- Community innovation (Valibot's 1 kB tree-shaking, ArkType's 100x perf, TypeBox's native JSON Schema) can't be leveraged
+
+The goal: **users pick their schema library; the framework adapts.**
+
+## Standard Schema v1 (Industry Standard)
+
+[Standard Schema](https://github.com/standard-schema/standard-schema) is a ~60-line TypeScript interface spec created by the maintainers of Zod, Valibot, and ArkType. It solves the N x M problem (N validators x M consumers) by defining one universal contract.
+
+### The Interface
+
+```ts
+interface StandardSchemaV1<Input = unknown, Output = Input> {
+  readonly '~standard': {
+    readonly version: 1
+    readonly vendor: string
+    readonly validate: (value: unknown) => Result<Output> | Promise<Result<Output>>
+    readonly types?: { readonly input: Input; readonly output: Output }
+  }
+}
+
+type Result<Output> =
+  | { readonly value: Output; readonly issues?: undefined }
+  | { readonly issues: ReadonlyArray<Issue> }
+
+interface Issue {
+  readonly message: string
+  readonly path?: ReadonlyArray<PropertyKey | { readonly key: PropertyKey }>
+}
+```
+
+### Adoption Status
+
+**Schema libraries implementing Standard Schema:**
+
+| Library       | Version               | Bundle | Notes                                 |
+| ------------- | --------------------- | ------ | ------------------------------------- |
+| Zod           | v3.23+ (native in v4) | ~13 kB | Most popular, `.toJSONSchema()` in v4 |
+| Valibot       | v1+                   | ~1 kB  | Tree-shakable, modular                |
+| ArkType       | v2+                   | ~5 kB  | Fastest runtime validation            |
+| Effect Schema | via adapter           | ~20 kB | Bidirectional encode/decode           |
+| TypeBox       | community adapter     | ~8 kB  | Schemas ARE JSON Schema at runtime    |
+
+**Frameworks consuming Standard Schema:**
+
+| Consumer        | Version                               | Integration                      |
+| --------------- | ------------------------------------- | -------------------------------- |
+| tRPC            | v11                                   | Input/output validators          |
+| Hono            | `@hono/standard-validator`            | Middleware validators            |
+| React Hook Form | `@hookform/resolvers/standard-schema` | Form validation                  |
+| TanStack Form   | v1+                                   | Field validators                 |
+| TanStack Router | v1+                                   | Search param validation          |
+| oRPC            | v1                                    | Full-stack type safety + OpenAPI |
+| Drizzle ORM     | proposed                              | Insert/select schemas            |
+
+### Standard JSON Schema (for OpenAPI)
+
+A companion spec for JSON Schema generation:
+
+```ts
+interface StandardJSONSchemaV1<Input = unknown, Output = Input> {
+  readonly '~standard': {
+    readonly version: 1
+    readonly vendor: string
+    readonly validate: (value: unknown) => any
+    readonly jsonSchema: {
+      input(options?: {
+        target?: 'draft-2020-12' | 'draft-07' | 'openapi-3.0'
+      }): Record<string, unknown>
+      output(options?: {
+        target?: 'draft-2020-12' | 'draft-07' | 'openapi-3.0'
+      }): Record<string, unknown>
+    }
+    readonly types?: { readonly input: Input; readonly output: Output }
+  }
+}
+```
+
+## How Other Frameworks Handle This
+
+### tRPC (Duck-Typed Priority Chain)
+
+tRPC accepts schemas via priority-ordered duck-typing:
+
+```ts
+// 1. Standard Schema (~standard.validate)
+// 2. ZodEsque (.parse() + ._input/_output)
+// 3. YupEsque (.validateSync() + __outputType)
+// 4. CustomValidator (bare function)
+```
+
+Key insight: tRPC does NOT require wrapping. Raw Zod, Valibot, or ArkType schemas work directly because they all implement Standard Schema.
+
+### Hono (Standard Schema Middleware)
+
+```ts
+import { sValidator } from '@hono/standard-validator'
+
+// Works with ANY Standard Schema library
+app.post('/users', sValidator('json', mySchema), (c) => {
+  const data = c.req.valid('json') // fully typed
+})
+```
+
+Accepts targets: `'json'`, `'query'`, `'param'`, `'header'`, `'cookie'`, `'form'`.
+
+### React Hook Form (Resolver Pattern)
+
+```ts
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
+
+// One resolver for ALL Standard Schema libraries
+const form = useForm({
+  resolver: standardSchemaResolver(anySchema),
+})
+```
+
+### Elysia (TypeBox-Only, Deliberate)
+
+Elysia couples to TypeBox deliberately -- schemas ARE JSON Schema at runtime, eliminating any conversion step. This is optimal for performance but sacrifices library choice.
+
+### NestJS (Pipe Pattern)
+
+NestJS is NOT schema-agnostic at the framework level. Each library needs its own `PipeTransform` implementation. No Standard Schema integration exists.
+
+## KickJS Current State
+
+### Already Schema-Agnostic (Duck-Typed)
+
+The `validate()` middleware accepts any object with `.safeParse()`:
+
+```ts
+// packages/kickjs/src/http/middleware/validate.ts
+interface ValidationSchema {
+  body?: any // anything with .safeParse(data)
+  query?: any
+  params?: any
+}
+```
+
+Protocol: `.safeParse(data)` returns `{ success: true, data }` or `{ success: false, error: { issues } }`.
+
+### Already Pluggable (Swagger)
+
+The Swagger package has a `SchemaParser` interface:
+
+```ts
+// packages/swagger/src/schema-parser.ts
+interface SchemaParser {
+  readonly name: string
+  supports(schema: unknown): boolean
+  toJsonSchema(schema: unknown): Record<string, unknown>
+}
+```
+
+### Still Zod-Coupled (To Fix)
+
+| Integration Point        | Coupling                                          |
+| ------------------------ | ------------------------------------------------- |
+| MCP tool registration    | Passes raw Zod to SDK, uses `.toJSONSchema()`     |
+| Config/env (`defineEnv`) | Uses `z.object()`, `z.infer<T>`, `z.coerce`       |
+| Error formatting         | Assumes Zod issue shape `{ path, message, code }` |
+| Route type inference     | `Ctx<>` relies on Zod-style `_output` type        |
+
+## Proposed KickJS Schema Interface
+
+### Core Types (`@forinda/kickjs-schema`)
+
+```ts
+interface KickSchema<TOutput = unknown, TInput = unknown> {
+  /** Validate input -- return typed output or structured errors */
+  safeParse(data: TInput): SchemaResult<TOutput>
+
+  /** Convert to JSON Schema (for Swagger, MCP, AI tools) */
+  toJsonSchema(options?: { target?: 'draft-2020-12' | 'openapi-3.0' }): JsonSchema
+
+  /** Original schema for SDK passthrough (MCP SDK expects raw Zod) */
+  readonly _raw?: unknown
+}
+
+type SchemaResult<T> = { success: true; data: T } | { success: false; issues: SchemaIssue[] }
+
+interface SchemaIssue {
+  path: string[]
+  message: string
+  code: string
+  expected?: string
+  received?: string
+}
+```
+
+### Adapters
+
+```ts
+import { fromZod } from '@forinda/kickjs-schema/zod'
+import { fromYup } from '@forinda/kickjs-schema/yup'
+import { fromValibot } from '@forinda/kickjs-schema/valibot'
+import { fromJoi } from '@forinda/kickjs-schema/joi'
+import { fromStandard } from '@forinda/kickjs-schema/standard'
+
+// Wrap once, use everywhere
+const CreateUser = fromZod(z.object({ name: z.string() }))
+const CreateUser = fromValibot(v.object({ name: v.string() }))
+const CreateUser = fromStandard(anyStandardSchemaV1Object)
+```
+
+### Type Inference
+
+Each adapter preserves full type inference:
+
+```ts
+function fromZod<T extends z.ZodType>(schema: T): KickSchema<z.infer<T>>
+function fromYup<T extends yup.Schema>(schema: T): KickSchema<yup.InferType<T>>
+function fromValibot<T extends v.BaseSchema>(schema: T): KickSchema<v.InferOutput<T>>
+function fromStandard<T extends StandardSchemaV1>(
+  schema: T,
+): KickSchema<StandardSchemaV1.InferOutput<T>>
+```
+
+### Error Normalization
+
+All adapters normalize errors to `SchemaIssue[]`:
+
+```ts
+// Zod:  error.issues[].path → string[], error.issues[].message, error.issues[].code
+// Yup:  error.inner[].path → split('.'), error.inner[].message, error.inner[].type
+// Joi:  error.details[].path → string[], error.details[].message, error.details[].type
+// Valibot: issues[].path[].key → string[], issues[].message, issues[].type
+// Standard Schema: issues[].path → mapped, issues[].message, code = 'validation'
+```
+
+HTTP response always:
+
+```json
+{
+  "status": 422,
+  "message": "Validation failed",
+  "errors": [
+    { "field": "email", "message": "Invalid email", "code": "pattern" },
+    { "field": "age", "message": "Must be >= 18", "code": "min" }
+  ]
+}
+```
+
+### Custom Error Formatter
+
+```ts
+bootstrap({
+  validation: {
+    formatError: (issues: SchemaIssue[]) => ({
+      type: 'https://api.example.com/problems/validation',
+      title: 'Validation Error',
+      violations: issues.map((i) => ({ property: i.path.join('.'), message: i.message })),
+    }),
+  },
+})
+```
+
+## Integration Map
+
+| Integration Point       | Current                           | After                                                  |
+| ----------------------- | --------------------------------- | ------------------------------------------------------ |
+| `validate()` middleware | Duck-types `.safeParse()`         | Accepts `KickSchema` or `StandardSchemaV1`             |
+| Route decorators        | `@Post('/', { body: zodSchema })` | `@Post('/', { body: KickSchema \| StandardSchemaV1 })` |
+| Swagger/OpenAPI         | `SchemaParser` interface          | Calls `schema.toJsonSchema()` directly                 |
+| MCP tool registration   | `zodToJsonSchema()` + raw Zod     | `schema.toJsonSchema()` + `schema._raw` fallback       |
+| Config/env              | Deep Zod (keep internally)        | `defineEnv()` stays Zod (framework plumbing)           |
+| Error handler           | Assumes Zod issue shape           | Reads normalized `SchemaIssue[]`                       |
+
+## Package Structure
+
+```
+packages/schema/
+  src/
+    types.ts              # KickSchema, SchemaResult, SchemaIssue
+    standard.ts           # fromStandard() — wraps StandardSchemaV1
+    auto-detect.ts        # Given unknown schema, detect + wrap
+    adapters/
+      zod.ts             # fromZod()
+      yup.ts             # fromYup()
+      valibot.ts         # fromValibot()
+      joi.ts             # fromJoi()
+    json-schema.ts        # JsonSchema type definition
+    error-formatter.ts    # Default + pluggable formatting
+```
+
+Separate export paths for tree-shaking:
+
+```json
+{
+  "exports": {
+    ".": "./src/types.ts",
+    "./zod": "./src/adapters/zod.ts",
+    "./yup": "./src/adapters/yup.ts",
+    "./valibot": "./src/adapters/valibot.ts",
+    "./joi": "./src/adapters/joi.ts",
+    "./standard": "./src/standard.ts"
+  }
+}
+```
+
+## Migration Path (Non-Breaking)
+
+1. **Raw Zod schemas continue to work** -- auto-detect wraps them transparently
+2. **`SchemaParser` deprecated** -- `schema.toJsonSchema()` replaces it
+3. **MCP SDK passthrough** uses `schema._raw` when Zod, falls back to JSON Schema
+4. **No breaking changes** -- existing apps upgrading to v5.x need zero modifications
+
+## Decision: Standard Schema vs Custom Interface
+
+| Approach                          | Pros                                                                 | Cons                                                                         |
+| --------------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Accept Standard Schema directly   | Zero wrapping for Zod/Valibot/ArkType, industry standard             | No JSON Schema in base spec (need companion spec), no `code` field on issues |
+| Custom `KickSchema` with adapters | Richer error info, JSON Schema built-in                              | Users must wrap schemas                                                      |
+| Both (recommended)                | Best DX -- unwrapped Standard Schema works, adapters add JSON Schema | Slightly more code                                                           |
+
+**Recommendation**: Accept both. If a schema has `~standard`, use it directly. If it also has `.toJsonSchema()` (KickSchema adapter or StandardJSONSchemaV1), use that for OpenAPI. Fallback: auto-detect Zod/Yup/Joi via duck-typing for backwards compat.
+
+## References
+
+- [Standard Schema Spec](https://github.com/standard-schema/standard-schema)
+- [Standard Schema Docs](https://standardschema.dev)
+- [tRPC Validators](https://trpc.io/docs/server/validators)
+- [Hono Standard Validator](https://www.npmjs.com/package/@hono/standard-validator)
+- [React Hook Form Resolvers](https://github.com/react-hook-form/resolvers)
+- [Valibot v1](https://valibot.dev)
+- [ArkType](https://arktype.io)
+- [TypeBox](https://github.com/sinclairzx81/typebox)
+- [Effect Schema](https://effect.website/docs/schema/introduction)
+- [oRPC](https://orpc.dev)

--- a/docs/schemas/index.md
+++ b/docs/schemas/index.md
@@ -278,19 +278,16 @@ bootstrap({
 
 ## Package Structure
 
-```
+```text
 packages/schema/
   src/
     types.ts              # KickSchema, SchemaResult, SchemaIssue
-    standard.ts           # fromStandard() — wraps StandardSchemaV1
-    auto-detect.ts        # Given unknown schema, detect + wrap
+    infer.ts              # InferSchemaOutput<T> utility type
+    detect.ts             # detectSchema() auto-detection + registerAdapter()
     adapters/
       zod.ts             # fromZod()
-      yup.ts             # fromYup()
       valibot.ts         # fromValibot()
-      joi.ts             # fromJoi()
-    json-schema.ts        # JsonSchema type definition
-    error-formatter.ts    # Default + pluggable formatting
+      yup.ts             # fromYup()
 ```
 
 Separate export paths for tree-shaking:
@@ -298,12 +295,10 @@ Separate export paths for tree-shaking:
 ```json
 {
   "exports": {
-    ".": "./src/types.ts",
-    "./zod": "./src/adapters/zod.ts",
-    "./yup": "./src/adapters/yup.ts",
-    "./valibot": "./src/adapters/valibot.ts",
-    "./joi": "./src/adapters/joi.ts",
-    "./standard": "./src/standard.ts"
+    ".": "./dist/index.mjs",
+    "./zod": "./dist/zod.mjs",
+    "./valibot": "./dist/valibot.mjs",
+    "./yup": "./dist/yup.mjs"
   }
 }
 ```

--- a/docs/schemas/integration.md
+++ b/docs/schemas/integration.md
@@ -6,13 +6,13 @@ How the schema abstraction connects to KickJS's existing systems: HTTP validatio
 
 ### Current Flow (Zod-Coupled)
 
-```
+```text
 Route Decorator → validate() middleware → .safeParse() → 422 or next()
 ```
 
 ### Target Flow (Schema-Agnostic)
 
-```
+```text
 Route Decorator → validate() middleware → detectSchema() → .safeParse() → normalize issues → 422 or next()
 ```
 

--- a/docs/schemas/integration.md
+++ b/docs/schemas/integration.md
@@ -1,0 +1,220 @@
+# Framework Integration Points
+
+How the schema abstraction connects to KickJS's existing systems: HTTP validation, Swagger/OpenAPI, MCP tools, and AI tool definitions.
+
+## HTTP Validation Pipeline
+
+### Current Flow (Zod-Coupled)
+
+```
+Route Decorator → validate() middleware → .safeParse() → 422 or next()
+```
+
+### Target Flow (Schema-Agnostic)
+
+```
+Route Decorator → validate() middleware → detectSchema() → .safeParse() → normalize issues → 422 or next()
+```
+
+The `validate()` middleware becomes a thin orchestrator:
+
+```ts
+function validate(schemas: ValidationSchema): RequestHandler {
+  return (req, res, next) => {
+    const targets = [
+      { key: 'body', source: req.body, schema: schemas.body },
+      { key: 'query', source: req.query, schema: schemas.query },
+      { key: 'params', source: req.params, schema: schemas.params },
+    ]
+
+    for (const { key, source, schema } of targets) {
+      if (!schema) continue
+
+      const wrapped = detectSchema(schema) // auto-detect + wrap
+      const result = wrapped.safeParse(source)
+
+      if (!result.success) {
+        const message =
+          key === 'query'
+            ? 'Invalid query parameters'
+            : key === 'params'
+              ? 'Invalid path parameters'
+              : (result.issues[0]?.message ?? 'Validation failed')
+
+        throw HttpException.unprocessable(message, result.issues)
+      }
+
+      // Replace raw data with validated + transformed output
+      assignValidated(req, key, result.data)
+    }
+    next()
+  }
+}
+```
+
+## Swagger / OpenAPI Integration
+
+### Current: SchemaParser Interface
+
+```ts
+interface SchemaParser {
+  readonly name: string
+  supports(schema: unknown): boolean
+  toJsonSchema(schema: unknown): Record<string, unknown>
+}
+```
+
+### Target: Direct .toJsonSchema() Call
+
+```ts
+function schemaToOpenApi(schema: unknown, target: 'openapi-3.0' = 'openapi-3.0') {
+  const wrapped = detectSchema(schema)
+  return wrapped.toJsonSchema({ target })
+}
+```
+
+The Swagger adapter uses this at startup when building the OpenAPI spec:
+
+```ts
+// openapi-builder.ts
+for (const route of routes) {
+  if (route.validation?.body) {
+    const jsonSchema = schemaToOpenApi(route.validation.body)
+    spec.components.schemas[route.schemaName] = jsonSchema
+    // ... wire into requestBody.$ref
+  }
+}
+```
+
+### Schema Name Resolution
+
+For `components/schemas` naming:
+
+1. Explicit: `@Post('/', { body: schema, name: 'CreateUser' })` -- uses provided name
+2. Inferred: schema adapter exposes `schema.title` or `schema._raw.description`
+3. Fallback: `${ControllerName}_${methodName}_body`
+
+## MCP Tool Registration
+
+### Current Flow
+
+```ts
+// mcp.adapter.ts
+const jsonSchema = zodToJsonSchema(route.validation?.body) ?? { type: 'object' }
+const zodInput = route.validation?.body // raw Zod for SDK
+
+server.registerTool(
+  name,
+  {
+    inputSchema: jsonSchema,
+    ...(zodInput ? { config: { inputSchema: zodInput } } : {}),
+  },
+  handler,
+)
+```
+
+### Target Flow
+
+```ts
+const wrapped = detectSchema(route.validation?.body)
+const jsonSchema = wrapped?.toJsonSchema() ?? { type: 'object' }
+const rawSchema = wrapped?._raw // for MCP SDK passthrough (expects Zod)
+
+server.registerTool(
+  name,
+  {
+    inputSchema: jsonSchema,
+    ...(rawSchema ? { config: { inputSchema: rawSchema } } : {}),
+  },
+  handler,
+)
+```
+
+The MCP SDK currently requires a raw Zod schema for its type inference. The `_raw` property preserves this. When the MCP SDK adopts Standard Schema (tracked in their roadmap), the passthrough becomes unnecessary.
+
+## AI Tool Definitions
+
+Same pattern as MCP:
+
+```ts
+// ai.adapter.ts
+const wrapped = detectSchema(route.validation?.body)
+tools.push({
+  name: toolName,
+  description: meta.description,
+  inputSchema: wrapped?.toJsonSchema() ?? { type: 'object', properties: {} },
+})
+```
+
+## Config / Environment Validation
+
+Config stays Zod-internal. This is framework plumbing, not user-facing validation:
+
+```ts
+// Users still write:
+export default defineEnv((base) =>
+  base.extend({
+    DATABASE_URL: z.string().url(),
+    REDIS_URL: z.string().url().optional(),
+  }),
+)
+```
+
+Rationale: env validation runs once at boot, isn't user-facing, and Zod's `.coerce` + `.default()` + `.transform()` features are essential for env parsing. Abstracting this provides no user benefit.
+
+## Type Generation (typegen)
+
+The `kick typegen` command generates a `KickRoutes` namespace for compile-time safety:
+
+```ts
+// Generated: src/__generated__/routes.d.ts
+declare namespace KickRoutes {
+  interface TodoController {
+    create: { body: { title: string; priority: 'low' | 'medium' | 'high' } }
+  }
+}
+```
+
+### How It Works with Schema Abstraction
+
+Type generation reads the schemas at build time. For each adapter:
+
+- **Zod**: `z.infer<typeof schema>`
+- **Valibot**: `v.InferOutput<typeof schema>`
+- **Standard Schema**: `StandardSchemaV1.InferOutput<typeof schema>`
+
+The typegen plugin resolves the output type via the `KickSchema<TOutput>` generic:
+
+```ts
+type RouteBody<T> =
+  T extends KickSchema<infer O> ? O : T extends StandardSchemaV1<any, infer O> ? O : unknown
+```
+
+## RequestContext Typing
+
+With schema abstraction, `ctx.body`, `ctx.query`, `ctx.params` remain fully typed:
+
+```ts
+@Post('/', { body: createUserSchema }) // KickSchema<CreateUserDTO>
+async create(ctx: RequestContext) {
+  ctx.body // CreateUserDTO — typed regardless of library
+}
+```
+
+The validated data replaces the raw request data after `.safeParse()` succeeds. Since all adapters return the same `{ success: true, data: T }` shape, the type flows through unchanged.
+
+## Migration Checklist
+
+For the schema abstraction to be complete:
+
+- [ ] Create `packages/schema` with core types + adapters
+- [ ] Update `validate()` middleware to use `detectSchema()`
+- [ ] Update Swagger `openapi-builder.ts` to call `.toJsonSchema()` directly
+- [ ] Update MCP `mcp.adapter.ts` to use `detectSchema()` + `._raw`
+- [ ] Update AI `ai.adapter.ts` similarly
+- [ ] Update error handler to accept normalized `SchemaIssue[]`
+- [ ] Add `validation.formatError` option to `bootstrap()`
+- [ ] Deprecate `SchemaParser` interface (keep working for 1 minor cycle)
+- [ ] Update typegen to resolve types from `KickSchema<T>`
+- [ ] Add tests for each adapter
+- [ ] Document migration in changelog

--- a/docs/schemas/standard-schema.md
+++ b/docs/schemas/standard-schema.md
@@ -1,0 +1,131 @@
+# Standard Schema v1
+
+The industry-standard interface for schema interoperability. Created by the maintainers of Zod, Valibot, and ArkType.
+
+## Spec
+
+```ts
+interface StandardSchemaV1<Input = unknown, Output = Input> {
+  readonly '~standard': StandardSchemaV1.Props<Input, Output>
+}
+
+namespace StandardSchemaV1 {
+  interface Props<Input = unknown, Output = Input> {
+    readonly version: 1
+    readonly vendor: string
+    readonly validate: (value: unknown) => Result<Output> | Promise<Result<Output>>
+    readonly types?: Types<Input, Output> | undefined
+  }
+
+  type Result<Output> = SuccessResult<Output> | FailureResult
+
+  interface SuccessResult<Output> {
+    readonly value: Output
+    readonly issues?: undefined
+  }
+
+  interface FailureResult {
+    readonly issues: ReadonlyArray<Issue>
+  }
+
+  interface Issue {
+    readonly message: string
+    readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined
+  }
+
+  interface PathSegment {
+    readonly key: PropertyKey
+  }
+
+  interface Types<Input = unknown, Output = Input> {
+    readonly input: Input
+    readonly output: Output
+  }
+}
+```
+
+## Key Design Decisions
+
+1. **`~standard` namespace key** -- uses `~` prefix to avoid conflicts with user-facing properties (tilde sorts last alphabetically, unlikely to collide)
+2. **Sync or async** -- `validate` may return a `Promise` for async validation (e.g., checking uniqueness in a database)
+3. **Types are phantom** -- the `types` property is never populated at runtime; it exists only for TypeScript inference via conditional types
+4. **Path segments** -- can be `PropertyKey` (string/number/symbol) or `{ key: PropertyKey }` for richer metadata
+
+## Type Inference
+
+```ts
+import type { StandardSchemaV1 } from '@standard-schema/spec'
+
+type InferInput<T> = T extends StandardSchemaV1<infer I, any> ? I : never
+type InferOutput<T> = T extends StandardSchemaV1<any, infer O> ? O : never
+```
+
+## Implementing Standard Schema (for library authors)
+
+```ts
+class MySchema<T> implements StandardSchemaV1<unknown, T> {
+  readonly '~standard' = {
+    version: 1 as const,
+    vendor: 'my-library',
+    validate: (value: unknown) => {
+      const result = this.internalValidate(value)
+      if (result.ok) return { value: result.data }
+      return {
+        issues: result.errors.map((e) => ({
+          message: e.message,
+          path: e.path,
+        })),
+      }
+    },
+    types: undefined as unknown as { input: unknown; output: T },
+  }
+}
+```
+
+## Standard JSON Schema (Companion Spec)
+
+For OpenAPI/Swagger integration, the companion spec adds JSON Schema conversion:
+
+```ts
+interface StandardJSONSchemaV1<Input = unknown, Output = Input> {
+  readonly '~standard': {
+    readonly version: 1
+    readonly vendor: string
+    readonly validate: (value: unknown) => any
+    readonly jsonSchema: {
+      input(options?: JsonSchemaOptions): Record<string, unknown>
+      output(options?: JsonSchemaOptions): Record<string, unknown>
+    }
+    readonly types?: { readonly input: Input; readonly output: Output }
+  }
+}
+
+interface JsonSchemaOptions {
+  readonly target?: 'draft-2020-12' | 'draft-07' | 'openapi-3.0'
+}
+```
+
+The `target` option ensures correct output for different consumers:
+
+- `draft-2020-12` -- modern JSON Schema (default)
+- `draft-07` -- legacy tooling (Ajv, older OpenAPI generators)
+- `openapi-3.0` -- OpenAPI 3.0 compatible subset (no `$defs`, uses `nullable`)
+
+## Library Support Matrix
+
+| Library       | Standard Schema             | Standard JSON Schema             | Install             |
+| ------------- | --------------------------- | -------------------------------- | ------------------- |
+| Zod v4        | Native                      | Native (`.toJSONSchema()`)       | `zod`               |
+| Zod v3.23+    | Native                      | Via `zod-to-json-schema`         | `zod`               |
+| Valibot v1    | Native                      | `@valibot/to-json-schema`        | `valibot`           |
+| ArkType v2    | Native                      | Native                           | `arktype`           |
+| Effect Schema | `Schema.standardSchemaV1()` | `JSONSchema.make()`              | `effect`            |
+| TypeBox       | Community adapter           | Native (schemas ARE JSON Schema) | `@sinclair/typebox` |
+| Yup           | Not yet                     | Via `@sodaru/yup-to-json-schema` | `yup`               |
+| Joi           | Not yet                     | Via `joi-to-json`                | `joi`               |
+
+## References
+
+- [GitHub Repository](https://github.com/standard-schema/standard-schema)
+- [Documentation](https://standardschema.dev)
+- [npm: @standard-schema/spec](https://www.npmjs.com/package/@standard-schema/spec)

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -32,13 +32,16 @@ interface TypegenCliOptions {
  * flag was not passed (so the config default applies), `'zod'` if a
  * supported value was passed, or `false` if explicitly disabled.
  */
-function parseSchemaValidatorFlag(value: string | undefined): 'zod' | false | undefined {
+function parseSchemaValidatorFlag(
+  value: string | undefined,
+): 'zod' | 'kickjs-schema' | false | undefined {
   if (value === undefined) return undefined
   if (value === 'false' || value === 'off' || value === 'none') return false
   if (value === 'zod') return 'zod'
+  if (value === 'kickjs-schema' || value === 'schema') return 'kickjs-schema'
   console.warn(
-    `  kick typegen: unknown --schema-validator '${value}' (only 'zod' and 'false' are supported). ` +
-      `Falling back to project config.`,
+    `  kick typegen: unknown --schema-validator '${value}' ` +
+      `(supported: 'zod', 'kickjs-schema', 'false'). Falling back to project config.`,
   )
   return undefined
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -46,10 +46,13 @@ export type RepoTypeConfig = BuiltinRepoType | CustomRepoType
 
 /**
  * Supported schema validators for `kick typegen` body/query/params
- * type extraction. Only `'zod'` ships built-in for now; other libraries
- * (Joi, Yup, JSON Schema) will be added later as the adapter system
- * grows. Set to `false` (or omit) to disable schema-driven body typing
- * entirely (the route entries will keep `body: unknown`).
+ * type extraction.
+ *
+ * - `'zod'` — emits `import('zod').infer<typeof schema>` (default)
+ * - `'kickjs-schema'` — emits `InferSchemaOutput<typeof schema>` from
+ *   `@forinda/kickjs-schema`, works with Zod, Valibot, Yup, and any
+ *   Standard Schema v1 or KickSchema adapter
+ * - `false` — disables schema-driven body typing (fields stay `unknown`)
  */
 export type SchemaValidator = 'zod' | 'kickjs-schema' | false
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -51,7 +51,7 @@ export type RepoTypeConfig = BuiltinRepoType | CustomRepoType
  * grows. Set to `false` (or omit) to disable schema-driven body typing
  * entirely (the route entries will keep `body: unknown`).
  */
-export type SchemaValidator = 'zod' | false
+export type SchemaValidator = 'zod' | 'kickjs-schema' | false
 
 /**
  * One entry in the typed `assetMap` config record (`assets-plan.md`).

--- a/packages/cli/src/typegen/builtin/env.ts
+++ b/packages/cli/src/typegen/builtin/env.ts
@@ -34,8 +34,9 @@ export const kickEnvTypegen = (): TypegenPlugin => ({
     })
     if (!scan.env) return null
 
+    const schemaValidator = ctx.config?.typegen?.schemaValidator ?? 'zod'
     const outFile = path.resolve(ctx.cwd, '.kickjs/types/kick__env.ts')
-    return renderEnv(scan.env, outFile)
+    return renderEnv(scan.env, outFile, schemaValidator)
   },
 })
 

--- a/packages/cli/src/typegen/generator.ts
+++ b/packages/cli/src/typegen/generator.ts
@@ -366,9 +366,10 @@ export interface GenerateOptions {
    * are ignored and `body`/`query`/`params` keep their `unknown`
    * placeholders.
    *
-   * Future: `'joi'`, `'yup'`, `'json-schema'`, custom adapters.
+   * `'kickjs-schema'` uses `InferSchemaOutput<>` from `@forinda/kickjs-schema`
+   * which infers from Zod, Valibot, ArkType, or any KickSchema adapter.
    */
-  schemaValidator?: 'zod' | false
+  schemaValidator?: 'zod' | 'kickjs-schema' | false
 }
 
 /** Write all generated `.d.ts` files to `outDir` */

--- a/packages/cli/src/typegen/index.ts
+++ b/packages/cli/src/typegen/index.ts
@@ -53,7 +53,7 @@ export interface RunTypegenOptions {
    * default) leaves these fields as `unknown`. Loaded from
    * `kick.config.ts` `typegen.schemaValidator` when invoked via the CLI.
    */
-  schemaValidator?: 'zod' | false
+  schemaValidator?: 'zod' | 'kickjs-schema' | false
   /**
    * Path to the env schema file (relative to `cwd`). The file must
    * default-export a `defineEnv(...)` schema for the typed `KickEnv`
@@ -87,7 +87,7 @@ function resolveOptions(opts: RunTypegenOptions): {
   outDir: string
   silent: boolean
   allowDuplicates: boolean
-  schemaValidator: 'zod' | false
+  schemaValidator: 'zod' | 'kickjs-schema' | false
   envFile: string | false
 } {
   const cwd = opts.cwd ?? process.cwd()

--- a/packages/cli/src/typegen/render/env.ts
+++ b/packages/cli/src/typegen/render/env.ts
@@ -23,7 +23,11 @@ const ENV_HEADER = `/* eslint-disable */
  * so the caller can skip emission entirely (rather than emitting an
  * empty augmentation that would shadow `KickEnv` to a useless `{}`).
  */
-export function renderEnv(env: DiscoveredEnv | null, envOutFile: string): string | null {
+export function renderEnv(
+  env: DiscoveredEnv | null,
+  envOutFile: string,
+  schemaValidator: 'zod' | 'kickjs-schema' | false = 'zod',
+): string | null {
   if (!env) return null
   // Compute the relative import path from the output file back to the
   // user's env schema source, stripping the extension so TS resolves it.
@@ -41,7 +45,7 @@ import type _envSchema from '${rel}'
 // Local type alias — interfaces can only \`extend\` an identifier,
 // not an inline import expression, so we resolve the schema's
 // inferred shape into a named type first.
-type _KickEnvShape = import('zod').infer<typeof _envSchema>
+type _KickEnvShape = ${schemaValidator === 'kickjs-schema' ? "import('@forinda/kickjs-schema').InferSchemaOutput<typeof _envSchema>" : "import('zod').infer<typeof _envSchema>"}
 
 declare global {
   /**

--- a/packages/cli/src/typegen/render/routes.ts
+++ b/packages/cli/src/typegen/render/routes.ts
@@ -32,7 +32,7 @@ const ROUTES_HEADER = `/* eslint-disable */
 export function renderRoutes(
   routes: DiscoveredRoute[],
   routesOutFile: string,
-  schemaValidator: 'zod' | false,
+  schemaValidator: 'zod' | 'kickjs-schema' | false,
 ): string {
   if (routes.length === 0) {
     return `${ROUTES_HEADER}
@@ -72,7 +72,11 @@ export {}
       schemaValidator,
       schemaImports,
     )
-    return alias ? `import('zod').infer<typeof ${alias}>` : null
+    if (!alias) return null
+    if (schemaValidator === 'kickjs-schema') {
+      return `import('@forinda/kickjs-schema').InferSchemaOutput<typeof ${alias}>`
+    }
+    return `import('zod').infer<typeof ${alias}>`
   }
 
   const interfaces: string[] = []
@@ -161,10 +165,10 @@ function planSchemaImport(
   schema: { identifier: string; source: string | null } | null,
   routeFilePath: string,
   routesOutFile: string,
-  schemaValidator: 'zod' | false,
+  schemaValidator: 'zod' | 'kickjs-schema' | false,
   imports: Map<string, { identifier: string; specifier: string }>,
 ): string | null {
-  if (!schema || schemaValidator !== 'zod') return null
+  if (!schema || schemaValidator === false) return null
   if (schema.source === null) return null
   const specifier = resolveSchemaImportSpecifier(schema.source, routeFilePath, routesOutFile)
   if (specifier === 'unknown') return null

--- a/packages/kickjs/package.json
+++ b/packages/kickjs/package.json
@@ -114,10 +114,14 @@
       ],
       "output": [
         "dist/**"
+      ],
+      "dependencies": [
+        "../schema:build"
       ]
     }
   },
   "dependencies": {
+    "@forinda/kickjs-schema": "workspace:*",
     "reflect-metadata": "^0.2.2"
   },
   "peerDependencies": {

--- a/packages/kickjs/src/config/env.ts
+++ b/packages/kickjs/src/config/env.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { detectSchema, type KickSchema } from '@forinda/kickjs-schema'
 import { Container } from '../core/container'
 import type { EnvKey } from '../core/decorators'
 
@@ -203,6 +204,43 @@ export function reloadEnv(): void {
 export function resetEnvCache(): void {
   cachedEnv = null
   cachedSchema = null
+}
+
+/**
+ * Schema-agnostic env loader. Accepts any schema supported by
+ * `@forinda/kickjs-schema` (Zod, Valibot, Yup, Joi, Standard Schema,
+ * KickSchema adapters, or plain validator functions).
+ *
+ * Unlike `loadEnv()` which uses Zod's `.parse()` and throws a
+ * `ZodError`, this function uses `detectSchema().safeParse()` and
+ * throws a plain `Error` with structured issue messages on failure.
+ *
+ * @example
+ * ```ts
+ * import * as v from 'valibot'
+ * import { fromValibot } from '@forinda/kickjs-schema/valibot'
+ *
+ * const envSchema = fromValibot(v.object({
+ *   PORT: v.pipe(v.string(), v.transform(Number)),
+ *   NODE_ENV: v.picklist(['development', 'production', 'test']),
+ * }))
+ *
+ * export const env = loadEnvFromSchema(envSchema)
+ * ```
+ */
+export function loadEnvFromSchema<T = Record<string, unknown>>(schema: KickSchema<T> | unknown): T {
+  const wrapped = detectSchema(schema)
+  const result = wrapped.safeParse(process.env)
+  if (!result.success) {
+    const details = result.issues
+      .map((i) => `  ${i.path.join('.') || '(root)'}: ${i.message}`)
+      .join('\n')
+    throw new Error(`Environment validation failed:\n${details}`)
+  }
+  cachedEnv = result.data
+  cachedSchema = schema
+  Container._envResolver = (key: string) => cachedEnv?.[key]
+  return result.data as T
 }
 
 export type Env = z.infer<typeof baseEnvSchema>

--- a/packages/kickjs/src/config/env.ts
+++ b/packages/kickjs/src/config/env.ts
@@ -191,7 +191,11 @@ export function reloadEnv(): void {
   // re-trigger any cache-population step.
   cachedEnv = null
   if (cachedSchema) {
-    loadEnv(cachedSchema)
+    if (typeof cachedSchema.parse === 'function') {
+      loadEnv(cachedSchema)
+    } else {
+      loadEnvFromSchema(cachedSchema)
+    }
   }
 }
 

--- a/packages/kickjs/src/config/index.ts
+++ b/packages/kickjs/src/config/index.ts
@@ -8,6 +8,7 @@ export {
   baseEnvSchema,
   defineEnv,
   loadEnv,
+  loadEnvFromSchema,
   getEnv,
   reloadEnv,
   resetEnvCache,

--- a/packages/kickjs/src/http/middleware/validate.ts
+++ b/packages/kickjs/src/http/middleware/validate.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express'
 import { HttpException, HttpStatus } from '../../core'
+import { detectSchema, type SchemaIssue } from '@forinda/kickjs-schema'
 
 export interface ValidationSchema {
   body?: any
@@ -8,13 +9,12 @@ export interface ValidationSchema {
 }
 
 function toValidationException(
-  error: any,
+  issues: SchemaIssue[],
   message: string,
   useFirstIssueMessage: boolean,
 ): HttpException {
-  const issues = error.issues || []
-  const details = issues.map((i: any) => ({
-    field: i.path?.join('.') ?? '',
+  const details = issues.map((i) => ({
+    field: i.path.join('.') || '',
     message: i.message,
   }))
   const finalMessage = useFirstIssueMessage ? (issues[0]?.message ?? message) : message
@@ -42,37 +42,43 @@ function assignReqProperty(req: Request, key: 'query' | 'params', value: unknown
 
 /**
  * Express middleware that validates request body/query/params against schemas.
- * Works with any validation library that exposes `.safeParse(data)` returning
- * `{ success: true, data }` or `{ success: false, error: { issues } }`.
+ *
+ * Accepts any schema supported by `@forinda/kickjs-schema`:
+ * - Zod schemas (auto-detected)
+ * - Standard Schema v1 objects
+ * - KickSchema instances (from adapters like fromZod, fromValibot, etc.)
+ * - Plain validator functions
  *
  * Validation failures are forwarded via `next(err)` as an `HttpException`, so
  * they flow through the application's global error handler (`onError`) and
- * produce a uniform response envelope. Apps that keep the built-in handler
- * continue to see the same `{ message, errors: [{ field, message }] }` body.
+ * produce a uniform response envelope.
  */
 export function validate(schema: ValidationSchema) {
   return (req: Request, _res: Response, next: NextFunction) => {
     try {
       if (schema.body) {
-        const result = schema.body.safeParse(req.body)
+        const wrapped = detectSchema(schema.body)
+        const result = wrapped.safeParse(req.body)
         if (!result.success) {
-          return next(toValidationException(result.error, 'Validation failed', true))
+          return next(toValidationException(result.issues, 'Validation failed', true))
         }
         req.body = result.data
       }
 
       if (schema.query) {
-        const result = schema.query.safeParse(req.query)
+        const wrapped = detectSchema(schema.query)
+        const result = wrapped.safeParse(req.query)
         if (!result.success) {
-          return next(toValidationException(result.error, 'Invalid query parameters', false))
+          return next(toValidationException(result.issues, 'Invalid query parameters', false))
         }
         assignReqProperty(req, 'query', result.data)
       }
 
       if (schema.params) {
-        const result = schema.params.safeParse(req.params)
+        const wrapped = detectSchema(schema.params)
+        const result = wrapped.safeParse(req.params)
         if (!result.success) {
-          return next(toValidationException(result.error, 'Invalid path parameters', false))
+          return next(toValidationException(result.issues, 'Invalid path parameters', false))
         }
         assignReqProperty(req, 'params', result.data)
       }

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -104,6 +104,7 @@ export {
   baseEnvSchema,
   defineEnv,
   loadEnv,
+  loadEnvFromSchema,
   getEnv,
   reloadEnv,
   resetEnvCache,

--- a/packages/kickjs/tsdown.config.ts
+++ b/packages/kickjs/tsdown.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
   minify: { compress: true, mangle: false },
   dts: { tsgo: true },
   external: [
+    '@forinda/kickjs-schema',
     'express',
     'reflect-metadata',
     'multer',

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -51,11 +51,13 @@
         "dist/**"
       ],
       "dependencies": [
-        "../kickjs:build"
+        "../kickjs:build",
+        "../schema:build"
       ]
     }
   },
   "dependencies": {
+    "@forinda/kickjs-schema": "workspace:*",
     "reflect-metadata": "^0.2.2"
   },
   "peerDependencies": {

--- a/packages/mcp/src/mcp.adapter.ts
+++ b/packages/mcp/src/mcp.adapter.ts
@@ -176,6 +176,7 @@ export const McpAdapter = defineAdapter<McpAdapterOptions, McpAdapterExtensions>
       const candidateSchema = meta?.inputSchema ?? route.validation?.body ?? route.validation?.query
 
       let inputSchema: Record<string, unknown>
+      let resolvedZodInput: unknown = candidateSchema
       try {
         const wrapped = candidateSchema ? detectSchema(candidateSchema) : undefined
         inputSchema = wrapped?.toJsonSchema() ?? {
@@ -185,6 +186,7 @@ export const McpAdapter = defineAdapter<McpAdapterOptions, McpAdapterExtensions>
         }
       } catch {
         inputSchema = { type: 'object', properties: {}, additionalProperties: false }
+        resolvedZodInput = undefined
       }
 
       let outputSchema: Record<string, unknown> | undefined
@@ -200,10 +202,7 @@ export const McpAdapter = defineAdapter<McpAdapterOptions, McpAdapterExtensions>
         name,
         description,
         inputSchema,
-        // Keep the original Zod schema alongside the JSON Schema. The MCP
-        // SDK accepts Zod directly via `registerTool`, while `inputSchema`
-        // (above) is what `getTools()` and inspection surfaces consume.
-        zodInputSchema: candidateSchema,
+        zodInputSchema: resolvedZodInput,
         outputSchema: outputSchema ?? undefined,
         httpMethod: route.method.toUpperCase(),
         mountPath: joinMountPath(mountPath, route.path),

--- a/packages/mcp/src/mcp.adapter.ts
+++ b/packages/mcp/src/mcp.adapter.ts
@@ -13,8 +13,8 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { detectSchema } from '@forinda/kickjs-schema'
 import { getMcpToolMeta } from './decorators'
-import { zodToJsonSchema } from './zod-to-json-schema'
 import type { McpAdapterOptions, McpToolDefinition, McpTransport } from './types'
 
 const log = Logger.for('McpAdapter')
@@ -175,13 +175,26 @@ export const McpAdapter = defineAdapter<McpAdapterOptions, McpAdapterExtensions>
       // fall back to whatever schema the route decorator declared.
       const candidateSchema = meta?.inputSchema ?? route.validation?.body ?? route.validation?.query
 
-      const inputSchema = zodToJsonSchema(candidateSchema) ?? {
-        type: 'object',
-        properties: {},
-        additionalProperties: false,
+      let inputSchema: Record<string, unknown>
+      try {
+        const wrapped = candidateSchema ? detectSchema(candidateSchema) : undefined
+        inputSchema = wrapped?.toJsonSchema() ?? {
+          type: 'object',
+          properties: {},
+          additionalProperties: false,
+        }
+      } catch {
+        inputSchema = { type: 'object', properties: {}, additionalProperties: false }
       }
 
-      const outputSchema = meta?.outputSchema ? zodToJsonSchema(meta.outputSchema) : undefined
+      let outputSchema: Record<string, unknown> | undefined
+      if (meta?.outputSchema) {
+        try {
+          outputSchema = detectSchema(meta.outputSchema).toJsonSchema()
+        } catch {
+          outputSchema = undefined
+        }
+      }
 
       return {
         name,

--- a/packages/mcp/tsdown.config.ts
+++ b/packages/mcp/tsdown.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   dts: { tsgo: true },
   external: [
     '@forinda/kickjs',
+    '@forinda/kickjs-schema',
     /^@modelcontextprotocol\/sdk/,
     'express',
     'reflect-metadata',

--- a/packages/schema/__tests__/valibot-adapter.test.ts
+++ b/packages/schema/__tests__/valibot-adapter.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest'
+import * as v from 'valibot'
+import { fromValibot, valibotAdapter } from '../src/adapters/valibot'
+import { detectSchema, isKickSchema } from '../src/detect'
+
+describe('fromValibot() — Valibot adapter', () => {
+  const UserSchema = v.object({
+    name: v.pipe(v.string(), v.minLength(1, 'Name is required')),
+    email: v.pipe(v.string(), v.email('Invalid email')),
+    age: v.pipe(v.number(), v.integer(), v.minValue(18, 'Must be 18 or older')),
+  })
+
+  it('wraps a Valibot schema into KickSchema', () => {
+    const schema = fromValibot(UserSchema)
+    expect(schema).toBeDefined()
+    expect(typeof schema.safeParse).toBe('function')
+    expect(typeof schema.toJsonSchema).toBe('function')
+    expect(schema._raw).toBe(UserSchema)
+  })
+
+  it('validates valid input successfully', () => {
+    const schema = fromValibot(UserSchema)
+    const result = schema.safeParse({ name: 'Alice', email: 'alice@test.com', age: 25 })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual({ name: 'Alice', email: 'alice@test.com', age: 25 })
+    }
+  })
+
+  it('returns structured issues for invalid input', () => {
+    const schema = fromValibot(UserSchema)
+    const result = schema.safeParse({ name: '', email: 'bad', age: 12 })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.issues.length).toBeGreaterThanOrEqual(3)
+
+      const nameIssue = result.issues.find((i) => i.path[0] === 'name')
+      expect(nameIssue).toBeDefined()
+      expect(nameIssue!.message).toBe('Name is required')
+
+      const emailIssue = result.issues.find((i) => i.path[0] === 'email')
+      expect(emailIssue).toBeDefined()
+      expect(emailIssue!.message).toBe('Invalid email')
+
+      const ageIssue = result.issues.find((i) => i.path[0] === 'age')
+      expect(ageIssue).toBeDefined()
+      expect(ageIssue!.message).toBe('Must be 18 or older')
+    }
+  })
+
+  it('handles missing required fields', () => {
+    const schema = fromValibot(UserSchema)
+    const result = schema.safeParse({})
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.issues.length).toBeGreaterThanOrEqual(3)
+      for (const issue of result.issues) {
+        expect(issue.path.length).toBe(1)
+        expect(issue.message).toBeTruthy()
+        expect(issue.code).toBeTruthy()
+      }
+    }
+  })
+
+  it('handles nested object validation', () => {
+    const nested = v.object({
+      user: v.object({
+        address: v.object({
+          zip: v.pipe(v.string(), v.minLength(5, 'ZIP too short')),
+        }),
+      }),
+    })
+    const schema = fromValibot(nested)
+    const result = schema.safeParse({ user: { address: { zip: '12' } } })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.issues[0]
+      expect(issue.path).toEqual(['user', 'address', 'zip'])
+      expect(issue.message).toBe('ZIP too short')
+    }
+  })
+
+  it('preserves Valibot defaults and transforms', () => {
+    const schema = fromValibot(
+      v.object({
+        count: v.optional(v.number(), 10),
+        active: v.optional(v.boolean(), true),
+      }),
+    )
+    const result = schema.safeParse({})
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual({ count: 10, active: true })
+    }
+  })
+
+  it('generates JSON Schema via toJsonSchema()', () => {
+    const schema = fromValibot(UserSchema)
+    const jsonSchema = schema.toJsonSchema()
+    expect(jsonSchema.type).toBe('object')
+    expect(jsonSchema.properties).toBeDefined()
+    expect((jsonSchema.properties as any).name).toBeDefined()
+    expect((jsonSchema.properties as any).email).toBeDefined()
+    expect((jsonSchema.properties as any).age).toBeDefined()
+    expect(jsonSchema.$schema).toBeUndefined()
+  })
+
+  it('maps expected/received on issues', () => {
+    const schema = fromValibot(v.pipe(v.number(), v.minValue(10)))
+    const result = schema.safeParse(3)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.issues[0]
+      expect(issue.expected).toBeDefined()
+      expect(issue.received).toBeDefined()
+    }
+  })
+
+  it('handles enum/picklist validation', () => {
+    const schema = fromValibot(v.picklist(['a', 'b', 'c']))
+    const result = schema.safeParse('d')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.issues[0].code).toBeTruthy()
+      expect(result.issues[0].message).toBeTruthy()
+    }
+  })
+
+  it('handles array item validation', () => {
+    const schema = fromValibot(v.array(v.string()))
+    const result = schema.safeParse([1, 'ok', 3])
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.issues.map((i) => i.path)
+      expect(paths).toContainEqual(['0'])
+      expect(paths).toContainEqual(['2'])
+    }
+  })
+})
+
+describe('valibotAdapter', () => {
+  it('detects Valibot schemas', () => {
+    const schema = v.object({ name: v.string() })
+    expect(valibotAdapter.detect(schema)).toBe(true)
+  })
+
+  it('rejects non-Valibot objects', () => {
+    expect(valibotAdapter.detect({})).toBe(false)
+    expect(valibotAdapter.detect(null)).toBe(false)
+    expect(valibotAdapter.detect('string')).toBe(false)
+    expect(valibotAdapter.detect(42)).toBe(false)
+  })
+
+  it('wraps via valibotAdapter.wrap()', () => {
+    const raw = v.pipe(v.string(), v.email())
+    const schema = valibotAdapter.wrap(raw)
+    expect(schema._raw).toBe(raw)
+    const result = schema.safeParse('hello@test.com')
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('detectSchema() — Valibot auto-detection', () => {
+  it('auto-detects Valibot schemas', () => {
+    const valibotSchema = v.object({ x: v.number() })
+    const wrapped = detectSchema(valibotSchema)
+    expect(isKickSchema(wrapped)).toBe(true)
+    expect(wrapped._raw).toBe(valibotSchema)
+
+    const valid = wrapped.safeParse({ x: 42 })
+    expect(valid.success).toBe(true)
+
+    const invalid = wrapped.safeParse({ x: 'nope' })
+    expect(invalid.success).toBe(false)
+  })
+
+  it('generates JSON Schema from auto-detected Valibot schema', () => {
+    const valibotSchema = v.object({
+      title: v.pipe(v.string(), v.minLength(1)),
+      count: v.number(),
+    })
+    const wrapped = detectSchema(valibotSchema)
+    const jsonSchema = wrapped.toJsonSchema()
+    expect(jsonSchema.type).toBe('object')
+    expect((jsonSchema.properties as any).title).toBeDefined()
+    expect((jsonSchema.properties as any).count).toBeDefined()
+  })
+})

--- a/packages/schema/__tests__/yup-adapter.test.ts
+++ b/packages/schema/__tests__/yup-adapter.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest'
+import * as yup from 'yup'
+import { fromYup, yupAdapter } from '../src/adapters/yup'
+import { detectSchema, isKickSchema } from '../src/detect'
+
+describe('fromYup() — Yup adapter', () => {
+  const UserSchema = yup.object({
+    name: yup.string().required('Name is required').min(1),
+    email: yup.string().required().email('Invalid email'),
+    age: yup.number().required().integer().min(18, 'Must be 18 or older'),
+  })
+
+  it('wraps a Yup schema into KickSchema', () => {
+    const schema = fromYup(UserSchema)
+    expect(schema).toBeDefined()
+    expect(typeof schema.safeParse).toBe('function')
+    expect(typeof schema.toJsonSchema).toBe('function')
+    expect(schema._raw).toBe(UserSchema)
+  })
+
+  it('validates valid input successfully', () => {
+    const schema = fromYup(UserSchema)
+    const result = schema.safeParse({ name: 'Alice', email: 'alice@test.com', age: 25 })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual({ name: 'Alice', email: 'alice@test.com', age: 25 })
+    }
+  })
+
+  it('returns structured issues for invalid input', () => {
+    const schema = fromYup(UserSchema)
+    const result = schema.safeParse({ name: '', email: 'bad', age: 12 })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.issues.length).toBeGreaterThanOrEqual(2)
+
+      const emailIssue = result.issues.find((i) => i.path[0] === 'email')
+      expect(emailIssue).toBeDefined()
+      expect(emailIssue!.message).toBe('Invalid email')
+
+      const ageIssue = result.issues.find((i) => i.path[0] === 'age')
+      expect(ageIssue).toBeDefined()
+      expect(ageIssue!.message).toBe('Must be 18 or older')
+    }
+  })
+
+  it('handles missing required fields', () => {
+    const schema = fromYup(UserSchema)
+    const result = schema.safeParse({})
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.issues.length).toBeGreaterThanOrEqual(3)
+      for (const issue of result.issues) {
+        expect(issue.message).toBeTruthy()
+        expect(issue.code).toBeTruthy()
+      }
+    }
+  })
+
+  it('handles nested object validation', () => {
+    const nested = yup.object({
+      user: yup.object({
+        address: yup.object({
+          zip: yup.string().required().min(5, 'ZIP too short'),
+        }),
+      }),
+    })
+    const schema = fromYup(nested)
+    const result = schema.safeParse({ user: { address: { zip: '12' } } })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.issues[0]
+      expect(issue.path).toEqual(['user', 'address', 'zip'])
+      expect(issue.message).toBe('ZIP too short')
+    }
+  })
+
+  it('preserves Yup defaults', () => {
+    const schema = fromYup(
+      yup.object({
+        count: yup.number().default(10),
+        active: yup.boolean().default(true),
+      }),
+    )
+    const result = schema.safeParse({})
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual({ count: 10, active: true })
+    }
+  })
+
+  it('generates JSON Schema via toJsonSchema()', () => {
+    const schema = fromYup(UserSchema)
+    const jsonSchema = schema.toJsonSchema()
+    expect(jsonSchema.type).toBe('object')
+    expect(jsonSchema.properties).toBeDefined()
+    expect((jsonSchema.properties as any).name).toBeDefined()
+    expect((jsonSchema.properties as any).email).toBeDefined()
+    expect((jsonSchema.properties as any).age).toBeDefined()
+  })
+
+  it('maps expected on min/max issues', () => {
+    const schema = fromYup(yup.number().required().min(10))
+    const result = schema.safeParse(3)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.issues[0]
+      expect(issue.code).toBe('min')
+      expect(issue.expected).toBe('>=10')
+    }
+  })
+
+  it('handles oneOf/enum validation', () => {
+    const schema = fromYup(yup.string().required().oneOf(['a', 'b', 'c']))
+    const result = schema.safeParse('d')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.issues[0].code).toBeTruthy()
+      expect(result.issues[0].message).toBeTruthy()
+    }
+  })
+
+  it('handles array item validation', () => {
+    const schema = fromYup(yup.array().of(yup.string().required().min(2)))
+    const result = schema.safeParse(['a', 'ok', 'b'])
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.issues.length).toBeGreaterThanOrEqual(1)
+    }
+  })
+})
+
+describe('yupAdapter', () => {
+  it('detects Yup schemas', () => {
+    const schema = yup.object({ name: yup.string() })
+    expect(yupAdapter.detect(schema)).toBe(true)
+  })
+
+  it('rejects non-Yup objects', () => {
+    expect(yupAdapter.detect({})).toBe(false)
+    expect(yupAdapter.detect(null)).toBe(false)
+    expect(yupAdapter.detect('string')).toBe(false)
+    expect(yupAdapter.detect(42)).toBe(false)
+  })
+
+  it('wraps via yupAdapter.wrap()', () => {
+    const raw = yup.string().email()
+    const schema = yupAdapter.wrap(raw)
+    expect(schema._raw).toBe(raw)
+    const result = schema.safeParse('hello@test.com')
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('detectSchema() — Yup auto-detection', () => {
+  it('auto-detects Yup schemas', () => {
+    const yupSchema = yup.object({ x: yup.number().required() })
+    const wrapped = detectSchema(yupSchema)
+    expect(isKickSchema(wrapped)).toBe(true)
+    expect(wrapped._raw).toBe(yupSchema)
+
+    const valid = wrapped.safeParse({ x: 42 })
+    expect(valid.success).toBe(true)
+
+    const invalid = wrapped.safeParse({ x: 'nope' })
+    expect(invalid.success).toBe(false)
+  })
+
+  it('generates JSON Schema from auto-detected Yup schema', () => {
+    const yupSchema = yup.object({
+      title: yup.string().required(),
+      count: yup.number().required(),
+    })
+    const wrapped = detectSchema(yupSchema)
+    const jsonSchema = wrapped.toJsonSchema()
+    expect(jsonSchema.type).toBe('object')
+    expect((jsonSchema.properties as any).title).toBeDefined()
+    expect((jsonSchema.properties as any).count).toBeDefined()
+  })
+})

--- a/packages/schema/__tests__/zod-adapter.test.ts
+++ b/packages/schema/__tests__/zod-adapter.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { z } from 'zod'
 import { fromZod, zodAdapter } from '../src/adapters/zod'
 import { detectSchema, isKickSchema, registerAdapter } from '../src/detect'
-import type { KickSchema, SchemaIssue } from '../src/types'
+import type { KickSchema } from '../src/types'
 
 describe('fromZod() — Zod adapter', () => {
   const UserSchema = z.object({

--- a/packages/schema/__tests__/zod-adapter.test.ts
+++ b/packages/schema/__tests__/zod-adapter.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { fromZod, zodAdapter } from '../src/adapters/zod'
+import { detectSchema, isKickSchema, registerAdapter } from '../src/detect'
+import type { KickSchema, SchemaIssue } from '../src/types'
+
+describe('fromZod() — Zod adapter', () => {
+  const UserSchema = z.object({
+    name: z.string().min(1, 'Name is required'),
+    email: z.string().email('Invalid email'),
+    age: z.number().int().min(18, 'Must be 18 or older'),
+  })
+
+  it('wraps a Zod schema into KickSchema', () => {
+    const schema = fromZod(UserSchema)
+    expect(schema).toBeDefined()
+    expect(typeof schema.safeParse).toBe('function')
+    expect(typeof schema.toJsonSchema).toBe('function')
+    expect(schema._raw).toBe(UserSchema)
+  })
+
+  it('validates valid input successfully', () => {
+    const schema = fromZod(UserSchema)
+    const result = schema.safeParse({ name: 'Alice', email: 'alice@test.com', age: 25 })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual({ name: 'Alice', email: 'alice@test.com', age: 25 })
+    }
+  })
+
+  it('returns structured issues for invalid input', () => {
+    const schema = fromZod(UserSchema)
+    const result = schema.safeParse({ name: '', email: 'bad', age: 12 })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.issues.length).toBeGreaterThanOrEqual(3)
+
+      const nameIssue = result.issues.find((i) => i.path[0] === 'name')
+      expect(nameIssue).toBeDefined()
+      expect(nameIssue!.message).toBe('Name is required')
+      expect(nameIssue!.code).toBe('too_small')
+
+      const emailIssue = result.issues.find((i) => i.path[0] === 'email')
+      expect(emailIssue).toBeDefined()
+      expect(emailIssue!.message).toBe('Invalid email')
+
+      const ageIssue = result.issues.find((i) => i.path[0] === 'age')
+      expect(ageIssue).toBeDefined()
+      expect(ageIssue!.message).toBe('Must be 18 or older')
+      expect(ageIssue!.code).toBe('too_small')
+      expect(ageIssue!.expected).toBe('>=18')
+    }
+  })
+
+  it('handles missing required fields', () => {
+    const schema = fromZod(UserSchema)
+    const result = schema.safeParse({})
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.issues.length).toBeGreaterThanOrEqual(3)
+      for (const issue of result.issues) {
+        expect(issue.path.length).toBe(1)
+        expect(issue.message).toBeTruthy()
+        expect(issue.code).toBeTruthy()
+      }
+    }
+  })
+
+  it('handles nested object validation', () => {
+    const nested = z.object({
+      user: z.object({
+        address: z.object({
+          zip: z.string().min(5, 'ZIP too short'),
+        }),
+      }),
+    })
+    const schema = fromZod(nested)
+    const result = schema.safeParse({ user: { address: { zip: '12' } } })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.issues[0]
+      expect(issue.path).toEqual(['user', 'address', 'zip'])
+      expect(issue.message).toBe('ZIP too short')
+    }
+  })
+
+  it('preserves Zod transforms and defaults', () => {
+    const schema = fromZod(
+      z.object({
+        count: z.coerce.number().default(10),
+        active: z.boolean().default(true),
+      }),
+    )
+    const result = schema.safeParse({})
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual({ count: 10, active: true })
+    }
+  })
+
+  it('generates JSON Schema via toJsonSchema()', () => {
+    const schema = fromZod(UserSchema)
+    const jsonSchema = schema.toJsonSchema()
+    expect(jsonSchema.type).toBe('object')
+    expect(jsonSchema.properties).toBeDefined()
+    expect((jsonSchema.properties as any).name).toBeDefined()
+    expect((jsonSchema.properties as any).email).toBeDefined()
+    expect((jsonSchema.properties as any).age).toBeDefined()
+    expect(jsonSchema.$schema).toBeUndefined()
+  })
+
+  it('returns fallback JSON Schema for schemas without .toJSONSchema()', () => {
+    const fakeSchema = {
+      safeParse: () => ({ success: true, data: {} }),
+      _def: {},
+    }
+    const schema = fromZod(fakeSchema)
+    const jsonSchema = schema.toJsonSchema()
+    expect(jsonSchema).toEqual({ type: 'object' })
+  })
+})
+
+describe('zodAdapter', () => {
+  it('detects Zod schemas', () => {
+    const zodSchema = z.object({ name: z.string() })
+    expect(zodAdapter.detect(zodSchema)).toBe(true)
+  })
+
+  it('rejects non-Zod objects', () => {
+    expect(zodAdapter.detect({})).toBe(false)
+    expect(zodAdapter.detect(null)).toBe(false)
+    expect(zodAdapter.detect('string')).toBe(false)
+    expect(zodAdapter.detect(42)).toBe(false)
+    expect(zodAdapter.detect({ safeParse: () => {} })).toBe(false)
+  })
+
+  it('wraps via zodAdapter.wrap()', () => {
+    const raw = z.string().email()
+    const schema = zodAdapter.wrap(raw)
+    expect(schema._raw).toBe(raw)
+    const result = schema.safeParse('hello@test.com')
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('detectSchema() — auto-detection', () => {
+  it('passes through an existing KickSchema', () => {
+    const kick: KickSchema<string> = {
+      safeParse: (d) => ({ success: true, data: d as string }),
+      toJsonSchema: () => ({ type: 'string' }),
+    }
+    expect(detectSchema(kick)).toBe(kick)
+  })
+
+  it('auto-detects Zod schemas', () => {
+    const zodSchema = z.object({ x: z.number() })
+    const wrapped = detectSchema(zodSchema)
+    expect(isKickSchema(wrapped)).toBe(true)
+    expect(wrapped._raw).toBe(zodSchema)
+
+    const result = wrapped.safeParse({ x: 42 })
+    expect(result.success).toBe(true)
+  })
+
+  it('auto-detects Standard Schema v1 objects', () => {
+    const standardSchema = {
+      '~standard': {
+        version: 1,
+        vendor: 'test',
+        validate: (value: unknown) => {
+          if (typeof value === 'string') return { value }
+          return { issues: [{ message: 'Expected string' }] }
+        },
+      },
+    }
+
+    const wrapped = detectSchema(standardSchema)
+    expect(wrapped.safeParse('hello')).toEqual({ success: true, data: 'hello' })
+
+    const fail = wrapped.safeParse(42)
+    expect(fail.success).toBe(false)
+    if (!fail.success) {
+      expect(fail.issues[0].message).toBe('Expected string')
+      expect(fail.issues[0].code).toBe('validation')
+    }
+  })
+
+  it('wraps plain validator functions', () => {
+    const validator = (data: unknown) => {
+      if (typeof data !== 'number') throw new Error('Expected a number')
+      return data
+    }
+
+    const wrapped = detectSchema(validator)
+    expect(wrapped.safeParse(42)).toEqual({ success: true, data: 42 })
+
+    const fail = wrapped.safeParse('nope')
+    expect(fail.success).toBe(false)
+    if (!fail.success) {
+      expect(fail.issues[0].message).toBe('Expected a number')
+      expect(fail.issues[0].code).toBe('custom')
+    }
+  })
+
+  it('throws for unrecognized schemas', () => {
+    expect(() => detectSchema({})).toThrow('Unrecognized schema')
+    expect(() => detectSchema(42)).toThrow('Unrecognized schema')
+    expect(() => detectSchema('string')).toThrow('Unrecognized schema')
+  })
+
+  it('supports custom adapters via registerAdapter()', () => {
+    class FancySchema {
+      constructor(public readonly type: string) {}
+      check(data: unknown): boolean {
+        return typeof data === this.type
+      }
+    }
+
+    registerAdapter({
+      name: 'fancy',
+      detect: (s) => s instanceof FancySchema,
+      wrap: (s) => {
+        const fancy = s as FancySchema
+        return {
+          safeParse(data: unknown) {
+            if (fancy.check(data)) return { success: true as const, data }
+            return {
+              success: false as const,
+              issues: [{ path: [], message: `Expected ${fancy.type}`, code: 'type' }],
+            }
+          },
+          toJsonSchema: () => ({ type: fancy.type }),
+          _raw: s,
+        }
+      },
+    })
+
+    const fancy = new FancySchema('string')
+    const wrapped = detectSchema(fancy)
+    expect(wrapped.safeParse('hello')).toEqual({ success: true, data: 'hello' })
+
+    const fail = wrapped.safeParse(42)
+    expect(fail.success).toBe(false)
+  })
+})
+
+describe('isKickSchema()', () => {
+  it('returns true for valid KickSchema objects', () => {
+    const schema: KickSchema = {
+      safeParse: () => ({ success: true, data: null }),
+      toJsonSchema: () => ({}),
+    }
+    expect(isKickSchema(schema)).toBe(true)
+  })
+
+  it('returns false for objects missing methods', () => {
+    expect(isKickSchema({})).toBe(false)
+    expect(isKickSchema({ safeParse: () => {} })).toBe(false)
+    expect(isKickSchema({ toJsonSchema: () => {} })).toBe(false)
+    expect(isKickSchema(null)).toBe(false)
+  })
+})
+
+describe('SchemaIssue — error normalization', () => {
+  it('normalizes too_small issues with expected', () => {
+    const schema = fromZod(z.number().min(10))
+    const result = schema.safeParse(3)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.issues[0]
+      expect(issue.code).toBe('too_small')
+      expect(issue.expected).toBe('>=10')
+    }
+  })
+
+  it('normalizes too_big issues with expected', () => {
+    const schema = fromZod(z.number().max(100))
+    const result = schema.safeParse(200)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.issues[0]
+      expect(issue.code).toBe('too_big')
+      expect(issue.expected).toBe('<=100')
+    }
+  })
+
+  it('normalizes enum issues', () => {
+    const schema = fromZod(z.enum(['a', 'b', 'c']))
+    const result = schema.safeParse('d')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.issues[0].code).toBeTruthy()
+      expect(result.issues[0].message).toBeTruthy()
+    }
+  })
+
+  it('handles array item validation', () => {
+    const schema = fromZod(z.array(z.string()))
+    const result = schema.safeParse([1, 'ok', 3])
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.issues.map((i) => i.path)
+      expect(paths).toContainEqual(['0'])
+      expect(paths).toContainEqual(['2'])
+    }
+  })
+})

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -25,6 +25,10 @@
     "./zod": {
       "import": "./dist/zod.mjs",
       "types": "./dist/zod.d.mts"
+    },
+    "./valibot": {
+      "import": "./dist/valibot.mjs",
+      "types": "./dist/valibot.d.mts"
     }
   },
   "files": [
@@ -56,9 +60,13 @@
   },
   "dependencies": {},
   "peerDependencies": {
+    "valibot": ">=1.0.0",
     "zod": ">=3.23.0"
   },
   "peerDependenciesMeta": {
+    "valibot": {
+      "optional": true
+    },
     "zod": {
       "optional": true
     }
@@ -66,7 +74,9 @@
   "devDependencies": {
     "@swc/core": "^1.15.33",
     "@types/node": "^25.8.0",
+    "@valibot/to-json-schema": "^1.7.0",
     "typescript": "^6.0.3",
+    "valibot": "^1.4.1",
     "vitest": "^4.1.6",
     "zod": "^4.4.3"
   },

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -29,6 +29,10 @@
     "./valibot": {
       "import": "./dist/valibot.mjs",
       "types": "./dist/valibot.d.mts"
+    },
+    "./yup": {
+      "import": "./dist/yup.mjs",
+      "types": "./dist/yup.d.mts"
     }
   },
   "files": [
@@ -61,10 +65,14 @@
   "dependencies": {},
   "peerDependencies": {
     "valibot": ">=1.0.0",
+    "yup": ">=1.0.0",
     "zod": ">=3.23.0"
   },
   "peerDependenciesMeta": {
     "valibot": {
+      "optional": true
+    },
+    "yup": {
       "optional": true
     },
     "zod": {
@@ -78,6 +86,7 @@
     "typescript": "^6.0.3",
     "valibot": "^1.4.1",
     "vitest": "^4.1.6",
+    "yup": "^1.7.1",
     "zod": "^4.4.3"
   },
   "publishConfig": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,0 +1,90 @@
+{
+  "name": "@forinda/kickjs-schema",
+  "version": "0.0.0",
+  "description": "Schema-agnostic validation abstraction for KickJS — use Zod, Valibot, Yup, Joi, or any Standard Schema library",
+  "keywords": [
+    "kickjs",
+    "schema",
+    "validation",
+    "zod",
+    "valibot",
+    "yup",
+    "joi",
+    "standard-schema",
+    "json-schema",
+    "typescript"
+  ],
+  "type": "module",
+  "main": "dist/index.mjs",
+  "types": "dist/index.d.mts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.mts"
+    },
+    "./zod": {
+      "import": "./dist/zod.mjs",
+      "types": "./dist/zod.d.mts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "wireit",
+    "dev": "tsdown --watch",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "typecheck": "tsgo --noEmit",
+    "clean": "rm -rf dist .wireit",
+    "lint": "tsc --noEmit"
+  },
+  "wireit": {
+    "build": {
+      "command": "tsdown",
+      "files": [
+        "src/**/*.ts",
+        "tsdown.config.ts",
+        "tsconfig.json",
+        "package.json"
+      ],
+      "output": [
+        "dist/**"
+      ],
+      "dependencies": []
+    }
+  },
+  "dependencies": {},
+  "peerDependencies": {
+    "zod": ">=3.23.0"
+  },
+  "peerDependenciesMeta": {
+    "zod": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@swc/core": "^1.15.33",
+    "@types/node": "^25.8.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.6",
+    "zod": "^4.4.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "author": "Felix Orinda",
+  "engines": {
+    "node": ">=20.0"
+  },
+  "homepage": "https://forinda.github.io/kick-js/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/forinda/kick-js.git",
+    "directory": "packages/schema"
+  },
+  "bugs": {
+    "url": "https://github.com/forinda/kick-js/issues"
+  }
+}

--- a/packages/schema/src/adapters/valibot.ts
+++ b/packages/schema/src/adapters/valibot.ts
@@ -24,27 +24,19 @@ function mapValibotIssues(issues: v.BaseIssue<unknown>[]): SchemaIssue[] {
   })
 }
 
-let _toJsonSchemaPromise: Promise<((schema: any) => Record<string, unknown>) | null> | undefined
-let _toJsonSchemaResolved: ((schema: any) => Record<string, unknown>) | null | undefined
+let _toJsonSchemaFn: ((schema: any) => Record<string, unknown>) | null | undefined
 
-function initToJsonSchema(): void {
-  if (_toJsonSchemaPromise) return
-  _toJsonSchemaPromise = import('@valibot/to-json-schema')
-    .then((mod) => {
-      _toJsonSchemaResolved = mod.toJsonSchema ?? null
-      return _toJsonSchemaResolved
-    })
-    .catch(() => {
-      _toJsonSchemaResolved = null
-      return null
-    })
-}
-
-initToJsonSchema()
+import('@valibot/to-json-schema')
+  .then((mod) => {
+    _toJsonSchemaFn = mod.toJsonSchema as (schema: any) => Record<string, unknown>
+  })
+  .catch(() => {
+    _toJsonSchemaFn = null
+  })
 
 function valibotToJsonSchema(schema: any, _options?: JsonSchemaOptions): Record<string, unknown> {
-  if (_toJsonSchemaResolved) {
-    const { $schema: _, ...rest } = _toJsonSchemaResolved(schema) as Record<string, unknown>
+  if (_toJsonSchemaFn) {
+    const { $schema: _, ...rest } = _toJsonSchemaFn(schema)
     return rest
   }
   return { type: 'object' }

--- a/packages/schema/src/adapters/valibot.ts
+++ b/packages/schema/src/adapters/valibot.ts
@@ -24,22 +24,27 @@ function mapValibotIssues(issues: v.BaseIssue<unknown>[]): SchemaIssue[] {
   })
 }
 
-let _toJsonSchema: ((schema: any) => Record<string, unknown>) | null | undefined
+let _toJsonSchemaPromise: Promise<((schema: any) => Record<string, unknown>) | null> | undefined
+let _toJsonSchemaResolved: ((schema: any) => Record<string, unknown>) | null | undefined
 
-function getToJsonSchema(): ((schema: any) => Record<string, unknown>) | null {
-  if (_toJsonSchema !== undefined) return _toJsonSchema
-  try {
-    _toJsonSchema = require('@valibot/to-json-schema').toJsonSchema ?? null
-  } catch {
-    _toJsonSchema = null
-  }
-  return _toJsonSchema!
+function initToJsonSchema(): void {
+  if (_toJsonSchemaPromise) return
+  _toJsonSchemaPromise = import('@valibot/to-json-schema')
+    .then((mod) => {
+      _toJsonSchemaResolved = mod.toJsonSchema ?? null
+      return _toJsonSchemaResolved
+    })
+    .catch(() => {
+      _toJsonSchemaResolved = null
+      return null
+    })
 }
 
+initToJsonSchema()
+
 function valibotToJsonSchema(schema: any, _options?: JsonSchemaOptions): Record<string, unknown> {
-  const convert = getToJsonSchema()
-  if (convert) {
-    const { $schema: _, ...rest } = convert(schema) as Record<string, unknown>
+  if (_toJsonSchemaResolved) {
+    const { $schema: _, ...rest } = _toJsonSchemaResolved(schema) as Record<string, unknown>
     return rest
   }
   return { type: 'object' }

--- a/packages/schema/src/adapters/valibot.ts
+++ b/packages/schema/src/adapters/valibot.ts
@@ -1,0 +1,70 @@
+import * as v from 'valibot'
+import type { KickSchema, SchemaResult, SchemaIssue, JsonSchemaOptions } from '../types.js'
+
+export function isValibotSchema(schema: unknown): boolean {
+  return (
+    schema != null &&
+    typeof schema === 'object' &&
+    'kind' in (schema as any) &&
+    'type' in (schema as any) &&
+    'async' in (schema as any)
+  )
+}
+
+function mapValibotIssues(issues: v.BaseIssue<unknown>[]): SchemaIssue[] {
+  return issues.map((issue) => {
+    const mapped: SchemaIssue = {
+      path: (issue.path ?? []).map((seg: any) => String(seg?.key ?? seg)),
+      message: issue.message ?? 'Validation failed',
+      code: issue.type ?? 'unknown',
+    }
+    if (issue.expected !== undefined) mapped.expected = String(issue.expected)
+    if (issue.received !== undefined) mapped.received = String(issue.received)
+    return mapped
+  })
+}
+
+let _toJsonSchema: ((schema: any) => Record<string, unknown>) | null | undefined
+
+function getToJsonSchema(): ((schema: any) => Record<string, unknown>) | null {
+  if (_toJsonSchema !== undefined) return _toJsonSchema
+  try {
+    _toJsonSchema = require('@valibot/to-json-schema').toJsonSchema
+  } catch {
+    _toJsonSchema = null
+  }
+  return _toJsonSchema
+}
+
+function valibotToJsonSchema(schema: any, _options?: JsonSchemaOptions): Record<string, unknown> {
+  const convert = getToJsonSchema()
+  if (convert) {
+    const { $schema: _, ...rest } = convert(schema) as Record<string, unknown>
+    return rest
+  }
+  return { type: 'object' }
+}
+
+export function fromValibot<TOutput = unknown>(schema: any): KickSchema<TOutput> {
+  return {
+    safeParse(data: unknown): SchemaResult<TOutput> {
+      const result = v.safeParse(schema, data)
+      if (result.success) {
+        return { success: true, data: result.output as TOutput }
+      }
+      return { success: false, issues: mapValibotIssues(result.issues) }
+    },
+
+    toJsonSchema(options?: JsonSchemaOptions): Record<string, unknown> {
+      return valibotToJsonSchema(schema, options)
+    },
+
+    _raw: schema,
+  }
+}
+
+export const valibotAdapter = {
+  name: 'valibot' as const,
+  detect: isValibotSchema,
+  wrap: fromValibot,
+}

--- a/packages/schema/src/adapters/valibot.ts
+++ b/packages/schema/src/adapters/valibot.ts
@@ -29,11 +29,11 @@ let _toJsonSchema: ((schema: any) => Record<string, unknown>) | null | undefined
 function getToJsonSchema(): ((schema: any) => Record<string, unknown>) | null {
   if (_toJsonSchema !== undefined) return _toJsonSchema
   try {
-    _toJsonSchema = require('@valibot/to-json-schema').toJsonSchema
+    _toJsonSchema = require('@valibot/to-json-schema').toJsonSchema ?? null
   } catch {
     _toJsonSchema = null
   }
-  return _toJsonSchema
+  return _toJsonSchema!
 }
 
 function valibotToJsonSchema(schema: any, _options?: JsonSchemaOptions): Record<string, unknown> {

--- a/packages/schema/src/adapters/yup.ts
+++ b/packages/schema/src/adapters/yup.ts
@@ -70,12 +70,16 @@ function descToJsonSchema(desc: any): Record<string, unknown> {
   const schema: Record<string, unknown> = { type: typeMap[desc.type] ?? desc.type }
 
   for (const test of desc.tests ?? []) {
-    if (test.name === 'min' && test.params?.min !== undefined) schema.minLength = test.params.min
-    if (test.name === 'max' && test.params?.max !== undefined) schema.maxLength = test.params.max
     if (test.name === 'email') schema.format = 'email'
     if (test.name === 'url') schema.format = 'uri'
-    if (test.name === 'min' && desc.type === 'number') schema.minimum = test.params?.min
-    if (test.name === 'max' && desc.type === 'number') schema.maximum = test.params?.max
+    if (test.name === 'min' && test.params?.min !== undefined) {
+      if (desc.type === 'number') schema.minimum = test.params.min
+      else schema.minLength = test.params.min
+    }
+    if (test.name === 'max' && test.params?.max !== undefined) {
+      if (desc.type === 'number') schema.maximum = test.params.max
+      else schema.maxLength = test.params.max
+    }
   }
 
   if (desc.oneOf && desc.oneOf.length > 0) schema.enum = desc.oneOf

--- a/packages/schema/src/adapters/yup.ts
+++ b/packages/schema/src/adapters/yup.ts
@@ -1,0 +1,112 @@
+import type { KickSchema, SchemaResult, SchemaIssue, JsonSchemaOptions } from '../types.js'
+
+export function isYupSchema(schema: unknown): boolean {
+  return (
+    schema != null &&
+    typeof schema === 'object' &&
+    typeof (schema as any).validateSync === 'function' &&
+    typeof (schema as any).describe === 'function' &&
+    typeof (schema as any).isValidSync === 'function'
+  )
+}
+
+function mapYupErrors(err: any): SchemaIssue[] {
+  const inner: any[] = err.inner ?? []
+  if (inner.length === 0) {
+    return [
+      {
+        path: err.path ? err.path.split('.') : [],
+        message: err.message ?? 'Validation failed',
+        code: err.type ?? 'unknown',
+      },
+    ]
+  }
+  return inner.map((e: any) => {
+    const mapped: SchemaIssue = {
+      path: e.path ? e.path.split('.') : [],
+      message: e.message ?? 'Validation failed',
+      code: e.type ?? 'unknown',
+    }
+    if (e.params?.min !== undefined) mapped.expected = `>=${e.params.min}`
+    if (e.params?.max !== undefined) mapped.expected = `<=${e.params.max}`
+    if (e.params?.regex !== undefined) mapped.expected = String(e.params.regex)
+    return mapped
+  })
+}
+
+function yupToJsonSchema(schema: any, _options?: JsonSchemaOptions): Record<string, unknown> {
+  const desc = schema.describe()
+  return descToJsonSchema(desc)
+}
+
+function descToJsonSchema(desc: any): Record<string, unknown> {
+  if (desc.type === 'object') {
+    const properties: Record<string, unknown> = {}
+    const required: string[] = []
+    for (const [key, field] of Object.entries(desc.fields ?? {})) {
+      properties[key] = descToJsonSchema(field as any)
+      if (!(field as any).optional && !(field as any).nullable) {
+        required.push(key)
+      }
+    }
+    const schema: Record<string, unknown> = { type: 'object', properties }
+    if (required.length > 0) schema.required = required
+    return schema
+  }
+
+  if (desc.type === 'array') {
+    const schema: Record<string, unknown> = { type: 'array' }
+    if (desc.innerType) schema.items = descToJsonSchema(desc.innerType)
+    return schema
+  }
+
+  const typeMap: Record<string, string> = {
+    string: 'string',
+    number: 'number',
+    boolean: 'boolean',
+    date: 'string',
+  }
+
+  const schema: Record<string, unknown> = { type: typeMap[desc.type] ?? desc.type }
+
+  for (const test of desc.tests ?? []) {
+    if (test.name === 'min' && test.params?.min !== undefined) schema.minLength = test.params.min
+    if (test.name === 'max' && test.params?.max !== undefined) schema.maxLength = test.params.max
+    if (test.name === 'email') schema.format = 'email'
+    if (test.name === 'url') schema.format = 'uri'
+    if (test.name === 'min' && desc.type === 'number') schema.minimum = test.params?.min
+    if (test.name === 'max' && desc.type === 'number') schema.maximum = test.params?.max
+  }
+
+  if (desc.oneOf && desc.oneOf.length > 0) schema.enum = desc.oneOf
+
+  return schema
+}
+
+export function fromYup<TOutput = unknown>(schema: any): KickSchema<TOutput> {
+  return {
+    safeParse(data: unknown): SchemaResult<TOutput> {
+      try {
+        const result = schema.validateSync(data, { abortEarly: false, stripUnknown: false })
+        return { success: true, data: result as TOutput }
+      } catch (err: any) {
+        if (err.name === 'ValidationError') {
+          return { success: false, issues: mapYupErrors(err) }
+        }
+        throw err
+      }
+    },
+
+    toJsonSchema(options?: JsonSchemaOptions): Record<string, unknown> {
+      return yupToJsonSchema(schema, options)
+    },
+
+    _raw: schema,
+  }
+}
+
+export const yupAdapter = {
+  name: 'yup' as const,
+  detect: isYupSchema,
+  wrap: fromYup,
+}

--- a/packages/schema/src/adapters/zod.ts
+++ b/packages/schema/src/adapters/zod.ts
@@ -1,0 +1,64 @@
+import type { KickSchema, SchemaResult, SchemaIssue, JsonSchemaOptions } from '../types.js'
+
+export function isZodSchema(schema: unknown): boolean {
+  return (
+    schema != null &&
+    typeof schema === 'object' &&
+    typeof (schema as any).safeParse === 'function' &&
+    '_def' in (schema as any)
+  )
+}
+
+function mapZodIssues(error: any): SchemaIssue[] {
+  const issues: any[] = error?.issues ?? error?.errors ?? []
+  return issues.map((issue: any) => {
+    const mapped: SchemaIssue = {
+      path: (issue.path ?? []).map(String),
+      message: issue.message ?? 'Validation failed',
+      code: issue.code ?? 'unknown',
+    }
+    if (issue.expected !== undefined) mapped.expected = String(issue.expected)
+    if (issue.received !== undefined) mapped.received = String(issue.received)
+    if (mapped.code === 'too_small' && issue.minimum !== undefined) {
+      mapped.expected = `>=${issue.minimum}`
+      if (issue.input !== undefined) mapped.received = String(issue.input)
+    }
+    if (mapped.code === 'too_big' && issue.maximum !== undefined) {
+      mapped.expected = `<=${issue.maximum}`
+      if (issue.input !== undefined) mapped.received = String(issue.input)
+    }
+    return mapped
+  })
+}
+
+function zodToJsonSchema(schema: any, _options?: JsonSchemaOptions): Record<string, unknown> {
+  if (typeof schema.toJSONSchema === 'function') {
+    const { $schema: _, ...rest } = schema.toJSONSchema()
+    return rest
+  }
+  return { type: 'object' }
+}
+
+export function fromZod<TOutput = unknown>(schema: any): KickSchema<TOutput> {
+  return {
+    safeParse(data: unknown): SchemaResult<TOutput> {
+      const result = schema.safeParse(data)
+      if (result.success) {
+        return { success: true, data: result.data as TOutput }
+      }
+      return { success: false, issues: mapZodIssues(result.error) }
+    },
+
+    toJsonSchema(options?: JsonSchemaOptions): Record<string, unknown> {
+      return zodToJsonSchema(schema, options)
+    },
+
+    _raw: schema,
+  }
+}
+
+export const zodAdapter = {
+  name: 'zod' as const,
+  detect: isZodSchema,
+  wrap: fromZod,
+}

--- a/packages/schema/src/detect.ts
+++ b/packages/schema/src/detect.ts
@@ -1,6 +1,7 @@
 import type { KickSchema, SchemaAdapter } from './types.js'
 import { isZodSchema, fromZod } from './adapters/zod.js'
 import { isValibotSchema, fromValibot } from './adapters/valibot.js'
+import { isYupSchema, fromYup } from './adapters/yup.js'
 
 const customAdapters: SchemaAdapter[] = []
 
@@ -94,6 +95,8 @@ export function detectSchema(schema: unknown): KickSchema {
   if (isZodSchema(schema)) return fromZod(schema)
 
   if (isValibotSchema(schema)) return fromValibot(schema)
+
+  if (isYupSchema(schema)) return fromYup(schema)
 
   if (hasStandardSchema(schema)) return fromStandardSchema(schema)
 

--- a/packages/schema/src/detect.ts
+++ b/packages/schema/src/detect.ts
@@ -1,0 +1,94 @@
+import type { KickSchema, SchemaAdapter } from './types.js'
+import { isZodSchema, fromZod } from './adapters/zod.js'
+
+const customAdapters: SchemaAdapter[] = []
+
+export function registerAdapter(adapter: SchemaAdapter): void {
+  customAdapters.push(adapter)
+}
+
+export function isKickSchema(schema: unknown): schema is KickSchema {
+  return (
+    schema != null &&
+    typeof schema === 'object' &&
+    typeof (schema as any).safeParse === 'function' &&
+    typeof (schema as any).toJsonSchema === 'function'
+  )
+}
+
+function hasStandardSchema(schema: unknown): boolean {
+  return schema != null && typeof schema === 'object' && '~standard' in (schema as any)
+}
+
+function fromStandardSchema(schema: any): KickSchema {
+  const std = schema['~standard']
+  return {
+    safeParse(data: unknown) {
+      const result = std.validate(data)
+      if ('value' in result && result.issues === undefined) {
+        return { success: true, data: result.value }
+      }
+      if (result instanceof Promise) {
+        throw new Error(
+          'Async Standard Schema validation is not supported in synchronous context. ' +
+            'Use an adapter that supports sync validation.',
+        )
+      }
+      const issues = (result.issues ?? []).map((issue: any) => ({
+        path: (issue.path ?? []).map((seg: any) => String(seg?.key ?? seg)),
+        message: issue.message ?? 'Validation failed',
+        code: 'validation',
+      }))
+      return { success: false, issues }
+    },
+
+    toJsonSchema() {
+      if (std.jsonSchema && typeof std.jsonSchema.input === 'function') {
+        return std.jsonSchema.input()
+      }
+      if (typeof schema.toJSONSchema === 'function') {
+        const { $schema: _, ...rest } = schema.toJSONSchema()
+        return rest
+      }
+      return { type: 'object' }
+    },
+
+    _raw: schema,
+  }
+}
+
+export function detectSchema(schema: unknown): KickSchema {
+  if (isKickSchema(schema)) return schema
+
+  for (const adapter of customAdapters) {
+    if (adapter.detect(schema)) return adapter.wrap(schema)
+  }
+
+  if (hasStandardSchema(schema)) return fromStandardSchema(schema)
+
+  if (isZodSchema(schema)) return fromZod(schema)
+
+  if (typeof schema === 'function') {
+    return {
+      safeParse(data: unknown) {
+        try {
+          const result = (schema as Function)(data)
+          return { success: true, data: result }
+        } catch (err: any) {
+          return {
+            success: false,
+            issues: [{ path: [], message: err.message ?? 'Validation failed', code: 'custom' }],
+          }
+        }
+      },
+      toJsonSchema() {
+        return { type: 'object' }
+      },
+    }
+  }
+
+  throw new Error(
+    'Unrecognized schema. Wrap it with fromZod(), fromValibot(), etc., ' +
+      'or implement the StandardSchemaV1 interface.',
+  )
+}

--- a/packages/schema/src/detect.ts
+++ b/packages/schema/src/detect.ts
@@ -57,6 +57,32 @@ function fromStandardSchema(schema: any): KickSchema {
   }
 }
 
+function fromSafeParseDuckType(schema: any): KickSchema {
+  return {
+    safeParse(data: unknown) {
+      const result = schema.safeParse(data)
+      if (result.success) {
+        return { success: true, data: result.data }
+      }
+      const rawIssues = result.error?.issues ?? result.issues ?? []
+      const issues = rawIssues.map((i: any) => ({
+        path: (i.path ?? []).map(String),
+        message: i.message ?? 'Validation failed',
+        code: i.code ?? 'unknown',
+      }))
+      return { success: false, issues }
+    },
+    toJsonSchema() {
+      if (typeof schema.toJSONSchema === 'function') {
+        const { $schema: _, ...rest } = schema.toJSONSchema()
+        return rest
+      }
+      return { type: 'object' }
+    },
+    _raw: schema,
+  }
+}
+
 export function detectSchema(schema: unknown): KickSchema {
   if (isKickSchema(schema)) return schema
 
@@ -85,6 +111,14 @@ export function detectSchema(schema: unknown): KickSchema {
         return { type: 'object' }
       },
     }
+  }
+
+  if (
+    typeof schema === 'object' &&
+    schema != null &&
+    typeof (schema as any).safeParse === 'function'
+  ) {
+    return fromSafeParseDuckType(schema)
   }
 
   throw new Error(

--- a/packages/schema/src/detect.ts
+++ b/packages/schema/src/detect.ts
@@ -1,5 +1,6 @@
 import type { KickSchema, SchemaAdapter } from './types.js'
 import { isZodSchema, fromZod } from './adapters/zod.js'
+import { isValibotSchema, fromValibot } from './adapters/valibot.js'
 
 const customAdapters: SchemaAdapter[] = []
 
@@ -90,9 +91,11 @@ export function detectSchema(schema: unknown): KickSchema {
     if (adapter.detect(schema)) return adapter.wrap(schema)
   }
 
-  if (hasStandardSchema(schema)) return fromStandardSchema(schema)
-
   if (isZodSchema(schema)) return fromZod(schema)
+
+  if (isValibotSchema(schema)) return fromValibot(schema)
+
+  if (hasStandardSchema(schema)) return fromStandardSchema(schema)
 
   if (typeof schema === 'function') {
     return {

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -6,4 +6,6 @@ export type {
   SchemaAdapter,
 } from './types.js'
 
+export type { InferSchemaOutput } from './infer.js'
+
 export { detectSchema, isKickSchema, registerAdapter } from './detect.js'

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,0 +1,9 @@
+export type {
+  KickSchema,
+  SchemaResult,
+  SchemaIssue,
+  JsonSchemaOptions,
+  SchemaAdapter,
+} from './types.js'
+
+export { detectSchema, isKickSchema, registerAdapter } from './detect.js'

--- a/packages/schema/src/infer.ts
+++ b/packages/schema/src/infer.ts
@@ -1,0 +1,24 @@
+import type { KickSchema } from './types.js'
+
+/**
+ * Infer the output type of any supported schema.
+ *
+ * Resolution order:
+ * 1. KickSchema<TOutput> — reads TOutput generic
+ * 2. Zod — reads `_output` (v3) or `~output` (v4) phantom type
+ * 3. Standard Schema v1 — reads `~standard.types.output`
+ * 4. Fallback — `unknown`
+ *
+ * Used by `kick typegen` to generate typed route interfaces without
+ * being coupled to any specific schema library.
+ */
+export type InferSchemaOutput<T> =
+  T extends KickSchema<infer O>
+    ? O
+    : T extends { '~output': infer O }
+      ? O
+      : T extends { _output: infer O }
+        ? O
+        : T extends { '~standard': { types?: { output: infer O } } }
+          ? O
+          : unknown

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -1,0 +1,25 @@
+export interface SchemaIssue {
+  path: string[]
+  message: string
+  code: string
+  expected?: string
+  received?: string
+}
+
+export type SchemaResult<T> = { success: true; data: T } | { success: false; issues: SchemaIssue[] }
+
+export interface KickSchema<TOutput = unknown, TInput = unknown> {
+  safeParse(data: TInput): SchemaResult<TOutput>
+  toJsonSchema(options?: JsonSchemaOptions): Record<string, unknown>
+  readonly _raw?: unknown
+}
+
+export interface JsonSchemaOptions {
+  readonly target?: 'draft-2020-12' | 'draft-07' | 'openapi-3.0'
+}
+
+export interface SchemaAdapter {
+  readonly name: string
+  detect(schema: unknown): boolean
+  wrap(schema: unknown): KickSchema
+}

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/schema/tsconfig.test.json
+++ b/packages/schema/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "baseUrl": ".",
+    "types": [],
+    "paths": {
+      "@forinda/kickjs-schema": ["src/index.ts"],
+      "@forinda/kickjs-schema/*": ["src/*"]
+    }
+  },
+  "include": ["src", "__tests__"]
+}

--- a/packages/schema/tsdown.config.ts
+++ b/packages/schema/tsdown.config.ts
@@ -7,11 +7,12 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
     zod: 'src/adapters/zod.ts',
+    valibot: 'src/adapters/valibot.ts',
   },
   format: ['esm'],
   platform: 'node',
   minify: { compress: true, mangle: false },
   dts: { tsgo: true },
-  external: ['zod', /^node:/],
+  external: ['valibot', '@valibot/to-json-schema', 'zod', /^node:/],
   banner: { js: createBanner(pkg.name, pkg.version) },
 })

--- a/packages/schema/tsdown.config.ts
+++ b/packages/schema/tsdown.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'tsdown'
+import { createBanner, readPkg } from '../../build.utils.mjs'
+
+const pkg = readPkg(import.meta.dirname)
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    zod: 'src/adapters/zod.ts',
+  },
+  format: ['esm'],
+  platform: 'node',
+  minify: { compress: true, mangle: false },
+  dts: { tsgo: true },
+  external: ['zod', /^node:/],
+  banner: { js: createBanner(pkg.name, pkg.version) },
+})

--- a/packages/schema/tsdown.config.ts
+++ b/packages/schema/tsdown.config.ts
@@ -8,11 +8,12 @@ export default defineConfig({
     index: 'src/index.ts',
     zod: 'src/adapters/zod.ts',
     valibot: 'src/adapters/valibot.ts',
+    yup: 'src/adapters/yup.ts',
   },
   format: ['esm'],
   platform: 'node',
   minify: { compress: true, mangle: false },
   dts: { tsgo: true },
-  external: ['valibot', '@valibot/to-json-schema', 'zod', /^node:/],
+  external: ['valibot', '@valibot/to-json-schema', 'yup', 'zod', /^node:/],
   banner: { js: createBanner(pkg.name, pkg.version) },
 })

--- a/packages/schema/vitest.config.ts
+++ b/packages/schema/vitest.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vitest/config'
 import swc from 'unplugin-swc'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   plugins: [

--- a/packages/schema/vitest.config.ts
+++ b/packages/schema/vitest.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
       '@forinda/kickjs-schema': path.resolve(__dirname, 'src/index.ts'),
     },
   },
+  ssr: {
+    noExternal: ['valibot', '@valibot/to-json-schema'],
+  },
   test: {
     typecheck: {
       tsconfig: './tsconfig.test.json',
@@ -25,5 +28,10 @@ export default defineConfig({
     globals: false,
     pool: 'threads',
     maxConcurrency: 1,
+    server: {
+      deps: {
+        inline: ['valibot', '@valibot/to-json-schema'],
+      },
+    },
   },
 })

--- a/packages/schema/vitest.config.ts
+++ b/packages/schema/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     },
   },
   ssr: {
-    noExternal: ['valibot', '@valibot/to-json-schema'],
+    noExternal: ['valibot', '@valibot/to-json-schema', 'yup'],
   },
   test: {
     typecheck: {
@@ -30,7 +30,7 @@ export default defineConfig({
     maxConcurrency: 1,
     server: {
       deps: {
-        inline: ['valibot', '@valibot/to-json-schema'],
+        inline: ['valibot', '@valibot/to-json-schema', 'yup'],
       },
     },
   },

--- a/packages/schema/vitest.config.ts
+++ b/packages/schema/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vitest/config'
+import swc from 'unplugin-swc'
+import path from 'node:path'
+
+export default defineConfig({
+  plugins: [
+    swc.vite({
+      jsc: {
+        parser: { syntax: 'typescript', decorators: true },
+        transform: { legacyDecorator: true, decoratorMetadata: true },
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      '@forinda/kickjs-schema': path.resolve(__dirname, 'src/index.ts'),
+    },
+  },
+  test: {
+    typecheck: {
+      tsconfig: './tsconfig.test.json',
+    },
+    environment: 'node',
+    include: ['__tests__/**/*.test.ts'],
+    globals: false,
+    pool: 'threads',
+    maxConcurrency: 1,
+  },
+})

--- a/packages/swagger/__tests__/swagger.test.ts
+++ b/packages/swagger/__tests__/swagger.test.ts
@@ -402,17 +402,16 @@ describe('registerControllerForDocs / clearRegisteredRoutes', () => {
 // ── Schema Parser Tests ───────────────────────────────────────────────
 
 describe('zodSchemaParser', () => {
-  it('should have name "zod"', () => {
-    expect(zodSchemaParser.name).toBe('zod')
+  it('should have name "kickjs-schema"', () => {
+    expect(zodSchemaParser.name).toBe('kickjs-schema')
   })
 
-  it('should not support non-Zod values', () => {
+  it('should not support non-schema values', () => {
     expect(zodSchemaParser.supports(null)).toBe(false)
     expect(zodSchemaParser.supports(undefined)).toBe(false)
     expect(zodSchemaParser.supports('string')).toBe(false)
     expect(zodSchemaParser.supports(123)).toBe(false)
     expect(zodSchemaParser.supports({})).toBe(false)
-    expect(zodSchemaParser.supports({ safeParse: () => {} })).toBe(false)
   })
 
   it('should support objects with safeParse and toJSONSchema', () => {

--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -49,10 +49,13 @@
       "output": [
         "dist/**"
       ],
-      "dependencies": []
+      "dependencies": [
+        "../schema:build"
+      ]
     }
   },
   "dependencies": {
+    "@forinda/kickjs-schema": "workspace:*",
     "reflect-metadata": "^0.2.2",
     "swagger-ui-dist": "^5.32.6"
   },

--- a/packages/swagger/src/schema-parser.ts
+++ b/packages/swagger/src/schema-parser.ts
@@ -1,4 +1,4 @@
-import { detectSchema, isKickSchema } from '@forinda/kickjs-schema'
+import { detectSchema } from '@forinda/kickjs-schema'
 
 /**
  * Interface for converting validation library schemas to JSON Schema.
@@ -49,16 +49,12 @@ export const zodSchemaParser: SchemaParser = {
 
   supports(schema: unknown): boolean {
     if (schema == null) return false
-    if (isKickSchema(schema)) return true
-    if (typeof schema === 'object' && '~standard' in (schema as object)) return true
-    if (
-      typeof schema === 'object' &&
-      typeof (schema as any).safeParse === 'function' &&
-      typeof (schema as any).toJSONSchema === 'function'
-    )
+    try {
+      detectSchema(schema)
       return true
-    if (typeof schema === 'object' && typeof (schema as any).safeParse === 'function') return true
-    return false
+    } catch {
+      return false
+    }
   },
 
   toJsonSchema(schema: unknown): Record<string, unknown> {

--- a/packages/swagger/src/schema-parser.ts
+++ b/packages/swagger/src/schema-parser.ts
@@ -1,9 +1,12 @@
+import { detectSchema, isKickSchema } from '@forinda/kickjs-schema'
+
 /**
  * Interface for converting validation library schemas to JSON Schema.
  *
- * KickJS ships with a Zod parser by default. To use a different validation
- * library (Yup, Joi, Valibot, ArkType, etc.), implement this interface and
- * pass it to the SwaggerAdapter.
+ * @deprecated Use `@forinda/kickjs-schema` adapters instead. Schemas that
+ * implement KickSchema or StandardSchemaV1 are auto-detected and converted
+ * via `detectSchema().toJsonSchema()`. This interface is preserved for
+ * backwards compatibility with custom parsers passed to SwaggerAdapter.
  *
  * @example
  * ```ts
@@ -38,23 +41,28 @@ export interface SchemaParser {
 }
 
 /**
- * Default schema parser for Zod v4+.
- * Uses Zod's built-in `.toJSONSchema()` instance method.
+ * Default schema parser using @forinda/kickjs-schema auto-detection.
+ * Supports Zod, Standard Schema v1, and any KickSchema adapter.
  */
 export const zodSchemaParser: SchemaParser = {
-  name: 'zod',
+  name: 'kickjs-schema',
 
   supports(schema: unknown): boolean {
-    return (
-      schema != null &&
+    if (schema == null) return false
+    if (isKickSchema(schema)) return true
+    if (typeof schema === 'object' && '~standard' in (schema as object)) return true
+    if (
       typeof schema === 'object' &&
       typeof (schema as any).safeParse === 'function' &&
       typeof (schema as any).toJSONSchema === 'function'
     )
+      return true
+    if (typeof schema === 'object' && typeof (schema as any).safeParse === 'function') return true
+    return false
   },
 
   toJsonSchema(schema: unknown): Record<string, unknown> {
-    const { $schema: _, ...rest } = (schema as any).toJSONSchema() as Record<string, unknown>
-    return rest
+    const wrapped = detectSchema(schema)
+    return wrapped.toJsonSchema({ target: 'openapi-3.0' })
   },
 }

--- a/packages/swagger/tsdown.config.ts
+++ b/packages/swagger/tsdown.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   dts: { tsgo: true },
   external: [
     '@forinda/kickjs',
+    '@forinda/kickjs-schema',
     'reflect-metadata',
     'swagger-ui-dist',
     'zod',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,6 +417,9 @@ importers:
 
   packages/kickjs:
     dependencies:
+      '@forinda/kickjs-schema':
+        specifier: workspace:*
+        version: link:../schema
       dotenv:
         specifier: ^17.0.0
         version: 17.3.1
@@ -469,6 +472,9 @@ importers:
 
   packages/mcp:
     dependencies:
+      '@forinda/kickjs-schema':
+        specifier: workspace:*
+        version: link:../schema
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -574,6 +580,9 @@ importers:
 
   packages/swagger:
     dependencies:
+      '@forinda/kickjs-schema':
+        specifier: workspace:*
+        version: link:../schema
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -580,6 +580,9 @@ importers:
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+      yup:
+        specifier: ^1.7.1
+        version: 1.7.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -4747,6 +4750,9 @@ packages:
     resolution: {integrity: sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==}
     engines: {node: '>=18'}
 
+  property-expr@2.0.6:
+    resolution: {integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -5205,6 +5211,9 @@ packages:
     resolution: {integrity: sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA==}
     engines: {node: '>=8'}
 
+  tiny-case@1.0.3:
+    resolution: {integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -5235,6 +5244,9 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  toposort@2.0.2:
+    resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -5293,6 +5305,10 @@ packages:
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -5659,6 +5675,9 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yup@1.7.1:
+    resolution: {integrity: sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==}
 
   zeptomatch@2.1.0:
     resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
@@ -9495,6 +9514,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  property-expr@2.0.6: {}
+
   property-information@7.1.0: {}
 
   protobufjs@7.5.7:
@@ -10151,6 +10172,8 @@ snapshots:
 
   timestring@6.0.0: {}
 
+  tiny-case@1.0.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.2: {}
@@ -10171,6 +10194,8 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  toposort@2.0.2: {}
 
   tr46@0.0.3: {}
 
@@ -10220,6 +10245,8 @@ snapshots:
       safe-buffer: 5.2.1
 
   tweetnacl@0.14.5: {}
+
+  type-fest@2.19.0: {}
 
   type-is@1.6.18:
     dependencies:
@@ -10613,6 +10640,13 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yup@1.7.1:
+    dependencies:
+      property-expr: 2.0.6
+      tiny-case: 1.0.3
+      toposort: 2.0.2
+      type-fest: 2.19.0
 
   zeptomatch@2.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -568,9 +568,15 @@ importers:
       '@types/node':
         specifier: ^25.8.0
         version: 25.8.0
+      '@valibot/to-json-schema':
+        specifier: ^1.7.0
+        version: 1.7.0(valibot@1.4.1(typescript@6.0.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      valibot:
+        specifier: ^1.4.1
+        version: 1.4.1(typescript@6.0.3)
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -2661,6 +2667,11 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+
+  '@valibot/to-json-schema@1.7.0':
+    resolution: {integrity: sha512-Y3pPVibbIOHzohrlxSINvO7w/bvXkoYS3BQHoImV9ynE+bXKf171bdMucPurV2zp7gdmt0L1HCcNAsbo7cFRQw==}
+    peerDependencies:
+      valibot: ^1.4.0
 
   '@vitalets/google-translate-api@9.2.1':
     resolution: {integrity: sha512-zlwQWSjXUZhbZQ6qwtIQ7GdYXFQmJ4wYqzcrYJUxtvzQQwUP+uKUb/SRJaBOQuBntjBjzcdcJoLFrpCKUbIkOg==}
@@ -5381,6 +5392,14 @@ packages:
       typescript:
         optional: true
 
+  valibot@1.4.1:
+    resolution: {integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -7437,6 +7456,10 @@ snapshots:
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260521.1
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@valibot/to-json-schema@1.7.0(valibot@1.4.1(typescript@6.0.3))':
+    dependencies:
+      valibot: 1.4.1(typescript@6.0.3)
 
   '@vitalets/google-translate-api@9.2.1':
     dependencies:
@@ -10290,6 +10313,10 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
     optional: true
+
+  valibot@1.4.1(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
   vary@1.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,6 +554,24 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/schema:
+    devDependencies:
+      '@swc/core':
+        specifier: ^1.15.33
+        version: 1.15.33
+      '@types/node':
+        specifier: ^25.8.0
+        version: 25.8.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+
   packages/swagger:
     dependencies:
       reflect-metadata:


### PR DESCRIPTION
## Summary

- **New package `@forinda/kickjs-schema`** — schema-agnostic validation abstraction with adapters for Zod, Valibot, and Yup
- **Framework integration** — `validate()` middleware, Swagger, and MCP now use `detectSchema()` for library-agnostic validation
- **Typegen** — new `schemaValidator: 'kickjs-schema'` option emits `InferSchemaOutput<>` for route/env types (default `'zod'` unchanged)
- **`loadEnvFromSchema()`** — schema-agnostic env loader alongside existing Zod-only `loadEnv()`
- **Alpha pre-release mode** entered for all affected packages
- **Reference docs** at `docs/schemas/` covering Standard Schema v1, adapters, error format, and integration points

### Adapters (tree-shakable sub-exports)

| Adapter | Import | Tests |
|---|---|---|
| Zod | `@forinda/kickjs-schema/zod` | 23 |
| Valibot | `@forinda/kickjs-schema/valibot` | 15 |
| Yup | `@forinda/kickjs-schema/yup` | 15 |
| **Total** | | **53** |

### Package bumps

| Package | Bump |
|---|---|
| `@forinda/kickjs-schema` | minor (new) |
| `@forinda/kickjs` | minor |
| `@forinda/kickjs-cli` | minor |
| `@forinda/kickjs-swagger` | patch |
| `@forinda/kickjs-mcp` | patch |

## Test plan

- [x] 53 schema adapter tests (Zod 23, Valibot 15, Yup 15)
- [x] 509 kickjs tests pass (validate middleware backward compat)
- [x] 49 swagger tests pass (schema parser name + detection update)
- [x] 17 MCP tests pass
- [x] Typegen tested with both `'zod'` and `'kickjs-schema'` validators on example app
- [x] End-to-end example app (`examples/schema-test`) with raw Zod, fromZod, and Standard Schema v1 endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added schema-agnostic validation abstraction supporting Zod, Valibot, Yup, and Joi adapters
  * Introduced unified error format across all supported validation libraries
  * Added `loadEnvFromSchema()` helper for environment variable validation
  * New `schemaValidator` typegen configuration option (with `--schema-validator kickjs-schema` CLI flag)

* **Documentation**
  * Added comprehensive schema integration guides covering adapters, error formats, and framework integration patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->