### PR TITLE
feat(cli): kick g contributor generator (--type http|bare, --params → withParams<T>)

### DIFF
--- a/.changeset/kick-g-contributor.md
+++ b/.changeset/kick-g-contributor.md
@@ -1,0 +1,12 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+Add `kick g contributor <name>` to scaffold a Context Contributor.
+
+- `--type http` (default) → `defineHttpContextDecorator`, resolver typed against `RequestContext`.
+- `--type bare` → `defineContextDecorator`, resolver typed against the transport-agnostic `ExecutionContext`.
+- `--params "source:string,region:number"` → emits the curried `.withParams<T>()` form with a generated params `type` alias and `paramDefaults` stub (mirrors how `kick g scaffold` takes field definitions).
+- `--key <key>` overrides the context key (defaults to camelCase of the name); `-m <module>` scopes the file into a module folder.
+
+The scaffold also drops a `ContextMeta` augmentation stub so `ctx.get('<key>')` is typed and `dependsOn: ['<key>']` is checked.

--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -117,6 +117,17 @@ Same job, different ergonomics. Each line below maps a middleware pain point to 
 
 ## Quickstart
 
+Scaffold one with the CLI:
+
+```bash
+kick g contributor tenant                          # HTTP (RequestContext), key 'tenant'
+kick g contributor session --type bare             # ExecutionContext (transport-agnostic)
+kick g contributor tenant --params "source:string" # emits the withParams<T>() form
+kick g contributor admin -m users                  # scoped inside the users module
+```
+
+`--type http` (default) types the resolver against `RequestContext`; `--type bare` against `ExecutionContext`. `--params` switches to the curried `.withParams<T>()` form with a generated params type. The scaffold also drops a `ContextMeta` augmentation stub for the key. Or write one by hand:
+
 ```ts
 import { defineHttpContextDecorator, Controller, Get, type RequestContext } from '@forinda/kickjs'
 

--- a/packages/cli/__tests__/leaf-generators.test.ts
+++ b/packages/cli/__tests__/leaf-generators.test.ts
@@ -101,6 +101,66 @@ describe('kick g <leaf>', () => {
     })
   })
 
+  describe('contributor', () => {
+    it('generates an HTTP context contributor (defaults: --type http)', () => {
+      const result = runCli(fixture, ['g', 'contributor', 'tenant'])
+      assertCliOk(result, 'kick g contributor tenant')
+      const file = join(fixture, 'src/contributors/tenant.contributor.ts')
+      expect(existsSync(file)).toBe(true)
+      const content = readFileSync(file, 'utf-8')
+      expect(content).toContain('defineHttpContextDecorator')
+      expect(content).toContain('RequestContext')
+      expect(content).toContain("key: 'tenant'") // key defaults to camelCase(name)
+      expect(content).toContain('export const Tenant')
+      // Registers the key for typed ctx.get + dependsOn checking.
+      expect(content).toContain('interface ContextMeta')
+    })
+
+    it('generates a bare contributor with --type bare', () => {
+      runCli(fixture, ['g', 'contributor', 'session', '--type', 'bare'])
+      const content = readFileSync(
+        join(fixture, 'src/contributors/session.contributor.ts'),
+        'utf-8',
+      )
+      expect(content).toContain('defineContextDecorator')
+      expect(content).not.toContain('defineHttpContextDecorator')
+      expect(content).toContain('ExecutionContext')
+    })
+
+    it('emits the withParams<T>() form when --params is supplied', () => {
+      runCli(fixture, ['g', 'contributor', 'tenant', '--params', 'source:string,region:number'])
+      const content = readFileSync(join(fixture, 'src/contributors/tenant.contributor.ts'), 'utf-8')
+      // type alias (not interface) so it satisfies P extends Record<string, unknown>
+      expect(content).toContain('export type TenantParams = {')
+      expect(content).toContain('source: string')
+      expect(content).toContain('region: number')
+      expect(content).toContain('.withParams<TenantParams>()')
+      expect(content).toContain('paramDefaults')
+      expect(content).toContain('(ctx, _deps, params)')
+    })
+
+    it('honours an explicit --key', () => {
+      runCli(fixture, ['g', 'contributor', 'load-tenant', '--key', 'tenant'])
+      const content = readFileSync(
+        join(fixture, 'src/contributors/load-tenant.contributor.ts'),
+        'utf-8',
+      )
+      expect(content).toContain("key: 'tenant'")
+      expect(content).toContain('export const LoadTenant')
+    })
+
+    it('passes tsc --noEmit (http, bare, and withParams forms)', () => {
+      runCli(fixture, ['g', 'contributor', 'tenant'])
+      runCli(fixture, ['g', 'contributor', 'session', '--type', 'bare'])
+      runCli(fixture, ['g', 'contributor', 'project', '--params', 'depth:number'])
+      const tsc = runTsc(fixture)
+      if (tsc.exitCode !== 0) {
+        throw new Error(`tsc failed:\n${tsc.stdout}\n${tsc.stderr}`)
+      }
+      expect(tsc.exitCode).toBe(0)
+    })
+  })
+
   describe('dto', () => {
     it('generates a Zod DTO schema', () => {
       const result = runCli(fixture, ['g', 'dto', 'create-user'])

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -13,6 +13,7 @@ import { generateAdapter } from '../generators/adapter'
 import { generatePlugin } from '../generators/plugin'
 import { generateMiddleware } from '../generators/middleware'
 import { generateGuard } from '../generators/guard'
+import { generateContributor, type ContributorType } from '../generators/contributor'
 import { generateService } from '../generators/service'
 import { generateController } from '../generators/controller'
 import { generateDto } from '../generators/dto'
@@ -146,6 +147,10 @@ const GENERATORS = [
   { name: 'service <name>', description: '@Service() singleton             [-m module]' },
   { name: 'middleware <name>', description: 'Express middleware function     [-m module]' },
   { name: 'guard <name>', description: 'Route guard (auth, roles, etc.)  [-m module]' },
+  {
+    name: 'contributor <name>',
+    description: 'Context contributor       [--type http|bare] [--params a:string] [-m]',
+  },
   { name: 'dto <name>', description: 'Zod DTO schema                  [-m module]' },
   { name: 'adapter <name>', description: 'AppAdapter with lifecycle hooks (app-level only)' },
   { name: 'test <name>', description: 'Vitest test scaffold            [-m module]' },
@@ -434,6 +439,51 @@ export function registerGenerateCommand(program: Command, ctx?: KickCliPluginCon
       })
       printGenerated(files, dryRun)
     })
+
+  // ── kick g contributor <name> ──────────────────────────────────────
+  gen
+    .command('contributor <name>')
+    .description(
+      'Generate a Context Contributor (typed alternative to @Middleware for ctx.set)\n' +
+        '  --type http (default, RequestContext) | bare (ExecutionContext)\n' +
+        '  --params "source:string,region:number" → emits the withParams<T>() form\n' +
+        '  Use -m to scope it to a module: kick g contributor tenant -m users',
+    )
+    .option('-o, --out <dir>', 'Output directory (overrides --module)')
+    .option('-m, --module <module>', 'Place inside a module folder')
+    .option('-t, --type <type>', 'Contributor flavour: http | bare', 'http')
+    .option('-k, --key <key>', 'Context key it writes (defaults to camelCase of name)')
+    .option('--params <fields>', 'Per-call params, e.g. "source:string,region:number"')
+    .action(
+      async (
+        name: string,
+        opts: ModuleScopedOpts & { type?: string; key?: string; params?: string },
+        cmd: Command,
+      ) => {
+        const dryRun = isDryRun(cmd)
+        setDryRun(dryRun)
+        let type = (opts.type ?? 'http').toLowerCase()
+        if (type !== 'http' && type !== 'bare') {
+          console.warn(`  kick g contributor: unknown --type '${opts.type}', using 'http'.`)
+          type = 'http'
+        }
+        const config = await loadKickConfig(process.cwd())
+        const mc = resolveModuleConfig(config)
+        const modulesDir = mc.dir ?? 'src/modules'
+        const files = await generateContributor({
+          name,
+          type: type as ContributorType,
+          key: opts.key,
+          params: opts.params,
+          outDir: opts.out,
+          moduleName: opts.module,
+          modulesDir,
+          pattern: config?.pattern,
+          pluralize: mc.pluralize ?? true,
+        })
+        printGenerated(files, dryRun)
+      },
+    )
 
   // ── kick g service <name> ──────────────────────────────────────────
   gen

--- a/packages/cli/src/generators/contributor.ts
+++ b/packages/cli/src/generators/contributor.ts
@@ -1,0 +1,178 @@
+import { join } from 'node:path'
+import { writeFileSafe } from '../utils/fs'
+import { toPascalCase, toKebabCase, toCamelCase } from '../utils/naming'
+import { resolveOutDir } from '../utils/resolve-out-dir'
+import type { ProjectPattern } from '../config'
+
+/**
+ * Context-contributor generator (#107). Scaffolds a Context Contributor
+ * — the typed, ordered alternative to `@Middleware()` for populating
+ * `ctx.set(key, value)` before a handler runs.
+ *
+ * Two flavours via `--type`:
+ *  - `http` (default) → `defineHttpContextDecorator`, resolver typed
+ *    against `RequestContext` (`ctx.req`, `ctx.headers`, `ctx.params`).
+ *  - `bare` → `defineContextDecorator`, resolver typed against the
+ *    transport-agnostic `ExecutionContext` (HTTP + WS + queue + cron).
+ *
+ * When `--params` is supplied, the curried `.withParams<T>()` form is
+ * emitted (per-call parameters with full inference), mirroring how
+ * `kick g scaffold` takes field definitions.
+ */
+
+export type ContributorType = 'http' | 'bare'
+
+/** One parsed `--params` entry, e.g. `source:string` → `{ name, type }`. */
+export interface ContributorParam {
+  name: string
+  type: string
+}
+
+export interface GenerateContributorOptions {
+  name: string
+  /** `http` (RequestContext) or `bare` (ExecutionContext). Default `http`. */
+  type?: ContributorType
+  /** Context key the contributor writes. Defaults to camelCase(name). */
+  key?: string
+  /**
+   * Per-call params. When non-empty, the `.withParams<T>()` curried form
+   * is generated. Accepts the parsed array or a raw `a:string,b:number`
+   * string (see {@link parseContributorParams}).
+   */
+  params?: ContributorParam[] | string
+  outDir?: string
+  moduleName?: string
+  modulesDir?: string
+  pattern?: ProjectPattern
+  pluralize?: boolean
+}
+
+/**
+ * Parse a `--params` string (`source:string,region:number`) into typed
+ * fields. Whitespace tolerant; entries without an explicit `:type`
+ * default to `string`. Returns `[]` for empty/undefined input.
+ */
+export function parseContributorParams(raw: string | undefined): ContributorParam[] {
+  if (!raw) return []
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const [name, type] = entry.split(':').map((s) => s.trim())
+      return { name, type: type || 'string' }
+    })
+    .filter((p) => p.name.length > 0)
+}
+
+/** Safe primitive default for `paramDefaults` so the scaffold compiles. */
+function defaultForType(type: string): string | null {
+  switch (type) {
+    case 'string':
+      return "''"
+    case 'number':
+      return '0'
+    case 'boolean':
+      return 'false'
+    default:
+      // Non-primitive — omit from paramDefaults (the field is `Partial<P>`)
+      // so we don't emit an un-typeable placeholder.
+      return null
+  }
+}
+
+export async function generateContributor(options: GenerateContributorOptions): Promise<string[]> {
+  const { name, moduleName, modulesDir, pattern } = options
+  const type: ContributorType = options.type ?? 'http'
+  const kebab = toKebabCase(name)
+  const pascal = toPascalCase(name)
+  const key = options.key ?? toCamelCase(name)
+  const params = Array.isArray(options.params)
+    ? options.params
+    : parseContributorParams(options.params)
+
+  const outDir = resolveOutDir({
+    type: 'contributor',
+    outDir: options.outDir,
+    moduleName,
+    modulesDir,
+    defaultDir: 'src/contributors',
+    pattern,
+    shouldPluralize: options.pluralize ?? true,
+  })
+
+  const factory = type === 'http' ? 'defineHttpContextDecorator' : 'defineContextDecorator'
+  const ctxType = type === 'http' ? 'RequestContext' : 'ExecutionContext'
+
+  // Emit a `type` alias, NOT an `interface`: `withParams<P>` constrains
+  // `P extends Record<string, unknown>`, and an object-literal type alias
+  // satisfies that index-signature constraint whereas an interface does
+  // not (TS2344).
+  const paramsInterface =
+    params.length > 0
+      ? `\nexport type ${pascal}Params = {\n${params
+          .map((p) => `  ${p.name}: ${p.type}`)
+          .join('\n')}\n}\n`
+      : ''
+
+  // `.withParams<T>()(...)` curried form when params are supplied; the
+  // plain `factory({...})` form otherwise.
+  const callOpen = params.length > 0 ? `${factory}.withParams<${pascal}Params>()({` : `${factory}({`
+
+  const paramDefaultsEntries = params
+    .map((p) => ({ name: p.name, def: defaultForType(p.type) }))
+    .filter((p) => p.def !== null)
+    .map((p) => `    ${p.name}: ${p.def},`)
+  const paramDefaultsBlock =
+    params.length > 0 ? `  paramDefaults: {\n${paramDefaultsEntries.join('\n')}\n  },\n` : ''
+
+  const resolveSig = params.length > 0 ? '(ctx, _deps, params)' : '(ctx)'
+  const resolveHint =
+    params.length > 0
+      ? `    // \`params\` is typed as ${pascal}Params (call-site overrides merged onto paramDefaults).`
+      : `    // \`ctx\` is a ${ctxType} — read ctx.req / ctx.headers / ctx.params (http) or ctx.get (bare).`
+
+  const content = `import { ${factory} } from '@forinda/kickjs'
+import type { ${ctxType} } from '@forinda/kickjs'
+
+/**
+ * ${pascal} context contributor (${type}).
+ *
+ * Computes a value and writes it to \`ctx.set('${key}', …)\` before a
+ * matched handler runs — the typed, ordered alternative to
+ * \`@Middleware()\` when the only job is to populate \`ctx\`.
+ *
+ * Apply per method/class, or register globally via
+ * \`bootstrap({ contributors: [${pascal}] })\`:
+ *
+ *   @${pascal}${params.length > 0 ? `({ ${params[0]?.name}: … })` : ''}
+ *   @Get('/')
+ *   handler(ctx: ${ctxType}) {
+ *     return ctx.json(ctx.get('${key}'))
+ *   }
+ */
+
+// Register '${key}' so \`ctx.get('${key}')\` is typed and \`dependsOn: ['${key}']\`
+// is checked. Replace \`unknown\` with the resolved value's real type.
+// (For a key you only depend on — no value type needed — declare it in
+// \`interface ContextKeys\` instead.)
+declare module '@forinda/kickjs' {
+  interface ContextMeta {
+    '${key}': unknown
+  }
+}
+${paramsInterface}
+export const ${pascal} = ${callOpen}
+  key: '${key}',
+${paramDefaultsBlock}  resolve: ${resolveSig} => {
+${resolveHint}
+    // TODO: compute and return the value written to ctx.set('${key}', …)
+    throw new Error("${pascal} contributor: resolve() not implemented")
+  },
+})
+`
+
+  const filePath = join(outDir, `${kebab}.contributor.ts`)
+  await writeFileSafe(filePath, content)
+  return [filePath]
+}

--- a/packages/cli/src/utils/resolve-out-dir.ts
+++ b/packages/cli/src/utils/resolve-out-dir.ts
@@ -11,6 +11,7 @@ const DDD_FOLDER_MAP: Record<string, string> = {
   dto: 'application/dtos',
   guard: 'presentation/guards',
   middleware: 'middleware',
+  contributor: 'presentation/contributors',
 }
 
 /**
@@ -23,6 +24,7 @@ const FLAT_FOLDER_MAP: Record<string, string> = {
   dto: 'dtos',
   guard: 'guards',
   middleware: 'middleware',
+  contributor: 'contributors',
 }
 
 /**
@@ -34,6 +36,7 @@ const CQRS_FOLDER_MAP: Record<string, string> = {
   dto: 'dtos',
   guard: 'guards',
   middleware: 'middleware',
+  contributor: 'contributors',
   command: 'commands',
   query: 'queries',
   event: 'events',


### PR DESCRIPTION
Adds `kick g contributor <name>` — scaffolds a [Context Contributor](../docs/guide/context-decorators.md), the typed/ordered alternative to `@Middleware()` for populating `ctx.set(key, value)`.

## Usage

```bash
kick g contributor tenant                            # HTTP (RequestContext), key 'tenant'
kick g contributor session --type bare               # ExecutionContext (transport-agnostic)
kick g contributor tenant --params "source:string"   # curried withParams<T>() form
kick g contributor admin -m users                    # scoped into the users module
kick g contributor load-tenant --key tenant          # explicit context key
```

## Flags

- `--type http` (default) → `defineHttpContextDecorator`, resolver typed against `RequestContext` (`ctx.req` / `ctx.headers` / `ctx.params`).
- `--type bare` → `defineContextDecorator`, resolver typed against the transport-agnostic `ExecutionContext`.
- `--params "a:string,b:number"` → emits the curried `.withParams<T>()` form with a generated params **`type` alias** + a `paramDefaults` stub. (Type alias, not `interface` — `withParams<P>` constrains `P extends Record<string, unknown>`, which an interface doesn't satisfy: TS2344.)
- `--key <key>` overrides the context key (default: camelCase of name).
- `-m <module>` scopes the file into a module folder; `-o <dir>` overrides output.

Every scaffold drops a `ContextMeta` augmentation stub for the key, so `ctx.get('<key>')` is typed and `dependsOn: ['<key>']` is checked out of the box.

## Implementation

- `src/generators/contributor.ts` — `generateContributor()` + `parseContributorParams()`, mirroring the existing leaf generators (`guard`, `middleware`).
- `contributor` subcommand registered in `commands/generate.ts` + added to the `--list` catalogue.
- `contributor` folder mapping added to `resolve-out-dir.ts` (DDD → `presentation/contributors`, flat/CQRS → `contributors`).

## Verification

- 5 generator tests (http / bare / withParams / `--key` / tsc-compile across all three forms) — pass.
- Generated output independently verified with `tsgo` for the http, bare, and `withParams` forms.

## Related

- Pairs with #311 (the `ContextKeys` registry) — the scaffold's comment points adopters at `ContextKeys` for key-only deps.
- #312 (auto-populate `ContextKeys` via typegen) would make the manual augmentation stub unnecessary; until then this generator drops it for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
