### PR TITLE
fix(cli): typegen polling watch + kick dev startup (follow-up to #310)

### DIFF
--- a/.changeset/fix-typegen-watch-polling.md
+++ b/.changeset/fix-typegen-watch-polling.md
@@ -1,0 +1,8 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+Fix two issues in the plugin-only typegen pipeline (follow-up to the generator.ts retirement):
+
+- **Polling watch never regenerated types.** `kick typegen --watch` / `kick dev` on the polling paths (forced via `KICKJS_WATCH_POLLING`, or the `fs.watch` fallback used on Docker bind mounts / WSL / NFS) ran only the scan + collision gate, not the plugin pass — so no `.kickjs/types/kick__*` file refreshed on change. Both polling paths now drive the full `runLegacy().then(runPlugins)` chain, matching the event-based watcher.
+- **`kick dev` startup could abort on a typegen error.** The startup plugin pass + artifact write were unguarded, so a scanner/fs error would exit the dev server with code 1. Now wrapped in try/catch + warn, consistent with the scan/gate pass and the debounced refresh.

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -69,12 +69,17 @@ async function startDevServer(
   }
 
   // Plugin typegens — the sole emitter of `.kickjs/types/*`. Same
-  // swallow-on-error semantics: a broken plugin shouldn't block the dev
-  // server from coming up. `writeTypegenArtifacts` then writes the
-  // `.kickjs/.gitignore` guard + sweeps legacy orphans.
+  // swallow-on-error semantics as the scan/gate pass above: a broken
+  // plugin (or a scanner/fs error, or a writeTypegenArtifacts hiccup)
+  // shouldn't block the dev server from coming up. `writeTypegenArtifacts`
+  // then writes the `.kickjs/.gitignore` guard + sweeps legacy orphans.
   const typesOutDir = resolve(cwd, devConfig?.typegen?.outDir ?? '.kickjs/types')
-  const startupPluginResults = await runAllPluginTypegens({ cwd, config: devConfig })
-  await writeTypegenArtifacts(typesOutDir, startupPluginResults, false)
+  try {
+    const startupPluginResults = await runAllPluginTypegens({ cwd, config: devConfig })
+    await writeTypegenArtifacts(typesOutDir, startupPluginResults, false)
+  } catch (err: any) {
+    console.warn(`  kick typegen: plugin pass skipped (${err?.message ?? err})`)
+  }
 
   // Resolve vite from the user's project, not the CLI package.
   // On Windows, require.resolve returns an absolute path like

--- a/packages/cli/src/typegen/index.ts
+++ b/packages/cli/src/typegen/index.ts
@@ -401,8 +401,12 @@ export async function watchTypegen(opts: RunTypegenOptions = {}): Promise<() => 
     if (!silent) {
       console.log('  kick typegen: polling mode (KICKJS_WATCH_POLLING)')
     }
+    // Must drive BOTH phases — the plugin pass owns every
+    // `.kickjs/types/kick__*` file now, so scan/gate alone (runLegacy)
+    // would never refresh types on the polling path. Both closures
+    // swallow their own errors, so the interval loop never dies.
     const interval = setInterval(() => {
-      safeRun({ ...runOpts, silent: true }, true)
+      void runLegacy().then(runPlugins)
     }, 2000)
     return () => clearInterval(interval)
   }
@@ -418,9 +422,11 @@ export async function watchTypegen(opts: RunTypegenOptions = {}): Promise<() => 
         `  kick typegen: watch mode unavailable (${err?.message ?? err}). Falling back to polling.`,
       )
     }
-    // Polling fallback — re-scan every 2s
+    // Polling fallback — re-run both phases every 2s (see forcePolling
+    // note above: the plugin pass is the sole emitter, so scan/gate
+    // alone would never refresh types).
     const interval = setInterval(() => {
-      safeRun({ ...runOpts, silent: true }, true)
+      void runLegacy().then(runPlugins)
     }, 2000)
     return () => clearInterval(interval)
   }
@@ -428,21 +434,6 @@ export async function watchTypegen(opts: RunTypegenOptions = {}): Promise<() => 
   return () => {
     if (timer) clearTimeout(timer)
     watcher.close()
-  }
-}
-
-/** Run typegen swallowing errors so the watcher loop never dies */
-async function safeRun(opts: RunTypegenOptions, silent: boolean): Promise<void> {
-  try {
-    await runTypegen(opts)
-  } catch (err) {
-    if (silent) return
-    if (err instanceof TokenCollisionError) {
-      console.error('\n' + err.message + '\n')
-    } else {
-      const msg = err instanceof Error ? err.message : String(err)
-      console.error(`  kick typegen failed: ${msg}`)
-    }
   }
 }
 


### PR DESCRIPTION
Follow-up to #310 (plugin-only `kick typegen`) — addresses the two CodeRabbit findings, which merged before the fixes landed.

## 1. Polling watch never regenerated types 🔴

`watchTypegen`'s polling paths — forced via `KICKJS_WATCH_POLLING`, and the `fs.watch` fallback used on Docker bind mounts / WSL / NFS — called `safeRun` with `runPlugins: false`, i.e. scan + collision gate only. Now that every `.kickjs/types/kick__*` file is emitted by the plugin pass (generator.ts is gone), those paths refreshed *nothing* on change — exactly for the audience the polling path targets.

Both polling paths now drive `runLegacy().then(runPlugins)`, identical to the event-based trigger. Removed the now-unused `safeRun`.

## 2. `kick dev` startup could abort on a typegen error 🟠

The startup plugin pass + `writeTypegenArtifacts` ran unguarded, so a scanner/fs error (or a `mkdir`/`writeFile` hiccup) propagated out of `startDevServer` and exited the dev server with code 1 — contradicting the swallow-on-error intent stated in the comment, and inconsistent with the scan/gate pass (wrapped) and the debounced refresh (`.catch`). Now wrapped in `try/catch` + warn.

## Verification

- Full CLI suite: 348 pass / 3 fail — the 3 are pre-existing **Windows-only** path-separator assertions (`generator-extension`, `migrate-modules`), green on Linux CI.
- Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
