### PR TITLE
fix(dev): kick dev bootstraps at startup + runs graceful shutdown on Ctrl+C

### DIFF
--- a/.changeset/kick-dev-bootstrap-shutdown.md
+++ b/.changeset/kick-dev-bootstrap-shutdown.md
@@ -1,0 +1,10 @@
+---
+'@forinda/kickjs-vite': patch
+'@forinda/kickjs-cli': patch
+'@forinda/kickjs': patch
+---
+
+Fix two `kick dev` (Vite) lifecycle gaps — neither was Windows-specific, though Windows made the shutdown one worse.
+
+- **App now bootstraps at startup, not on first request.** The dev-server plugin evaluated the app lazily via `ssrLoadModule` inside the request middleware, so `bootstrap()`, adapter `afterStart`, and your startup logs didn't run until the first HTTP request hit. The plugin now warms the module once the HTTP server is listening, so `kick dev` behaves like `node`/`tsx` — logs + adapters + the server come up immediately.
+- **Graceful shutdown now runs on Ctrl+C in dev.** The app deliberately suppresses its own SIGINT/SIGTERM handlers in dev (Vite owns the lifecycle), and the CLI dev server only closed Vite — so `adapter.shutdown()`, request draining, and shutdown logs never ran. `Application.start()` now exposes its `shutdown()` on `globalThis` in dev, and `kick dev` awaits it before tearing down Vite. Also wires `SIGBREAK` (Windows Ctrl+Break) since Windows never raises `SIGTERM`.

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -177,14 +177,32 @@ async function startDevServer(
 
   console.log(`\n  KickJS dev server running (Vite + @forinda/kickjs-vite)\n`)
 
-  // Graceful shutdown — Vite closes the server + all HMR connections
+  // Graceful shutdown — Vite closes the server + all HMR connections.
+  // The app suppresses its own signal handlers in dev (Vite owns the
+  // lifecycle), so drive its graceful shutdown here: drain in-flight
+  // requests + run adapter.shutdown() + emit shutdown logs BEFORE Vite
+  // tears the server down. The hook is set on globalThis by
+  // Application.start() once the app has bootstrapped (same process).
+  let shuttingDown = false
   const shutdown = async () => {
+    if (shuttingDown) return
+    shuttingDown = true
     if (typegenTimer) clearTimeout(typegenTimer)
+    try {
+      await (
+        globalThis as { __kickjs_app_shutdown?: () => Promise<void> }
+      ).__kickjs_app_shutdown?.()
+    } catch (err: any) {
+      console.error(`  app shutdown hook failed: ${err?.message ?? err}`)
+    }
     await server.close()
     process.exit(0)
   }
   process.on('SIGINT', shutdown)
   process.on('SIGTERM', shutdown)
+  // Windows delivers Ctrl+Break as SIGBREAK (and SIGTERM is never raised);
+  // wire it so graceful shutdown works there too.
+  process.on('SIGBREAK', shutdown)
 }
 
 export function registerRunCommands(program: Command): void {

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -753,6 +753,14 @@ export class Application {
       this.httpServer = g.__kickjs_httpServer
       log.debug('Attached to Vite dev server')
 
+      // Dev mode suppresses our own SIGINT/SIGTERM handlers (Vite owns
+      // the process lifecycle), so a Ctrl+C would otherwise skip graceful
+      // shutdown entirely — `adapter.shutdown()`, request draining, and
+      // any shutdown logs never run. Expose `shutdown()` on globalThis so
+      // the CLI dev server (`kick dev`) can drive it before tearing down
+      // Vite. Same process, so the CLI's signal handler can reach this.
+      g.__kickjs_app_shutdown = () => this.shutdown()
+
       for (const adapter of this.adapters) {
         const ctx = this.adapterCtx(this.httpServer!)
         await this.callHook(adapter.afterStart?.bind(adapter), ctx)

--- a/packages/vite/src/dev-server.ts
+++ b/packages/vite/src/dev-server.ts
@@ -105,6 +105,30 @@ export function kickjsDevServerPlugin(_ctx: PluginContext): Plugin {
       globalThis.__kickjs_httpServer = viteServer.httpServer ?? null
       globalThis.__kickjs_viteServer = viteServer
 
+      // ━━━ Eagerly bootstrap the app once the server is listening ━━━
+      // The post-middleware below only evaluates the entry on the FIRST
+      // request (lazy SSR). That means `bootstrap()`, adapter
+      // `afterStart`, and the app's startup logs don't run until someone
+      // hits the URL — the app looks "not started" until then. Warm the
+      // module once the HTTP server is listening so startup behaves like
+      // `node`/`tsx` (logs + adapters + the in-dev shutdown hook ready
+      // immediately). Errors surface with a fixed stacktrace.
+      const warm = () => {
+        viteServer.ssrLoadModule(VIRTUAL_APP).catch((err: unknown) => {
+          if (err instanceof Error) viteServer.ssrFixStacktrace(err)
+          viteServer.config.logger.error(
+            `[kickjs] failed to bootstrap app on startup: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          )
+        })
+      }
+      const httpServer = viteServer.httpServer
+      if (httpServer) {
+        if (httpServer.listening) warm()
+        else httpServer.once('listening', warm)
+      }
+
       // Return post-middleware — runs after Vite's static/HMR middleware
       return () => {
         viteServer.middlewares.use(async (req, res, next) => {


### PR DESCRIPTION
Fixes two `kick dev` (Vite) lifecycle gaps reported on Windows. Neither is actually Windows-specific — but Windows made the shutdown one worse (no `SIGTERM`). With plain `tsx src/index.ts` the entry runs eagerly so both worked; under `kick dev` they didn't.

## 1. App now bootstraps at startup (not on first request)

`packages/vite/src/dev-server.ts` evaluated the app **lazily** — `ssrLoadModule(VIRTUAL_APP)` was only called inside the request middleware, so `bootstrap()` → `app.start()` (adapter `afterStart`, the "app running" log, etc.) didn't run until the first HTTP request arrived. The app looked dead until you hit the URL.

Fix: warm the module once the HTTP server is `listening`, so `kick dev` comes up like `node`/`tsx` — logs + adapters + the in-dev shutdown hook are ready immediately. Idempotent (`ssrLoadModule` caches; the request middleware reuses it).

## 2. Graceful shutdown now runs on Ctrl+C in dev

`Application.start()` deliberately **suppresses its own SIGINT/SIGTERM handlers in dev** (Vite owns the lifecycle — `application.ts` documents this). The CLI dev server only did `viteServer.close()` + `process.exit(0)`, so `app.shutdown()` — request draining, `adapter.shutdown()`, and any shutdown logs — **never ran**.

Fix:
- `Application.start()` sets `globalThis.__kickjs_app_shutdown = () => this.shutdown()` in the dev branch (same process as the CLI).
- `kick dev` awaits that hook before tearing down Vite.
- Also wires `SIGBREAK` (Windows Ctrl+Break) since Windows never raises `SIGTERM`.

`bootstrap()` already awaits `app.start()`, so with fix #1 the hook is registered at startup and is available the moment you Ctrl+C.

## Verification

- Typecheck clean across `kickjs` / `vite` / `cli`.
- `kickjs` shutdown suite 9/9, `vite` suite 79/79, all three build.
- (Live `kick dev` signal behaviour is environment-driven; the change is small + the wiring is verified by typecheck + the existing shutdown tests.)

Three patch changesets (`kickjs`, `kickjs-vite`, `kickjs-cli`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Application now initializes immediately when running `kick dev` instead of waiting for the first request, ensuring startup logs and initialization hooks execute promptly
* Graceful shutdown now responds properly to Ctrl+C interruption (and Ctrl+Break on Windows), allowing the app to clean up resources before the development server closes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->