### PR TITLE
fix(db-pg): cancel blocking backends in abort-signal test beforeEach

### DIFF
--- a/packages/db-pg/__tests__/integration/abort-signal-pg.test.ts
+++ b/packages/db-pg/__tests__/integration/abort-signal-pg.test.ts
@@ -60,11 +60,24 @@ afterAll(async () => {
 })
 
 beforeEach(async () => {
+  // The mid-flight cancel test leaves `pg_sleep(10)` running
+  // server-side because Kysely 0.29's default abort strategy is
+  // `'ignore query'` — JS rejects fast but the Postgres backend
+  // keeps holding an access-share lock on `sleeper`. Cancel any
+  // other in-progress backends before dropping the table so we
+  // don't wait out the lock here.
+  await pool.query(`
+    SELECT pg_cancel_backend(pid)
+    FROM pg_stat_activity
+    WHERE datname = current_database()
+      AND pid <> pg_backend_pid()
+      AND state = 'active'
+  `)
   await pool.query(`
     DROP TABLE IF EXISTS "sleeper" CASCADE;
     CREATE TABLE "sleeper" (id serial PRIMARY KEY, label varchar(64));
   `)
-})
+}, 30_000)
 
 describe('M5.A.2 — AbortSignal cancels in-flight PG queries', () => {
   it('rejects with RelationalQueryCancelledError when the signal fires mid-flight', async () => {


### PR DESCRIPTION
## Why

`packages/db-pg/__tests__/integration/abort-signal-pg.test.ts` was the only failing test on `main` after the recent dependency-bump cluster. The mid-flight cancel test ("rejects with RelationalQueryCancelledError when the signal fires mid-flight") leaves `pg_sleep(10)` running server-side because Kysely 0.29's default abort strategy is `'ignore query'` — the JS promise rejects fast (the test passes), but the Postgres backend keeps holding an access-share lock on `sleeper`. The next test's `beforeEach` then blocks on `DROP TABLE` waiting for the lock and hits the default 10s `hookTimeout`:

```
× rejects immediately when the signal is already aborted at call time 10013ms
Error: Hook timed out in 10000ms.
 ❯ __tests__/integration/abort-signal-pg.test.ts:62:1
     62| beforeEach(async () => {
```

## What

Two surgical changes to the fixture only — production behaviour unchanged.

1. Cancel any other in-progress backends in `beforeEach` before dropping the table:

   ```sql
   SELECT pg_cancel_backend(pid)
   FROM pg_stat_activity
   WHERE datname = current_database()
     AND pid <> pg_backend_pid()
     AND state = 'active'
   ```

2. Raise the hook timeout to 30s so a slow Docker host can absorb the cancel round-trip without flaking.

The behaviour the existing tests assert (`RelationalQueryCancelledError`, sub-3s rejection, pre-aborted short-circuit) is untouched.

## Test plan

- [x] `npx vitest run __tests__/integration/abort-signal-pg.test.ts` — 3/3
- [x] Full db-pg suite: `npx vitest run` — 74/74 across 10 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup to prevent database lock interference between tests by ensuring previous in-flight operations are properly cleaned up before each test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->