### PR TITLE
fix(kickjs,cli): optional zod peer, resilient typegen, dev asset resolution for .ts configs

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -231,12 +231,35 @@ git checkout -b feat/route-table-on-startup
 git add packages/http/
 git commit -m "feat: print route table on application startup (#31)"
 
-# 3. Push and create PR
+# 3. Push and create PR (rich bodies go through a temp file — see below)
 git push -u origin feat/route-table-on-startup
-gh pr create --title "feat: print route table on startup" --body "Closes #31"
+gh pr create --title "feat: print route table on startup" --body-file /tmp/pr-body.md
 
 # 4. After review, merge via GitHub (squash or merge commit)
 ```
+
+### PR / issue bodies with markdown — always via a temp file
+
+Anything richer than a single-line description (code fences, lists, tables, backticks, `$`, multi-paragraph) goes through a temp file. **Never** inline a multi-line body in `gh pr create --body "$(cat <<'EOF' ... EOF)"` or `gh pr edit --body "..."` — the shell escapes backticks and dollar signs, fenced code blocks lose their language hint, and the body lands on GitHub with literal `\`` everywhere.
+
+```bash
+# Right — write the body to a file, then pass it:
+cat > /tmp/pr-body.md <<'EOF'
+## Why
+…full markdown, no escape gymnastics…
+EOF
+
+gh pr create --base main --title "…" --body-file /tmp/pr-body.md
+
+# Edits to existing PRs take --body-file too:
+gh pr edit 123 --body-file /tmp/pr-body.md
+
+# If `gh pr edit` exits non-zero (often: projects-classic deprecation),
+# fall back to the API:
+gh api -X PATCH /repos/<owner>/<repo>/pulls/123 -F body=@/tmp/pr-body.md
+```
+
+Same rule for `gh issue create`, `gh release create`, comment posts (`gh pr comment 123 --body-file …`), and changeset bodies committed to disk.
 
 ### Branch naming
 

--- a/.changeset/lazy-zod-peer.md
+++ b/.changeset/lazy-zod-peer.md
@@ -1,0 +1,7 @@
+---
+'@forinda/kickjs': patch
+---
+
+Make `zod` a truly optional peer dependency. `src/config/env.ts` previously did a top-level `import { z } from 'zod'` and built `baseEnvSchema` eagerly; since the env module is re-exported from the main entry, `import { anything } from '@forinda/kickjs'` pulled zod into the eager graph and crashed at build/load time for apps that validate env with Valibot/Yup/Standard Schema and never installed zod.
+
+zod is now lazy-loaded only when the Zod env helpers (`baseEnvSchema`, `defineEnv`, `loadEnv`) are actually used, with a clear error if it's missing. `baseEnvSchema` is now a lazy view that doesn't construct (or load zod) until accessed. The non-zod path (`loadEnvFromSchema`) needs no zod at all. `zod` is also marked `optional` in `peerDependenciesMeta`.

--- a/.changeset/typegen-resilience-and-dev-assets.md
+++ b/.changeset/typegen-resilience-and-dev-assets.md
@@ -1,0 +1,10 @@
+---
+'@forinda/kickjs-cli': patch
+'@forinda/kickjs': patch
+---
+
+Fix asset manager interfering with controller typegen, and make `assets.x.y()` resolve in dev for `kick.config.ts` projects.
+
+- **Typegen runner is now per-plugin isolated.** A throw in one typegen plugin (e.g. `kick/assets`) no longer aborts the whole pass — it's reported as an `error` and the remaining plugins (e.g. `kick/routes`) still run. Previously one failing plugin left the controller route types ungenerated.
+- **The stale-file sweep is now an allowlist, not a denylist.** It only removes the known pre-carve legacy filenames (`assets.d.ts`, `env.ts`, `routes.ts`) and never touches unknown/custom files. Previously, when the plugin pass returned nothing (e.g. it aborted), the sweep deleted live `kick__routes.ts` / `kick__assets.d.ts` — wiping controller types project-wide.
+- **Dev-mode asset resolution now works with `kick.config.ts`.** The runtime resolver reads config synchronously and can't transpile TS, so a `.ts`-config project had no manifest to resolve from until the first production build (`assets.x.y()` threw `UnknownAssetError`). The CLI now mirrors the JSON-serialisable `assetMap` + `build.outDir` into `.kickjs/kick.config.json` whenever it loads the config, and the runtime resolver reads that snapshot as a fallback.

--- a/packages/cli/__tests__/helpers.ts
+++ b/packages/cli/__tests__/helpers.ts
@@ -198,8 +198,18 @@ export function runCli(cwd: string, args: string[]): CliResult {
  * generate.
  */
 export function runTsc(cwd: string): CliResult {
-  const tsgoBin = resolve(WORKSPACE_ROOT, 'node_modules', '.pnpm', 'node_modules', '.bin', 'tsgo')
-  const candidates = [tsgoBin, resolve(WORKSPACE_ROOT, 'node_modules', '.bin', 'tsgo')]
+  // On Windows the runnable shim is `tsgo.CMD` / `tsgo.cmd`, not the
+  // extensionless `tsgo` (a POSIX shell script). spawnSync can't launch
+  // the latter on win32 — it returns status -1 with empty output, which
+  // surfaces as a bogus "tsc failed" carrying no diagnostics. Probe the
+  // platform-correct names so the helper works on every host.
+  const dirs = [
+    resolve(WORKSPACE_ROOT, 'node_modules', '.pnpm', 'node_modules', '.bin'),
+    resolve(WORKSPACE_ROOT, 'node_modules', '.bin'),
+  ]
+  const names =
+    process.platform === 'win32' ? ['tsgo.CMD', 'tsgo.cmd', 'tsgo.exe', 'tsgo'] : ['tsgo']
+  const candidates = dirs.flatMap((d) => names.map((n) => resolve(d, n)))
   const tsc = candidates.find((p) => existsSync(p))
   if (!tsc) {
     throw new Error(
@@ -210,6 +220,8 @@ export function runTsc(cwd: string): CliResult {
     cwd,
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
+    // `.CMD` shims require a shell on Windows.
+    shell: process.platform === 'win32',
   })
   return {
     exitCode: result.status ?? -1,

--- a/packages/cli/__tests__/typegen-legacy-cleanup.test.ts
+++ b/packages/cli/__tests__/typegen-legacy-cleanup.test.ts
@@ -10,8 +10,10 @@
  *     plugin actually emits it (i.e. assetMap is non-empty). With no
  *     assets, the import would dangle.
  *  3. `sweepStaleTypegen` removes orphaned files left by older CLI
- *     versions (`assets.d.ts`, `env.ts`, `routes.ts`, plus any other
- *     top-level file not in the current expected set).
+ *     versions (`assets.d.ts`, `env.ts`, `routes.ts`) — and ONLY those
+ *     known legacy names. It is an allowlist, not a denylist: unknown /
+ *     custom files are always preserved so an aborted plugin pass can
+ *     never wipe live output (e.g. `kick__routes.ts`).
  *
  * @module @forinda/kickjs-cli/__tests__/typegen-legacy-cleanup.test
  */
@@ -164,27 +166,38 @@ describe('sweepStaleTypegen', () => {
     expect(removed).toEqual([])
   })
 
-  it('skips orphan removal for plugin outputs that the runner reported', async () => {
-    // Reproduces the upgrade case: the plugin runner names its output
-    // `kick__assets.d.ts` based on the plugin id; sweep must keep
-    // that file even though no generator wrote it.
+  it('preserves unknown/custom files — only known legacy orphans are candidates', async () => {
+    // Safety regression: the sweep used to be a denylist ("delete
+    // anything not in the expected set"). That meant an aborted plugin
+    // pass (empty pluginResults) could delete live files like
+    // `kick__routes.ts` — wiping controller route types project-wide.
+    // It's now an allowlist of pre-carve legacy filenames, so unknown
+    // files are always left alone regardless of the expected set.
     await mkdir(outDir, { recursive: true })
     writeFileSync(join(outDir, 'kick__assets.d.ts'), '/* plugin */')
-    writeFileSync(join(outDir, 'leftover.d.ts'), '/* orphan */')
+    writeFileSync(join(outDir, 'kick__routes.ts'), '/* plugin */')
+    writeFileSync(join(outDir, 'leftover.d.ts'), '/* custom — must survive */')
 
+    // Empty generator + plugin results simulate the aborted-pass case.
+    const removed = await sweepStaleTypegen(outDir, [], [], true)
+    expect(removed).toEqual([])
+    expect(existsSync(join(outDir, 'kick__assets.d.ts'))).toBe(true)
+    expect(existsSync(join(outDir, 'kick__routes.ts'))).toBe(true)
+    expect(existsSync(join(outDir, 'leftover.d.ts'))).toBe(true)
+  })
+
+  it('keeps a legacy-named file when the runner reported it as a plugin output', async () => {
+    // Contrived collision: a plugin output whose filename matches a
+    // legacy orphan name. The reported `outFile` wins — never swept.
+    await mkdir(outDir, { recursive: true })
+    writeFileSync(join(outDir, 'assets.d.ts'), '/* still owned */')
     const removed = await sweepStaleTypegen(
       outDir,
       [],
-      [
-        {
-          id: 'kick/assets',
-          status: 'written',
-          outFile: join(outDir, 'kick__assets.d.ts'),
-        },
-      ],
+      [{ id: 'legacy/assets', status: 'written', outFile: join(outDir, 'assets.d.ts') }],
       true,
     )
-    expect(removed).toEqual(['leftover.d.ts'])
-    expect(existsSync(join(outDir, 'kick__assets.d.ts'))).toBe(true)
+    expect(removed).toEqual([])
+    expect(existsSync(join(outDir, 'assets.d.ts'))).toBe(true)
   })
 })

--- a/packages/cli/__tests__/typegen-runner.test.ts
+++ b/packages/cli/__tests__/typegen-runner.test.ts
@@ -76,6 +76,38 @@ describe('runTypegen', () => {
     expect(r[0].outFile).toMatch(/kick__db\.d\.ts$/)
   })
 
+  it('isolates a throwing plugin so later plugins still run', async () => {
+    // Regression: a throw in one plugin used to abort the whole loop,
+    // so a downstream plugin (e.g. kick/routes after kick/assets) never
+    // ran. Order here mirrors that: the thrower precedes the survivor.
+    const thrower: TypegenPlugin = {
+      id: 'kick/assets',
+      inputs: [],
+      async generate() {
+        throw new Error('boom')
+      },
+    }
+    const survivor: TypegenPlugin = {
+      id: 'kick/routes',
+      inputs: [],
+      async generate() {
+        return 'export type R = 1'
+      },
+    }
+    const r = await runTypegen({
+      cwd: dir,
+      config: {} as never,
+      plugins: [thrower, survivor],
+    })
+    expect(r[0]).toMatchObject({ id: 'kick/assets', status: 'error' })
+    // The errored plugin still reports its outFile so a downstream sweep
+    // keeps any previously-good output instead of deleting it.
+    expect(r[0].outFile).toMatch(/kick__assets\.d\.ts$/)
+    expect(r[1]).toMatchObject({ id: 'kick/routes', status: 'written' })
+    const out = await readFile(r[1].outFile!, 'utf8')
+    expect(out).toContain('R = 1')
+  })
+
   it('getScanResult memoizes across plugins within the same pass', async () => {
     let scanCalls = 0
     const stubScan = async () => {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { readFile, access } from 'node:fs/promises'
 import { isAbsolute, join, relative, resolve } from 'node:path'
 
@@ -621,6 +621,7 @@ export async function loadKickConfig(startDir: string): Promise<KickConfig | nul
         const config = (await jiti.import(filepath, { default: true })) as KickConfig
         const warnings = validateAssetMap(config, root)
         for (const warning of warnings) console.warn(`  Warning: ${warning}`)
+        writeAssetConfigSnapshot(root, config)
         return config
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
@@ -635,6 +636,7 @@ export async function loadKickConfig(startDir: string): Promise<KickConfig | nul
       const config = (mod.default ?? mod) as KickConfig
       const warnings = validateAssetMap(config, root)
       for (const warning of warnings) console.warn(`  Warning: ${warning}`)
+      writeAssetConfigSnapshot(root, config)
       return config
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
@@ -643,6 +645,44 @@ export async function loadKickConfig(startDir: string): Promise<KickConfig | nul
     }
   }
   return null
+}
+
+/**
+ * Mirror the JSON-serialisable slice of a TS/JS `kick.config` that the
+ * runtime asset resolver needs (`assetMap` + `build.outDir`) into
+ * `.kickjs/kick.config.json`.
+ *
+ * Why: the runtime resolver in `@forinda/kickjs` reads its config
+ * *synchronously* (it sits on the hot path of `assets.x.y()` /
+ * `resolveAsset()`), so it can only parse `kick.config.{json,js,cjs}` —
+ * it deliberately can't transpile `kick.config.ts`. For a `.ts`-config
+ * project in dev (no built `dist/.kickjs-assets.json` yet), that left
+ * the resolver with no config to synthesise a manifest from, so
+ * `assets.x.y()` threw `UnknownAssetError` until the first build.
+ *
+ * The CLI already transpiles the `.ts` config here, so it drops this
+ * tiny snapshot the runtime can read with a plain `JSON.parse`. Best
+ * effort: any failure (read-only fs, etc.) is swallowed — a missing
+ * snapshot just falls back to the previous behaviour.
+ */
+export function writeAssetConfigSnapshot(root: string, config: KickConfig | null): void {
+  // Only meaningful for asset-manager users — don't litter `.kickjs/`
+  // for projects that never declare an assetMap.
+  if (!config?.assetMap || Object.keys(config.assetMap).length === 0) return
+  try {
+    const dir = join(root, '.kickjs')
+    mkdirSync(dir, { recursive: true })
+    const snapshot = {
+      // Marker so a future shape change can be detected/migrated.
+      version: 1 as const,
+      assetMap: config.assetMap,
+      ...(config.build?.outDir ? { build: { outDir: config.build.outDir } } : {}),
+    }
+    writeFileSync(join(dir, 'kick.config.json'), JSON.stringify(snapshot, null, 2) + '\n', 'utf-8')
+  } catch {
+    // Best effort — snapshot is an optimisation, not a correctness
+    // requirement. Production reads the real dist manifest.
+  }
 }
 
 /**

--- a/packages/cli/src/typegen/index.ts
+++ b/packages/cli/src/typegen/index.ts
@@ -400,9 +400,6 @@ export async function sweepStaleTypegen(
   for (const r of pluginResults) {
     if (r.outFile) expected.add(basename(r.outFile))
   }
-  // Hidden files we own at the types/ level — none today, but the
-  // gitignore at .kickjs/.gitignore lives one level up so it's not
-  // a candidate here.
   let entries: string[]
   try {
     entries = await readdir(outDir)
@@ -411,6 +408,16 @@ export async function sweepStaleTypegen(
   }
   const removed: string[] = []
   for (const name of entries) {
+    // Allowlist, NOT denylist. The earlier "delete anything not in the
+    // expected set" form was a footgun: if the plugin pass aborted
+    // (e.g. one plugin threw and the runner bubbled it up, so
+    // `pluginResults` came back empty), the expected set lost
+    // `kick__routes.ts` / `kick__assets.d.ts` / `kick__env.ts` and the
+    // sweep deleted those good files — wiping controller route types
+    // project-wide. We now only remove the specific pre-carve filenames
+    // the legacy generator used to emit, and only when the current pass
+    // didn't (re)write them. Anything else is left untouched.
+    if (!LEGACY_ORPHAN_FILES.has(name)) continue
     if (expected.has(name)) continue
     const abs = resolve(outDir, name)
     try {
@@ -427,3 +434,15 @@ export async function sweepStaleTypegen(
   }
   return removed
 }
+
+/**
+ * Pre-carve filenames the legacy generator emitted directly before
+ * `kick/routes`, `kick/env`, and `kick/assets` became typegen plugins
+ * (which now write `kick__routes.ts` / `kick__env.ts` /
+ * `kick__assets.d.ts`). A project that upgraded across the M2.B-T8
+ * carve has these as orphans on disk; the sweep removes them so the
+ * augmentations aren't declared twice. None of these names collide with
+ * any file the current generator or plugins emit, so the sweep can
+ * never touch live output.
+ */
+const LEGACY_ORPHAN_FILES: ReadonlySet<string> = new Set(['assets.d.ts', 'env.ts', 'routes.ts'])

--- a/packages/cli/src/typegen/plugin.ts
+++ b/packages/cli/src/typegen/plugin.ts
@@ -73,7 +73,7 @@ export interface TypegenPlugin {
 
 export interface TypegenPluginResult {
   id: string
-  status: 'written' | 'unchanged' | 'skipped'
+  status: 'written' | 'unchanged' | 'skipped' | 'error'
   outFile?: string
 }
 

--- a/packages/cli/src/typegen/runner.ts
+++ b/packages/cli/src/typegen/runner.ts
@@ -76,18 +76,35 @@ export async function runTypegen(opts: RunTypegenOptions): Promise<TypegenPlugin
 
   const results: TypegenPluginResult[] = []
   for (const plugin of opts.plugins) {
-    const out = await plugin.generate(ctx)
+    // Slashes in ids (kick/db) → __ on disk so they're valid filenames.
+    // Default extension is .d.ts (declaration only); plugins emitting
+    // hoisted top-level imports (kick/routes) override to .ts so the
+    // bundler resolver sees them as proper modules.
+    // Computed BEFORE generate() so a failing plugin can still report
+    // its `outFile` — the downstream sweep keeps any file in the
+    // result set, so a transient generate() throw never deletes this
+    // plugin's previously-good output.
+    const ext = plugin.outExtension ?? '.d.ts'
+    const file = path.join(typesDirAbs, `${plugin.id.replace(/\//g, '__')}${ext}`)
+
+    let out: string | null
+    try {
+      out = await plugin.generate(ctx)
+    } catch (err) {
+      // Isolate the failure: one plugin throwing must not abort the
+      // rest of the pass (before this guard, a throw in e.g. kick/assets
+      // aborted the whole loop, so kick/routes never ran and the sweep
+      // then deleted the stale-looking controller route types).
+      const msg = err instanceof Error ? err.message : String(err)
+      ctx.log.error(`  ${plugin.id}: typegen failed (${msg}) — keeping previous output`)
+      results.push({ id: plugin.id, status: 'error', outFile: file })
+      continue
+    }
     if (out === null) {
       results.push({ id: plugin.id, status: 'skipped' })
       continue
     }
 
-    // Slashes in ids (kick/db) → __ on disk so they're valid filenames.
-    // Default extension is .d.ts (declaration only); plugins emitting
-    // hoisted top-level imports (kick/routes) override to .ts so the
-    // bundler resolver sees them as proper modules.
-    const ext = plugin.outExtension ?? '.d.ts'
-    const file = path.join(typesDirAbs, `${plugin.id.replace(/\//g, '__')}${ext}`)
     const banner = `${BANNER_PREFIX}${plugin.id} */\n\n`
     const next = banner + out + '\n'
 

--- a/packages/kickjs/__tests__/env-lazy-zod.test.ts
+++ b/packages/kickjs/__tests__/env-lazy-zod.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Locks the "zod is an optional peer" guarantee.
+ *
+ * `packages/kickjs/src/config/env.ts` used to `import { z } from 'zod'`
+ * at module top-level and build `baseEnvSchema = z.object(...)` eagerly.
+ * Because the env module is re-exported from the main `@forinda/kickjs`
+ * entry, that turned zod into a *hard* dependency of the whole
+ * framework: `import { anything } from '@forinda/kickjs'` crashed at
+ * load time for any app that validates env via Valibot / Yup / a plain
+ * function and never installed zod.
+ *
+ * zod is now lazy-loaded only inside `baseEnvSchema` / `defineEnv` /
+ * `loadEnv`. The non-zod path (`loadEnvFromSchema` → `detectSchema`)
+ * must validate env without ever touching zod.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { Container, loadEnvFromSchema, resetEnvCache } from '../src'
+
+afterEach(() => {
+  resetEnvCache()
+  Container.reset()
+  delete process.env.LAZY_ZOD_PORT
+})
+
+describe('env validation without zod (loadEnvFromSchema)', () => {
+  it('validates process.env via a plain function schema — no zod required', () => {
+    process.env.LAZY_ZOD_PORT = '4321'
+    // A function validator is one of the non-zod shapes detectSchema
+    // accepts. Reaching this far never loads zod.
+    const env = loadEnvFromSchema((raw: Record<string, string | undefined>) => ({
+      LAZY_ZOD_PORT: Number(raw.LAZY_ZOD_PORT),
+    })) as { LAZY_ZOD_PORT: number }
+
+    expect(env.LAZY_ZOD_PORT).toBe(4321)
+  })
+
+  it('wires the @Value resolver from the non-zod result', () => {
+    process.env.LAZY_ZOD_PORT = '9999'
+    loadEnvFromSchema((raw: Record<string, string | undefined>) => ({
+      LAZY_ZOD_PORT: Number(raw.LAZY_ZOD_PORT),
+    }))
+    // _envResolver is what @Value() / ConfigService read through.
+    expect(Container._envResolver?.('LAZY_ZOD_PORT')).toBe(9999)
+  })
+})

--- a/packages/kickjs/package.json
+++ b/packages/kickjs/package.json
@@ -119,6 +119,9 @@
     },
     "multer": {
       "optional": true
+    },
+    "zod": {
+      "optional": true
     }
   },
   "devDependencies": {

--- a/packages/kickjs/src/config/env.ts
+++ b/packages/kickjs/src/config/env.ts
@@ -70,16 +70,34 @@ tryLoadDotenv()
  * schema instance (matters for the `cachedSchema === s` identity check
  * in {@link loadEnv}). Loads zod lazily via {@link getZod}.
  */
-let _baseEnvSchema: z.ZodObject<any> | undefined
-export function getBaseEnvSchema(): z.ZodObject<any> {
-  if (_baseEnvSchema) return _baseEnvSchema
+// Build the concrete base schema. This function is the single source of
+// the *type* of `baseEnvSchema` (via `ReturnType<typeof buildBaseEnvSchema>`)
+// AND its runtime value (via `getBaseEnvSchema`). It is NEVER called at
+// module load — only lazily through `getBaseEnvSchema()` — so referencing
+// its return type stays compile-time-only and pulls no eager zod import.
+// Spelling the type this way (rather than `z.ZodObject<any>`) preserves the
+// precise PORT/NODE_ENV/LOG_LEVEL shape, which `defineEnv` composition and
+// the `kick typegen` `KickEnv` inference depend on.
+function buildBaseEnvSchema() {
   const z = getZod()
-  _baseEnvSchema = z.object({
+  return z.object({
     // Server
     PORT: z.coerce.number().default(3000),
     NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
     LOG_LEVEL: z.string().default('info'),
   })
+}
+
+/** Precise type of the base env schema — no runtime value, no eager zod. */
+export type BaseEnvSchema = ReturnType<typeof buildBaseEnvSchema>
+
+/**
+ * Memoized base schema. Reuses one instance so the `cachedSchema === s`
+ * identity check in {@link loadEnv} holds. Loads zod lazily.
+ */
+let _baseEnvSchema: BaseEnvSchema | undefined
+export function getBaseEnvSchema(): BaseEnvSchema {
+  if (!_baseEnvSchema) _baseEnvSchema = buildBaseEnvSchema()
   return _baseEnvSchema
 }
 
@@ -91,9 +109,9 @@ export function getBaseEnvSchema(): z.ZodObject<any> {
  * Proxy does NOT load zod — zod is only required the moment a property
  * (`.extend`, `.parse`, `.shape`, …) is actually accessed. This keeps
  * `import { baseEnvSchema } from '@forinda/kickjs'` zero-cost for apps
- * that don't use the Zod env path.
+ * that don't use the Zod env path, while keeping the precise schema type.
  */
-export const baseEnvSchema: z.ZodObject<any> = new Proxy({} as z.ZodObject<any>, {
+export const baseEnvSchema: BaseEnvSchema = new Proxy({} as BaseEnvSchema, {
   get(_t, prop) {
     const real = getBaseEnvSchema() as unknown as Record<string | symbol, unknown>
     const value = real[prop]
@@ -103,7 +121,7 @@ export const baseEnvSchema: z.ZodObject<any> = new Proxy({} as z.ZodObject<any>,
   has(_t, prop) {
     return prop in (getBaseEnvSchema() as object)
   },
-}) as z.ZodObject<any>
+}) as BaseEnvSchema
 
 /** Cached env config to avoid re-parsing — keyed by schema reference */
 let cachedEnv: any = null

--- a/packages/kickjs/src/config/env.ts
+++ b/packages/kickjs/src/config/env.ts
@@ -1,7 +1,39 @@
-import { z } from 'zod'
+import type { z } from 'zod'
 import { detectSchema, type InferSchemaOutput } from '@forinda/kickjs-schema'
 import { Container } from '../core/container'
 import type { EnvKey } from '../core/decorators'
+
+/**
+ * Lazy `zod` accessor. `zod` is an **optional** peer of
+ * `@forinda/kickjs` — only the Zod-based env helpers (`baseEnvSchema`,
+ * `defineEnv`, `loadEnv`) need it. Apps that validate env via Valibot /
+ * Yup / Standard Schema go through `loadEnvFromSchema` (which only
+ * touches the validator-agnostic `detectSchema`) and never load zod.
+ *
+ * Importing `zod` at module top-level made it a *hard* dependency of
+ * the whole framework: `import { anything } from '@forinda/kickjs'`
+ * eagerly evaluated this module, so a non-Zod app with no `zod`
+ * installed crashed at module load / build time ("Cannot find module
+ * 'zod'"). Deferring the require to first use keeps the import out of
+ * the eager graph.
+ */
+let _zod: typeof import('zod') | undefined
+function getZod(): typeof import('zod') {
+  if (_zod) return _zod
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    _zod = require('zod') as typeof import('zod')
+  } catch {
+    throw new Error(
+      "@forinda/kickjs: the 'zod' peer dependency is required for " +
+        'baseEnvSchema / defineEnv / loadEnv but is not installed. ' +
+        'Install it (`pnpm add zod`), or define your env with a non-Zod ' +
+        'schema and call loadEnvFromSchema() instead — @forinda/kickjs-schema ' +
+        'supports Valibot, Yup, and any Standard Schema validator without zod.',
+    )
+  }
+  return _zod
+}
 
 /**
  * Lazily load `.env` via dotenv if it is installed in the consumer app.
@@ -34,15 +66,44 @@ function tryLoadDotenv(): void {
 tryLoadDotenv()
 
 /**
+ * Build the base env schema. Memoized so repeated calls reuse one
+ * schema instance (matters for the `cachedSchema === s` identity check
+ * in {@link loadEnv}). Loads zod lazily via {@link getZod}.
+ */
+let _baseEnvSchema: z.ZodObject<any> | undefined
+export function getBaseEnvSchema(): z.ZodObject<any> {
+  if (_baseEnvSchema) return _baseEnvSchema
+  const z = getZod()
+  _baseEnvSchema = z.object({
+    // Server
+    PORT: z.coerce.number().default(3000),
+    NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+    LOG_LEVEL: z.string().default('info'),
+  })
+  return _baseEnvSchema
+}
+
+/**
  * Base environment schema with common server variables.
  * Users extend this with their own application-specific vars.
+ *
+ * Back-compat lazy view over {@link getBaseEnvSchema}: constructing the
+ * Proxy does NOT load zod — zod is only required the moment a property
+ * (`.extend`, `.parse`, `.shape`, …) is actually accessed. This keeps
+ * `import { baseEnvSchema } from '@forinda/kickjs'` zero-cost for apps
+ * that don't use the Zod env path.
  */
-export const baseEnvSchema = z.object({
-  // Server
-  PORT: z.coerce.number().default(3000),
-  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
-  LOG_LEVEL: z.string().default('info'),
-})
+export const baseEnvSchema: z.ZodObject<any> = new Proxy({} as z.ZodObject<any>, {
+  get(_t, prop) {
+    const real = getBaseEnvSchema() as Record<string | symbol, unknown>
+    const value = real[prop]
+    // Bind methods to the real schema so zod's internal `this` works.
+    return typeof value === 'function' ? (value as (...a: unknown[]) => unknown).bind(real) : value
+  },
+  has(_t, prop) {
+    return prop in (getBaseEnvSchema() as object)
+  },
+}) as z.ZodObject<any>
 
 /** Cached env config to avoid re-parsing — keyed by schema reference */
 let cachedEnv: any = null
@@ -81,11 +142,12 @@ let cachedSchema: any = null
 export function defineEnv<T extends z.ZodRawShape>(
   extend: (base: typeof baseEnvSchema) => z.ZodObject<T>,
 ): z.ZodObject<typeof baseEnvSchema.shape & T> {
-  const userSchema = extend(baseEnvSchema)
+  const base = getBaseEnvSchema()
+  const userSchema = extend(base as typeof baseEnvSchema)
   // Always merge the base in. `extend` lets the user's shape override
   // any colliding base keys, which preserves the escape hatch for
   // projects that want to re-type `PORT` etc.
-  return baseEnvSchema.extend(userSchema.shape) as z.ZodObject<typeof baseEnvSchema.shape & T>
+  return base.extend(userSchema.shape) as z.ZodObject<typeof baseEnvSchema.shape & T>
 }
 
 /**
@@ -116,7 +178,7 @@ export function loadEnv(): [EnvKey] extends [never] ? Env : KickEnv
 export function loadEnv<T extends z.ZodObject<any>>(schema?: T): any {
   // Sticky: when called with no arg, prefer the most recently cached
   // schema over re-parsing with the base schema.
-  const s = schema ?? cachedSchema ?? baseEnvSchema
+  const s = schema ?? cachedSchema ?? getBaseEnvSchema()
   // Re-parse if schema changed or no cache yet
   if (cachedEnv && cachedSchema === s) return cachedEnv
   cachedSchema = s
@@ -261,4 +323,15 @@ export function loadEnvFromSchema(schema: unknown): unknown {
   return result.data
 }
 
-export type Env = z.infer<typeof baseEnvSchema>
+/**
+ * Output type of {@link baseEnvSchema}. Hand-written (rather than
+ * `z.infer<typeof baseEnvSchema>`) so the type is available without the
+ * eager `zod` value import — `baseEnvSchema` is now a lazy Proxy typed
+ * as `z.ZodObject<any>`, from which `z.infer` could not recover the
+ * precise shape anyway.
+ */
+export type Env = {
+  PORT: number
+  NODE_ENV: 'development' | 'production' | 'test'
+  LOG_LEVEL: string
+}

--- a/packages/kickjs/src/config/env.ts
+++ b/packages/kickjs/src/config/env.ts
@@ -95,7 +95,7 @@ export function getBaseEnvSchema(): z.ZodObject<any> {
  */
 export const baseEnvSchema: z.ZodObject<any> = new Proxy({} as z.ZodObject<any>, {
   get(_t, prop) {
-    const real = getBaseEnvSchema() as Record<string | symbol, unknown>
+    const real = getBaseEnvSchema() as unknown as Record<string | symbol, unknown>
     const value = real[prop]
     // Bind methods to the real schema so zod's internal `this` works.
     return typeof value === 'function' ? (value as (...a: unknown[]) => unknown).bind(real) : value

--- a/packages/kickjs/src/core/assets.ts
+++ b/packages/kickjs/src/core/assets.ts
@@ -317,6 +317,21 @@ function loadConfigSync(cwd: string): AssetMapConfigShape | null {
       continue
     }
   }
+
+  // Fallback: the CLI snapshot of a transpiled `kick.config.ts`. We
+  // can't transpile TS synchronously on the asset hot path, so the CLI
+  // (`loadKickConfig`) mirrors the JSON-serialisable `assetMap` +
+  // `build.outDir` into `.kickjs/kick.config.json` whenever it loads a
+  // `.ts`/`.js` config. This is what makes `assets.x.y()` resolve in
+  // dev for `.ts`-config projects before the first production build.
+  const snapshotPath = join(cwd, '.kickjs', 'kick.config.json')
+  if (existsSync(snapshotPath)) {
+    try {
+      return JSON.parse(readFileSync(snapshotPath, 'utf-8')) as AssetMapConfigShape
+    } catch {
+      return null
+    }
+  }
   return null
 }
 


### PR DESCRIPTION
## Why

Three related issues hit asset-manager + env adopters, with one shared root cause (Zod hard-coupling) and one fragile typegen pipeline:

1. **`zod` was a hard dependency, not an optional peer.** `packages/kickjs/src/config/env.ts` did a top-level `import { z } from 'zod'` and built `baseEnvSchema = z.object({...})` at module load. That module is re-exported from the main `@forinda/kickjs` entry, so `import { anything } from '@forinda/kickjs'` eagerly evaluated it — crashing the **build** (`Cannot find module 'zod'`) for any app validating env via Valibot / Yup / Standard Schema without zod installed.
2. **The asset manager blocked controller typegen.** A throw in one typegen plugin aborted the whole pass, and the stale-file sweep then deleted the surviving plugins' output.
3. **`assets.x.y()` threw `UnknownAssetError` in dev** for `kick.config.ts` projects until the first production build.

## What changed

### `@forinda/kickjs`

- `env.ts` lazy-loads zod (`import type` + a memoized `require('zod')`) only when `baseEnvSchema` / `defineEnv` / `loadEnv` are actually used, with a clear error if it's missing. `baseEnvSchema` is now a lazy proxy that doesn't construct (or load zod) until accessed. `loadEnvFromSchema` (Valibot/Yup/Standard Schema/function) needs no zod at all.
- `zod` marked `optional` in `peerDependenciesMeta`.
- Runtime asset resolver reads `.kickjs/kick.config.json` as a fallback so dev resolution works for `.ts` configs (it can't transpile TS on the sync hot path).

### `@forinda/kickjs-cli`

- **Per-plugin isolation in the typegen runner.** A throw in one plugin (e.g. `kick/assets`) is reported as `error` and the remaining plugins (e.g. `kick/routes`) still run. The errored plugin reports its `outFile` so the sweep keeps its previous output.
- **Sweep is now an allowlist**, not a denylist. Only the known pre-carve legacy filenames (`assets.d.ts`, `env.ts`, `routes.ts`) are removal candidates; unknown/custom files are always preserved. Previously an aborted plugin pass deleted live `kick__routes.ts` / `kick__assets.d.ts`.
- `loadKickConfig` mirrors the JSON-serialisable `assetMap` + `build.outDir` into `.kickjs/kick.config.json` whenever it loads a TS/JS config.

## Tests

- `packages/kickjs/__tests__/env-lazy-zod.test.ts` — env validation via a non-zod function schema.
- `packages/cli/__tests__/typegen-runner.test.ts` — a throwing plugin doesn't abort later plugins.
- `packages/cli/__tests__/typegen-legacy-cleanup.test.ts` — allowlist sweep preserves custom + route files; reported plugin outputs survive even on a name collision.

Manually verified end-to-end against a scaffolded `rest` app with an `assetMap` + a controller: `kick typegen` emits both `kick__routes.ts` and `kick__assets.d.ts`; the runtime resolver returns the src path for `mails/welcome` in dev (`NODE_ENV=development`, no `dist/`) with a `kick.config.ts`.

## Notes

- Pre-existing `typegen.test.ts > tsc-clean` failure reproduces on clean `main` (local tsc/version env issue) — unrelated to this PR.
- Follow-up (not in this PR): the legacy `generator.ts` could shed its route/env/asset holdovers entirely once the `ServiceToken`/`ModuleToken` unions + `KickJsPluginRegistry` + `index.d.ts` barrel move into the plugin pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
