### PR TITLE
fix(schema): lazy-load valibot peer so package loads without it

### DIFF
--- a/.changeset/valibot-peer-lazy.md
+++ b/.changeset/valibot-peer-lazy.md
@@ -1,0 +1,9 @@
+---
+'@forinda/kickjs-schema': patch
+---
+
+Fix module-load crash when the `valibot` peer is not installed. `packages/schema/src/adapters/valibot.ts` static-imported `valibot` at the top of the file, so any consumer of `@forinda/kickjs-schema` (including the CLI, which loads `detect.ts` which static-imports every adapter) crashed with `ERR_MODULE_NOT_FOUND` when the peer was absent — even adopters who only used Zod paid the cost.
+
+Switched to top-level `await import('valibot')` inside try/catch (same pattern as the `@valibot/to-json-schema` fix in 0.1.1). When the peer is absent `v` lands at `null` and `fromValibot()` throws a clear error message at call time. When present, behaviour is identical to before.
+
+`isValibotSchema()` works without the peer (pure duck-type), so `detectSchema()` can still skip past a non-Valibot input on a Zod-only project.

--- a/.changeset/valibot-tojsonschema-race.md
+++ b/.changeset/valibot-tojsonschema-race.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-schema': patch
+---
+
+Fix race condition where `fromValibot(...).toJsonSchema()` returned the `{ type: 'object' }` fallback on fast runners (CI). The previous dangling `import('@valibot/to-json-schema').then(...)` resolved asynchronously, so the first `toJsonSchema()` call frequently fired before `_toJsonSchemaFn` got assigned. Replaced with top-level `await import(...)` inside a try/catch — adopters without the peer still land at the same `_toJsonSchemaFn = null` fallback, but adopters who have it installed get the real conversion every time.

--- a/packages/schema/src/adapters/valibot.ts
+++ b/packages/schema/src/adapters/valibot.ts
@@ -25,15 +25,21 @@ function mapValibotIssues(issues: v.BaseIssue<unknown>[]): SchemaIssue[] {
   })
 }
 
-let _toJsonSchemaFn: ((schema: any) => Record<string, unknown>) | null | undefined
-
-import('@valibot/to-json-schema')
-  .then((mod) => {
-    _toJsonSchemaFn = mod.toJsonSchema as (schema: any) => Record<string, unknown>
-  })
-  .catch(() => {
-    _toJsonSchemaFn = null
-  })
+// Resolve `@valibot/to-json-schema` synchronously at module-load via
+// top-level await. The previous dangling-promise pattern raced with
+// the first `toJsonSchema()` call on fast CI runners — tests that
+// asserted on `properties` saw the `{ type: 'object' }` fallback
+// because the dynamic import hadn't resolved yet. Top-level await
+// blocks the importer until the optional peer either loads or
+// confirms it's missing; adopters without the peer installed still
+// land at the same `_toJsonSchemaFn = null` fallback (the catch).
+let _toJsonSchemaFn: ((schema: any) => Record<string, unknown>) | null
+try {
+  const mod = await import('@valibot/to-json-schema')
+  _toJsonSchemaFn = mod.toJsonSchema as (schema: any) => Record<string, unknown>
+} catch {
+  _toJsonSchemaFn = null
+}
 
 function valibotToJsonSchema(schema: any, _options?: JsonSchemaOptions): Record<string, unknown> {
   if (_toJsonSchemaFn) {

--- a/packages/schema/src/adapters/valibot.ts
+++ b/packages/schema/src/adapters/valibot.ts
@@ -1,8 +1,29 @@
-import * as v from 'valibot'
+import type * as VType from 'valibot'
 import type { KickSchema, SchemaResult, SchemaIssue, JsonSchemaOptions } from '../types.js'
 import type { InferSchemaOutput } from '../infer.js'
 
+// Resolve the `valibot` peer synchronously at module load. The previous
+// static `import * as v from 'valibot'` crashed the entire schema
+// package whenever the optional peer wasn't installed — even adopters
+// who only used Zod paid the cost because `detect.ts` static-imports
+// every adapter for runtime routing. Top-level `await import(...)`
+// inside try/catch keeps the package loadable when the peer is absent;
+// `fromValibot()` then throws the contextual error below on first call.
+let v: typeof VType | null
+try {
+  v = await import('valibot')
+} catch {
+  v = null
+}
+
+const PEER_MISSING_ERROR =
+  '@forinda/kickjs-schema/valibot requires the `valibot` peer to be installed. ' +
+  'Run `pnpm add valibot` (or your package manager equivalent).'
+
 export function isValibotSchema(schema: unknown): boolean {
+  // Pure duck-type — works without the peer installed (callers can
+  // ask "is this Valibot?" against arbitrary input even when they
+  // never intend to wrap it).
   return (
     schema != null &&
     typeof schema === 'object' &&
@@ -12,7 +33,7 @@ export function isValibotSchema(schema: unknown): boolean {
   )
 }
 
-function mapValibotIssues(issues: v.BaseIssue<unknown>[]): SchemaIssue[] {
+function mapValibotIssues(issues: VType.BaseIssue<unknown>[]): SchemaIssue[] {
   return issues.map((issue) => {
     const mapped: SchemaIssue = {
       path: (issue.path ?? []).map((seg: any) => String(seg?.key ?? seg)),
@@ -54,9 +75,11 @@ function valibotToJsonSchema(schema: any, _options?: JsonSchemaOptions): Record<
  * Schema phantom so `kick typegen` can extend `KickEnv` from it. */
 export function fromValibot<TSchema>(schema: TSchema): KickSchema<InferSchemaOutput<TSchema>>
 export function fromValibot(schema: any): KickSchema<any> {
+  if (!v) throw new Error(PEER_MISSING_ERROR)
+  const valibot = v
   return {
     safeParse(data: unknown): SchemaResult<any> {
-      const result = v.safeParse(schema, data)
+      const result = valibot.safeParse(schema, data)
       if (result.success) {
         return { success: true, data: result.output }
       }

--- a/packages/schema/src/adapters/valibot.ts
+++ b/packages/schema/src/adapters/valibot.ts
@@ -2,17 +2,40 @@ import type * as VType from 'valibot'
 import type { KickSchema, SchemaResult, SchemaIssue, JsonSchemaOptions } from '../types.js'
 import type { InferSchemaOutput } from '../infer.js'
 
+/**
+ * Recognise the specific "optional peer not installed" rejection from
+ * `await import(...)`. Bare `catch {}` would also swallow real
+ * import-time / evaluation errors (the peer is installed but threw
+ * while initialising, or its version is incompatible) — those should
+ * surface as the actual crash, not silently degrade to the `null`
+ * fallback.
+ *
+ * Node throws `ERR_MODULE_NOT_FOUND` for ESM dynamic imports and
+ * `MODULE_NOT_FOUND` for CJS; the message embeds the missing
+ * specifier so a transitive peer crash inside the optional package
+ * doesn't match this filter.
+ */
+function isMissingOptionalPeer(error: unknown, specifier: string): boolean {
+  if (!(error instanceof Error)) return false
+  const code = (error as { code?: unknown }).code
+  if (code !== 'ERR_MODULE_NOT_FOUND' && code !== 'MODULE_NOT_FOUND') return false
+  return error.message.includes(specifier)
+}
+
 // Resolve the `valibot` peer synchronously at module load. The previous
 // static `import * as v from 'valibot'` crashed the entire schema
 // package whenever the optional peer wasn't installed — even adopters
 // who only used Zod paid the cost because `detect.ts` static-imports
 // every adapter for runtime routing. Top-level `await import(...)`
-// inside try/catch keeps the package loadable when the peer is absent;
-// `fromValibot()` then throws the contextual error below on first call.
+// inside a narrowed try/catch keeps the package loadable when the peer
+// is absent; `fromValibot()` then throws the contextual error below on
+// first call. Anything *other* than a missing-peer error re-throws so
+// init failures surface instead of degrading silently.
 let v: typeof VType | null
 try {
   v = await import('valibot')
-} catch {
+} catch (err) {
+  if (!isMissingOptionalPeer(err, 'valibot')) throw err
   v = null
 }
 
@@ -58,7 +81,8 @@ let _toJsonSchemaFn: ((schema: any) => Record<string, unknown>) | null
 try {
   const mod = await import('@valibot/to-json-schema')
   _toJsonSchemaFn = mod.toJsonSchema as (schema: any) => Record<string, unknown>
-} catch {
+} catch (err) {
+  if (!isMissingOptionalPeer(err, '@valibot/to-json-schema')) throw err
   _toJsonSchemaFn = null
 }
 


### PR DESCRIPTION
## Why

`@forinda/kickjs-schema@0.1.1` crashes any consumer that doesn't have `valibot` installed:

```
Failed to load CLI: Error [ERR_MODULE_NOT_FOUND]:
Cannot find package 'valibot' imported from
node_modules/@forinda/kickjs-schema/dist/valibot-*.mjs
```

Repro: `npx -y @forinda/kickjs-cli@latest new myapp --yes` — the CLI itself fails to boot because `detect.ts` static-imports every adapter for runtime routing, and `valibot.ts` had a top-of-file `import * as v from 'valibot'`. Zod-only adopters paid the cost too.

This also blocked the new `--schema` flag from being exercised (CLI couldn't even print `--help`).

## What

Mirrors the `@valibot/to-json-schema` fix from #302: top-level `await import('valibot')` inside try/catch, with `v` typed against `import type * as VType from 'valibot'`.

- Peer present → behaviour identical to before.
- Peer absent → `v = null`, `fromValibot()` throws `@forinda/kickjs-schema/valibot requires the valibot peer to be installed.` at call time.
- `isValibotSchema()` keeps working without the peer (pure duck-type), so `detectSchema()` can still skip Valibot when scanning arbitrary input.

## Test plan

- [x] `pnpm --filter @forinda/kickjs-schema test` — 60/60
- [x] Pre-commit hooks (lint, format) — green
- [ ] After publish: `npx -y @forinda/kickjs-cli@latest new myapp --yes` succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved race condition in JSON schema conversion from Valibot schemas that could produce incomplete output.
  * Improved optional Valibot peer dependency handling: module no longer crashes on startup when Valibot is missing; instead, clear error messages appear when Valibot features are actually used.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/forinda/kick-js/pull/304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->