### PR TITLE
fix(cli): kick g fallback rejects reserved generator names (stop silent module scaffolding)

### DIFF
--- a/.changeset/g-fallback-reserved-names.md
+++ b/.changeset/g-fallback-reserved-names.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+`kick g <generator> <name>` no longer silently scaffolds modules when the generator name fails to route. The bare `kick g <names...>` form is module shorthand and previously sent ANY unmatched first token straight to module generation — so on a CLI older than a given generator (e.g. `contributor`), `kick g contributor tenant` quietly created modules named `contributor` and `tenant` instead of erroring. The fallback now refuses a reserved generator name with a clear message (and an "upgrade your CLI" hint) instead of scaffolding modules. Plain module shorthand (`kick g user task`) is unaffected.

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -162,6 +162,16 @@ const GENERATORS = [
   },
 ]
 
+/**
+ * First token of every built-in generator (`'module <name>'` → `'module'`).
+ * Used by the bare `kick g <names...>` action to refuse silently
+ * scaffolding modules when the first arg is actually a generator name
+ * that failed to route (older CLI, typo'd flag).
+ */
+const RESERVED_GENERATOR_NAMES: ReadonlySet<string> = new Set(
+  GENERATORS.map((g) => g.name.split(' ')[0]),
+)
+
 async function printGeneratorList(): Promise<void> {
   console.log('\n  Built-in generators:\n')
   const maxName = Math.max(...GENERATORS.map((g) => g.name.length))
@@ -332,6 +342,25 @@ export function registerGenerateCommand(program: Command, ctx?: KickCliPluginCon
         )
         if (result) {
           printGenerated(result.files, dryRun)
+          return
+        }
+
+        // Guard the module fallback against a reserved generator name.
+        // Commander routes `kick g <gen> <name>` to its dedicated
+        // subcommand — so reaching here with a known generator name as
+        // the first token means it DIDN'T route: typically the installed
+        // CLI predates that generator (e.g. `contributor`), or a typo in
+        // a flag broke parsing. Without this guard the names fall through
+        // to `runModuleGeneration` and silently scaffold MODULES named
+        // after the generator + its argument (`kick g contributor tenant`
+        // → modules `contributor` and `tenant`). Fail loud instead.
+        if (generatorName !== 'module' && RESERVED_GENERATOR_NAMES.has(generatorName)) {
+          console.error(`\n  '${generatorName}' is a generator, not a module name.`)
+          console.error(`  Did you mean:  kick g ${generatorName} ${itemName ?? '<name>'}`)
+          console.error(
+            `  If that errors, your @forinda/kickjs-cli is older than the '${generatorName}' generator — upgrade it.\n`,
+          )
+          process.exitCode = 1
           return
         }
       }


### PR DESCRIPTION
## Symptom

`kick g contributor <name>` generated **modules** (`contributor` + `<name>`) instead of a contributor — on any CLI older than the `contributor` generator (#313).

## Root cause

The bare `kick g <names...>` form is module shorthand (`kick g user task` → two modules). After the plugin-generator dispatch misses, it sent **any** first token straight to `runModuleGeneration`. So when a generator's subcommand didn't route — because the installed CLI predates it, or a typo'd flag broke parsing — the generator name + its arg fell through and got scaffolded as modules. Silent + confusing.

(On a current CLI every built-in generator routes correctly — audited `GENERATORS` vs registered `.command()`s, all match — so this is the version-mismatch / typo footgun, not a current-CLI miss.)

## Fix

Guard the module fallback: if the first token is a **reserved generator name** (derived from the `GENERATORS` list), fail loudly with the correct invocation and an "upgrade your CLI" hint instead of scaffolding modules.

```
$ kick g contributor tenant   # on a CLI lacking the contributor subcommand
  'contributor' is a generator, not a module name.
  Did you mean:  kick g contributor tenant
  If that errors, your @forinda/kickjs-cli is older than the 'contributor' generator — upgrade it.
```

Plain module shorthand (`kick g user task`) is unaffected — only reserved generator names are guarded.

Verified: typecheck clean; `kick g contributor tenant` still routes to the contributor generator, `kick g billing` still scaffolds a module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `kick g` command now properly validates generator names and displays clear error messages when reserved names are used, instead of silently scaffolding modules as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->