### PR TITLE
feat(kickjs): ContextKeys registry — stop ContextMeta augmentation breaking dependsOn

### DIFF
--- a/.changeset/context-keys-registry.md
+++ b/.changeset/context-keys-registry.md
@@ -1,0 +1,22 @@
+---
+'@forinda/kickjs': minor
+---
+
+Add a `ContextKeys` registry so augmenting `ContextMeta` no longer breaks `dependsOn` on unrelated context decorators.
+
+`ContextMeta` was doing double duty: the value-type registry for `ctx.get`/`set` AND (via `keyof ContextMeta`) the valid-key registry for `dependsOn`. So the moment a project augmented `ContextMeta` for some keys, any contributor that `dependsOn`-ed a key you hadn't added to `ContextMeta` stopped compiling (`Type '"session"' is not assignable to type '"tenant" | "user"'`) — even though it was a perfectly valid contributor key.
+
+`dependsOn` is now typed against the **union** of `keyof ContextMeta` and the new key-only `ContextKeys` registry:
+
+```ts
+declare module '@forinda/kickjs' {
+  interface ContextMeta {
+    tenant: { id: string; name: string }
+  } // typed ctx.get
+  interface ContextKeys {
+    session: true
+  } // dependsOn-able, value stays unknown
+}
+```
+
+Adding a value type via `ContextMeta` now always makes that key a valid `dependsOn` target, and you can register a dependsOn-able key without inventing a value type for it. Typo-protection and the empty-registry `string` fallback are preserved. Non-breaking: existing `ContextMeta`-only projects keep working unchanged.

--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -209,10 +209,32 @@ Both errors are raised once during `app.setup()`, not per request. Bad pipelines
 
 ::: tip `dependsOn` and `deps` are statically typed
 
-- `dependsOn` is typed as `(keyof ContextMeta)[]`. Augment `ContextMeta` and the editor surfaces a string-literal autocomplete for every known key. A typo (`dependsOn: ['tenent']`) is a TS error with "Did you mean 'tenant'?" — not a boot-time `MissingContributorError`.
+- `dependsOn` is typed against the **union of two registries**: `keyof ContextMeta` (keys that have a value type) **and** `keyof ContextKeys` (key-only registry). Augment either and the editor surfaces a string-literal autocomplete for every known key. A typo (`dependsOn: ['tenent']`) is a TS error with "Did you mean 'tenant'?" — not a boot-time `MissingContributorError`.
 - `deps` is typed as `Record<string, DepValue>` where `DepValue = InjectionToken<T> | Constructor<T>`. Passing a string literal, an array, or a plain object errors at compile time instead of failing inside `container.resolve` at boot.
 
-Both narrow gracefully — projects without any `ContextMeta` augmentation see `dependsOn` accept plain `string[]` so first-day code keeps compiling; the narrowing kicks in as soon as the first `declare module` block lands.
+Both narrow gracefully — projects without any augmentation see `dependsOn` accept plain `string[]` so first-day code keeps compiling; the narrowing kicks in as soon as the first `declare module` block lands.
+:::
+
+::: tip `ContextMeta` vs `ContextKeys`
+
+Two augmentable registries, deliberately separate:
+
+- **`ContextMeta`** — maps a key to its **value type**, so `ctx.get('tenant')` is typed. Augment this when downstream code reads the value.
+- **`ContextKeys`** — a **key-only** registry for context keys that don't need a value type (markers, or values you only ever read with an explicit generic). The value you assign is irrelevant — `true` is conventional.
+
+`dependsOn` accepts keys from **both**. This matters: before they were split, `dependsOn` was keyed off `ContextMeta` alone, so the moment you augmented `ContextMeta` for _some_ keys, any contributor that depended on a key you hadn't added there stopped compiling. Now adding a value type via `ContextMeta` never breaks an unrelated `dependsOn` — and you can register a dependsOn-able key without inventing a value type for it:
+
+```ts
+declare module '@forinda/kickjs' {
+  interface ContextMeta {
+    tenant: { id: string; name: string } // ctx.get('tenant') is typed
+  }
+  interface ContextKeys {
+    session: true // valid in dependsOn; ctx.get('session') stays `unknown`
+  }
+}
+```
+
 :::
 
 ## Error handling

--- a/packages/kickjs/src/core/context-decorator.ts
+++ b/packages/kickjs/src/core/context-decorator.ts
@@ -2,21 +2,31 @@ import 'reflect-metadata'
 import { METADATA, type Constructor, type MaybePromise } from './interfaces'
 import { pushClassMeta, pushMethodMeta } from './metadata'
 import type { InjectionToken } from './token'
-import type { ContextMeta, ExecutionContext, MetaValue } from './execution-context'
+import type { ContextKeys, ContextMeta, ExecutionContext, MetaValue } from './execution-context'
 
 /**
- * String-literal union of every key declared on the augmentable
- * {@link ContextMeta} interface. Resolves to `string` when the
- * project hasn't augmented `ContextMeta` yet (so a first-day project
- * keeps compiling), and narrows to the concrete keys once the
- * `declare module '@forinda/kickjs' { interface ContextMeta { ... } }`
+ * String-literal union of every known context key — the union of the
+ * keys declared on {@link ContextKeys} (key-only registry) and
+ * {@link ContextMeta} (value-type registry). Resolves to `string` when
+ * the project hasn't augmented either yet (so a first-day project keeps
+ * compiling), and narrows to the concrete keys once the
+ * `declare module '@forinda/kickjs' { interface ContextKeys/ContextMeta { ... } }`
  * blocks land.
  *
  * Used as the element type of `dependsOn`, so a typo like
  * `dependsOn: ['tenent']` becomes a TS error instead of a boot-time
  * `MissingContributorError`.
+ *
+ * Unioning BOTH registries is deliberate: it means adding a value type
+ * via `ContextMeta` automatically makes that key a valid `dependsOn`
+ * target, and you can register a dependsOn-able key in `ContextKeys`
+ * without being forced to give it a value type. (Before the split,
+ * `dependsOn` was keyed off `ContextMeta` alone, so augmenting
+ * `ContextMeta` for some keys broke `dependsOn` for every key you
+ * hadn't added there.)
  */
-export type ContextMetaKey = keyof ContextMeta extends never ? string : keyof ContextMeta & string
+type KnownContextKey = keyof ContextMeta | keyof ContextKeys
+export type ContextMetaKey = [KnownContextKey] extends [never] ? string : KnownContextKey & string
 
 /**
  * What a single `deps` entry is allowed to be — the runtime calls
@@ -71,12 +81,12 @@ export interface ContextDecoratorSpec<
    * Other contributor keys that must populate before this one runs.
    * Enforced via topo-sort at startup; missing deps and cycles fail boot.
    *
-   * Typed against `keyof ContextMeta` once the project augments it — so
+   * Typed against {@link ContextMetaKey} — the union of `keyof ContextMeta`
+   * and `keyof ContextKeys` — once the project augments either, so
    * `dependsOn: ['tenent']` (typo) is a TS error, not a boot-time
-   * `MissingContributorError`. Falls back to plain `string[]` when the
-   * registry is empty (no augmentation yet) so first-day projects keep
-   * compiling. Cast-as-any escape hatch:
-   * `dependsOn: ['custom-key' as keyof ContextMeta]`.
+   * `MissingContributorError`. Falls back to plain `string[]` when both
+   * registries are empty (no augmentation yet) so first-day projects keep
+   * compiling. Cast escape hatch: `dependsOn: ['custom-key' as ContextMetaKey]`.
    */
   dependsOn?: readonly ContextMetaKey[]
   /**

--- a/packages/kickjs/src/core/execution-context.ts
+++ b/packages/kickjs/src/core/execution-context.ts
@@ -26,14 +26,57 @@
  */
 
 /**
- * Augmentable per-request metadata registry.
+ * Augmentable per-request **value-type** registry.
  *
  * Extend via module augmentation to give `ctx.get()` / `ctx.set()` static
  * type information for a given key. Unknown keys still resolve via an
  * explicit generic: `ctx.get<MyType>('custom')`.
+ *
+ * ```ts
+ * declare module '@forinda/kickjs' {
+ *   interface ContextMeta {
+ *     tenant: { id: string; name: string }
+ *   }
+ * }
+ * ```
+ *
+ * Every key declared here is automatically a valid `dependsOn` key — see
+ * {@link ContextKeys} for the relationship.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ContextMeta {}
+
+/**
+ * Augmentable per-request **key** registry — the set of context keys a
+ * project's contributors populate, independent of whether each key has a
+ * declared value type in {@link ContextMeta}.
+ *
+ * This exists so `dependsOn` (and any other key-level typing) can be
+ * narrowed to real keys WITHOUT forcing every key to carry a value type.
+ * Before it, `dependsOn` was typed against `keyof ContextMeta` alone, so
+ * the moment a project augmented `ContextMeta` for *some* keys, any
+ * contributor that depended on a key you hadn't added to `ContextMeta`
+ * stopped compiling — even though that key was a perfectly valid
+ * contributor. Splitting the two registries removes that coupling:
+ *
+ * - Put a key in `ContextMeta` when you want `ctx.get(key)` typed.
+ * - Put a key in `ContextKeys` when it's a real contributor key but you
+ *   don't need a value type for it (e.g. a marker, or a value you only
+ *   ever read with an explicit generic).
+ *
+ * Keys from BOTH registries are accepted by `dependsOn`, so adding a
+ * value type via `ContextMeta` never breaks a `dependsOn` elsewhere.
+ *
+ * ```ts
+ * declare module '@forinda/kickjs' {
+ *   interface ContextKeys {
+ *     session: true       // value type irrelevant; the key just exists
+ *   }
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ContextKeys {}
 
 /** Resolve a {@link ContextMeta} value type, falling back to `Fallback` for unknown keys. */
 export type MetaValue<K extends string, Fallback = unknown> = K extends keyof ContextMeta

--- a/packages/kickjs/src/core/index.ts
+++ b/packages/kickjs/src/core/index.ts
@@ -175,7 +175,12 @@ export {
 } from './reactivity'
 
 // Execution Context (transport-agnostic)
-export { type ContextMeta, type MetaValue, type ExecutionContext } from './execution-context'
+export {
+  type ContextMeta,
+  type ContextKeys,
+  type MetaValue,
+  type ExecutionContext,
+} from './execution-context'
 
 // Context Contributor pipeline (#107) — Phase 1: types + factory only.
 // Topo-sort, runner, and HTTP integration land in Phases 2 and 4.


### PR DESCRIPTION
## The bug

`ContextMeta` was doing double duty — the **value-type** registry for `ctx.get`/`set` AND, via `keyof ContextMeta`, the **valid-key** registry for `dependsOn`. So the moment a project augmented `ContextMeta` for *some* keys, any context decorator that `dependsOn`-ed a key you hadn't added to `ContextMeta` stopped compiling:

```
Type '"session"' is not assignable to type '"tenant" | "user"'.
```

…even though `session` was a perfectly valid contributor key. (Reproduced with `tsgo` on a fixture: augment `ContextMeta { tenant, user }`, define a `key: 'session'` contributor, then `dependsOn: ['session']` elsewhere → error.)

## The fix

Split the two concerns:

- **`ContextMeta`** — maps a key to its value type (`ctx.get('tenant')` typed).
- **`ContextKeys`** — new **key-only** registry for keys that don't need a value type.

`dependsOn` is now typed against the **union** `keyof ContextMeta | keyof ContextKeys` (`ContextMetaKey`). So:

- Adding a value type via `ContextMeta` automatically makes that key a valid `dependsOn` target — augmenting it never breaks an unrelated `dependsOn` again.
- A dependsOn-able key with no value type registers in `ContextKeys` without inventing a value.
- Typo-protection is preserved (`dependsOn: ['tenent']` still errors — *"Did you mean 'tenant'?"*, against the full union).
- Empty-registry `string` fallback preserved → first-day projects keep compiling. **Non-breaking** for existing `ContextMeta`-only projects.

```ts
declare module '@forinda/kickjs' {
  interface ContextMeta { tenant: { id: string; name: string } } // typed ctx.get
  interface ContextKeys { session: true }                        // dependsOn-able, value stays unknown
}
```

## Verification

- `tsgo` fixture: `dependsOn: ['session']` (ContextKeys) and `['tenant']` (ContextMeta) compile; `['tenent']` errors against `"session" | "tenant" | "thing" | "thing2" | "user"`.
- Existing context/contributor suites: 88/88 pass (empty registries → `string` fallback unchanged).

## Follow-up

A `kick/context` typegen plugin could auto-populate `ContextKeys` by scanning every `defineContextDecorator`/`defineHttpContextDecorator` `key:` literal — so `dependsOn` typo-checking becomes automatic and adopters never hand-maintain `ContextKeys`. Raised separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
