### PR TITLE
fix(schema): resolve @valibot/to-json-schema synchronously

### DIFF
--- a/.changeset/valibot-tojsonschema-race.md
+++ b/.changeset/valibot-tojsonschema-race.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-schema': patch
+---
+
+Fix race condition where `fromValibot(...).toJsonSchema()` returned the `{ type: 'object' }` fallback on fast runners (CI). The previous dangling `import('@valibot/to-json-schema').then(...)` resolved asynchronously, so the first `toJsonSchema()` call frequently fired before `_toJsonSchemaFn` got assigned. Replaced with top-level `await import(...)` inside a try/catch — adopters without the peer still land at the same `_toJsonSchemaFn = null` fallback, but adopters who have it installed get the real conversion every time.

--- a/packages/schema/src/adapters/valibot.ts
+++ b/packages/schema/src/adapters/valibot.ts
@@ -25,15 +25,21 @@ function mapValibotIssues(issues: v.BaseIssue<unknown>[]): SchemaIssue[] {
   })
 }
 
-let _toJsonSchemaFn: ((schema: any) => Record<string, unknown>) | null | undefined
-
-import('@valibot/to-json-schema')
-  .then((mod) => {
-    _toJsonSchemaFn = mod.toJsonSchema as (schema: any) => Record<string, unknown>
-  })
-  .catch(() => {
-    _toJsonSchemaFn = null
-  })
+// Resolve `@valibot/to-json-schema` synchronously at module-load via
+// top-level await. The previous dangling-promise pattern raced with
+// the first `toJsonSchema()` call on fast CI runners — tests that
+// asserted on `properties` saw the `{ type: 'object' }` fallback
+// because the dynamic import hadn't resolved yet. Top-level await
+// blocks the importer until the optional peer either loads or
+// confirms it's missing; adopters without the peer installed still
+// land at the same `_toJsonSchemaFn = null` fallback (the catch).
+let _toJsonSchemaFn: ((schema: any) => Record<string, unknown>) | null
+try {
+  const mod = await import('@valibot/to-json-schema')
+  _toJsonSchemaFn = mod.toJsonSchema as (schema: any) => Record<string, unknown>
+} catch {
+  _toJsonSchemaFn = null
+}
 
 function valibotToJsonSchema(schema: any, _options?: JsonSchemaOptions): Record<string, unknown> {
   if (_toJsonSchemaFn) {


### PR DESCRIPTION
## Why

CI failed on `packages/schema` with two Valibot JSON-Schema tests:

```
× generates JSON Schema via toJsonSchema()
× generates JSON Schema from auto-detected Valibot schema
AssertionError: expected undefined to be defined
 ❯ __tests__/valibot-adapter.test.ts:101:35
   expect(jsonSchema.properties).toBeDefined()
```

Race condition. `packages/schema/src/adapters/valibot.ts` resolved `@valibot/to-json-schema` via a dangling `import(...).then(...)` promise — adopters and tests racing the resolution would call `toJsonSchema()` before `_toJsonSchemaFn` got assigned, landing at the `{ type: 'object' }` fallback. Local runs were slow enough that the import resolved first; CI runners are faster and lost the race consistently.

## What

Top-level `await import(...)` inside a try/catch. Blocks `valibot.ts` module load until the optional peer either resolves or confirms it's missing. Adopters without the peer still land at the same `_toJsonSchemaFn = null` fallback (the catch); adopters with it installed get the real conversion on every call after module load.

Dist is ESM (`tsdown.config.ts` ships `format: ['esm']`), so top-level await emits cleanly. `@valibot/to-json-schema` is ESM-only, so `createRequire(import.meta.url)` wasn't an option.

## Test plan

- [x] `pnpm --filter @forinda/kickjs-schema test` — 60/60
- [x] Pre-commit hooks (lint, format, lint-tokens) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
