### PR TITLE
fix(db,cli): kick db config loader (jiti) + non-string column defaults

### DIFF
--- a/.changeset/db-config-loader-and-defaults.md
+++ b/.changeset/db-config-loader-and-defaults.md
@@ -1,0 +1,10 @@
+---
+'@forinda/kickjs-cli': patch
+'@forinda/kickjs-db': patch
+---
+
+Fix `kick db` with plugin-importing configs, and non-string column defaults.
+
+- **`kick db` commands now load `kick.config.ts` through the CLI's jiti loader** (`loadKickConfig`) instead of `@forinda/kickjs-db`'s native `import()`. Native ESM can't resolve the extensionless, relative TypeScript imports a config commonly uses — e.g. `import { toolsPlugin } from './tools/cli-plugin'` to mount a CLI plugin — so every `kick db ...` command failed with `Cannot find module` whenever the config imported local TS. It now resolves exactly like the rest of the CLI.
+
+- **Column `.default()` accepts `string | number | boolean`** and normalises non-strings to their SQL-literal text. `boolean().default(false)` / `integer().default(0)` previously stored a raw boolean/number in the snapshot, which crashed migration emit with `value.replace is not a function`. The Postgres emitter (`formatDefault`) is also hardened to coerce booleans/numbers defensively, so a pre-existing snapshot with a non-string default emits a bare SQL literal (`false`, `0`) instead of throwing.

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -6,7 +6,6 @@ import { writeFile } from 'node:fs/promises'
 import {
   detectCompositeReferences,
   generate,
-  resolveDbConfig,
   migrateLatest,
   migrateUp,
   migrateDown,
@@ -17,13 +16,34 @@ import {
   type DbConfig,
   type MigrationAdapter,
 } from '@forinda/kickjs-db'
+import { loadKickConfig } from '../config'
 
 interface BaseOpts {
   config: string
 }
 
+/**
+ * Resolve the `db` block from `kick.config.ts` using the CLI's own jiti
+ * loader (`loadKickConfig`) rather than `@forinda/kickjs-db`'s
+ * `resolveDbConfig`, which does a native `import()` of the config file.
+ *
+ * Native ESM can't resolve the extensionless, relative TypeScript
+ * imports a `kick.config.ts` commonly uses (e.g. `import { toolsPlugin }
+ * from './tools/cli-plugin'` to mount a CLI plugin) — so any config that
+ * imports local TS broke every `kick db` command with "Cannot find
+ * module". jiti handles those exactly like the rest of the CLI does.
+ */
 async function loadConfig(opts: BaseOpts): Promise<DbConfig> {
-  return resolveDbConfig({ configPath: path.resolve(process.cwd(), opts.config) })
+  const startDir = path.dirname(path.resolve(process.cwd(), opts.config))
+  const cfg = await loadKickConfig(startDir)
+  const db = cfg?.db ?? {}
+  return {
+    schemaPath: db.schemaPath ?? 'src/db/schema.ts',
+    migrationsDir: db.migrationsDir ?? 'db/migrations',
+    dialect: db.dialect ?? 'postgres',
+    connectionString: db.connectionString ?? process.env.DATABASE_URL,
+    adapter: db.adapter as DbConfig['adapter'],
+  }
 }
 
 /**

--- a/packages/db/__tests__/unit/emit-pg-columns.test.ts
+++ b/packages/db/__tests__/unit/emit-pg-columns.test.ts
@@ -93,4 +93,39 @@ describe('emitPg() — column changes', () => {
         'ALTER TABLE "users" ALTER COLUMN "age" DROP NOT NULL;',
     )
   })
+
+  // Regression: a non-string default (e.g. from `boolean().default(false)`)
+  // must not crash the emitter (`value.replace is not a function`).
+  it('emits non-string defaults (boolean / number) as bare SQL literals', () => {
+    const cs: ChangeSet = [
+      {
+        kind: 'addColumn',
+        table: 'tasks',
+        // `default` is typed string, but harden against a raw boolean/number
+        // slipping through (snapshot drift / pre-normalisation defaults).
+        column: {
+          name: 'done',
+          type: 'boolean',
+          nullable: false,
+          default: false as unknown as string,
+          primaryKey: false,
+        },
+      },
+      {
+        kind: 'addColumn',
+        table: 'tasks',
+        column: {
+          name: 'qty',
+          type: 'integer',
+          nullable: false,
+          default: 0 as unknown as string,
+          primaryKey: false,
+        },
+      },
+    ]
+    expect(emitPg(cs)).toBe(
+      'ALTER TABLE "tasks" ADD COLUMN "done" boolean NOT NULL DEFAULT false;\n' +
+        'ALTER TABLE "tasks" ADD COLUMN "qty" integer NOT NULL DEFAULT 0;',
+    )
+  })
 })

--- a/packages/db/src/dsl/columns/types.ts
+++ b/packages/db/src/dsl/columns/types.ts
@@ -142,9 +142,16 @@ export class ColumnBuilder<T = unknown> {
    * Mark the column as having a runtime / DB-assigned default. The
    * `GeneratedBrand` flows into `SchemaToTypes<S>` so the column wraps
    * in `Generated<T>` — adopters can `INSERT` without specifying it.
+   *
+   * Accepts the natural literal for the column type — `boolean().default(false)`,
+   * `integer().default(0)`, `varchar().default('active')`. Non-string
+   * literals are normalised to their SQL-literal text so the snapshot
+   * (`ColumnSnapshot.default: string | null`) and migration emitter stay
+   * string-only. For a quoted string default the text is the value
+   * itself (`'active'`); booleans/numbers emit bare (`false`, `0`).
    */
-  default(value: string): this & GeneratedBrand {
-    this.state.default = value
+  default(value: string | number | boolean): this & GeneratedBrand {
+    this.state.default = typeof value === 'string' ? value : String(value)
     return this as this & GeneratedBrand
   }
 

--- a/packages/db/src/emit/pg.ts
+++ b/packages/db/src/emit/pg.ts
@@ -303,12 +303,18 @@ function emitColumnDecl(c: ColumnSnapshot): string {
   return s
 }
 
-function formatDefault(value: string): string {
+function formatDefault(value: unknown): string {
+  // Defensive: a snapshot authored before defaults were normalised to
+  // strings (or hand-edited) may carry a raw boolean/number. Coerce so
+  // `quoteLiteral` (String.prototype.replace) never sees a non-string.
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'number' || typeof value === 'bigint') return String(value)
+  const str = String(value)
   // SQL keywords pass through bare.
-  if (/^[A-Z_]+$/.test(value)) return value // CURRENT_TIMESTAMP, CURRENT_DATE, NULL, etc.
+  if (/^[A-Z_]+$/.test(str)) return str // CURRENT_TIMESTAMP, CURRENT_DATE, NULL, etc.
   // SQL function calls pass through bare: NOW(), gen_random_uuid(), etc.
-  if (/^[a-z_][a-z0-9_]*\s*\([^)]*\)$/i.test(value)) return value
-  if (/^-?\d+(\.\d+)?$/.test(value)) return value // numeric
-  if (value === 'true' || value === 'false') return value // boolean literal
-  return quoteLiteral(value)
+  if (/^[a-z_][a-z0-9_]*\s*\([^)]*\)$/i.test(str)) return str
+  if (/^-?\d+(\.\d+)?$/.test(str)) return str // numeric
+  if (str === 'true' || str === 'false') return str // boolean literal
+  return quoteLiteral(str)
 }


### PR DESCRIPTION
## Why

Found while setting up a self-contained example that mounts a **CLI plugin** (custom command + generator) from `kick.config.ts` and uses `@forinda/kickjs-db`. Two real bugs surfaced.

## Fixes

### 1. `kick db` couldn't load a config that imports local TypeScript
`kick db <cmd>` resolved `kick.config.ts` via `@forinda/kickjs-db`'s `resolveDbConfig`, which does a **native `import()`** of the config file. Native ESM can't resolve the extensionless, relative TS imports a config commonly uses — e.g. `import { toolsPlugin } from './tools/cli-plugin'` to mount a CLI plugin — so every `kick db ...` command failed with `Cannot find module '.../tools/cli-plugin'`. The rest of the CLI loads config through **jiti** (`loadKickConfig`), which handles this fine. `kick db`'s `loadConfig` now uses the same loader.

### 2. Non-string column defaults crashed migration emit
`boolean().default(false)` / `integer().default(0)` stored a raw boolean/number in the snapshot (the `.default()` param was typed `string`, so the wrong type slipped through at runtime). Migration emit then called `String.prototype.replace` on it → `value.replace is not a function`. 
- `.default()` now accepts `string | number | boolean` and normalises non-strings to their SQL-literal text.
- The Postgres emitter's `formatDefault` is hardened to coerce booleans/numbers defensively (emits bare `false` / `0`).

## Tests

`@forinda/kickjs-db`: **402 passing** + a new regression test for non-string defaults. CLI builds clean. Verified end-to-end against a live example: `kick db generate` now produces a correct migration (`"done" boolean NOT NULL DEFAULT false`) for a config that also mounts a CLI plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
