### PR TITLE
refactor(db)!: consolidate pg/sqlite/mysql adapters into @forinda/kickjs-db subpaths

### DIFF
--- a/.changeset/db-consolidate-adapters.md
+++ b/.changeset/db-consolidate-adapters.md
@@ -1,0 +1,30 @@
+---
+'@forinda/kickjs-db': minor
+'@forinda/kickjs-db-pg': minor
+'@forinda/kickjs-db-sqlite': minor
+'@forinda/kickjs-db-mysql': minor
+'@forinda/kickjs-cli': patch
+---
+
+Consolidate the SQL dialect adapters into `@forinda/kickjs-db` subpaths.
+
+The PostgreSQL / SQLite / MySQL adapters + dialects now ship from **subpaths of `@forinda/kickjs-db`** instead of separate packages — mirroring how `@forinda/kickjs-schema` exposes `./zod` / `./valibot` / `./yup`. Install one package plus the single driver you use:
+
+```bash
+# before
+pnpm add @forinda/kickjs-db @forinda/kickjs-db-pg pg
+# after
+pnpm add @forinda/kickjs-db pg
+```
+
+```ts
+// before
+import { pgAdapter, pgDialect } from '@forinda/kickjs-db-pg'
+// after
+import { pgAdapter, pgDialect } from '@forinda/kickjs-db/pg'
+```
+
+- New subpaths: `@forinda/kickjs-db/pg` (now also carries `pgAdapter` + `pgDialect` alongside the PG column types), `@forinda/kickjs-db/sqlite`, `@forinda/kickjs-db/mysql`.
+- `pg`, `better-sqlite3`, `mysql2` are **optional peer deps** of `@forinda/kickjs-db` — the relevant subpath imports its driver lazily, so the core install never pulls all three.
+- `@forinda/kickjs-db-pg` / `-sqlite` / `-mysql` remain as **deprecated re-export shims** (`export * from '@forinda/kickjs-db/<dialect>'`) so existing installs keep working; they'll be removed in a future major.
+- CLI: `kick db` resolves the pg adapter from `@forinda/kickjs-db/pg`; `kick add pg|sqlite|mysql` installs `@forinda/kickjs-db` plus the matching driver.

--- a/docs/db/architecture.md
+++ b/docs/db/architecture.md
@@ -59,7 +59,7 @@ Why not fork drizzle: license-clean greenfield is preferred; idiom-borrowing (br
 
 The node SQL dialects (PostgreSQL / SQLite / MySQL) ship as **subpaths of the core package** — one install plus the one driver you use. The pattern mirrors `@forinda/kickjs-schema` (`./zod` / `./valibot` / `./yup` + optional peer deps).
 
-```
+```text
 packages/
   db/                        @forinda/kickjs-db                 (core + /pg /sqlite /mysql adapters)
   db-pg/                     @forinda/kickjs-db-pg              (deprecated shim → @forinda/kickjs-db/pg)
@@ -74,12 +74,12 @@ packages/
 - `db` core — `kysely` + `@forinda/kickjs` (peer). Drivers (`pg`, `better-sqlite3`, `mysql2`) are **optional peer deps** — the relevant subpath imports its driver lazily, so installing `@forinda/kickjs-db` never pulls all three.
 - Edge adapters — driver-specific separate packages (`@neondatabase/serverless`, etc), v6.2.
 
-**Subpath exports** (core package) — each dialect subpath bundles its column quirks **plus** the migration adapter + Kysely dialect:
+**Subpath exports** (core package) — each dialect subpath ships the migration adapter + Kysely dialect, and (for PG today) the dialect-specific column types. Cross-dialect column constructors (`uuid`, `varchar`, `timestamp`, …) live on the **root** entry, not the subpaths.
 
-- `@forinda/kickjs-db` — root: cross-dialect DSL, client, hooks, `$extends`, `defineTenantDbContributor`.
-- `@forinda/kickjs-db/pg` — PG column types (`tsvector`, `vector`, `citext`, `money`, `inet`, `cidr`, `xml`) + `pgAdapter` + `pgDialect`. Needs `pg`.
-- `@forinda/kickjs-db/sqlite` — `sqliteAdapter` + `sqliteDialect` (+ SQLite quirks). Needs `better-sqlite3`.
-- `@forinda/kickjs-db/mysql` — `mysqlAdapter` + `mysqlDialect` (+ MySQL types). Needs `mysql2`.
+- `@forinda/kickjs-db` — root: cross-dialect DSL + column constructors, client, hooks, `$extends`, `defineTenantDbContributor`.
+- `@forinda/kickjs-db/pg` — `pgAdapter` + `pgDialect` **+ PG-only column types** (`tsvector`, `vector`, `citext`, `money`, `inet`, `cidr`, `xml`). Needs `pg`.
+- `@forinda/kickjs-db/sqlite` — `sqliteAdapter` + `sqliteDialect`. No SQLite-specific column types today (reserved for future quirks). Needs `better-sqlite3`.
+- `@forinda/kickjs-db/mysql` — `mysqlAdapter` + `mysqlDialect`. No MySQL-specific column types today (reserved for future types). Needs `mysql2`.
 - `@forinda/kickjs-db/edge` — edge-safe entry; omits the migration runner, introspection, and any `node:fs`/`node:path` import path. v6.2.
 
 **Versioning** — lockstep across all `db*` packages, matching KickJS convention. Bumped via `scripts/release.js`.

--- a/docs/db/architecture.md
+++ b/docs/db/architecture.md
@@ -57,29 +57,29 @@ Why not fork drizzle: license-clean greenfield is preferred; idiom-borrowing (br
 
 ## 3. Package topology
 
+The node SQL dialects (PostgreSQL / SQLite / MySQL) ship as **subpaths of the core package** — one install plus the one driver you use. The pattern mirrors `@forinda/kickjs-schema` (`./zod` / `./valibot` / `./yup` + optional peer deps).
+
 ```
 packages/
-  db/                        @forinda/kickjs-db                 (core)
-  db-pg/                     @forinda/kickjs-db-pg              (node-postgres)
-  db-sqlite/                 @forinda/kickjs-db-sqlite          (better-sqlite3)
-  db-mysql/                  @forinda/kickjs-db-mysql           (mysql2, v6.1)
+  db/                        @forinda/kickjs-db                 (core + /pg /sqlite /mysql adapters)
+  db-pg/                     @forinda/kickjs-db-pg              (deprecated shim → @forinda/kickjs-db/pg)
+  db-sqlite/                 @forinda/kickjs-db-sqlite          (deprecated shim → @forinda/kickjs-db/sqlite)
+  db-mysql/                  @forinda/kickjs-db-mysql           (deprecated shim → @forinda/kickjs-db/mysql)
   db-neon-http/              @forinda/kickjs-db-neon-http       (edge, v6.2)
   db-d1/                     @forinda/kickjs-db-d1              (Cloudflare D1, v6.2)
 ```
 
-**Dependencies** (all peer):
+**Dependencies:**
 
-- `db` core — `kysely`, `@forinda/kickjs`.
-- `db-pg` — `pg` (peer), `kickjs-db` (peer). ~50 LOC factory wrapping Kysely's `PostgresDialect` and exposing the `KickDbAdapter` interface.
-- `db-sqlite` — `better-sqlite3` (peer), `kickjs-db` (peer).
-- Edge adapters — driver-specific (`@neondatabase/serverless`, etc).
+- `db` core — `kysely` + `@forinda/kickjs` (peer). Drivers (`pg`, `better-sqlite3`, `mysql2`) are **optional peer deps** — the relevant subpath imports its driver lazily, so installing `@forinda/kickjs-db` never pulls all three.
+- Edge adapters — driver-specific separate packages (`@neondatabase/serverless`, etc), v6.2.
 
-**Subpath exports** (core package):
+**Subpath exports** (core package) — each dialect subpath bundles its column quirks **plus** the migration adapter + Kysely dialect:
 
 - `@forinda/kickjs-db` — root: cross-dialect DSL, client, hooks, `$extends`, `defineTenantDbContributor`.
-- `@forinda/kickjs-db/pg` — PG-only column types (`tsvector`, `vector`, `citext`, `money`, `inet`, `cidr`, `xml`).
-- `@forinda/kickjs-db/sqlite` — SQLite-only quirks.
-- `@forinda/kickjs-db/mysql` — MySQL-only types.
+- `@forinda/kickjs-db/pg` — PG column types (`tsvector`, `vector`, `citext`, `money`, `inet`, `cidr`, `xml`) + `pgAdapter` + `pgDialect`. Needs `pg`.
+- `@forinda/kickjs-db/sqlite` — `sqliteAdapter` + `sqliteDialect` (+ SQLite quirks). Needs `better-sqlite3`.
+- `@forinda/kickjs-db/mysql` — `mysqlAdapter` + `mysqlDialect` (+ MySQL types). Needs `mysql2`.
 - `@forinda/kickjs-db/edge` — edge-safe entry; omits the migration runner, introspection, and any `node:fs`/`node:path` import path. v6.2.
 
 **Versioning** — lockstep across all `db*` packages, matching KickJS convention. Bumped via `scripts/release.js`.

--- a/docs/db/plan-adapter-consolidation.md
+++ b/docs/db/plan-adapter-consolidation.md
@@ -1,0 +1,97 @@
+# Plan — consolidate `db-pg` / `db-sqlite` / `db-mysql` into `@forinda/kickjs-db` subpaths
+
+> Status: proposal for review
+> Pattern source: `@forinda/kickjs-schema` (`./zod` `./valibot` `./yup` + optional peer deps)
+
+## Goal
+
+Adopters install **one** package + the single driver they use, instead of `@forinda/kickjs-db` **plus** `@forinda/kickjs-db-pg` **plus** `pg`. Mirror the `kickjs-schema` model: one package, per-dialect subpath adapters, drivers as **optional peer deps**, mapped through a common interface.
+
+The common interface already exists in core — `MigrationAdapter` + Kysely `Dialect` — exactly the role `KickSchema` plays in schema. We are only relocating the per-driver implementations into subpaths.
+
+## Before → after
+
+| Today | After |
+| --- | --- |
+| `npm i @forinda/kickjs-db @forinda/kickjs-db-pg pg` | `npm i @forinda/kickjs-db pg` |
+| `import { pgAdapter } from '@forinda/kickjs-db-pg'` | `import { pgAdapter } from '@forinda/kickjs-db/pg'` |
+| 3 published packages (lockstep) | 0 extra packages; 3 subpaths |
+| driver = peer of the sub-package | driver = **optional** peer of `@forinda/kickjs-db` |
+
+`@forinda/kickjs-db/pg` already exists today as the **PG column types** (`tsvector`, `vector`, `citext`, …). The adapter folds into the **same** subpath, so `@forinda/kickjs-db/pg` becomes "everything PG-specific": column types **+** `pgAdapter` **+** `pgDialect`. Same for `/sqlite` and `/mysql`.
+
+## Surface being moved
+
+| From package | Exports | Driver peer |
+| --- | --- | --- |
+| `@forinda/kickjs-db-pg` | `pgAdapter`, `pgDialect`, `PgAdapterOptions`, `PgPoolLike`, `PgClientLike`, `PgDialectOptions` | `pg >=8.11` |
+| `@forinda/kickjs-db-sqlite` | `sqliteAdapter`, `sqliteDialect`, `SqliteAdapterOptions`, `SqliteDatabaseLike`, `SqliteStatement`, `SqliteDialectOptions` | `better-sqlite3 >=12` |
+| `@forinda/kickjs-db-mysql` | `mysqlAdapter`, `mysqlDialect`, `MysqlAdapterOptions`, `MysqlDialectOptions` | `mysql2 >=3` |
+
+All three already depend only on `kysely` (already a dep of core) + their driver + the core `MigrationAdapter` interface. No logic rewrite.
+
+## Steps
+
+### 1. Relocate sources into core
+- `packages/db-pg/src/{adapter,dialect}.ts` → `packages/db/src/adapters/pg/{adapter,dialect}.ts`
+- `packages/db-sqlite/src/{adapter,dialect}.ts` → `packages/db/src/adapters/sqlite/{adapter,dialect}.ts`
+- `packages/db-mysql/src/{adapter,dialect}.ts` → `packages/db/src/adapters/mysql/{adapter,dialect}.ts`
+- Fix internal imports: `from '../adapter'` (core `MigrationAdapter`) → `from '../../migrate/adapter'` etc. (relative within core).
+
+### 2. Subpath barrels
+- `packages/db/src/pg.ts` (the existing `/pg` entry) becomes a barrel:
+  ```ts
+  export * from './dsl/columns/pg'      // existing PG column types
+  export * from './adapters/pg/adapter' // pgAdapter
+  export * from './adapters/pg/dialect' // pgDialect
+  ```
+- New `packages/db/src/sqlite.ts` and `packages/db/src/mysql.ts` barrels (column quirks, if any, + adapter + dialect).
+
+### 3. Build + exports (`packages/db`)
+- `tsdown.config.ts` `entry`: add `sqlite: 'src/sqlite.ts'`, `mysql: 'src/mysql.ts'` (`pg` already present). Add `pg`/`better-sqlite3`/`mysql2` to `external`.
+- `package.json` `exports`: add `./sqlite`, `./mysql` (pattern matches existing `./pg`).
+- `package.json`: add optional peer deps
+  ```jsonc
+  "peerDependencies": { "pg": ">=8.11.0", "better-sqlite3": ">=12.0.0", "mysql2": ">=3.0.0", ...existing },
+  "peerDependenciesMeta": { "pg": {"optional": true}, "better-sqlite3": {"optional": true}, "mysql2": {"optional": true}, ...existing }
+  ```
+- Add `@types/pg`, `@types/better-sqlite3`, `better-sqlite3`, `pg`, `mysql2` to **devDependencies** so the moved code typechecks + tests run.
+
+### 4. Deprecated shim packages (keep, per decision)
+Each old package becomes a 2-line re-export + deprecation:
+```ts
+// packages/db-pg/src/index.ts
+/** @deprecated Import from `@forinda/kickjs-db/pg` instead. */
+export * from '@forinda/kickjs-db/pg'
+```
+- Drop the driver from its `peerDependencies` (now optional-peer on core), keep `@forinda/kickjs-db` peer.
+- Add a `console.warn` once-per-process deprecation in the shim entry (optional).
+- README note: "merged into `@forinda/kickjs-db/<dialect>`".
+
+### 5. CLI
+- `commands/db.ts:78` — `import('@forinda/kickjs-db-pg')` → `import('@forinda/kickjs-db/pg')`; keep the `import('pg')` probe. Update the comment.
+- `commands/add.ts:80` — registry entry: `kick add pg` should now add `@forinda/kickjs-db` + `pg` (driver), not `@forinda/kickjs-db-pg`. Revisit the whole db row set: `kick add db` (core), and `pg`/`sqlite`/`mysql` add the matching driver.
+- `package.json` devDep `@forinda/kickjs-db-pg` → `@forinda/kickjs-db` (already present) — drop the sub-package devDep.
+
+### 6. Example (`examples/typegen-test`)
+- `kick.config.ts`: `import { sqliteAdapter } from '@forinda/kickjs-db-sqlite'` → `from '@forinda/kickjs-db/sqlite'`.
+- `package.json`: drop `@forinda/kickjs-db-sqlite`, keep `@forinda/kickjs-db` + `better-sqlite3`.
+
+### 7. Docs
+- `architecture.md §3` already describes subpath exports — update to state adapters live there too (not separate packages); fix the "Package topology" tree.
+- API sidebar (`docs/.vitepress/config.mts`): the Packages group lists `@forinda/kickjs-db-pg/-sqlite/-mysql`? (it does **not** today — only `db`, `db-pg`, `db-sqlite`, `db-mysql` API pages exist). Decide: keep the `/api/db-*` pages as adapter reference, or fold into `/api/db` with subpath sections.
+- Database guide `drivers.md`: update install + import lines to the subpath form.
+
+### 8. Changeset
+- `@forinda/kickjs-db`: **minor** (new subpaths + optional peers).
+- `@forinda/kickjs-db-pg` / `-sqlite` / `-mysql`: **major** (now deprecated shims) — or patch if we treat the re-export as non-breaking (imports still resolve). Lean: **minor** + deprecation notice, since the public API is unchanged for existing importers.
+
+## Risks / call-outs
+- **Optional peer = no auto-install.** Adopters must install the driver themselves; the subpath throws a clear "install `pg`" error if missing (add a friendly guard at the top of each adapter, like schema's detect try/catch).
+- **`kysely` stays a hard dep** of core (already is) — fine, it's the typed core for every dialect.
+- **Testcontainers / better-sqlite3 native build** move into the core package's test matrix (they already run in the sub-packages).
+- **`@forinda/kickjs-db/pg` dual meaning** (column types + adapter) is intentional and matches the spec, but worth a one-line note in the guide so people aren't surprised the adapter lives next to the column types.
+- Lockstep versioning: the shims still version-lockstep with core.
+
+## Rough size
+Mechanical move + barrels + exports + optional peers + CLI 2-line + example + docs. No algorithm changes. ~1 focused PR; the only thinking is the `kick add` driver-row redesign and the changeset bump call.

--- a/docs/db/plan-adapter-consolidation.md
+++ b/docs/db/plan-adapter-consolidation.md
@@ -11,43 +11,46 @@ The common interface already exists in core — `MigrationAdapter` + Kysely `Dia
 
 ## Before → after
 
-| Today | After |
-| --- | --- |
-| `npm i @forinda/kickjs-db @forinda/kickjs-db-pg pg` | `npm i @forinda/kickjs-db pg` |
+| Today                                               | After                                               |
+| --------------------------------------------------- | --------------------------------------------------- |
+| `npm i @forinda/kickjs-db @forinda/kickjs-db-pg pg` | `npm i @forinda/kickjs-db pg`                       |
 | `import { pgAdapter } from '@forinda/kickjs-db-pg'` | `import { pgAdapter } from '@forinda/kickjs-db/pg'` |
-| 3 published packages (lockstep) | 0 extra packages; 3 subpaths |
-| driver = peer of the sub-package | driver = **optional** peer of `@forinda/kickjs-db` |
+| 3 published packages (lockstep)                     | 0 extra packages; 3 subpaths                        |
+| driver = peer of the sub-package                    | driver = **optional** peer of `@forinda/kickjs-db`  |
 
 `@forinda/kickjs-db/pg` already exists today as the **PG column types** (`tsvector`, `vector`, `citext`, …). The adapter folds into the **same** subpath, so `@forinda/kickjs-db/pg` becomes "everything PG-specific": column types **+** `pgAdapter` **+** `pgDialect`. Same for `/sqlite` and `/mysql`.
 
 ## Surface being moved
 
-| From package | Exports | Driver peer |
-| --- | --- | --- |
-| `@forinda/kickjs-db-pg` | `pgAdapter`, `pgDialect`, `PgAdapterOptions`, `PgPoolLike`, `PgClientLike`, `PgDialectOptions` | `pg >=8.11` |
+| From package                | Exports                                                                                                                   | Driver peer           |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `@forinda/kickjs-db-pg`     | `pgAdapter`, `pgDialect`, `PgAdapterOptions`, `PgPoolLike`, `PgClientLike`, `PgDialectOptions`                            | `pg >=8.11`           |
 | `@forinda/kickjs-db-sqlite` | `sqliteAdapter`, `sqliteDialect`, `SqliteAdapterOptions`, `SqliteDatabaseLike`, `SqliteStatement`, `SqliteDialectOptions` | `better-sqlite3 >=12` |
-| `@forinda/kickjs-db-mysql` | `mysqlAdapter`, `mysqlDialect`, `MysqlAdapterOptions`, `MysqlDialectOptions` | `mysql2 >=3` |
+| `@forinda/kickjs-db-mysql`  | `mysqlAdapter`, `mysqlDialect`, `MysqlAdapterOptions`, `MysqlDialectOptions`                                              | `mysql2 >=3`          |
 
 All three already depend only on `kysely` (already a dep of core) + their driver + the core `MigrationAdapter` interface. No logic rewrite.
 
 ## Steps
 
 ### 1. Relocate sources into core
+
 - `packages/db-pg/src/{adapter,dialect}.ts` → `packages/db/src/adapters/pg/{adapter,dialect}.ts`
 - `packages/db-sqlite/src/{adapter,dialect}.ts` → `packages/db/src/adapters/sqlite/{adapter,dialect}.ts`
 - `packages/db-mysql/src/{adapter,dialect}.ts` → `packages/db/src/adapters/mysql/{adapter,dialect}.ts`
 - Fix internal imports: `from '../adapter'` (core `MigrationAdapter`) → `from '../../migrate/adapter'` etc. (relative within core).
 
 ### 2. Subpath barrels
+
 - `packages/db/src/pg.ts` (the existing `/pg` entry) becomes a barrel:
   ```ts
-  export * from './dsl/columns/pg'      // existing PG column types
+  export * from './dsl/columns/pg' // existing PG column types
   export * from './adapters/pg/adapter' // pgAdapter
   export * from './adapters/pg/dialect' // pgDialect
   ```
 - New `packages/db/src/sqlite.ts` and `packages/db/src/mysql.ts` barrels (column quirks, if any, + adapter + dialect).
 
 ### 3. Build + exports (`packages/db`)
+
 - `tsdown.config.ts` `entry`: add `sqlite: 'src/sqlite.ts'`, `mysql: 'src/mysql.ts'` (`pg` already present). Add `pg`/`better-sqlite3`/`mysql2` to `external`.
 - `package.json` `exports`: add `./sqlite`, `./mysql` (pattern matches existing `./pg`).
 - `package.json`: add optional peer deps
@@ -58,35 +61,43 @@ All three already depend only on `kysely` (already a dep of core) + their driver
 - Add `@types/pg`, `@types/better-sqlite3`, `better-sqlite3`, `pg`, `mysql2` to **devDependencies** so the moved code typechecks + tests run.
 
 ### 4. Deprecated shim packages (keep, per decision)
+
 Each old package becomes a 2-line re-export + deprecation:
+
 ```ts
 // packages/db-pg/src/index.ts
 /** @deprecated Import from `@forinda/kickjs-db/pg` instead. */
 export * from '@forinda/kickjs-db/pg'
 ```
+
 - Drop the driver from its `peerDependencies` (now optional-peer on core), keep `@forinda/kickjs-db` peer.
 - Add a `console.warn` once-per-process deprecation in the shim entry (optional).
 - README note: "merged into `@forinda/kickjs-db/<dialect>`".
 
 ### 5. CLI
+
 - `commands/db.ts:78` — `import('@forinda/kickjs-db-pg')` → `import('@forinda/kickjs-db/pg')`; keep the `import('pg')` probe. Update the comment.
 - `commands/add.ts:80` — registry entry: `kick add pg` should now add `@forinda/kickjs-db` + `pg` (driver), not `@forinda/kickjs-db-pg`. Revisit the whole db row set: `kick add db` (core), and `pg`/`sqlite`/`mysql` add the matching driver.
 - `package.json` devDep `@forinda/kickjs-db-pg` → `@forinda/kickjs-db` (already present) — drop the sub-package devDep.
 
 ### 6. Example (`examples/typegen-test`)
+
 - `kick.config.ts`: `import { sqliteAdapter } from '@forinda/kickjs-db-sqlite'` → `from '@forinda/kickjs-db/sqlite'`.
 - `package.json`: drop `@forinda/kickjs-db-sqlite`, keep `@forinda/kickjs-db` + `better-sqlite3`.
 
 ### 7. Docs
+
 - `architecture.md §3` already describes subpath exports — update to state adapters live there too (not separate packages); fix the "Package topology" tree.
 - API sidebar (`docs/.vitepress/config.mts`): the Packages group lists `@forinda/kickjs-db-pg/-sqlite/-mysql`? (it does **not** today — only `db`, `db-pg`, `db-sqlite`, `db-mysql` API pages exist). Decide: keep the `/api/db-*` pages as adapter reference, or fold into `/api/db` with subpath sections.
 - Database guide `drivers.md`: update install + import lines to the subpath form.
 
 ### 8. Changeset
+
 - `@forinda/kickjs-db`: **minor** (new subpaths + optional peers).
 - `@forinda/kickjs-db-pg` / `-sqlite` / `-mysql`: **major** (now deprecated shims) — or patch if we treat the re-export as non-breaking (imports still resolve). Lean: **minor** + deprecation notice, since the public API is unchanged for existing importers.
 
 ## Risks / call-outs
+
 - **Optional peer = no auto-install.** Adopters must install the driver themselves; the subpath throws a clear "install `pg`" error if missing (add a friendly guard at the top of each adapter, like schema's detect try/catch).
 - **`kysely` stays a hard dep** of core (already is) — fine, it's the typed core for every dialect.
 - **Testcontainers / better-sqlite3 native build** move into the core package's test matrix (they already run in the sub-packages).
@@ -94,4 +105,5 @@ export * from '@forinda/kickjs-db/pg'
 - Lockstep versioning: the shims still version-lockstep with core.
 
 ## Rough size
+
 Mechanical move + barrels + exports + optional peers + CLI 2-line + example + docs. No algorithm changes. ~1 focused PR; the only thinking is the `kick add` driver-row redesign and the changeset bump call.

--- a/docs/guide/database/drivers.md
+++ b/docs/guide/database/drivers.md
@@ -9,22 +9,22 @@ Both factories share the same underlying connection (one pool / handle, no dupli
 
 | Package                     | Dialect factory | Adapter factory | Driver dependency | Database                   |
 | --------------------------- | --------------- | --------------- | ----------------- | -------------------------- |
-| `@forinda/kickjs-db-pg`     | `pgDialect`     | `pgAdapter`     | `pg`              | PostgreSQL                 |
-| `@forinda/kickjs-db-sqlite` | `sqliteDialect` | `sqliteAdapter` | `better-sqlite3`  | SQLite                     |
-| `@forinda/kickjs-db-mysql`  | `mysqlDialect`  | `mysqlAdapter`  | `mysql2`          | MySQL 8.0+ / MariaDB 10.5+ |
+| `@forinda/kickjs-db/pg`     | `pgDialect`     | `pgAdapter`     | `pg`              | PostgreSQL                 |
+| `@forinda/kickjs-db/sqlite` | `sqliteDialect` | `sqliteAdapter` | `better-sqlite3`  | SQLite                     |
+| `@forinda/kickjs-db/mysql`  | `mysqlDialect`  | `mysqlAdapter`  | `mysql2`          | MySQL 8.0+ / MariaDB 10.5+ |
 
 Set the matching `dialect` in your `kick.config.ts` `db:` block (`'postgres'`, `'sqlite'`, or `'mysql'`).
 
-## PostgreSQL — `@forinda/kickjs-db-pg`
+## PostgreSQL — `@forinda/kickjs-db/pg`
 
 ```bash
-pnpm add @forinda/kickjs-db @forinda/kickjs-db-pg pg
+pnpm add @forinda/kickjs-db pg
 ```
 
 ```ts
 import { Pool } from 'pg'
 import { createDbClient } from '@forinda/kickjs-db'
-import { pgAdapter, pgDialect } from '@forinda/kickjs-db-pg'
+import { pgAdapter, pgDialect } from '@forinda/kickjs-db/pg'
 import * as schema from './schema'
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL })
@@ -47,16 +47,16 @@ Postgres is the most complete dialect:
 - The `@forinda/kickjs-db/pg` subpath types are available: `pgEnum`, `tsvector`, `vector(n)`, `citext`, `money`, `inet`, `cidr`, `xml`.
 - The built-in CLI migration path uses `pgAdapter` automatically when you set `connectionString` (or `DATABASE_URL`) — no `adapter` factory needed.
 
-## SQLite — `@forinda/kickjs-db-sqlite`
+## SQLite — `@forinda/kickjs-db/sqlite`
 
 ```bash
-pnpm add @forinda/kickjs-db @forinda/kickjs-db-sqlite better-sqlite3
+pnpm add @forinda/kickjs-db better-sqlite3
 ```
 
 ```ts
 import Database from 'better-sqlite3'
 import { createDbClient } from '@forinda/kickjs-db'
-import { sqliteAdapter, sqliteDialect } from '@forinda/kickjs-db-sqlite'
+import { sqliteAdapter, sqliteDialect } from '@forinda/kickjs-db/sqlite'
 import * as schema from './schema'
 
 const database = new Database('app.db') // or ':memory:'
@@ -77,16 +77,16 @@ Notes:
 - **`introspect()` is not implemented in v1** — it throws `KickDbError` with code `KICK_DB_INTROSPECT_NOT_SUPPORTED`. Set `driftCheck: 'off'` (or `'ignore'`) on the runner until a follow-up lands.
 - The built-in CLI adapter only resolves Postgres from `connectionString`. For SQLite migrations, supply an `adapter` factory in the `db:` block (see [Migrations → Non-Postgres dialects](./migrations#non-postgres-dialects)).
 
-## MySQL / MariaDB — `@forinda/kickjs-db-mysql`
+## MySQL / MariaDB — `@forinda/kickjs-db/mysql`
 
 ```bash
-pnpm add @forinda/kickjs-db @forinda/kickjs-db-mysql mysql2
+pnpm add @forinda/kickjs-db mysql2
 ```
 
 ```ts
 import { createPool } from 'mysql2/promise'
 import { createDbClient } from '@forinda/kickjs-db'
-import { mysqlAdapter, mysqlDialect } from '@forinda/kickjs-db-mysql'
+import { mysqlAdapter, mysqlDialect } from '@forinda/kickjs-db/mysql'
 import * as schema from './schema'
 
 const pool = createPool({

--- a/docs/guide/database/index.md
+++ b/docs/guide/database/index.md
@@ -3,7 +3,7 @@
 `@forinda/kickjs-db` is the first-party database layer for KickJS — a code-first ORM built on top of [Kysely](https://kysely.dev). You declare your schema as TypeScript, get fully typed queries with zero codegen, and ship reversible migrations through the `kick db` CLI.
 
 ::: tip This is the database story for KickJS
-`@forinda/kickjs-db` and its driver packages (`@forinda/kickjs-db-pg`, `@forinda/kickjs-db-sqlite`, `@forinda/kickjs-db-mysql`) are the supported, first-party way to talk to a SQL database from a KickJS app.
+`@forinda/kickjs-db` and its driver packages (`@forinda/kickjs-db/pg`, `@forinda/kickjs-db/sqlite`, `@forinda/kickjs-db/mysql`) are the supported, first-party way to talk to a SQL database from a KickJS app.
 :::
 
 ## What you get
@@ -21,21 +21,21 @@ Install the core package plus the driver for your database. Use `kick add`:
 
 ```bash
 # PostgreSQL
-kick add db db-pg
+kick add pg
 
 # SQLite
-kick add db db-sqlite
+kick add sqlite
 
 # MySQL / MariaDB
-kick add db db-mysql
+kick add mysql
 ```
 
 Each driver package needs the underlying database client too:
 
 ```bash
-pnpm add @forinda/kickjs-db @forinda/kickjs-db-pg pg          # PostgreSQL
-pnpm add @forinda/kickjs-db @forinda/kickjs-db-sqlite better-sqlite3   # SQLite
-pnpm add @forinda/kickjs-db @forinda/kickjs-db-mysql mysql2   # MySQL
+pnpm add @forinda/kickjs-db pg          # PostgreSQL
+pnpm add @forinda/kickjs-db better-sqlite3   # SQLite
+pnpm add @forinda/kickjs-db mysql2   # MySQL
 ```
 
 See [Drivers](./drivers) for the differences between dialects.
@@ -94,7 +94,7 @@ See [Migrations](./migrations) for the full workflow.
 // src/db/client.ts
 import { Pool } from 'pg'
 import { createDbClient } from '@forinda/kickjs-db'
-import { pgAdapter, pgDialect } from '@forinda/kickjs-db-pg'
+import { pgAdapter, pgDialect } from '@forinda/kickjs-db/pg'
 import * as schema from './schema'
 
 export const pool = new Pool({ connectionString: process.env.DATABASE_URL })

--- a/docs/guide/database/migrations.md
+++ b/docs/guide/database/migrations.md
@@ -174,7 +174,7 @@ export default defineConfig({
     dialect: 'sqlite',
     adapter: async () => {
       const Database = (await import('better-sqlite3')).default
-      const { sqliteAdapter } = await import('@forinda/kickjs-db-sqlite')
+      const { sqliteAdapter } = await import('@forinda/kickjs-db/sqlite')
       return sqliteAdapter({ database: new Database('app.db') })
     },
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,7 +53,8 @@
   },
   "devDependencies": {
     "@forinda/kickjs-ai": "workspace:*",
-    "@forinda/kickjs-db-pg": "workspace:*",
+    "pg": "^8.21.0",
+    "@types/pg": "^8.11.10",
     "@swc/core": "^1.15.40",
     "@types/node": "^25.9.2",
     "@types/pg": "^8.11.10",

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -70,16 +70,28 @@ const PACKAGE_REGISTRY: Record<string, PackageEntry> = {
     peers: [],
     description: 'OpenAPI spec + Swagger UI + ReDoc',
   },
-  // Database
+  // Database — the dialect adapters now ship as subpaths of
+  // `@forinda/kickjs-db` (`/pg`, `/sqlite`, `/mysql`), so each `kick add`
+  // pulls the core package plus the one driver you need.
   db: {
     pkg: '@forinda/kickjs-db',
     peers: [],
     description: 'kick/db core — schema DSL, migrations, KickDbClient, customType',
   },
-  'db-pg': {
-    pkg: '@forinda/kickjs-db-pg',
+  pg: {
+    pkg: '@forinda/kickjs-db',
     peers: ['pg'],
-    description: 'kick/db PostgreSQL dialect + adapter (pgDialect, pgAdapter)',
+    description: 'kick/db + PostgreSQL driver (use @forinda/kickjs-db/pg)',
+  },
+  sqlite: {
+    pkg: '@forinda/kickjs-db',
+    peers: ['better-sqlite3'],
+    description: 'kick/db + SQLite driver (use @forinda/kickjs-db/sqlite)',
+  },
+  mysql: {
+    pkg: '@forinda/kickjs-db',
+    peers: ['mysql2'],
+    description: 'kick/db + MySQL driver (use @forinda/kickjs-db/mysql)',
   },
   drizzle: {
     pkg: '@forinda/kickjs-drizzle',

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -50,7 +50,7 @@ async function loadConfig(opts: BaseOpts): Promise<DbConfig> {
  * Resolve a MigrationAdapter from config:
  *  1. config.adapter() — explicit factory wins.
  *  2. config.connectionString — built-in pgAdapter path; we dynamically
- *     import @forinda/kickjs-db-pg + pg so the CLI doesn't pull pg into
+ *     import @forinda/kickjs-db/pg + pg so the CLI doesn't pull pg into
  *     non-PG workflows.
  */
 async function resolveAdapter(config: DbConfig): Promise<{
@@ -73,9 +73,9 @@ async function resolveAdapter(config: DbConfig): Promise<{
     )
   }
   // Dynamic import so the CLI doesn't hard-require pg unless this path runs.
-  // Both packages are devDependencies of @forinda/kickjs-cli so types resolve;
-  // adopters who use this path must also install them in their own app.
-  const [{ pgAdapter }, pg] = await Promise.all([import('@forinda/kickjs-db-pg'), import('pg')])
+  // The pg adapter ships from the `@forinda/kickjs-db/pg` subpath; adopters
+  // who use this path install `@forinda/kickjs-db` + `pg` in their own app.
+  const [{ pgAdapter }, pg] = await Promise.all([import('@forinda/kickjs-db/pg'), import('pg')])
   const pool = new pg.default.Pool({ connectionString: config.connectionString })
   const adapter = pgAdapter({ pool })
   return {

--- a/packages/db-mysql/src/index.ts
+++ b/packages/db-mysql/src/index.ts
@@ -1,11 +1,9 @@
-export {
-  mysqlAdapter,
-  parseMysqlMajorVersion,
-  parseMysqlVersion,
-  splitMysqlStatements,
-  type MysqlAdapterOptions,
-  type MysqlConnectionLike,
-  type MysqlPoolLike,
-  type ParsedMysqlVersion,
-} from './adapter'
-export { mysqlDialect, type MysqlDialectOptions } from './dialect'
+/**
+ * @deprecated This package is merged into `@forinda/kickjs-db`. Import
+ * from the `@forinda/kickjs-db/mysql` subpath instead and install the
+ * driver (`mysql2`) directly. This shim re-exports the same API
+ * and will be removed in a future major.
+ *
+ * @module @forinda/kickjs-db-mysql
+ */
+export * from '@forinda/kickjs-db/mysql'

--- a/packages/db-mysql/vitest.config.ts
+++ b/packages/db-mysql/vitest.config.ts
@@ -14,7 +14,9 @@ export default defineConfig({
   resolve: {
     alias: {
       '@forinda/kickjs': path.resolve(__dirname, '../kickjs/src/index.ts'),
-      '@forinda/kickjs-db/pg': path.resolve(__dirname, '../db/src/dsl/columns/pg.ts'),
+      '@forinda/kickjs-db/pg': path.resolve(__dirname, '../db/src/pg.ts'),
+      '@forinda/kickjs-db/sqlite': path.resolve(__dirname, '../db/src/sqlite.ts'),
+      '@forinda/kickjs-db/mysql': path.resolve(__dirname, '../db/src/mysql.ts'),
       '@forinda/kickjs-db': path.resolve(__dirname, '../db/src/index.ts'),
       '@forinda/kickjs-db-mysql': path.resolve(__dirname, 'src/index.ts'),
     },

--- a/packages/db-pg/src/index.ts
+++ b/packages/db-pg/src/index.ts
@@ -1,2 +1,9 @@
-export { pgAdapter, type PgAdapterOptions, type PgPoolLike, type PgClientLike } from './adapter'
-export { pgDialect, type PgDialectOptions } from './dialect'
+/**
+ * @deprecated This package is merged into `@forinda/kickjs-db`. Import
+ * from the `@forinda/kickjs-db/pg` subpath instead and install the
+ * driver (`pg`) directly. This shim re-exports the same API
+ * and will be removed in a future major.
+ *
+ * @module @forinda/kickjs-db-pg
+ */
+export * from '@forinda/kickjs-db/pg'

--- a/packages/db-pg/vitest.config.ts
+++ b/packages/db-pg/vitest.config.ts
@@ -16,7 +16,9 @@ export default defineConfig({
       '@forinda/kickjs': path.resolve(__dirname, '../kickjs/src/index.ts'),
       // Subpath aliases must come before bare-package aliases (Vite resolves
       // prefixes top-down).
-      '@forinda/kickjs-db/pg': path.resolve(__dirname, '../db/src/dsl/columns/pg.ts'),
+      '@forinda/kickjs-db/pg': path.resolve(__dirname, '../db/src/pg.ts'),
+      '@forinda/kickjs-db/sqlite': path.resolve(__dirname, '../db/src/sqlite.ts'),
+      '@forinda/kickjs-db/mysql': path.resolve(__dirname, '../db/src/mysql.ts'),
       '@forinda/kickjs-db': path.resolve(__dirname, '../db/src/index.ts'),
       '@forinda/kickjs-db-pg': path.resolve(__dirname, 'src/index.ts'),
     },

--- a/packages/db-sqlite/src/index.ts
+++ b/packages/db-sqlite/src/index.ts
@@ -1,7 +1,9 @@
-export {
-  sqliteAdapter,
-  type SqliteAdapterOptions,
-  type SqliteDatabaseLike,
-  type SqliteStatement,
-} from './adapter'
-export { sqliteDialect, type SqliteDialectOptions } from './dialect'
+/**
+ * @deprecated This package is merged into `@forinda/kickjs-db`. Import
+ * from the `@forinda/kickjs-db/sqlite` subpath instead and install the
+ * driver (`better-sqlite3`) directly. This shim re-exports the same API
+ * and will be removed in a future major.
+ *
+ * @module @forinda/kickjs-db-sqlite
+ */
+export * from '@forinda/kickjs-db/sqlite'

--- a/packages/db-sqlite/vitest.config.ts
+++ b/packages/db-sqlite/vitest.config.ts
@@ -14,7 +14,9 @@ export default defineConfig({
   resolve: {
     alias: {
       '@forinda/kickjs': path.resolve(__dirname, '../kickjs/src/index.ts'),
-      '@forinda/kickjs-db/pg': path.resolve(__dirname, '../db/src/dsl/columns/pg.ts'),
+      '@forinda/kickjs-db/pg': path.resolve(__dirname, '../db/src/pg.ts'),
+      '@forinda/kickjs-db/sqlite': path.resolve(__dirname, '../db/src/sqlite.ts'),
+      '@forinda/kickjs-db/mysql': path.resolve(__dirname, '../db/src/mysql.ts'),
       '@forinda/kickjs-db': path.resolve(__dirname, '../db/src/index.ts'),
       '@forinda/kickjs-db-sqlite': path.resolve(__dirname, 'src/index.ts'),
     },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -29,6 +29,14 @@
       "import": "./dist/pg.mjs",
       "types": "./dist/pg.d.mts"
     },
+    "./sqlite": {
+      "import": "./dist/sqlite.mjs",
+      "types": "./dist/sqlite.d.mts"
+    },
+    "./mysql": {
+      "import": "./dist/mysql.mjs",
+      "types": "./dist/mysql.d.mts"
+    },
     "./devtools-events": {
       "import": "./dist/devtools-events.mjs",
       "types": "./dist/devtools-events.d.mts"
@@ -50,10 +58,22 @@
   },
   "peerDependencies": {
     "@forinda/kickjs": ">=5.14.0-alpha.0",
-    "@forinda/kickjs-devtools-kit": ">=6.0.0-alpha.0"
+    "@forinda/kickjs-devtools-kit": ">=6.0.0-alpha.0",
+    "better-sqlite3": ">=12.0.0",
+    "mysql2": ">=3.0.0",
+    "pg": ">=8.11.0"
   },
   "peerDependenciesMeta": {
     "@forinda/kickjs-devtools-kit": {
+      "optional": true
+    },
+    "better-sqlite3": {
+      "optional": true
+    },
+    "mysql2": {
+      "optional": true
+    },
+    "pg": {
       "optional": true
     }
   },
@@ -61,9 +81,12 @@
     "@forinda/kickjs": "workspace:*",
     "@forinda/kickjs-devtools-kit": "workspace:*",
     "@testcontainers/postgresql": "^12.0.1",
+    "@types/better-sqlite3": "^7.6.11",
     "@types/node": "^25.9.2",
     "@types/pg": "^8.11.10",
+    "better-sqlite3": "^12.0.0",
     "kysely": "^0.29.2",
+    "mysql2": "^3.11.0",
     "pg": "^8.21.0",
     "typescript": "^6.0.3"
   },

--- a/packages/db/src/adapter.ts
+++ b/packages/db/src/adapter.ts
@@ -8,7 +8,7 @@ import type { DriftBehavior } from './migrate/drift'
 export type MigrationsOnBoot = 'fail-if-pending' | 'apply' | 'ignore'
 
 export interface KickDbAdapterConfig {
-  /** The driver-bound MigrationAdapter — pgAdapter() in @forinda/kickjs-db-pg, etc. */
+  /** The driver-bound MigrationAdapter — pgAdapter() in @forinda/kickjs-db/pg, etc. */
   migrationAdapter: MigrationAdapter
   /** Directory containing the generated migrations + _journal.json. */
   migrationsDir: string

--- a/packages/db/src/adapters/mysql/adapter.ts
+++ b/packages/db/src/adapters/mysql/adapter.ts
@@ -6,7 +6,7 @@ import {
   type MigrationAdapter,
   type MigrationRow,
   type SchemaSnapshot,
-} from '@forinda/kickjs-db'
+} from '../../index'
 
 /**
  * mysql2-shaped pool that `mysqlAdapter` consumes. Mirrors the

--- a/packages/db/src/adapters/mysql/dialect.ts
+++ b/packages/db/src/adapters/mysql/dialect.ts
@@ -27,7 +27,7 @@ export interface MysqlDialectOptions {
  * @example
  * ```ts
  * import { createDbClient } from '@forinda/kickjs-db'
- * import { mysqlAdapter, mysqlDialect } from '@forinda/kickjs-db-mysql'
+ * import { mysqlAdapter, mysqlDialect } from '@forinda/kickjs-db/mysql'
  * import { createPool } from 'mysql2/promise'
  *
  * const pool = createPool({

--- a/packages/db/src/adapters/mysql/dialect.ts
+++ b/packages/db/src/adapters/mysql/dialect.ts
@@ -1,6 +1,6 @@
 // mysqlDialect — thin factory over Kysely's MysqlDialect so adopters
 // never have to reach for `import { MysqlDialect } from 'kysely'`.
-// Mirrors the `@forinda/kickjs-db-pg` template; the kysely subpackage
+// Mirrors the `@forinda/kickjs-db/pg` template; the kysely subpackage
 // is a pinned internal dep of the framework.
 
 import { MysqlDialect, type Dialect as KyselyDialect } from 'kysely'

--- a/packages/db/src/adapters/pg/adapter.ts
+++ b/packages/db/src/adapters/pg/adapter.ts
@@ -6,7 +6,7 @@ import {
   type MigrationAdapter,
   type MigrationRow,
   type SchemaSnapshot,
-} from '@forinda/kickjs-db'
+} from '../../index'
 
 /**
  * Minimal client returned by PgPoolLike.connect(). Matches the shape of

--- a/packages/db/src/adapters/pg/dialect.ts
+++ b/packages/db/src/adapters/pg/dialect.ts
@@ -23,7 +23,7 @@ export interface PgDialectOptions {
  * @example
  * ```ts
  * import { createDbClient } from '@forinda/kickjs-db'
- * import { pgDialect, pgAdapter } from '@forinda/kickjs-db-pg'
+ * import { pgDialect, pgAdapter } from '@forinda/kickjs-db/pg'
  * import { Pool } from 'pg'
  *
  * const pool = new Pool({ connectionString: process.env.DATABASE_URL })

--- a/packages/db/src/adapters/sqlite/adapter.ts
+++ b/packages/db/src/adapters/sqlite/adapter.ts
@@ -6,7 +6,7 @@ import {
   type MigrationAdapter,
   type MigrationRow,
   type SchemaSnapshot,
-} from '@forinda/kickjs-db'
+} from '../../index'
 
 /**
  * better-sqlite3-shaped database handle that `sqliteAdapter` consumes.

--- a/packages/db/src/adapters/sqlite/dialect.ts
+++ b/packages/db/src/adapters/sqlite/dialect.ts
@@ -1,6 +1,6 @@
 // sqliteDialect — thin factory over Kysely's SqliteDialect so adopters
 // never have to reach for `import { SqliteDialect } from 'kysely'`.
-// Mirrors the `@forinda/kickjs-db-pg` template; the kysely subpackage
+// Mirrors the `@forinda/kickjs-db/pg` template; the kysely subpackage
 // is a pinned internal dep of the framework.
 
 import { SqliteDialect, type Dialect as KyselyDialect } from 'kysely'

--- a/packages/db/src/adapters/sqlite/dialect.ts
+++ b/packages/db/src/adapters/sqlite/dialect.ts
@@ -23,7 +23,7 @@ export interface SqliteDialectOptions {
  * @example
  * ```ts
  * import { createDbClient } from '@forinda/kickjs-db'
- * import { sqliteDialect, sqliteAdapter } from '@forinda/kickjs-db-sqlite'
+ * import { sqliteDialect, sqliteAdapter } from '@forinda/kickjs-db/sqlite'
  * import Database from 'better-sqlite3'
  *
  * const database = new Database(':memory:')

--- a/packages/db/src/migrate/adapter.ts
+++ b/packages/db/src/migrate/adapter.ts
@@ -13,7 +13,7 @@ export interface MigrationRow {
  * Slim contract that connects the runner to a concrete database driver.
  *
  * Concrete impls: MemoryMigrationAdapter (this package, test-only) and
- * pgAdapter from @forinda/kickjs-db-pg. Future db-sqlite / db-mysql adapter
+ * pgAdapter from @forinda/kickjs-db/pg. Future db-sqlite / db-mysql adapter
  * packages will satisfy this same shape so the runner stays driver-agnostic.
  */
 export interface MigrationAdapter {

--- a/packages/db/src/mysql.ts
+++ b/packages/db/src/mysql.ts
@@ -1,0 +1,5 @@
+// `@forinda/kickjs-db/mysql` — the MySQL migration adapter + Kysely
+// dialect. `mysql2` is an optional peer dependency of
+// `@forinda/kickjs-db`; install it alongside to use this subpath.
+export * from './adapters/mysql/adapter'
+export * from './adapters/mysql/dialect'

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1,0 +1,7 @@
+// `@forinda/kickjs-db/pg` — everything PostgreSQL-specific: the PG-only
+// column types (tsvector, vector, citext, …) plus the migration adapter
+// and Kysely dialect. `pg` is an optional peer dependency of
+// `@forinda/kickjs-db` — install it alongside to use this subpath.
+export * from './dsl/columns/pg'
+export * from './adapters/pg/adapter'
+export * from './adapters/pg/dialect'

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -1,0 +1,5 @@
+// `@forinda/kickjs-db/sqlite` — the SQLite migration adapter + Kysely
+// dialect. `better-sqlite3` is an optional peer dependency of
+// `@forinda/kickjs-db`; install it alongside to use this subpath.
+export * from './adapters/sqlite/adapter'
+export * from './adapters/sqlite/dialect'

--- a/packages/db/tsdown.config.ts
+++ b/packages/db/tsdown.config.ts
@@ -6,7 +6,9 @@ const pkg = readPkg(import.meta.dirname)
 export default defineConfig({
   entry: {
     index: 'src/index.ts',
-    pg: 'src/dsl/columns/pg.ts',
+    pg: 'src/pg.ts',
+    sqlite: 'src/sqlite.ts',
+    mysql: 'src/mysql.ts',
     'devtools-events': 'src/devtools-events.ts',
   },
   format: ['esm'],
@@ -18,6 +20,12 @@ export default defineConfig({
     '@forinda/kickjs-devtools-kit',
     '@forinda/kickjs-devtools-kit/bus',
     'kysely',
+    // Optional driver peers — bundled only into the subpath that needs
+    // them, never the core entry, and resolved from the adopter's install.
+    'pg',
+    'better-sqlite3',
+    'mysql2',
+    'mysql2/promise',
     /^node:/,
   ],
   banner: { js: createBanner(pkg.name, pkg.version) },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,9 +189,6 @@ importers:
       '@forinda/kickjs-ai':
         specifier: workspace:*
         version: link:../ai
-      '@forinda/kickjs-db-pg':
-        specifier: workspace:*
-        version: link:../db-pg
       '@swc/core':
         specifier: ^1.15.40
         version: 1.15.40
@@ -232,12 +229,21 @@ importers:
       '@testcontainers/postgresql':
         specifier: ^12.0.1
         version: 12.0.1
+      '@types/better-sqlite3':
+        specifier: ^7.6.11
+        version: 7.6.13
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.2
       '@types/pg':
         specifier: ^8.11.10
         version: 8.20.0
+      better-sqlite3:
+        specifier: ^12.0.0
+        version: 12.10.0
+      mysql2:
+        specifier: ^3.11.0
+        version: 3.22.5(@types/node@25.9.2)
       pg:
         specifier: ^8.21.0
         version: 8.21.0


### PR DESCRIPTION
## Why

Adopters needed three installs for a Postgres app — `@forinda/kickjs-db` + `@forinda/kickjs-db-pg` + `pg`. This collapses the dialect adapters into **subpaths of `@forinda/kickjs-db`**, mirroring how `@forinda/kickjs-schema` exposes `./zod` / `./valibot` / `./yup`. One package + the one driver you use.

## What

```bash
# before
pnpm add @forinda/kickjs-db @forinda/kickjs-db-pg pg
# after
pnpm add @forinda/kickjs-db pg
```
```ts
// before
import { pgAdapter } from '@forinda/kickjs-db-pg'
// after
import { pgAdapter } from '@forinda/kickjs-db/pg'
```

- **New subpaths**: `@forinda/kickjs-db/pg` (now also carries `pgAdapter` + `pgDialect` next to the PG column types), `/sqlite`, `/mysql`. Each bundles its column quirks + migration adapter + Kysely dialect.
- **`pg` / `better-sqlite3` / `mysql2` → optional peer deps** of the core package; the subpath imports its driver lazily, so the core install never pulls all three.
- **Old packages kept as deprecated re-export shims** (`export * from '@forinda/kickjs-db/<dialect>'`) — existing installs keep working; removed in a future major.
- **CLI**: `kick db` resolves the pg adapter from `@forinda/kickjs-db/pg`; `kick add pg|sqlite|mysql` installs core + the matching driver.
- The relocated adapter/dialect sources are unchanged logic — they already implemented the core `MigrationAdapter` / Kysely `Dialect` interface; this is a move + barrel + exports.

## Verification

- Full workspace build: **22/22**.
- `@forinda/kickjs-db`: **403** tests; `@forinda/kickjs-cli`: **381** tests.
- End-to-end against a real SQLite DB: `kick db migrate status` loads `kick.config.ts` (which imports `sqliteAdapter` from `@forinda/kickjs-db/sqlite`), builds the adapter, queries `kick_migrations`, prints the status table.

Design notes + the step-by-step plan: `docs/db/plan-adapter-consolidation.md`. Architecture doc §3 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database drivers now available via subpath imports: `@forinda/kickjs-db/pg`, `@forinda/kickjs-db/sqlite`, `@forinda/kickjs-db/mysql` for cleaner package organization.

* **Documentation**
  * Updated installation and import examples to reflect new subpath structure and combined install approach (core package plus individual driver dependency).

* **Deprecation**
  * Legacy dialect packages (`@forinda/kickjs-db-pg`, `-sqlite`, `-mysql`) transitioned to deprecated shims; continue working but new code should migrate to subpath imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->