### PR TITLE
feat(cli): kick add zod|valibot|yup installs the schema validator

### DIFF
--- a/.changeset/kick-add-schema-libs.md
+++ b/.changeset/kick-add-schema-libs.md
@@ -2,4 +2,11 @@
 '@forinda/kickjs-cli': patch
 ---
 
-`kick add zod | valibot | yup` now installs the schema validator. The validator is an optional peer of `@forinda/kickjs` (the framework lazy-loads it), so a project that adds one any other way hits `Cannot find module 'zod'` at startup. They weren't in the `kick add` registry before (`kick add zod` → "Unknown packages: zod"); now they're first-class entries, so existing projects can add or switch schema libs in one step. `kick new` already installs the chosen one.
+`kick add zod | valibot | yup` now installs the schema validator.
+
+The validator is an optional peer of `@forinda/kickjs` (the framework
+lazy-loads it), so a project that installs one in any other way hits
+`Cannot find module 'zod'` at startup. They weren't in the `kick add`
+registry before (`kick add zod` → "Unknown packages: zod"); now they're
+first-class entries, so existing projects can add or switch schema libs
+in one step. `kick new` already installs the chosen one.

--- a/.changeset/kick-add-schema-libs.md
+++ b/.changeset/kick-add-schema-libs.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+`kick add zod | valibot | yup` now installs the schema validator. The validator is an optional peer of `@forinda/kickjs` (the framework lazy-loads it), so a project that adds one any other way hits `Cannot find module 'zod'` at startup. They weren't in the `kick add` registry before (`kick add zod` → "Unknown packages: zod"); now they're first-class entries, so existing projects can add or switch schema libs in one step. `kick new` already installs the chosen one.

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -41,6 +41,29 @@ const PACKAGE_REGISTRY: Record<string, PackageEntry> = {
     core: true,
   },
 
+  // Schema validation — the validator backing env + DTO + OpenAPI
+  // schemas. `@forinda/kickjs-schema` (a core dep) wraps whichever one
+  // you pick behind `KickSchema`, but the validator itself is an
+  // optional peer of `@forinda/kickjs`, so it must be installed
+  // explicitly or the app errors at startup ("Cannot find module
+  // 'zod'"). `kick new` installs the chosen one; `kick add` lets an
+  // existing project add/switch.
+  zod: {
+    pkg: 'zod',
+    peers: [],
+    description: 'Zod schema validation (env, DTOs, OpenAPI) — wrap with fromZod()',
+  },
+  valibot: {
+    pkg: 'valibot',
+    peers: [],
+    description: 'Valibot schema validation — wrap with fromValibot()',
+  },
+  yup: {
+    pkg: 'yup',
+    peers: [],
+    description: 'Yup schema validation — wrap with fromYup()',
+  },
+
   // API
   swagger: {
     pkg: '@forinda/kickjs-swagger',


### PR DESCRIPTION
`kick add zod | valibot | yup` now installs the schema validator.

## Why

The schema validator is an **optional peer** of `@forinda/kickjs` (the framework lazy-loads it). A project that adds one via `kick add` got `Unknown packages: zod` — the libs weren't in the `kick add` registry — so people installed them inconsistently (or not at all) and hit `Cannot find module 'zod'` at startup.

## Change

Add `zod`, `valibot`, `yup` as first-class `kick add` entries (prod deps, no extra peers). `kick add zod` / `valibot` / `yup` now installs the lib; they show in `kick add --list --all`. `kick new` already installs the chosen one — this covers existing projects adding or switching.

Verified: `kick add --list --all` lists all three; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now install schema validators with `kick add`: zod, valibot, and yup are available directly.
* **Bug Fixes**
  * Resolves startup errors when a project uses only one schema validator and ensures adding or switching validators works in one step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->