### PR TITLE
feat(core): defineContextDecorator.withParams<P>() curried form

### DIFF
--- a/.changeset/context-decorator-with-params.md
+++ b/.changeset/context-decorator-with-params.md
@@ -1,0 +1,20 @@
+---
+'@forinda/kickjs': minor
+---
+
+Add `defineContextDecorator.withParams<P>()(spec)` and `defineHttpContextDecorator.withParams<P>()(spec)` curried entry points.
+
+Fixes the partial-inference problem on parameterised contributors. The positional `defineContextDecorator<K, D, P, Ctx>(spec)` signature forces adopters to spell `K` and `D` the moment they want to specify the per-call params shape `P` — which drops automatic `deps` inference, so `(ctx, deps, params) => …` resolvers end up with `deps` typed as `Record<string, never>` (or worse, the wrong shape) unless the deps type is duplicated by hand.
+
+The curried form takes only `P`; `K` (from `spec.key` literal), `D` (from `spec.deps` value shape), and `Ctx` all infer from the spec:
+
+```ts
+const LoadTenant = defineContextDecorator.withParams<{ source: 'header' | 'subdomain' }>()({
+  key: 'tenant',
+  deps: { repo: TENANT_REPO }, // D inferred
+  paramDefaults: { source: 'header' },
+  resolve: (ctx, { repo }, params) => repo.findFor(ctx, params),
+})
+```
+
+The positional form keeps working unchanged for back-compat.

--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -983,11 +983,7 @@ import { TENANT_DB_POOL } from './tenant-db-pool.service'
 // different header than the public-facing routes.
 type LoadTenantParams = { source: 'header' | 'subdomain'; headerName?: string }
 
-export const LoadTenant = defineContextDecorator<
-  'tenant',
-  { registry: typeof TENANT_REGISTRY },
-  LoadTenantParams
->({
+export const LoadTenant = defineContextDecorator.withParams<LoadTenantParams>()({
   key: 'tenant',
   deps: { registry: TENANT_REGISTRY },
   paramDefaults: { source: 'header', headerName: 'x-tenant-id' },
@@ -1006,11 +1002,7 @@ export const LoadTenant = defineContextDecorator<
 // identity contributor has already resolved when this one runs.
 type LoadTenantDbParams = { pool: 'primary' | 'replica' }
 
-export const LoadTenantDb = defineContextDecorator<
-  'tenantDb',
-  { dbPool: typeof TENANT_DB_POOL },
-  LoadTenantDbParams
->({
+export const LoadTenantDb = defineContextDecorator.withParams<LoadTenantDbParams>()({
   key: 'tenantDb',
   deps: { dbPool: TENANT_DB_POOL },
   dependsOn: ['tenant'],
@@ -1478,7 +1470,44 @@ See the [`@forinda/kickjs-testing` API reference](../api/testing.md) for the ful
 
 Decorators ship with one definition; adopters apply them with **per-call params**. The same `defineContextDecorator(...)` value can serve many call sites that differ only in configuration — header name, policy class, audit-log action, rate-limit window, anything.
 
-Pass `paramDefaults` and a third `params` argument on `resolve` / `onError`:
+Pass `paramDefaults` and a third `params` argument on `resolve` / `onError`.
+
+### Recommended: `.withParams<P>()` curried form
+
+TypeScript generics are positional, so once you want to specify the per-call params shape `P` on `defineContextDecorator<K, D, P, Ctx>(spec)`, you also have to spell `K` and `D` — which **loses the automatic `deps` inference** that drives the `(ctx, deps, params) => …` resolver signature.
+
+`defineContextDecorator.withParams<P>()(spec)` is the curried entry point that fixes this. You spell only `P`; `K`, `D`, and `Ctx` infer from the spec value, so `deps.<name>` ends up fully typed in the resolver without any annotation:
+
+```ts
+import { defineContextDecorator } from '@forinda/kickjs'
+import { TENANT_REGISTRY } from './tenant-registry.service'
+
+type LoadTenantParams = {
+  source: 'header' | 'subdomain' | 'jwt'
+  headerName?: string
+}
+
+export const LoadTenant = defineContextDecorator.withParams<LoadTenantParams>()({
+  key: 'tenant', // K inferred as 'tenant' literal
+  deps: { registry: TENANT_REGISTRY }, // D inferred → deps.registry typed
+  paramDefaults: { source: 'header', headerName: 'x-tenant-id' },
+  resolve: (ctx, { registry }, params) => {
+    if (params.source === 'header') {
+      return registry.findById(ctx.req.headers[params.headerName ?? 'x-tenant-id'] as string)
+    }
+    if (params.source === 'subdomain') {
+      return registry.findById(ctx.req.hostname.split('.')[0])
+    }
+    return registry.findById(ctx.req.user?.tenantId ?? '')
+  },
+})
+```
+
+The `defineHttpContextDecorator.withParams<P>()(spec)` mirror does the same for HTTP-flavoured contributors (`Ctx` is locked to `RequestContext`).
+
+### Positional form (no params)
+
+For contributors with **no per-call params**, the positional form is shorter — every generic infers, no curried call needed:
 
 ```ts
 import { defineContextDecorator } from '@forinda/kickjs'
@@ -1505,6 +1534,8 @@ export const LoadTenant = defineContextDecorator<'tenant', Record<string, never>
   },
 )
 ```
+
+The positional form **also accepts `paramDefaults` + a third `params` argument** — the only cost is the K/D generics you have to spell. Reach for `.withParams<P>()` the moment `D` is non-empty.
 
 ### Three call shapes
 
@@ -1567,7 +1598,7 @@ type RateLimitParams = {
   keyOf: (ctx: RequestContext) => string
 }
 
-export const RateLimited = defineContextDecorator<'rate-limit', RateLimiterDeps, RateLimitParams>({
+export const RateLimited = defineContextDecorator.withParams<RateLimitParams>()({
   key: 'rate-limit',
   deps: { limiter: RATE_LIMITER },
   paramDefaults: {
@@ -1692,7 +1723,7 @@ const LoadTenantFromSubdomain = defineContextDecorator({
 ```ts
 type LoadTenantParams = { source: 'header' | 'subdomain' | 'jwt'; headerName?: string }
 
-const LoadTenant = defineContextDecorator<'tenant', { repo: typeof TENANT_REPO }, LoadTenantParams>({
+const LoadTenant = defineContextDecorator.withParams<LoadTenantParams>()({
   key: 'tenant',
   deps: { repo: TENANT_REPO },
   paramDefaults: { source: 'header', headerName: 'x-tenant-id' },
@@ -1733,7 +1764,7 @@ interface Policy {
   check(user: User, req: Request): MaybePromise<boolean>
 }
 
-const RequirePolicy = defineContextDecorator<'authzCheck', {}, { policy: new () => Policy }>({
+const RequirePolicy = defineContextDecorator.withParams<{ policy: new () => Policy }>()({
   key: 'authzCheck',
   paramDefaults: { policy: AlwaysAllowPolicy },
   resolve: async (ctx, _deps, params) => {
@@ -1774,7 +1805,7 @@ type RateLimitParams = {
   keyOf: (ctx: RequestContext) => string
 }
 
-const RateLimited = defineContextDecorator<'rate-limit', { limiter: typeof RATE_LIMITER }, RateLimitParams>({
+const RateLimited = defineContextDecorator.withParams<RateLimitParams>()({
   key: 'rate-limit',
   deps: { limiter: RATE_LIMITER },
   paramDefaults: { window: '1m', max: 60, keyOf: (ctx) => ctx.req.ip },
@@ -1811,7 +1842,7 @@ The closure-returning-decorator pattern works but means every call site builds i
 type Validator<T> = { parse(value: unknown): T }
 type ValidateBodyParams = { schema: Validator<unknown>; on?: 'throw' | 'attach-issues' }
 
-const ValidateBody = defineContextDecorator<'validatedBody', {}, ValidateBodyParams>({
+const ValidateBody = defineContextDecorator.withParams<ValidateBodyParams>()({
   key: 'validatedBody',
   paramDefaults: { schema: { parse: (v) => v }, on: 'throw' },
   resolve: (ctx, _deps, params) => {
@@ -1862,7 +1893,7 @@ type VerifyParams = {
   algorithm: 'sha256' | 'sha1'
 }
 
-const VerifySignature = defineContextDecorator<'verifiedWebhook', {}, VerifyParams>({
+const VerifySignature = defineContextDecorator.withParams<VerifyParams>()({
   key: 'verifiedWebhook',
   paramDefaults: { secret: '', header: 'x-signature', algorithm: 'sha256' },
   resolve: (ctx, _deps, params) => {

--- a/packages/kickjs/__tests__/context-decorator.test.ts
+++ b/packages/kickjs/__tests__/context-decorator.test.ts
@@ -618,3 +618,65 @@ describe('parameterised contributors — factory call form', () => {
     expect(errors[0].params).toEqual({ tag: 'specific' })
   })
 })
+
+describe('defineContextDecorator.withParams — curried partial inference', () => {
+  // The positional generics force adopters to spell `K` and `D` the
+  // moment they want to specify `P`. These cases lock in the
+  // `.withParams<P>()` shape: `P` is spelled, `K` and `D` (and `Ctx`
+  // for the HTTP wrapper) infer from the spec, and the resolver's
+  // `deps`/`params` arguments end up typed without any casts.
+
+  type LoadProjectParams = {
+    source: 'route' | 'query'
+    fallback?: string
+  }
+
+  it('infers K and D from the spec while P is fixed by the curried call', () => {
+    const REPO = { findById: (id: string) => ({ id, name: `proj-${id}` }) }
+
+    const LoadProject = defineContextDecorator.withParams<LoadProjectParams>()({
+      key: 'project',
+      deps: { repo: REPO as { findById: (id: string) => { id: string; name: string } } },
+      paramDefaults: { source: 'route' },
+      resolve: (_ctx, deps, params) => {
+        // `deps.repo` is fully typed via D inference; calling a method
+        // that doesn't exist would fail to compile.
+        const id = params.source === 'route' ? '42' : (params.fallback ?? '0')
+        return deps.repo.findById(id)
+      },
+    })
+
+    expect(LoadProject.registration.key).toBe('project')
+    expect(LoadProject.registration.deps).toHaveProperty('repo')
+  })
+
+  it('default params from the curried form propagate to the resolver', async () => {
+    type Params = { greeting: string }
+    const Greet = defineContextDecorator.withParams<Params>()({
+      key: 'greeting',
+      paramDefaults: { greeting: 'hello' },
+      resolve: (_ctx, _deps, params) => params.greeting,
+    })
+
+    const value = await Greet.registration.resolve({} as never, {} as never)
+    expect(value).toBe('hello')
+  })
+
+  it('call-site params via .with() override curried-form defaults', async () => {
+    type Params = { source: 'a' | 'b' }
+    const Pick = defineContextDecorator.withParams<Params>()({
+      key: 'pick',
+      paramDefaults: { source: 'a' },
+      resolve: (_ctx, _deps, params) => params.source,
+    })
+
+    const overridden = Pick.with({ source: 'b' }).registration
+    const value = await overridden.resolve({} as never, {} as never)
+    expect(value).toBe('b')
+  })
+
+  it('the .withParams helper is itself frozen on the factory', () => {
+    expect(typeof defineContextDecorator.withParams).toBe('function')
+    expect(Object.isFrozen(defineContextDecorator)).toBe(true)
+  })
+})

--- a/packages/kickjs/src/core/context-decorator.ts
+++ b/packages/kickjs/src/core/context-decorator.ts
@@ -307,6 +307,70 @@ export interface ContextDecorator<
 }
 
 /**
+ * Curried params-first helper for {@link defineContextDecorator}.
+ *
+ * Solves the partial-inference problem: TS generics are positional, so
+ * the moment an adopter wants to specify the per-call params shape
+ * `P`, they're forced to spell `K` and `D` by hand — losing the
+ * automatic `deps` inference that drives the `(ctx, deps, params) =>`
+ * resolver signature:
+ *
+ * ```ts
+ * // ❌ Positional generics — must repeat the deps type, and `D` no
+ * // longer flows from `spec.deps` into `resolve(ctx, deps, ...)`.
+ * defineContextDecorator<'tenant', { repo: typeof TENANT_REPO }, MyParams>({
+ *   key: 'tenant',
+ *   deps: { repo: TENANT_REPO },
+ *   resolve: (ctx, { repo }, params) => ...,
+ * })
+ *
+ * // ✅ Curried form — only `P` is spelled; `K`, `D`, `Ctx` infer.
+ * defineContextDecorator.withParams<MyParams>()({
+ *   key: 'tenant',
+ *   deps: { repo: TENANT_REPO },     // D inferred
+ *   resolve: (ctx, { repo }, params) => ..., // deps + params both typed
+ * })
+ * ```
+ *
+ * Use this whenever the contributor takes call-site params; use the
+ * positional form when there are no params (the common case).
+ */
+export interface DefineContextDecoratorWithParams<P extends Record<string, unknown>> {
+  <
+    K extends string,
+    D extends Record<string, DepValue> = Record<string, never>,
+    Ctx extends ExecutionContext = ExecutionContext,
+  >(
+    spec: ContextDecoratorSpec<K, D, P, Ctx>,
+  ): ContextDecorator<K, D, P, Ctx>
+}
+
+/**
+ * The public shape of {@link defineContextDecorator}. Combines the
+ * original positional-generic call signature with the curried
+ * `.withParams<P>()` helper that fixes partial-inference for the
+ * parameterised case.
+ */
+export interface DefineContextDecoratorFn {
+  <
+    K extends string,
+    D extends Record<string, DepValue> = Record<string, never>,
+    P extends Record<string, unknown> = Record<string, never>,
+    Ctx extends ExecutionContext = ExecutionContext,
+  >(
+    spec: ContextDecoratorSpec<K, D, P, Ctx>,
+  ): ContextDecorator<K, D, P, Ctx>
+
+  /**
+   * Curried entry point. Spell only the per-call params shape `P`;
+   * `K`, `D`, and `Ctx` are inferred from the spec passed to the
+   * returned function. See {@link DefineContextDecoratorWithParams}
+   * for the rationale.
+   */
+  withParams<P extends Record<string, unknown>>(): DefineContextDecoratorWithParams<P>
+}
+
+/**
  * Define a typed context contributor.
  *
  * The returned function works as a method or class decorator:
@@ -332,8 +396,14 @@ export interface ContextDecorator<
  * non-array `dependsOn` throws `TypeError` here at definition time
  * (typically module-load) rather than waiting for the first request.
  * See `architecture.md` §20 for the full pipeline plan.
+ *
+ * **Parameterised contributors:** TS generics are positional, so to
+ * specify `P` (the per-call params shape) with this signature you
+ * also have to spell `K` and `D` — which loses automatic `deps`
+ * inference. Use {@link DefineContextDecoratorFn.withParams} instead:
+ * `defineContextDecorator.withParams<MyParams>()(spec)`.
  */
-export function defineContextDecorator<
+function defineContextDecoratorImpl<
   K extends string,
   D extends Record<string, DepValue> = Record<string, never>,
   P extends Record<string, unknown> = Record<string, never>,
@@ -614,3 +684,30 @@ export function defineContextDecorator<
 
   return Object.freeze(decorator)
 }
+
+/**
+ * Public export — the positional-generic implementation plus the
+ * curried `.withParams<P>()` helper attached as a method. Adopters
+ * pick whichever form fits the call site:
+ *
+ * - **Positional** — `defineContextDecorator(spec)` when there are
+ *   no per-call params (the common case). `K`, `D`, `Ctx` infer.
+ * - **Curried** — `defineContextDecorator.withParams<P>()(spec)`
+ *   when the contributor takes params; spell only `P`, the rest
+ *   still infer.
+ *
+ * Frozen so adopters can't reassign `.withParams` at runtime.
+ */
+export const defineContextDecorator: DefineContextDecoratorFn = Object.freeze(
+  Object.assign(defineContextDecoratorImpl, {
+    withParams: <P extends Record<string, unknown>>(): DefineContextDecoratorWithParams<P> => {
+      return <
+        K extends string,
+        D extends Record<string, DepValue> = Record<string, never>,
+        Ctx extends ExecutionContext = ExecutionContext,
+      >(
+        spec: ContextDecoratorSpec<K, D, P, Ctx>,
+      ): ContextDecorator<K, D, P, Ctx> => defineContextDecoratorImpl<K, D, P, Ctx>(spec)
+    },
+  }),
+) as DefineContextDecoratorFn

--- a/packages/kickjs/src/http/define-http-context-decorator.ts
+++ b/packages/kickjs/src/http/define-http-context-decorator.ts
@@ -27,7 +27,9 @@
  *   resolve: (ctx) => ({ id: ctx.req.headers['x-tenant-id'] as string }),
  * })
  *
- * // Parameterised: the third generic carries the per-call params shape.
+ * // Parameterised — the positional form forces you to also spell `K`
+ * // and `D`, which loses automatic `deps` inference. Prefer the curried
+ * // `.withParams<P>()` entry point below.
  * const LoadTenantParameterised = defineHttpContextDecorator<
  *   'tenant',
  *   Record<string, never>,
@@ -38,6 +40,18 @@
  *   resolve: (ctx, _deps, params) => {
  *     // params.source narrows inside `if` branches.
  *   },
+ * })
+ *
+ * // Parameterised + deps — only `P` is spelled; `K` and `D` infer from
+ * // the spec, so `deps.repo` is fully typed in the resolver.
+ * const LoadTenantWithRepo = defineHttpContextDecorator.withParams<{
+ *   source: 'header' | 'subdomain'
+ * }>()({
+ *   key: 'tenant',
+ *   deps: { repo: TENANT_REPO },
+ *   paramDefaults: { source: 'header' },
+ *   resolve: (ctx, { repo }, params) =>
+ *     repo.findFor(ctx.req.headers['x-tenant-id'] as string, params.source),
  * })
  * ```
  *
@@ -55,10 +69,63 @@ import {
 } from '../core/context-decorator'
 import type { RequestContext } from './context'
 
-export function defineHttpContextDecorator<
+/**
+ * Curried form returned by {@link DefineHttpContextDecoratorFn.withParams}.
+ * Spell only the per-call params shape `P`; `K` and `D` are inferred
+ * from the spec, and `Ctx` is locked to `RequestContext`.
+ */
+export interface DefineHttpContextDecoratorWithParams<P extends Record<string, unknown>> {
+  <K extends string, D extends Record<string, DepValue> = Record<string, never>>(
+    spec: ContextDecoratorSpec<K, D, P, RequestContext>,
+  ): ContextDecorator<K, D, P, RequestContext>
+}
+
+/**
+ * Public shape of {@link defineHttpContextDecorator} — the positional
+ * call signature plus the curried `.withParams<P>()` helper that fixes
+ * partial-inference for the parameterised case.
+ */
+export interface DefineHttpContextDecoratorFn {
+  <
+    K extends string,
+    D extends Record<string, DepValue> = Record<string, never>,
+    P extends Record<string, unknown> = Record<string, never>,
+  >(
+    spec: ContextDecoratorSpec<K, D, P, RequestContext>,
+  ): ContextDecorator<K, D, P, RequestContext>
+
+  /**
+   * Curried entry point. Spell only `P`; `K` and `D` infer from the
+   * spec. `Ctx` is locked to `RequestContext`.
+   *
+   * ```ts
+   * const LoadTenant = defineHttpContextDecorator.withParams<{
+   *   source: 'header' | 'subdomain'
+   * }>()({
+   *   key: 'tenant',
+   *   deps: { repo: TENANT_REPO },           // D inferred
+   *   paramDefaults: { source: 'header' },
+   *   resolve: (ctx, { repo }, params) => repo.findFor(ctx, params),
+   * })
+   * ```
+   */
+  withParams<P extends Record<string, unknown>>(): DefineHttpContextDecoratorWithParams<P>
+}
+
+function defineHttpContextDecoratorImpl<
   K extends string,
   D extends Record<string, DepValue> = Record<string, never>,
   P extends Record<string, unknown> = Record<string, never>,
 >(spec: ContextDecoratorSpec<K, D, P, RequestContext>): ContextDecorator<K, D, P, RequestContext> {
   return defineContextDecorator<K, D, P, RequestContext>(spec)
 }
+
+export const defineHttpContextDecorator: DefineHttpContextDecoratorFn = Object.freeze(
+  Object.assign(defineHttpContextDecoratorImpl, {
+    withParams: <P extends Record<string, unknown>>(): DefineHttpContextDecoratorWithParams<P> => {
+      return <K extends string, D extends Record<string, DepValue> = Record<string, never>>(
+        spec: ContextDecoratorSpec<K, D, P, RequestContext>,
+      ): ContextDecorator<K, D, P, RequestContext> => defineHttpContextDecoratorImpl<K, D, P>(spec)
+    },
+  }),
+) as DefineHttpContextDecoratorFn

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -564,10 +564,10 @@ importers:
     devDependencies:
       '@swc/core':
         specifier: ^1.15.33
-        version: 1.15.33
+        version: 1.15.40
       '@types/node':
         specifier: ^25.8.0
-        version: 25.8.0
+        version: 25.9.1
       '@valibot/to-json-schema':
         specifier: ^1.7.0
         version: 1.7.0(valibot@1.4.1(typescript@6.0.3))
@@ -579,7 +579,7 @@ importers:
         version: 1.4.1(typescript@6.0.3)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       yup:
         specifier: ^1.7.1
         version: 1.7.1


### PR DESCRIPTION
## Why

Positional generics on `defineContextDecorator<K, D, P, Ctx>(spec)` force adopters to spell `K` and `D` the moment they want to specify the per-call params shape `P` — which **drops automatic `deps` inference**. The resolver's `(ctx, deps, params) => …` signature ends up with `deps` typed as `Record<string, never>` (or worse, the duplicated wrong shape) unless the deps type is hand-written a second time.

Reported via real-world usage in a downstream project — adopter had to add a `DepsType` alias just to spell out the type they had already written in the value, and TS still wouldn't carry it into the resolver.

## What

Add `.withParams<P>()(spec)` curried entry points on both factories:

```ts
// Before — must spell K ('tenant') AND D, losing deps inference:
defineContextDecorator<'tenant', { repo: typeof TENANT_REPO }, LoadTenantParams>({
  key: 'tenant',
  deps: { repo: TENANT_REPO },
  resolve: (ctx, { repo }, params) => ..., // deps wrong shape, params wrong shape
})

// After — only P spelled. K, D, Ctx infer from spec:
defineContextDecorator.withParams<LoadTenantParams>()({
  key: 'tenant',                  // K inferred as literal 'tenant'
  deps: { repo: TENANT_REPO },    // D inferred → deps.repo typed
  paramDefaults: { source: 'header' },
  resolve: (ctx, { repo }, params) => ..., // all three typed
})
```

Same treatment for `defineHttpContextDecorator.withParams<P>()(spec)`; `Ctx` locked to `RequestContext` there.

Positional form keeps working unchanged — back-compat.

## Files

- `packages/kickjs/src/core/context-decorator.ts` — `DefineContextDecoratorFn` interface, internal `defineContextDecoratorImpl`, `Object.assign` + `Object.freeze` to attach `.withParams`
- `packages/kickjs/src/http/define-http-context-decorator.ts` — mirror for HTTP variant
- `packages/kickjs/__tests__/context-decorator.test.ts` — 4 new tests covering K/D inference, default params, `.with()` overrides, frozen factory
- `docs/guide/context-decorators.md` — new "Recommended: `.withParams<P>()` curried form" section, 7 canonical examples converted to the curried form
- `.changeset/context-decorator-with-params.md` — minor bump on `@forinda/kickjs`

## Test plan

- [x] `pnpm --filter @forinda/kickjs test` — 513/513 (1 pre-existing flaky `shutdown.test.ts` timing race)
- [x] `pnpm --filter @forinda/kickjs run build` — clean
- [x] Pre-commit hooks (build, test, format:check, lint) — green
- [x] Real-world verified: linked into a downstream project at `~/Desktop/p2`; previous `(28,37) Property 'withParams' does not exist` + 3 implicit-any errors on `(ctx, { userToken }, params)` all resolved. Remaining errors in that project are pre-existing user-code bugs unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added curried `defineContextDecorator.withParams<P>()` and `defineHttpContextDecorator.withParams<P>()` methods for better type inference in parameterized contributors.

* **Bug Fixes**
  * Fixed partial type inference issues when contributors use parameters; dependencies now infer correctly.

* **Documentation**
  * Updated context decorator guide with new `.withParams()` API examples and usage patterns.

* **Tests**
  * Added test suite validating curried decorator API and type inference behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->