### PR TITLE
docs(context-decorators): switch HTTP curried examples to defineHttpContextDecorator

### DIFF
--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -975,7 +975,7 @@ export class TenantDbPoolService {
 
 ```ts
 // src/tenant/contributors.ts
-import { defineContextDecorator, type RequestContext } from '@forinda/kickjs'
+import { defineHttpContextDecorator, type RequestContext } from '@forinda/kickjs'
 import { TENANT_REGISTRY } from './tenant-registry.service'
 import { TENANT_DB_POOL } from './tenant-db-pool.service'
 
@@ -983,7 +983,7 @@ import { TENANT_DB_POOL } from './tenant-db-pool.service'
 // different header than the public-facing routes.
 type LoadTenantParams = { source: 'header' | 'subdomain'; headerName?: string }
 
-export const LoadTenant = defineContextDecorator.withParams<LoadTenantParams>()({
+export const LoadTenant = defineHttpContextDecorator.withParams<LoadTenantParams>()({
   key: 'tenant',
   deps: { registry: TENANT_REGISTRY },
   paramDefaults: { source: 'header', headerName: 'x-tenant-id' },
@@ -1002,7 +1002,7 @@ export const LoadTenant = defineContextDecorator.withParams<LoadTenantParams>()(
 // identity contributor has already resolved when this one runs.
 type LoadTenantDbParams = { pool: 'primary' | 'replica' }
 
-export const LoadTenantDb = defineContextDecorator.withParams<LoadTenantDbParams>()({
+export const LoadTenantDb = defineHttpContextDecorator.withParams<LoadTenantDbParams>()({
   key: 'tenantDb',
   deps: { dbPool: TENANT_DB_POOL },
   dependsOn: ['tenant'],
@@ -1476,10 +1476,12 @@ Pass `paramDefaults` and a third `params` argument on `resolve` / `onError`.
 
 TypeScript generics are positional, so once you want to specify the per-call params shape `P` on `defineContextDecorator<K, D, P, Ctx>(spec)`, you also have to spell `K` and `D` — which **loses the automatic `deps` inference** that drives the `(ctx, deps, params) => …` resolver signature.
 
-`defineContextDecorator.withParams<P>()(spec)` is the curried entry point that fixes this. You spell only `P`; `K`, `D`, and `Ctx` infer from the spec value, so `deps.<name>` ends up fully typed in the resolver without any annotation:
+`defineContextDecorator.withParams<P>()(spec)` is the curried entry point that fixes this. You spell only `P`; `K`, `D`, and `Ctx` infer from the spec value, so `deps.<name>` ends up fully typed in the resolver without any annotation.
+
+For HTTP-flavoured contributors (the common case), reach for `defineHttpContextDecorator.withParams<P>()(spec)` — `Ctx` is locked to `RequestContext`, so `ctx.req`, `ctx.req.headers`, `ctx.req.hostname`, etc. are typed without a cast:
 
 ```ts
-import { defineContextDecorator } from '@forinda/kickjs'
+import { defineHttpContextDecorator } from '@forinda/kickjs'
 import { TENANT_REGISTRY } from './tenant-registry.service'
 
 type LoadTenantParams = {
@@ -1487,7 +1489,7 @@ type LoadTenantParams = {
   headerName?: string
 }
 
-export const LoadTenant = defineContextDecorator.withParams<LoadTenantParams>()({
+export const LoadTenant = defineHttpContextDecorator.withParams<LoadTenantParams>()({
   key: 'tenant', // K inferred as 'tenant' literal
   deps: { registry: TENANT_REGISTRY }, // D inferred → deps.registry typed
   paramDefaults: { source: 'header', headerName: 'x-tenant-id' },
@@ -1503,7 +1505,7 @@ export const LoadTenant = defineContextDecorator.withParams<LoadTenantParams>()(
 })
 ```
 
-The `defineHttpContextDecorator.withParams<P>()(spec)` mirror does the same for HTTP-flavoured contributors (`Ctx` is locked to `RequestContext`).
+Use the core `defineContextDecorator.withParams<P>()(spec)` form when authoring contributors for non-HTTP transports (WebSocket, queue, cron) or when sharing one definition across transports — the resolver then sticks to the `ExecutionContext` surface (`ctx.get`, `ctx.set`, `ctx.requestId`).
 
 ### Positional form (no params)
 
@@ -1590,7 +1592,7 @@ export const TenantPlugin = definePlugin({
 Params are **plain values** with no shape constraint — including functions and closures. Useful for "compute this from `ctx`" cases (rate-limit key, cache key, A/B variant assigner):
 
 ```ts
-import { defineContextDecorator } from '@forinda/kickjs'
+import { defineHttpContextDecorator } from '@forinda/kickjs'
 
 type RateLimitParams = {
   window: string
@@ -1598,7 +1600,7 @@ type RateLimitParams = {
   keyOf: (ctx: RequestContext) => string
 }
 
-export const RateLimited = defineContextDecorator.withParams<RateLimitParams>()({
+export const RateLimited = defineHttpContextDecorator.withParams<RateLimitParams>()({
   key: 'rate-limit',
   deps: { limiter: RATE_LIMITER },
   paramDefaults: {
@@ -1723,7 +1725,7 @@ const LoadTenantFromSubdomain = defineContextDecorator({
 ```ts
 type LoadTenantParams = { source: 'header' | 'subdomain' | 'jwt'; headerName?: string }
 
-const LoadTenant = defineContextDecorator.withParams<LoadTenantParams>()({
+const LoadTenant = defineHttpContextDecorator.withParams<LoadTenantParams>()({
   key: 'tenant',
   deps: { repo: TENANT_REPO },
   paramDefaults: { source: 'header', headerName: 'x-tenant-id' },
@@ -1764,7 +1766,7 @@ interface Policy {
   check(user: User, req: Request): MaybePromise<boolean>
 }
 
-const RequirePolicy = defineContextDecorator.withParams<{ policy: new () => Policy }>()({
+const RequirePolicy = defineHttpContextDecorator.withParams<{ policy: new () => Policy }>()({
   key: 'authzCheck',
   paramDefaults: { policy: AlwaysAllowPolicy },
   resolve: async (ctx, _deps, params) => {
@@ -1805,7 +1807,7 @@ type RateLimitParams = {
   keyOf: (ctx: RequestContext) => string
 }
 
-const RateLimited = defineContextDecorator.withParams<RateLimitParams>()({
+const RateLimited = defineHttpContextDecorator.withParams<RateLimitParams>()({
   key: 'rate-limit',
   deps: { limiter: RATE_LIMITER },
   paramDefaults: { window: '1m', max: 60, keyOf: (ctx) => ctx.req.ip },
@@ -1842,7 +1844,7 @@ The closure-returning-decorator pattern works but means every call site builds i
 type Validator<T> = { parse(value: unknown): T }
 type ValidateBodyParams = { schema: Validator<unknown>; on?: 'throw' | 'attach-issues' }
 
-const ValidateBody = defineContextDecorator.withParams<ValidateBodyParams>()({
+const ValidateBody = defineHttpContextDecorator.withParams<ValidateBodyParams>()({
   key: 'validatedBody',
   paramDefaults: { schema: { parse: (v) => v }, on: 'throw' },
   resolve: (ctx, _deps, params) => {
@@ -1893,7 +1895,7 @@ type VerifyParams = {
   algorithm: 'sha256' | 'sha1'
 }
 
-const VerifySignature = defineContextDecorator.withParams<VerifyParams>()({
+const VerifySignature = defineHttpContextDecorator.withParams<VerifyParams>()({
   key: 'verifiedWebhook',
   paramDefaults: { secret: '', header: 'x-signature', algorithm: 'sha256' },
   resolve: (ctx, _deps, params) => {

--- a/packages/kickjs/__tests__/context-decorator.test.ts
+++ b/packages/kickjs/__tests__/context-decorator.test.ts
@@ -6,6 +6,7 @@ import {
   type ContributorRegistration,
   type ExecutionContext,
 } from '../src/core'
+import { defineHttpContextDecorator } from '../src/http/define-http-context-decorator'
 
 /**
  * Method-level contributor metadata is stored on the constructor (matches the
@@ -678,5 +679,51 @@ describe('defineContextDecorator.withParams — curried partial inference', () =
   it('the .withParams helper is itself frozen on the factory', () => {
     expect(typeof defineContextDecorator.withParams).toBe('function')
     expect(Object.isFrozen(defineContextDecorator)).toBe(true)
+  })
+})
+
+describe('defineHttpContextDecorator.withParams — HTTP parity', () => {
+  // Mirrors the curried surface but locks `Ctx` to `RequestContext`. The
+  // core test suite covers K/D inference and frozen factory shape; this
+  // suite just verifies the HTTP wrapper exposes the same behaviour and
+  // that the runner-facing registration matches.
+
+  it('exposes a frozen .withParams helper on the HTTP factory', () => {
+    expect(typeof defineHttpContextDecorator.withParams).toBe('function')
+    expect(Object.isFrozen(defineHttpContextDecorator)).toBe(true)
+  })
+
+  it('locks ctx to RequestContext and resolves with the merged params', async () => {
+    const LoadTenant = defineHttpContextDecorator.withParams<{
+      source: 'header' | 'subdomain'
+    }>()({
+      key: 'tenant',
+      paramDefaults: { source: 'header' },
+      resolve: (ctx, _deps, params) =>
+        params.source === 'header'
+          ? ((ctx.req.headers['x-tenant-id'] as string | undefined) ?? 'missing')
+          : ctx.req.hostname,
+    })
+
+    const value = await LoadTenant.with({ source: 'header' }).registration.resolve(
+      {
+        req: { headers: { 'x-tenant-id': 't-1' }, hostname: 'acme.example' },
+      } as never,
+      {} as never,
+    )
+
+    expect(value).toBe('t-1')
+  })
+
+  it('forwards .with() overrides through the HTTP factory', async () => {
+    const Pick = defineHttpContextDecorator.withParams<{ source: 'a' | 'b' }>()({
+      key: 'pick',
+      paramDefaults: { source: 'a' },
+      resolve: (_ctx, _deps, params) => params.source,
+    })
+
+    const overridden = Pick.with({ source: 'b' }).registration
+    const value = await overridden.resolve({} as never, {} as never)
+    expect(value).toBe('b')
   })
 })


### PR DESCRIPTION
## Why

Code-review feedback on #295 flagged two items:

1. **Docs:** Several `defineContextDecorator.withParams<P>()` examples reach into `ctx.req.headers` / `ctx.req.hostname` / `ctx.req.user`. The core helper leaves `Ctx extends ExecutionContext = ExecutionContext`, so those resolver bodies don't type-check on copy/paste — they need `defineHttpContextDecorator.withParams<P>()` which locks `Ctx` to `RequestContext`.

2. **Tests:** The HTTP wrapper is a separate public surface with its own exported types + forwarding code. Worth a parity test so a future refactor doesn't quietly break `RequestContext` locking.

## What

**`docs/guide/context-decorators.md`** — switched 9 HTTP-shaped curried examples from `defineContextDecorator.withParams<P>()` to `defineHttpContextDecorator.withParams<P>()` (LoadTenant × 3, LoadTenantDb, RateLimited × 2, RequirePolicy, ValidateBody, VerifySignature). Reworded the "Recommended" section to point HTTP adopters at the HTTP helper first; left a single example showing the core helper for the non-HTTP / transport-agnostic case.

**`packages/kickjs/__tests__/context-decorator.test.ts`** — added a `defineHttpContextDecorator.withParams — HTTP parity` describe with three tests:
- frozen `.withParams` helper on the factory
- `ctx.req` access in the resolver, resolves with merged params
- `.with()` overrides forwarded through the HTTP factory

## Test plan

- [x] `npx vitest run __tests__/context-decorator.test.ts` — 40/40
- [x] Pre-commit hooks (lint, format, lint-tokens) — green
- [x] No code in `src/` touched — pure docs + tests; back-compat preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance on HTTP-specific vs. general-purpose context decorators for different transport types.
  * Updated examples for common use cases including tenant identity, authentication, rate limiting, body validation, and webhook verification.

* **Tests**
  * Added test coverage for HTTP-specific context decorator functionality to ensure behavioral consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->