### PR TITLE
feat(kickjs): respect LOG_LEVEL, opt-in route table, plural middlewares

### DIFF
--- a/.changeset/logger-respect-log-level.md
+++ b/.changeset/logger-respect-log-level.md
@@ -6,6 +6,6 @@ Quieter startup by default, plus clearer bootstrap option names.
 
 - **`ConsoleLoggerProvider` now respects `LOG_LEVEL`** (default `info`). Previously every `logger.debug()` printed unconditionally, dumping DI wiring and HMR ticks on each start. Messages below the threshold (`trace < debug < info < warn < error < fatal`, plus `silent`) are now dropped; run with `LOG_LEVEL=debug` to see them. Custom `LoggerProvider` implementations (pino, winston, …) are unaffected — they manage their own levels.
 
-- **The startup route table is now opt-in via `bootstrap({ logRouteTable: true })`** and defaults to **off**. It previously printed automatically in non-production. When enabled it logs at `info` level so it's visible regardless of `LOG_LEVEL`. The old `logRoutesTable` option keeps working as a deprecated alias (`logRouteTable` wins when both are set).
+- **The startup route table is now opt-in via `bootstrap({ logRouteTable: true })`** and defaults to **off**. It previously printed automatically in non-production. When enabled it logs at `info` level (so it appears whenever `LOG_LEVEL` permits `info`, i.e. the default). The old `logRoutesTable` option keeps working as a deprecated alias (`logRouteTable` wins when both are set).
 
 - **`bootstrap({ middlewares: [...] })`** is the new plural option name for the global middleware pipeline. The singular `middleware` is kept as a deprecated alias (`middlewares` wins when both are set), so existing apps keep working.

--- a/.changeset/logger-respect-log-level.md
+++ b/.changeset/logger-respect-log-level.md
@@ -1,0 +1,11 @@
+---
+'@forinda/kickjs': minor
+---
+
+Quieter startup by default, plus clearer bootstrap option names.
+
+- **`ConsoleLoggerProvider` now respects `LOG_LEVEL`** (default `info`). Previously every `logger.debug()` printed unconditionally, dumping DI wiring and HMR ticks on each start. Messages below the threshold (`trace < debug < info < warn < error < fatal`, plus `silent`) are now dropped; run with `LOG_LEVEL=debug` to see them. Custom `LoggerProvider` implementations (pino, winston, …) are unaffected — they manage their own levels.
+
+- **The startup route table is now opt-in via `bootstrap({ logRouteTable: true })`** and defaults to **off**. It previously printed automatically in non-production. When enabled it logs at `info` level so it's visible regardless of `LOG_LEVEL`. The old `logRoutesTable` option keeps working as a deprecated alias (`logRouteTable` wins when both are set).
+
+- **`bootstrap({ middlewares: [...] })`** is the new plural option name for the global middleware pipeline. The singular `middleware` is kept as a deprecated alias (`middlewares` wins when both are set), so existing apps keep working.

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -427,7 +427,7 @@ import { session } from '@forinda/kickjs'
 // Bootstrap with session middleware + strategy
 bootstrap({
   modules,
-  middleware: [session({ secret: process.env.SESSION_SECRET! }), express.json()],
+  middlewares: [session({ secret: process.env.SESSION_SECRET! }), express.json()],
   adapters: [
     AuthAdapter({
       strategies: [SessionStrategy()],

--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -105,7 +105,7 @@ Anything you repeatedly compute from the incoming request is a candidate. The pa
 Same job, different ergonomics. Each line below maps a middleware pain point to the contributor primitive that solves it.
 
 - **Type safety** — middleware mutates `req.user` / `(req as any).tenant`, all typed `any`. Contributors expose `ctx.get('user')` / `ctx.get('tenant')` typed via `ContextMeta` augmentation.
-- **Ordering** — middleware is an array in `bootstrap({ middleware: [...] })`; order is whatever you wrote. Contributors use `dependsOn: ['x']` — topo-sorted at boot, missing deps + cycles fail startup, not per-request.
+- **Ordering** — middleware is an array in `bootstrap({ middlewares: [...] })`; order is whatever you wrote. Contributors use `dependsOn: ['x']` — topo-sorted at boot, missing deps + cycles fail startup, not per-request.
 - **DI access** — middleware reaches for `Container.getInstance()` inside the body. Contributors declare `deps: { repo: TOKEN }` typed, resolved once, handed to `resolve(ctx, deps)`.
 - **Testing** — middleware needs `supertest` + the whole Express stack. Contributors test via `runContributor` (from `@forinda/kickjs-testing`) — single resolver against a stub ctx.
 - **Per-route override** — middleware is global: every route pays the cost, no opt-out per endpoint. Contributors have five precedence levels (method > class > module > adapter > global) — override per-route without forking the stack.

--- a/docs/guide/csrf.md
+++ b/docs/guide/csrf.md
@@ -20,7 +20,7 @@ import { csrf } from '@forinda/kickjs'
 
 bootstrap({
   modules,
-  middleware: [cookieParser(), csrf()],
+  middlewares: [cookieParser(), csrf()],
 })
 ```
 

--- a/docs/guide/dependency-injection.md
+++ b/docs/guide/dependency-injection.md
@@ -248,7 +248,7 @@ bootstrap({
   modules: [
     /* ... */
   ],
-  middleware: [
+  middlewares: [
     tracing(),
     requestScopeMiddleware(), // mount here instead of the default position
     // ... other middleware

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -165,7 +165,7 @@ export const app = await bootstrap({
   Total: 5 routes
 ```
 
-It is **off by default** (it used to print automatically in dev). When enabled it logs at `info` level, so it shows regardless of `LOG_LEVEL`. The old `logRoutesTable` option still works as a deprecated alias.
+It is **off by default** (it used to print automatically in dev). When enabled it logs at `info` level, so it appears at the default `LOG_LEVEL` but is hidden if you raise the threshold to `warn`/`error`/`silent`. The old `logRoutesTable` option still works as a deprecated alias.
 
 ## Add Swagger Docs
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-> 📖 **Reading this on GitHub?** The latest rendered version lives at <https://forinda.github.io/kick-js/guide/getting-started.html> — every `./*.md` link in this page resolves there too.
+> 📖 **Reading this on GitHub?** The full rendered docs live at <https://forinda.github.io/kick-js/> — every `./*.md` link in this page resolves there too.
 
 ## Prerequisites
 
@@ -150,7 +150,14 @@ That's it. Your API is running at `http://localhost:3000/api/v1/users`.
 
 ### Route Summary
 
-In dev mode, a compact route summary is logged at startup:
+Opt in to a compact route table at startup with `logRouteTable: true`:
+
+```ts
+export const app = await bootstrap({
+  modules,
+  logRouteTable: true,
+})
+```
 
 ```
 [Application] Routes:
@@ -158,15 +165,7 @@ In dev mode, a compact route summary is logged at startup:
   Total: 5 routes
 ```
 
-This is enabled by default when `NODE_ENV !== 'production'`. Override with `logRoutesTable`:
-
-```ts
-export const app = await bootstrap({
-  modules,
-  logRoutesTable: true, // always log (even in production)
-  // logRoutesTable: false, // never log
-})
-```
+It is **off by default** (it used to print automatically in dev). When enabled it logs at `info` level, so it shows regardless of `LOG_LEVEL`. The old `logRoutesTable` option still works as a deprecated alias.
 
 ## Add Swagger Docs
 

--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -71,7 +71,7 @@ if (env.SENTRY_DSN) {
 bootstrap({
   modules: [UserModule, ProductModule],
   adapters,
-  middleware: [helmet(), cors(), requestId(), express.json()],
+  middlewares: [helmet(), cors(), requestId(), express.json()],
 })
 ```
 

--- a/docs/guide/integrations/sentry.md
+++ b/docs/guide/integrations/sentry.md
@@ -90,7 +90,7 @@ bootstrap({
       info: { title: 'My API', version: '1.0.0' },
     }),
   ],
-  middleware: [helmet(), cors(), requestId(), requestLogger(), express.json()],
+  middlewares: [helmet(), cors(), requestId(), requestLogger(), express.json()],
 })
 ```
 
@@ -160,7 +160,7 @@ Add it before the default error handler:
 bootstrap({
   modules,
   adapters: [SentryAdapter({ dsn: env.SENTRY_DSN })],
-  middleware: [
+  middlewares: [
     helmet(),
     cors(),
     requestId(),
@@ -248,7 +248,7 @@ export function sentryContext() {
 Add after `requestId()` in the middleware pipeline:
 
 ```ts
-middleware: [
+middlewares: [
   requestId(),
   sentryContext(),  // Links request ID to Sentry traces
   requestLogger(),
@@ -276,7 +276,7 @@ if (env.SENTRY_DSN) {
   )
 }
 
-bootstrap({ modules, adapters, middleware: [...] })
+bootstrap({ modules, adapters, middlewares: [...] })
 ```
 
 ## Source Maps

--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -17,6 +17,8 @@ log.error('DB unreachable', err)
 log.debug('Cache miss for key=%s', key)
 ```
 
+The default provider respects the `LOG_LEVEL` env var (default `info`): messages below the threshold are dropped, ordered `trace < debug < info < warn < error < fatal` (plus `silent`). So `debug`/`trace` calls — including the framework's verbose startup detail like the route table and DI wiring — stay quiet unless you run with `LOG_LEVEL=debug`. Custom providers (Pino, Winston, …) manage their own levels.
+
 For most apps that's enough. When it isn't, plug in a real logger.
 
 ## The contract

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -661,15 +661,15 @@ dispatch and resolves the user as normal.
 
 ### Common issues
 
-| Symptom                                                | Cause                                                            | Fix                                                                                                                                  |
-| ------------------------------------------------------ | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| 404 on connect                                         | Wrong URL — missing `/_mcp/messages`                             | Use the full path: `http://localhost:<port>/_mcp/messages`                                                                           |
-| "Server already initialized"                           | Stale session from a previous connection                         | Restart your KickJS server to reset the MCP session                                                                                  |
-| "Not Acceptable: Client must accept text/event-stream" | Opened `/_mcp/messages` directly in a browser tab                | Use the Inspector UI, not a direct browser navigation — the endpoint expects JSON-RPC POST requests                                  |
-| CORS errors in browser console                         | Connecting from a different origin without CORS configured       | Add `cors()` middleware in your bootstrap: `middleware: [cors({ origin: '*', exposedHeaders: ['mcp-session-id'] }), express.json()]` |
-| Tool calls return "Not authenticated"                  | Auth header not configured in the Inspector                      | Expand Authentication, enable the Authorization header, set the value                                                                |
-| Tools not showing up                                   | Methods not decorated with `@McpTool` in explicit mode           | Add `@McpTool({ description: '...' })` to each method you want to expose                                                             |
-| `@Autowired()` service is undefined (500 on tool call) | Running with `tsx`/`ts-node` which don't emit decorator metadata | Use explicit token: `@Autowired(MyService)` instead of bare `@Autowired()` — see [DI caveats](#di-caveats-autowired-with-tsx) below  |
+| Symptom                                                | Cause                                                            | Fix                                                                                                                                   |
+| ------------------------------------------------------ | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| 404 on connect                                         | Wrong URL — missing `/_mcp/messages`                             | Use the full path: `http://localhost:<port>/_mcp/messages`                                                                            |
+| "Server already initialized"                           | Stale session from a previous connection                         | Restart your KickJS server to reset the MCP session                                                                                   |
+| "Not Acceptable: Client must accept text/event-stream" | Opened `/_mcp/messages` directly in a browser tab                | Use the Inspector UI, not a direct browser navigation — the endpoint expects JSON-RPC POST requests                                   |
+| CORS errors in browser console                         | Connecting from a different origin without CORS configured       | Add `cors()` middleware in your bootstrap: `middlewares: [cors({ origin: '*', exposedHeaders: ['mcp-session-id'] }), express.json()]` |
+| Tool calls return "Not authenticated"                  | Auth header not configured in the Inspector                      | Expand Authentication, enable the Authorization header, set the value                                                                 |
+| Tools not showing up                                   | Methods not decorated with `@McpTool` in explicit mode           | Add `@McpTool({ description: '...' })` to each method you want to expose                                                              |
+| `@Autowired()` service is undefined (500 on tool call) | Running with `tsx`/`ts-node` which don't emit decorator metadata | Use explicit token: `@Autowired(MyService)` instead of bare `@Autowired()` — see [DI caveats](#di-caveats-autowired-with-tsx) below   |
 
 ### Important caveats
 
@@ -767,7 +767,7 @@ import { bootstrap, cors } from '@forinda/kickjs'
 
 export const app = await bootstrap({
   modules,
-  middleware: [
+  middlewares: [
     cors({
       origin: '*',
       exposedHeaders: ['mcp-session-id'],

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -98,14 +98,18 @@ Rule of thumb: **if the middleware's only job is to compute a value other code r
 
 ## Global Middleware
 
-Global middleware is configured in `bootstrap()` via the `middleware` option. These run on every request before any route is matched.
+Global middleware is configured in `bootstrap()` via the `middlewares` option. These run on every request before any route is matched.
+
+::: tip Renamed from `middleware`
+The option is `middlewares` (plural). The singular `middleware` still works as a **deprecated alias** — existing apps keep running — but new code should use `middlewares`. If you set both, `middlewares` wins.
+:::
 
 ::: warning Different signature from @Middleware
 Global middleware uses the **raw Express signature** `(req, res, next)`, not the KickJS `MiddlewareHandler` signature `(ctx, next)`. This is because global middleware runs before routes are matched, outside the KickJS `RequestContext` pipeline.
 
 | Location                        | Signature          | Receives                                      |
 | ------------------------------- | ------------------ | --------------------------------------------- |
-| `bootstrap({ middleware })`     | `(req, res, next)` | Express `Request`, `Response`, `NextFunction` |
+| `bootstrap({ middlewares })`    | `(req, res, next)` | Express `Request`, `Response`, `NextFunction` |
 | `@Middleware()` on class/method | `(ctx, next)`      | KickJS `RequestContext`, `next()`             |
 | Adapter `middleware()`          | `(req, res, next)` | Express `Request`, `Response`, `NextFunction` |
 
@@ -119,14 +123,14 @@ import { modules } from './modules'
 
 bootstrap({
   modules,
-  middleware: [requestId(), express.json({ limit: '1mb' }), helmet(), cors(), morgan('dev')],
+  middlewares: [requestId(), express.json({ limit: '1mb' }), helmet(), cors(), morgan('dev')],
 })
 ```
 
-If you omit the `middleware` option, sensible defaults are applied:
+If you omit the `middlewares` option, sensible defaults are applied:
 
 ```ts
-// Default pipeline when middleware is not specified:
+// Default pipeline when middlewares is not specified:
 requestId()
 express.json({ limit: '100kb' })
 ```
@@ -134,7 +138,7 @@ express.json({ limit: '100kb' })
 Global middleware entries can be path-scoped:
 
 ```ts
-middleware: [express.json(), { path: '/api/v1/webhooks', handler: express.raw({ type: '*/*' }) }]
+middlewares: [express.json(), { path: '/api/v1/webhooks', handler: express.raw({ type: '*/*' }) }]
 ```
 
 ## Adapter Middleware Phases
@@ -322,7 +326,7 @@ import { bootstrap, traceContext, requestLogger } from '@forinda/kickjs'
 
 bootstrap({
   modules,
-  middleware: [
+  middlewares: [
     traceContext(), // extracts or generates traceId
     requestLogger(), // logger automatically includes traceId
     express.json(),

--- a/docs/guide/migration-from-express.md
+++ b/docs/guide/migration-from-express.md
@@ -7,7 +7,7 @@ KickJS is built on Express 5, so your existing Express knowledge applies directl
 | Express                      | KickJS                                      |
 | ---------------------------- | ------------------------------------------- |
 | `app.get('/users', handler)` | `@Get('/') list(ctx)` on a `@Controller`    |
-| `app.use(middleware)`        | `bootstrap({ middleware: [...] })`          |
+| `app.use(middleware)`        | `bootstrap({ middlewares: [...] })`         |
 | `req.body`                   | `ctx.body`                                  |
 | `req.params`                 | `ctx.params`                                |
 | `req.query`                  | `ctx.query` or `ctx.qs()`                   |
@@ -65,7 +65,7 @@ import { modules } from './modules'
 // In production, bootstrap() auto-starts the HTTP server.
 export const app = await bootstrap({
   modules,
-  middleware: [cors(), helmet(), express.json()],
+  middlewares: [cors(), helmet(), express.json()],
   adapters: [SwaggerAdapter({ info: { title: 'My API', version: '1.0.0' } })],
 })
 ```
@@ -230,7 +230,7 @@ Or keep your Express middleware as-is and apply it globally:
 ```ts
 export const app = await bootstrap({
   modules,
-  middleware: [authMiddleware, express.json()],
+  middlewares: [authMiddleware, express.json()],
 })
 ```
 
@@ -304,7 +304,7 @@ You don't have to convert everything at once. KickJS runs on Express 5, so you c
 ```ts
 export const app = await bootstrap({
   modules, // converted modules from src/modules/index.ts
-  middleware: [
+  middlewares: [
     cors(),
     express.json(),
     // Mount legacy Express router directly:

--- a/docs/guide/project-structure.md
+++ b/docs/guide/project-structure.md
@@ -41,7 +41,7 @@ export const app = bootstrap({
   modules,
   apiPrefix: '/api',
   defaultVersion: 1,
-  middleware: [
+  middlewares: [
     helmet(),
     cors({ origin: ['https://app.example.com'] }),
     requestId(),

--- a/docs/guide/rate-limiting.md
+++ b/docs/guide/rate-limiting.md
@@ -9,7 +9,7 @@ import { rateLimit } from '@forinda/kickjs'
 
 bootstrap({
   modules,
-  middleware: [rateLimit({ max: 100, windowMs: 60_000 })],
+  middlewares: [rateLimit({ max: 100, windowMs: 60_000 })],
 })
 ```
 

--- a/docs/guide/security-headers.md
+++ b/docs/guide/security-headers.md
@@ -8,7 +8,7 @@ The `helmet()` middleware sets security-related HTTP headers with sensible defau
 import { helmet } from '@forinda/kickjs'
 
 bootstrap({
-  middleware: [helmet(), requestId(), express.json()],
+  middlewares: [helmet(), requestId(), express.json()],
 })
 ```
 
@@ -66,12 +66,12 @@ import { cors } from '@forinda/kickjs'
 
 // Allow all origins (default)
 bootstrap({
-  middleware: [cors(), helmet(), express.json()],
+  middlewares: [cors(), helmet(), express.json()],
 })
 
 // Allowlist specific origins
 bootstrap({
-  middleware: [
+  middlewares: [
     cors({
       origin: ['https://app.example.com', /\.example\.com$/],
       credentials: true,

--- a/docs/guide/sessions.md
+++ b/docs/guide/sessions.md
@@ -9,7 +9,7 @@ import { session } from '@forinda/kickjs'
 
 bootstrap({
   modules,
-  middleware: [session({ secret: process.env.SESSION_SECRET! })],
+  middlewares: [session({ secret: process.env.SESSION_SECRET! })],
 })
 ```
 

--- a/packages/kickjs/__tests__/log-routes-table.test.ts
+++ b/packages/kickjs/__tests__/log-routes-table.test.ts
@@ -98,7 +98,11 @@ function setupLogCapture() {
   })
 }
 
-async function buildApp(options: { logRoutesTable?: boolean; nodeEnv?: string }) {
+async function buildApp(options: {
+  logRouteTable?: boolean
+  logRoutesTable?: boolean
+  nodeEnv?: string
+}) {
   if (options.nodeEnv !== undefined) {
     process.env.NODE_ENV = options.nodeEnv
   }
@@ -113,6 +117,7 @@ async function buildApp(options: { logRoutesTable?: boolean; nodeEnv?: string })
   const app = new Application({
     modules: [TestModule],
     middleware: [express.json()],
+    logRouteTable: options.logRouteTable,
     logRoutesTable: options.logRoutesTable,
   })
 
@@ -122,7 +127,7 @@ async function buildApp(options: { logRoutesTable?: boolean; nodeEnv?: string })
 
 // ── Tests ─────────────────────────────────────────────────────────────────
 
-describe('logRoutesTable option', () => {
+describe('logRouteTable option', () => {
   beforeEach(() => {
     originalNodeEnv = process.env.NODE_ENV
     setupLogCapture()
@@ -138,22 +143,20 @@ describe('logRoutesTable option', () => {
     Container.reset()
   })
 
-  // ── 1. Default: routes logged in non-production ──────────────────────
+  // ── 1. Default: routes NOT logged (opt-in) ───────────────────────────
 
-  it('logs routes by default when NODE_ENV is not production', async () => {
+  it('does not log routes by default (development)', async () => {
     await buildApp({ nodeEnv: 'development' })
 
     const messages = logCalls
     const hasRoutesHeader = messages.some((m: string) => m.includes('Routes:'))
-    const hasTotalLine = messages.some((m: string) => m.includes('Total:'))
 
-    expect(hasRoutesHeader).toBe(true)
-    expect(hasTotalLine).toBe(true)
+    expect(hasRoutesHeader).toBe(false)
   })
 
-  // ── 2. Default: routes NOT logged in production ──────────────────────
+  // ── 2. Default: routes NOT logged in production either ────────────────
 
-  it('does not log routes by default when NODE_ENV is production', async () => {
+  it('does not log routes by default (production)', async () => {
     await buildApp({ nodeEnv: 'production' })
 
     const messages = logCalls
@@ -162,10 +165,10 @@ describe('logRoutesTable option', () => {
     expect(hasRoutesHeader).toBe(false)
   })
 
-  // ── 3. logRoutesTable: true forces logging in production ─────────────
+  // ── 3. logRouteTable: true opts in (even in production) ───────────────
 
-  it('logs routes when logRoutesTable is true even in production', async () => {
-    await buildApp({ nodeEnv: 'production', logRoutesTable: true })
+  it('logs routes when logRouteTable is true', async () => {
+    await buildApp({ nodeEnv: 'production', logRouteTable: true })
 
     const messages = logCalls
     const hasRoutesHeader = messages.some((m: string) => m.includes('Routes:'))
@@ -175,21 +178,28 @@ describe('logRoutesTable option', () => {
     expect(hasTotalLine).toBe(true)
   })
 
-  // ── 4. logRoutesTable: false suppresses logging in development ───────
+  // ── 4. Deprecated alias logRoutesTable still works ───────────────────
 
-  it('does not log routes when logRoutesTable is false even in development', async () => {
-    await buildApp({ nodeEnv: 'development', logRoutesTable: false })
+  it('logs routes via the deprecated logRoutesTable alias', async () => {
+    await buildApp({ nodeEnv: 'production', logRoutesTable: true })
 
     const messages = logCalls
-    const hasRoutesHeader = messages.some((m: string) => m.includes('Routes:'))
+    expect(messages.some((m: string) => m.includes('Routes:'))).toBe(true)
+  })
 
-    expect(hasRoutesHeader).toBe(false)
+  // ── 4b. logRouteTable wins over the alias when both are set ───────────
+
+  it('logRouteTable: false overrides logRoutesTable: true', async () => {
+    await buildApp({ logRouteTable: false, logRoutesTable: true })
+
+    const messages = logCalls
+    expect(messages.some((m: string) => m.includes('Routes:'))).toBe(false)
   })
 
   // ── 5. Route log output includes correct HTTP methods and mount paths ─
 
   it('logs correct HTTP methods and mount paths for each controller', async () => {
-    await buildApp({ nodeEnv: 'development' })
+    await buildApp({ nodeEnv: 'development', logRouteTable: true })
 
     const messages = logCalls
 
@@ -219,7 +229,7 @@ describe('logRoutesTable option', () => {
   // ── 6. Routes are sorted by method order ─────────────────────────────
 
   it('sorts methods in deterministic order: GET, POST, PUT, PATCH, DELETE', async () => {
-    await buildApp({ nodeEnv: 'development' })
+    await buildApp({ nodeEnv: 'development', logRouteTable: true })
 
     const messages = logCalls
 
@@ -242,15 +252,15 @@ describe('logRoutesTable option', () => {
     expect(userPutIdx).toBeLessThan(userPatchIdx)
   })
 
-  // ── Edge: undefined NODE_ENV defaults to non-production ──────────────
+  // ── Edge: default is off regardless of NODE_ENV ──────────────────────
 
-  it('logs routes when NODE_ENV is undefined (treated as non-production)', async () => {
+  it('does not log routes when NODE_ENV is undefined and no option is set', async () => {
     delete process.env.NODE_ENV
     await buildApp({})
 
     const messages = logCalls
     const hasRoutesHeader = messages.some((m: string) => m.includes('Routes:'))
 
-    expect(hasRoutesHeader).toBe(true)
+    expect(hasRoutesHeader).toBe(false)
   })
 })

--- a/packages/kickjs/__tests__/logger-provider.test.ts
+++ b/packages/kickjs/__tests__/logger-provider.test.ts
@@ -66,7 +66,9 @@ describe('Logger.setProvider() — pluggable logger backend', () => {
     expect(childCalls).toContain('from child')
   })
 
-  it('ConsoleLoggerProvider works as fallback', () => {
+  it('ConsoleLoggerProvider works as fallback (default LOG_LEVEL=info suppresses debug)', () => {
+    const prevLevel = process.env.LOG_LEVEL
+    delete process.env.LOG_LEVEL // default → info
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -83,12 +85,30 @@ describe('Logger.setProvider() — pluggable logger backend', () => {
     expect(logSpy).toHaveBeenCalledWith('INFO [ConsoleTest] info message')
     expect(warnSpy).toHaveBeenCalledWith('WARN [ConsoleTest] warn message')
     expect(errorSpy).toHaveBeenCalledWith('ERROR [ConsoleTest] error message')
-    expect(debugSpy).toHaveBeenCalledWith('DEBUG [ConsoleTest] debug message')
+    // debug is below the default `info` threshold → suppressed.
+    expect(debugSpy).not.toHaveBeenCalled()
 
     logSpy.mockRestore()
     warnSpy.mockRestore()
     errorSpy.mockRestore()
     debugSpy.mockRestore()
+    if (prevLevel === undefined) delete process.env.LOG_LEVEL
+    else process.env.LOG_LEVEL = prevLevel
+  })
+
+  it('ConsoleLoggerProvider emits debug when LOG_LEVEL=debug', () => {
+    const prevLevel = process.env.LOG_LEVEL
+    process.env.LOG_LEVEL = 'debug'
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+
+    Logger.setProvider(new ConsoleLoggerProvider())
+    Logger.for('ConsoleTest').debug('debug message')
+
+    expect(debugSpy).toHaveBeenCalledWith('DEBUG [ConsoleTest] debug message')
+
+    debugSpy.mockRestore()
+    if (prevLevel === undefined) delete process.env.LOG_LEVEL
+    else process.env.LOG_LEVEL = prevLevel
   })
 
   it('setProvider() can be called multiple times (last wins)', () => {

--- a/packages/kickjs/src/core/logger.ts
+++ b/packages/kickjs/src/core/logger.ts
@@ -40,10 +40,39 @@ export interface LoggerProvider {
   child(bindings: { component: string }): LoggerProvider
 }
 
+// ── Log levels ─────────────────────────────────────────────────────────
+
+/** Severity ordering — a message prints only when its rank ≥ the threshold. */
+const LEVEL_RANK: Record<string, number> = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  fatal: 60,
+  silent: 100,
+}
+
+/**
+ * Resolve the active threshold rank from `LOG_LEVEL` (default `info`).
+ * Read per-call so a late `process.env.LOG_LEVEL` assignment still
+ * takes effect. An unrecognised value falls back to `info`.
+ */
+function thresholdRank(): number {
+  const level = (process.env.LOG_LEVEL ?? 'info').toLowerCase()
+  return LEVEL_RANK[level] ?? LEVEL_RANK.info
+}
+
 // ── ConsoleLoggerProvider (default) ────────────────────────────────────
 
 /**
  * Default provider — emits through `console.*` methods. Zero deps.
+ *
+ * Respects the `LOG_LEVEL` env var (default `info`): messages below the
+ * threshold are dropped, so the verbose startup detail (the route table,
+ * DI wiring, HMR ticks — all `debug`) stays quiet by default and only
+ * appears with `LOG_LEVEL=debug`. `error`/`fatal` always print unless
+ * `LOG_LEVEL=silent`.
  *
  * Swap it for pino, winston, bunyan, or anything else by implementing
  * the `LoggerProvider` interface and calling `Logger.setProvider()`
@@ -67,23 +96,29 @@ export class ConsoleLoggerProvider implements LoggerProvider {
     return `${level} ${tag ? `${tag} ` : ''}${msg}`
   }
 
+  /** Should a message at `rank` print under the current `LOG_LEVEL`? */
+  private enabled(rank: number): boolean {
+    return rank >= thresholdRank()
+  }
+
   info(msg: string, ...args: any[]) {
-    console.log(this.fmt('INFO', '\x1b[32m', msg), ...args)
+    if (this.enabled(LEVEL_RANK.info)) console.log(this.fmt('INFO', '\x1b[32m', msg), ...args)
   }
   warn(msg: string, ...args: any[]) {
-    console.warn(this.fmt('WARN', '\x1b[33m', msg), ...args)
+    if (this.enabled(LEVEL_RANK.warn)) console.warn(this.fmt('WARN', '\x1b[33m', msg), ...args)
   }
   error(msg: string, ...args: any[]) {
-    console.error(this.fmt('ERROR', '\x1b[31m', msg), ...args)
+    if (this.enabled(LEVEL_RANK.error)) console.error(this.fmt('ERROR', '\x1b[31m', msg), ...args)
   }
   debug(msg: string, ...args: any[]) {
-    console.debug(this.fmt('DEBUG', '\x1b[90m', msg), ...args)
+    if (this.enabled(LEVEL_RANK.debug)) console.debug(this.fmt('DEBUG', '\x1b[90m', msg), ...args)
   }
   trace(msg: string, ...args: any[]) {
-    console.trace(this.fmt('TRACE', '\x1b[90m', msg), ...args)
+    if (this.enabled(LEVEL_RANK.trace)) console.trace(this.fmt('TRACE', '\x1b[90m', msg), ...args)
   }
   fatal(msg: string, ...args: any[]) {
-    console.error(this.fmt('FATAL', '\x1b[1m\x1b[31m', msg), ...args)
+    if (this.enabled(LEVEL_RANK.fatal))
+      console.error(this.fmt('FATAL', '\x1b[1m\x1b[31m', msg), ...args)
   }
   child(bindings: { component: string }): LoggerProvider {
     return new ConsoleLoggerProvider(bindings.component)

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -185,8 +185,9 @@ export interface ApplicationOptions {
   /**
    * Print the route table on startup. Default: `false`. Set to `true`
    * to log a per-controller summary (method counts + mount paths) once
-   * the app has mounted. Printed at `info` level, so it shows regardless
-   * of `LOG_LEVEL` when enabled.
+   * the app has mounted. Emitted at `info` level, so it is still subject
+   * to `LOG_LEVEL` filtering (visible at the default `info`; hidden at
+   * `warn`/`error`/`silent`).
    */
   logRouteTable?: boolean
   /**

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -85,7 +85,7 @@ export interface ApplicationOptions {
    * ```ts
    * bootstrap({
    *   modules,
-   *   middleware: [
+   *   middlewares: [
    *     helmet(),
    *     cors(),
    *     compression(),
@@ -97,6 +97,12 @@ export interface ApplicationOptions {
    *
    * If omitted, a sensible default is applied:
    *   requestId(), express.json({ limit: '100kb' })
+   */
+  middlewares?: MiddlewareEntry[]
+  /**
+   * @deprecated Use {@link ApplicationOptions.middlewares} (plural).
+   * Kept as an alias for back-compat; `middlewares` wins when both are
+   * set.
    */
   middleware?: MiddlewareEntry[]
 
@@ -177,8 +183,15 @@ export interface ApplicationOptions {
   /** Maximum JSON body size (only used when middleware is not provided) */
   jsonLimit?: string | number
   /**
-   * Log route summary on startup. Default: true in dev, false in production.
-   * Set to `true` to always log, `false` to always suppress.
+   * Print the route table on startup. Default: `false`. Set to `true`
+   * to log a per-controller summary (method counts + mount paths) once
+   * the app has mounted. Printed at `info` level, so it shows regardless
+   * of `LOG_LEVEL` when enabled.
+   */
+  logRouteTable?: boolean
+  /**
+   * @deprecated Use {@link ApplicationOptions.logRouteTable}. Kept as an
+   * alias for back-compat; `logRouteTable` wins when both are set.
    */
   logRoutesTable?: boolean
   /**
@@ -489,9 +502,10 @@ export class Application {
       }
     }
 
-    if (this.options.middleware) {
+    const userMiddlewares = this.options.middlewares ?? this.options.middleware
+    if (userMiddlewares) {
       // User-declared pipeline — full control
-      for (const entry of this.options.middleware) {
+      for (const entry of userMiddlewares) {
         this.mountMiddlewareEntry(entry)
       }
     } else {
@@ -549,7 +563,9 @@ export class Application {
     // ── 8. Mount module routes with versioning ───────────────────────
     const apiPrefix = this.options.apiPrefix ?? '/api'
     const defaultVersion = this.options.defaultVersion ?? 1
-    const shouldLogRoutes = this.options.logRoutesTable ?? process.env.NODE_ENV !== 'production'
+    // Opt-in, default off. `logRouteTable` is the current name;
+    // `logRoutesTable` is the deprecated alias.
+    const shouldLogRoutes = this.options.logRouteTable ?? this.options.logRoutesTable ?? false
 
     // Collect route metadata during mounting (avoids calling mod.routes() twice)
     const mountedRoutes: Array<{ controller: any; mountPath: string }> = []
@@ -679,7 +695,7 @@ export class Application {
       }
 
       let totalRoutes = 0
-      log.debug('Routes:')
+      log.info('Routes:')
 
       for (const { controller, mountPath } of mountedRoutes) {
         const defs: RouteDefinition[] = getClassMeta<RouteDefinition[]>(
@@ -701,10 +717,10 @@ export class Application {
           .map(([m, n]) => `${n} ${m}`)
           .join(', ')
         const name = controller.name || 'Controller'
-        log.debug(`  ${name.padEnd(30)} ${mountPath.padEnd(25)} ${defs.length} routes (${methods})`)
+        log.info(`  ${name.padEnd(30)} ${mountPath.padEnd(25)} ${defs.length} routes (${methods})`)
       }
 
-      log.debug(`  Total: ${totalRoutes} routes`)
+      log.info(`  Total: ${totalRoutes} routes`)
     }
 
     // ── 9. Adapter middleware: afterRoutes ────────────────────────────
@@ -1022,7 +1038,7 @@ export class Application {
   private shouldAutoMountRequestScope(): boolean {
     if (this.options.contextStore === 'manual') return false
 
-    const userEntries = this.options.middleware ?? []
+    const userEntries = this.options.middlewares ?? this.options.middleware ?? []
     for (const entry of userEntries) {
       const handler = typeof entry === 'function' ? entry : entry.handler
       if (isRequestScopeMiddleware(handler)) return false


### PR DESCRIPTION
## Why

A normal `bootstrap()` printed the full route table, DI wiring, and HMR ticks on every start — all `debug`-level messages, but the default `ConsoleLoggerProvider` ignored log level entirely. Two bootstrap options also had confusing names.

## What

Three related, back-compat changes to `@forinda/kickjs`:

### 1. Logger respects `LOG_LEVEL` (default `info`)
`ConsoleLoggerProvider` now drops messages below the threshold (`trace < debug < info < warn < error < fatal`, plus `silent`). Default `info` → `debug`/`trace` suppressed. Run with `LOG_LEVEL=debug` to restore verbose output. Custom providers (pino, winston) are untouched.

### 2. Route table is opt-in: `bootstrap({ logRouteTable: true })`
Defaults to **off** (was: auto-printed in non-production). When enabled, prints at `info` level, so it's subject to `LOG_LEVEL` filtering (visible at the default `info`, hidden at `warn`/`error`/`silent`). `logRoutesTable` kept as a **deprecated alias** (`logRouteTable` wins when both set).

### 3. Plural `bootstrap({ middlewares: [...] })`
New plural option name for the global middleware pipeline. Singular `middleware` kept as a **deprecated alias** (`middlewares` wins when both set). Existing apps keep working.

## Compatibility

All three are non-breaking — old names (`logRoutesTable`, `middleware`) still work as deprecated aliases. The only behavior change is that the route table and other `debug` startup detail no longer print by default.

## Tests

`packages/kickjs` suite: **520 passing**. Logger-level gating (default-suppressed + `LOG_LEVEL=debug` enabled) and route-table opt-in / alias / precedence covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LOG_LEVEL environment variable now controls console logging verbosity (defaults to 'info')
  * Route table logging is now opt-in via the `logRouteTable` bootstrap option

* **Configuration**
  * Middleware configuration option renamed from `middleware` to `middlewares`
  * Route table logging option renamed from `logRoutesTable` to `logRouteTable`
  * Deprecated aliases remain supported for backward compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
