### PR TITLE
feat(cli): kick/context typegen — auto-populate ContextKeys from contributor keys

### DIFF
--- a/.changeset/kick-context-typegen.md
+++ b/.changeset/kick-context-typegen.md
@@ -1,0 +1,9 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+Add the `kick/context` typegen plugin — auto-populate `ContextKeys` from context-decorator key literals.
+
+`kick typegen` now scans every `defineContextDecorator({ key })` / `defineHttpContextDecorator({ key })` call (including the curried `.withParams<T>()({ key })` form) and emits `.kickjs/types/kick__context.d.ts` augmenting the `ContextKeys` registry. This makes a Context Contributor's `dependsOn` typo-checked automatically — no hand-maintained registry, and no need to give a key a value type in `ContextMeta` just to depend on it.
+
+Pairs with the `ContextKeys` registry: `dependsOn` narrows to `keyof ContextMeta | keyof ContextKeys`, so the generated augmentation feeds typo-checking while `ContextMeta` keeps driving `ctx.get(key)` value types. The plugin skips emission when no context decorators are found. Scanner gains `extractContextKeysFromSource` + `ScanResult.contextKeys`.

--- a/docs/guide/typegen.md
+++ b/docs/guide/typegen.md
@@ -21,6 +21,7 @@ After running `kick typegen` (or starting `kick dev`), you'll have:
     kick__env.ts                # KickEnv + NodeJS.ProcessEnv augmentation (when src/env.ts exists)
     kick__assets.d.ts           # KickAssets augmentation (when assetMap is set)
     kick__db.d.ts               # DB model types (when a DB adapter is configured)
+    kick__context.d.ts          # ContextKeys augmentation (when context decorators exist)
 ```
 
 Each file is emitted by its own typegen plugin. There is no barrel
@@ -438,6 +439,33 @@ Two payoffs:
 - **Discoverability.** IDE autocomplete inside `dependsOn: [...]` lists every plugin/adapter name in scope.
 
 When the registry is empty (fresh project, never ran `kick typegen`), `keyof KickJsPluginRegistry` resolves to `never` and the runtime falls back to `string` so existing code keeps compiling. Run `kick typegen` once and the narrowing kicks in.
+
+## Context keys (`dependsOn` on contributors)
+
+`kick typegen` also walks your `src/` for `defineContextDecorator({ key: '...' })` and `defineHttpContextDecorator({ key: '...' })` calls (including the curried `.withParams<T>()({ key: '...' })` form) and writes every discovered key into `.kickjs/types/kick__context.d.ts` as a `ContextKeys` augmentation:
+
+```ts
+// .kickjs/types/kick__context.d.ts (generated)
+declare module '@forinda/kickjs' {
+  interface ContextKeys {
+    tenant: true
+    session: true
+  }
+}
+```
+
+This is what makes a Context Contributor's `dependsOn` typo-checked **without you hand-maintaining a registry** — and without forcing a value type into `ContextMeta`. `dependsOn` narrows to the union of `keyof ContextMeta` (keys with a value type) and `keyof ContextKeys` (every contributor key), so:
+
+```ts
+defineHttpContextDecorator({
+  key: 'project',
+  dependsOn: ['tenant'], // ✓ — autocompletes from discovered keys
+  // dependsOn: ['tenent'], // ✗ — TS error: "Did you mean 'tenant'?"
+  resolve: (ctx) => loadProject(ctx),
+})
+```
+
+`ContextMeta` still drives the value type of `ctx.get('tenant')`; `ContextKeys` only records that the key exists. Scaffold a contributor (and its `ContextMeta` stub) with [`kick g contributor`](./context-decorators.md). Empty project → no `kick__context.d.ts` emitted and `dependsOn` falls back to `string[]`.
 
 ## Augmentation catalogue
 

--- a/packages/cli/__tests__/scanner-context-keys.test.ts
+++ b/packages/cli/__tests__/scanner-context-keys.test.ts
@@ -12,11 +12,11 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { Container } from '@forinda/kickjs'
 import { extractContextKeysFromSource } from '../src/typegen/scanner'
 
-// Project rule: every .test.ts isolates DI state. This is a pure-function
-// suite (no container use); a fresh isolated container per test keeps it
-// consistent without mutating the global singleton.
+// Project rule: every .test.ts resets DI state in beforeEach. This is a
+// pure-function suite (no container use), but the reset keeps it
+// consistent with the repo-wide isolation convention.
 beforeEach(() => {
-  Container.create()
+  Container.reset()
 })
 
 const FILE = '/proj/src/contributors/x.contributor.ts'

--- a/packages/cli/__tests__/scanner-context-keys.test.ts
+++ b/packages/cli/__tests__/scanner-context-keys.test.ts
@@ -8,8 +8,16 @@
  * `defineHttpContextDecorator`.
  */
 
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { Container } from '@forinda/kickjs'
 import { extractContextKeysFromSource } from '../src/typegen/scanner'
+
+// Project rule: every .test.ts isolates DI state. This is a pure-function
+// suite (no container use); a fresh isolated container per test keeps it
+// consistent without mutating the global singleton.
+beforeEach(() => {
+  Container.create()
+})
 
 const FILE = '/proj/src/contributors/x.contributor.ts'
 const keys = (source: string): string[] =>

--- a/packages/cli/__tests__/scanner-context-keys.test.ts
+++ b/packages/cli/__tests__/scanner-context-keys.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for `extractContextKeysFromSource` — the regex extraction
+ * that feeds the `kick/context` typegen plugin (auto-populates the
+ * `ContextKeys` registry from context-decorator `key:` literals).
+ *
+ * Covers every call shape: bare, generic, and the curried
+ * `.withParams<P>()` form, for both `defineContextDecorator` and
+ * `defineHttpContextDecorator`.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { extractContextKeysFromSource } from '../src/typegen/scanner'
+
+const FILE = '/proj/src/contributors/x.contributor.ts'
+const keys = (source: string): string[] =>
+  extractContextKeysFromSource(source, FILE, '/proj').map((k) => k.key)
+
+describe('extractContextKeysFromSource', () => {
+  it('extracts the key from a plain defineHttpContextDecorator call', () => {
+    expect(
+      keys(`export const Tenant = defineHttpContextDecorator({
+        key: 'tenant',
+        resolve: (ctx) => ({ id: ctx.req.headers['x-tenant-id'] }),
+      })`),
+    ).toEqual(['tenant'])
+  })
+
+  it('extracts from a bare defineContextDecorator call', () => {
+    expect(keys(`const S = defineContextDecorator({ key: 'session', resolve: () => 1 })`)).toEqual([
+      'session',
+    ])
+  })
+
+  it('handles explicit generics', () => {
+    expect(
+      keys(
+        `const T = defineHttpContextDecorator<'tenant', Record<string, never>>({ key: 'tenant', resolve: () => 1 })`,
+      ),
+    ).toEqual(['tenant'])
+  })
+
+  it('handles the curried .withParams<P>() form (http)', () => {
+    expect(
+      keys(`export const Project = defineHttpContextDecorator.withParams<{ depth: number }>()({
+        key: 'project',
+        paramDefaults: { depth: 0 },
+        resolve: (ctx, _deps, params) => params.depth,
+      })`),
+    ).toEqual(['project'])
+  })
+
+  it('handles the curried .withParams<P>() form (bare)', () => {
+    expect(
+      keys(
+        `const R = defineContextDecorator.withParams<{ scope: string }>()({ key: 'role', resolve: () => 1 })`,
+      ),
+    ).toEqual(['role'])
+  })
+
+  it('collects multiple decorators and dedupes repeated keys', () => {
+    const out = keys(`
+      const A = defineHttpContextDecorator({ key: 'tenant', resolve: () => 1 })
+      const B = defineContextDecorator({ key: 'session', resolve: () => 1 })
+      const C = defineHttpContextDecorator({ key: 'tenant', resolve: () => 2 })
+    `)
+    expect(out.toSorted()).toEqual(['session', 'tenant'])
+  })
+
+  it('ignores non-context define calls', () => {
+    expect(
+      keys(`const P = definePlugin({ name: 'X', build: () => ({}) })
+            const Ad = defineAdapter({ name: 'Y', build: () => ({}) })`),
+    ).toEqual([])
+  })
+
+  it('tolerates double/single/backtick quotes around the key', () => {
+    expect(keys(`defineContextDecorator({ key: "a", resolve: () => 1 })`)).toEqual(['a'])
+    expect(keys('defineContextDecorator({ key: `b`, resolve: () => 1 })')).toEqual(['b'])
+  })
+})

--- a/packages/cli/__tests__/typegen-plugin-registry.test.ts
+++ b/packages/cli/__tests__/typegen-plugin-registry.test.ts
@@ -261,6 +261,41 @@ describe('kick typegen — plugins.d.ts + augmentations.d.ts E2E', () => {
     expect(existsSync(join(fixture, '.kickjs/types/kick__augmentations.d.ts'))).toBe(true)
   })
 
+  it('auto-populates ContextKeys from context-decorator key literals', () => {
+    writeFile(
+      'src/contributors/tenant.contributor.ts',
+      `import { defineHttpContextDecorator } from '@forinda/kickjs'
+export const Tenant = defineHttpContextDecorator({
+  key: 'tenant',
+  resolve: (ctx) => ({ id: ctx.req.headers['x-tenant-id'] }),
+})
+`,
+    )
+    writeFile(
+      'src/contributors/session.contributor.ts',
+      `import { defineContextDecorator } from '@forinda/kickjs'
+export const Session = defineContextDecorator.withParams<{ source: string }>()({
+  key: 'session',
+  paramDefaults: { source: '' },
+  resolve: (_ctx, _deps, params) => ({ source: params.source }),
+})
+`,
+    )
+
+    runCli(fixture, ['typegen'])
+
+    const ctx = readFileSync(join(fixture, '.kickjs/types/kick__context.d.ts'), 'utf-8')
+    expect(ctx).toContain("declare module '@forinda/kickjs'")
+    expect(ctx).toContain('interface ContextKeys')
+    expect(ctx).toContain('tenant: true')
+    expect(ctx).toContain('session: true')
+  })
+
+  it('skips kick__context.d.ts when no context decorators exist', () => {
+    runCli(fixture, ['typegen'])
+    expect(existsSync(join(fixture, '.kickjs/types/kick__context.d.ts'))).toBe(false)
+  })
+
   it('augments KickJsPluginRegistry with discovered names', () => {
     writeFile(
       'src/adapters/tenant.adapter.ts',

--- a/packages/cli/__tests__/typegen-plugin-registry.test.ts
+++ b/packages/cli/__tests__/typegen-plugin-registry.test.ts
@@ -19,12 +19,11 @@ import {
 } from '../src/typegen/scanner'
 import { assertCliOk, cleanupFixture, createFixtureProject, runCli } from './helpers'
 
-// Project rule: isolate DI state before every test. A fresh isolated
-// container avoids mutating the global singleton across parallel tests.
-// Applies across all describes (runs before any describe-local
-// beforeEach, e.g. the E2E fixture setup).
+// Project rule: reset DI state before every test for isolation. Applies
+// across all describes (runs before any describe-local beforeEach, e.g.
+// the E2E fixture setup).
 beforeEach(() => {
-  Container.create()
+  Container.reset()
 })
 
 describe('scanner — extractPluginsAndAdaptersFromSource', () => {

--- a/packages/cli/__tests__/typegen-plugin-registry.test.ts
+++ b/packages/cli/__tests__/typegen-plugin-registry.test.ts
@@ -12,11 +12,20 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { Container } from '@forinda/kickjs'
 import {
   extractAugmentationsFromSource,
   extractPluginsAndAdaptersFromSource,
 } from '../src/typegen/scanner'
 import { assertCliOk, cleanupFixture, createFixtureProject, runCli } from './helpers'
+
+// Project rule: isolate DI state before every test. A fresh isolated
+// container avoids mutating the global singleton across parallel tests.
+// Applies across all describes (runs before any describe-local
+// beforeEach, e.g. the E2E fixture setup).
+beforeEach(() => {
+  Container.create()
+})
 
 describe('scanner — extractPluginsAndAdaptersFromSource', () => {
   it('discovers a defineAdapter call by its `name:` field', () => {

--- a/packages/cli/src/plugin/builtins.ts
+++ b/packages/cli/src/plugin/builtins.ts
@@ -32,6 +32,7 @@ import { kickServiceTokensTypegen } from '../typegen/builtin/service-tokens'
 import { kickModuleTokensTypegen } from '../typegen/builtin/module-tokens'
 import { kickPluginsRegistryTypegen } from '../typegen/builtin/plugins-registry'
 import { kickAugmentationsTypegen } from '../typegen/builtin/augmentations'
+import { kickContextTypegen } from '../typegen/builtin/context'
 
 import { defineCliPlugin, type KickCliPlugin } from './types'
 
@@ -66,6 +67,7 @@ export const builtinCliPlugins: readonly KickCliPlugin[] = [
   defineCliPlugin({ name: 'kick/modules', typegens: [kickModuleTokensTypegen()] }),
   defineCliPlugin({ name: 'kick/plugins', typegens: [kickPluginsRegistryTypegen()] }),
   defineCliPlugin({ name: 'kick/augmentations', typegens: [kickAugmentationsTypegen()] }),
+  defineCliPlugin({ name: 'kick/context', typegens: [kickContextTypegen()] }),
   defineCliPlugin({ name: 'kick/assets', typegens: [kickAssetsTypegen()] }),
   defineCliPlugin({ name: 'kick/routes', typegens: [kickRoutesTypegen()] }),
   defineCliPlugin({ name: 'kick/env', typegens: [kickEnvTypegen()] }),

--- a/packages/cli/src/typegen/builtin/context.ts
+++ b/packages/cli/src/typegen/builtin/context.ts
@@ -1,0 +1,26 @@
+// kick/context typegen plugin.
+//
+// Auto-populates the `ContextKeys` registry by scanning every
+// `defineContextDecorator` / `defineHttpContextDecorator` `key:` literal
+// in the project, emitting `.kickjs/types/kick__context.d.ts`. This
+// makes `dependsOn` typo-checking automatic and complete — adopters
+// never hand-maintain `ContextKeys`, and augmenting `ContextMeta` for a
+// value type can never break a `dependsOn` (every real contributor key
+// is already a known key).
+//
+// Returns null when no context decorators are discovered, so the runner
+// skips emission for projects that don't use the contributor pipeline.
+
+import { renderContextKeys } from '../render/manifest'
+import { sharedScanOptions } from './scan-opts'
+import type { TypegenPlugin } from '../plugin'
+
+export const kickContextTypegen = (): TypegenPlugin => ({
+  id: 'kick/context',
+  inputs: ['src/**/*.ts'],
+  async generate(ctx) {
+    const scan = await ctx.getScanResult(sharedScanOptions(ctx))
+    if (scan.contextKeys.length === 0) return null
+    return renderContextKeys(scan.contextKeys)
+  },
+})

--- a/packages/cli/src/typegen/render/manifest.ts
+++ b/packages/cli/src/typegen/render/manifest.ts
@@ -130,6 +130,40 @@ export {}
 `
 }
 
+/** True when `str` is a bare JS identifier (usable as an unquoted key). */
+function isIdentifierKey(str: string): boolean {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(str)
+}
+
+/**
+ * Render the `ContextKeys` augmentation from discovered context-decorator
+ * keys. Each `key:` literal becomes a `'<key>': true` entry — a key-only
+ * registry (the value type is irrelevant; `true` is conventional) so
+ * `dependsOn: ['<key>']` is autocompleted + typo-checked without forcing
+ * a value type into `ContextMeta`. Non-identifier keys are quoted.
+ */
+export function renderContextKeys(keys: readonly { key: string }[]): string {
+  const unique = [...new Set(keys.map((k) => k.key))].toSorted()
+  const body = unique
+    .map((k) => `    ${isIdentifierKey(k) ? k : JSON.stringify(k)}: true`)
+    .join('\n')
+  return `${HEADER}
+declare module '@forinda/kickjs' {
+  /**
+   * Key-only registry of every context key produced by a
+   * \`defineContextDecorator\` / \`defineHttpContextDecorator\` in the
+   * project. Feeds \`dependsOn\` typo-checking. Value types live in
+   * \`ContextMeta\`; this only records that the key exists.
+   */
+  interface ContextKeys {
+${body}
+  }
+}
+
+export {}
+`
+}
+
 /** Render a string-literal union type containing the given names */
 export function renderUnion(typeName: string, names: string[], emptyComment: string): string {
   if (names.length === 0) {

--- a/packages/cli/src/typegen/scanner.ts
+++ b/packages/cli/src/typegen/scanner.ts
@@ -169,6 +169,22 @@ export interface DiscoveredPluginOrAdapter {
 }
 
 /**
+ * A context key discovered from a `defineContextDecorator({ key })` or
+ * `defineHttpContextDecorator({ key })` call (including the curried
+ * `.withParams<P>()({ key })` form). Feeds the `kick/context` typegen
+ * plugin, which emits the `ContextKeys` augmentation so `dependsOn`
+ * typo-checking is automatic and complete.
+ */
+export interface DiscoveredContextKey {
+  /** The literal `key:` value the contributor writes. */
+  key: string
+  /** Absolute file path. */
+  filePath: string
+  /** Path relative to scan root, with forward slashes. */
+  relativePath: string
+}
+
+/**
  * A `defineAugmentation('Name', meta)` call discovered in source. Plugins
  * call this to advertise an augmentable interface so the typegen can list
  * every augmentation surface in one generated file.
@@ -219,6 +235,8 @@ export interface ScanResult {
   pluginsAndAdapters: DiscoveredPluginOrAdapter[]
   /** Augmentation interfaces declared via `defineAugmentation('Name', meta)` */
   augmentations: DiscoveredAugmentation[]
+  /** Context keys from `define(Http)ContextDecorator({ key })` calls */
+  contextKeys: DiscoveredContextKey[]
   /**
    * Decorated classes that sit inside a module directory but aren't
    * picked up by any of the module's `import.meta.glob(...)` patterns.
@@ -301,6 +319,20 @@ const INJECT_LITERAL_REGEX = /@Inject\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/g
  * `findBalancedClose` so nested objects/parens don't confuse us.
  */
 const DEFINE_HELPER_START = /\b(defineAdapter|definePlugin)\s*(?:<[^>]*>)?\s*\(/g
+
+/**
+ * Match the start of a `defineContextDecorator(...)` /
+ * `defineHttpContextDecorator(...)` call up to the `(` that opens the
+ * spec object — tolerating optional `<...>` generics AND the curried
+ * `.withParams<P>()(...)` form (the empty `()` is consumed so the next
+ * `(` is the spec). The spec's `key:` literal is then read forward via
+ * `findBalancedClose`, mirroring `DEFINE_HELPER_START`.
+ */
+// `(?:<(?:[^<>]|<[^<>]*>)*>)?` tolerates one level of nested generics
+// (e.g. `defineHttpContextDecorator<'tenant', Record<string, never>>`),
+// which a flat `<[^>]*>` would truncate at the inner `>`.
+const CONTEXT_DECORATOR_START =
+  /\b(?:defineContextDecorator|defineHttpContextDecorator)\s*(?:\.withParams\s*<(?:[^<>]|<[^<>]*>)*>\s*\(\s*\))?\s*(?:<(?:[^<>]|<[^<>]*>)*>)?\s*\(/g
 
 /**
  * Match a class declaration whose `implements` clause includes `AppAdapter`.
@@ -1037,6 +1069,45 @@ export function extractPluginsAndAdaptersFromSource(
 }
 
 /**
+ * Extract context keys from `defineContextDecorator({ key: '...' })` and
+ * `defineHttpContextDecorator({ key: '...' })` calls (including the
+ * curried `.withParams<P>()({ key: '...' })` form). Only the literal
+ * `key:` field feeds the result — the symbol on the LHS is irrelevant
+ * since `dependsOn` references the runtime key string.
+ *
+ * Mirrors {@link extractPluginsAndAdaptersFromSource}: regex to the spec
+ * object's opening paren, `findBalancedClose` to its end, then the first
+ * `key: 'literal'` inside.
+ */
+export function extractContextKeysFromSource(
+  source: string,
+  filePath: string,
+  cwd: string,
+): DiscoveredContextKey[] {
+  const out: DiscoveredContextKey[] = []
+  const relPath = toRelative(filePath, cwd)
+  const seen = new Set<string>()
+
+  CONTEXT_DECORATOR_START.lastIndex = 0
+  // The match value itself is unused — we only need the loop to advance
+  // and `lastIndex` to point just past the spec's opening paren.
+  while (CONTEXT_DECORATOR_START.exec(source) !== null) {
+    const openParen = CONTEXT_DECORATOR_START.lastIndex - 1
+    const closeParen = findBalancedClose(source, openParen)
+    if (closeParen < 0) continue
+    const callArgs = source.slice(openParen + 1, closeParen)
+    const keyMatch = /\bkey\s*:\s*['"`]([^'"`]+)['"`]/.exec(callArgs)
+    if (!keyMatch) continue
+    const key = keyMatch[1]
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push({ key, filePath, relativePath: relPath })
+  }
+
+  return out
+}
+
+/**
  * Extract `defineAugmentation('Name', { description, example })` calls
  * from a source file. The metadata object is optional — when absent both
  * `description` and `example` resolve to `null`.
@@ -1241,6 +1312,7 @@ export async function scanProject(opts: ScanOptions): Promise<ScanResult> {
   const injects: DiscoveredInject[] = []
   const pluginsAndAdapters: DiscoveredPluginOrAdapter[] = []
   const augmentations: DiscoveredAugmentation[] = []
+  const contextKeys: DiscoveredContextKey[] = []
 
   // Two passes: first collect all classes, then a second pass extracts
   // routes per file using the per-file class list as scoping context.
@@ -1259,6 +1331,7 @@ export async function scanProject(opts: ScanOptions): Promise<ScanResult> {
     injects.push(...extractInjectsFromSource(source, file, opts.cwd))
     pluginsAndAdapters.push(...extractPluginsAndAdaptersFromSource(source, file, opts.cwd))
     augmentations.push(...extractAugmentationsFromSource(source, file, opts.cwd))
+    contextKeys.push(...extractContextKeysFromSource(source, file, opts.cwd))
   }
 
   // forinda/kick-js#235 §3 — build a `Controller → mountPath` map from every
@@ -1338,6 +1411,9 @@ export async function scanProject(opts: ScanOptions): Promise<ScanResult> {
   augmentations.sort(
     (a, b) => a.name.localeCompare(b.name) || a.relativePath.localeCompare(b.relativePath),
   )
+  contextKeys.sort(
+    (a, b) => a.key.localeCompare(b.key) || a.relativePath.localeCompare(b.relativePath),
+  )
 
   const collisions = findCollisions(classes)
   const env = await detectEnvFile(opts.cwd, opts.envFile ?? 'src/env.ts')
@@ -1356,6 +1432,7 @@ export async function scanProject(opts: ScanOptions): Promise<ScanResult> {
     env,
     pluginsAndAdapters,
     augmentations,
+    contextKeys,
     orphanedClasses,
   }
 }


### PR DESCRIPTION
Closes #312. Implements the `kick/context` typegen plugin from that issue's spec.

## What

`kick typegen` now scans every `defineContextDecorator({ key })` / `defineHttpContextDecorator({ key })` call — including the curried `.withParams<T>()({ key })` form — and emits `.kickjs/types/kick__context.d.ts` augmenting the `ContextKeys` registry:

```ts
// generated
declare module '@forinda/kickjs' {
  interface ContextKeys {
    tenant: true
    session: true
  }
}
```

A Context Contributor's `dependsOn` is now typo-checked **automatically** — no hand-maintained `ContextKeys`, and no need to give a key a value type in `ContextMeta` just to depend on it.

## Pieces

- **Scanner**: `extractContextKeysFromSource` + `ScanResult.contextKeys`. Regex mirrors `extractPluginsAndAdaptersFromSource` (`findBalancedClose` to the spec object, first `key:` literal); tolerates one level of nested generics (`defineHttpContextDecorator<'tenant', Record<string, never>>`).
- **Render**: `renderContextKeys` (non-identifier keys quoted).
- **Plugin**: `builtin/context.ts` → `kick/context`, emits `kick__context.d.ts`, returns `null` when no decorators exist.
- Registered in `builtins.ts`; `typegen.disable: ['kick/context']` opts out like any other.

## Verification

- Scanner unit tests (8): every call form — bare / generic / nested-generic / curried `.withParams` (http + bare) / dedupe / ignores `defineAdapter`·`definePlugin` / quote styles.
- E2E: `kick g contributor` × 2 → `kick typegen` → `kick__context.d.ts` contains both keys; skipped when none.
- Full CLI suite: 363 pass / 3 fail (the 3 are pre-existing **Windows-only** path-separator assertions, green on Linux CI).

## Dependency note

The narrowing effect of the generated augmentation requires the `ContextKeys` registry from **#311** (`dependsOn = keyof ContextMeta | keyof ContextKeys`). This PR is based on `main` (which has #310/#313 but not yet #311), so the plugin builds + emits correctly today; the generated `ContextKeys` augmentation is inert until #311 lands, then becomes effective with zero further changes. Merge after #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Typegen now auto-generates a ContextKeys augmentation from discovered context decorators, enabling typo-checked `dependsOn` in contributors; generation is skipped when none are found.

* **Documentation**
  * Guide updated to document the context-keys type generation behavior, output, and fallback when no decorators exist.

* **Tests**
  * Added unit and E2E tests verifying extraction, deduplication, emission, and the negative (no-emission) case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->