### PR TITLE
chore: exit alpha pre-release mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "alpha",
   "initialVersions": {
     "@forinda/kickjs-ai": "5.2.2",


### PR DESCRIPTION
## Why

Pre-release alpha cycle done. Schema package shipped, schema-aware env / typegen / cli wiring shipped, swagger / mcp / db family etc. are at `*-alpha.0`. Time to consolidate to stable so adopters get a non-alpha tag and future fixes ship as normal patches.

## What

Drops `mode: 'pre'` from `.changeset/pre.json`. The next `changeset version` run will:

**Minor bumps** (from pending changesets):
- `@forinda/kickjs` → `5.14.0`
- `@forinda/kickjs-cli` → `5.10.0`
- `@forinda/kickjs-schema` → `0.1.0`

**Patch (alpha → stable consolidation)** — every package currently at `*-alpha.0` drops the alpha tag:
- `@forinda/kickjs-swagger` → `6.0.0`
- `@forinda/kickjs-mcp` → `6.0.0`
- `@forinda/kickjs-ai`, `-auth`, `-db`, `-db-mysql`, `-db-pg`, `-db-sqlite`, `-devtools`, `-devtools-kit`, `-drizzle`, `-prisma`, `-queue`, `-testing`, `-vite`, `-ws` → their `6.0.0` stable equivalents

The release workflow handles publishing automatically once this lands on main and the version PR merges.

## Test plan

- [x] `pnpm changeset:status` — clean status, lists every pending bump
- [x] Existing changesets intact (`cli-schema-scaffold`, `context-decorator-with-params`, `schema-abstraction`, `schema-inference-fixes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration for release management process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->