### PR TITLE
feat(db,cli): SQLite migration emitter + migrate review + non-pg drift skip

### DIFF
--- a/.changeset/db-sqlite-emit-review.md
+++ b/.changeset/db-sqlite-emit-review.md
@@ -1,0 +1,12 @@
+---
+'@forinda/kickjs-db': minor
+'@forinda/kickjs-cli': minor
+---
+
+SQLite migration generation, a `migrate review` command, and drift handling for non-Postgres dialects.
+
+- **`kick db generate` now emits SQLite DDL** when `db.dialect: 'sqlite'`. Previously the migration emitter was Postgres-only, so SQLite projects couldn't generate migrations from their schema (only the runner worked). The new `emitSqlite` maps PG types to SQLite affinities, normalises defaults (`gen_random_uuid()` → `(lower(hex(randomblob(16))))`, `false` → `0`, `now()` → `CURRENT_TIMESTAMP`), inlines a single integer PK as `INTEGER PRIMARY KEY` (rowid), and folds foreign keys into `CREATE TABLE` (SQLite has no `ALTER ... ADD CONSTRAINT`). Operations SQLite can't express via `ALTER TABLE` (column type/null/default changes, FK changes on an existing table) throw a clear `SqliteRebuildRequiredError` pointing at `kick db generate --empty` instead of emitting wrong SQL. `generate` now dispatches the emitter by dialect.
+
+- **`kick db migrate review <id>`** marks a migration reviewed: it flips `meta.json.reviewed`, swaps the `-- REVIEWED: false` markers in `up.sql`/`down.sql`, and recomputes the journal hash so all three stay in sync. Previously the only way to review was hand-editing `meta.json`, which left the SQL markers and the hash out of sync (the runner gates on `meta.json.reviewed`, not the comment).
+
+- **Drift detection is skipped for SQLite/MySQL** — only the Postgres adapter implements `introspect()`, so `kick db migrate` no longer fails with "introspection not supported" on those dialects (PostgreSQL keeps the default `error` behaviour).

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -11,6 +11,7 @@ import {
   migrateDown,
   migrateRollback,
   migrateStatus,
+  reviewMigration,
   renderSchemaSource,
   type CompositeQueryRunner,
   type DbConfig,
@@ -85,6 +86,17 @@ async function resolveAdapter(config: DbConfig): Promise<{
       await pool.end()
     },
   }
+}
+
+/**
+ * Drift detection introspects the live DB and compares it to the last
+ * applied snapshot. Only the Postgres adapter implements `introspect()`
+ * today, so for SQLite / MySQL we turn drift off (the runner would
+ * otherwise throw "introspection not supported"). PostgreSQL keeps the
+ * default `'error'` behaviour.
+ */
+function driftCheckFor(config: DbConfig): 'ignore' | undefined {
+  return (config.dialect ?? 'postgres') === 'postgres' ? undefined : 'ignore'
 }
 
 interface PgQueryRunnerProbe {
@@ -205,6 +217,7 @@ export function registerDbCommands(program: Command): void {
           adapter,
           migrationsDir: config.migrationsDir,
           confirmEnumDrop: opts.confirmEnumDrop,
+          driftCheck: driftCheckFor(config),
         })
         if (r.applied.length === 0) {
           console.log('No pending migrations.')
@@ -233,6 +246,7 @@ export function registerDbCommands(program: Command): void {
           adapter,
           migrationsDir: config.migrationsDir,
           confirmEnumDrop: opts.confirmEnumDrop,
+          driftCheck: driftCheckFor(config),
         })
         if (r.applied.length === 0) {
           console.log('No pending migrations.')
@@ -252,7 +266,11 @@ export function registerDbCommands(program: Command): void {
       const config = await loadConfig(opts)
       const { adapter, cleanup } = await resolveAdapter(config)
       try {
-        const r = await migrateDown({ adapter, migrationsDir: config.migrationsDir })
+        const r = await migrateDown({
+          adapter,
+          migrationsDir: config.migrationsDir,
+          driftCheck: driftCheckFor(config),
+        })
         if (!r.reversed) {
           console.log('Nothing to reverse.')
         } else {
@@ -271,7 +289,11 @@ export function registerDbCommands(program: Command): void {
       const config = await loadConfig(opts)
       const { adapter, cleanup } = await resolveAdapter(config)
       try {
-        const r = await migrateRollback({ adapter, migrationsDir: config.migrationsDir })
+        const r = await migrateRollback({
+          adapter,
+          migrationsDir: config.migrationsDir,
+          driftCheck: driftCheckFor(config),
+        })
         if (r.reversed.length === 0) {
           console.log('Nothing to roll back.')
         } else {
@@ -295,6 +317,21 @@ export function registerDbCommands(program: Command): void {
       } finally {
         await cleanup()
       }
+    })
+
+  migrate
+    .command('review <id>')
+    .description('Mark a migration reviewed (flips meta.json + the -- REVIEWED markers)')
+    .option('-c, --config <path>', 'Path to kick.config.ts', 'kick.config.ts')
+    .action(async (id: string, opts: BaseOpts) => {
+      // No adapter/DB needed — review only touches the migration files.
+      const config = await loadConfig(opts)
+      const r = await reviewMigration(config.migrationsDir, id)
+      console.log(
+        r.alreadyReviewed
+          ? `${r.id} was already reviewed.`
+          : `Reviewed ${r.id} — it can now be applied.`,
+      )
     })
 
   // ── kick db introspect ─────────────────────────────────────────────────

--- a/packages/db/__tests__/unit/emit-sqlite.test.ts
+++ b/packages/db/__tests__/unit/emit-sqlite.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest'
+import { emitSqlite, SqliteRebuildRequiredError } from '@forinda/kickjs-db'
+import type { ChangeSet } from '@forinda/kickjs-db'
+
+const col = (over: Partial<import('@forinda/kickjs-db').ColumnSnapshot> = {}) => ({
+  name: 'c',
+  type: 'text',
+  nullable: true,
+  default: null,
+  primaryKey: false,
+  ...over,
+})
+
+describe('emitSqlite — CREATE TABLE', () => {
+  it('maps PG types to SQLite affinities + normalises defaults', () => {
+    const cs: ChangeSet = [
+      {
+        kind: 'createTable',
+        table: {
+          name: 'tasks',
+          columns: {
+            id: col({
+              name: 'id',
+              type: 'uuid',
+              nullable: false,
+              primaryKey: true,
+              default: 'gen_random_uuid()',
+            }),
+            title: col({ name: 'title', type: 'varchar(200)', nullable: false }),
+            done: col({ name: 'done', type: 'boolean', nullable: false, default: 'false' }),
+            createdAt: col({
+              name: 'createdAt',
+              type: 'timestamp',
+              nullable: false,
+              default: 'CURRENT_TIMESTAMP',
+            }),
+          },
+          indexes: [],
+          foreignKeys: [],
+          checks: [],
+        },
+      },
+    ]
+    expect(emitSqlite(cs)).toBe(
+      'CREATE TABLE "tasks" (\n' +
+        '  "id" TEXT NOT NULL DEFAULT (lower(hex(randomblob(16)))),\n' +
+        '  "title" TEXT NOT NULL,\n' +
+        '  "done" INTEGER NOT NULL DEFAULT 0,\n' +
+        '  "createdAt" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,\n' +
+        '  PRIMARY KEY ("id")\n' +
+        ');',
+    )
+  })
+
+  it('inlines a single integer PK as INTEGER PRIMARY KEY (rowid alias)', () => {
+    const cs: ChangeSet = [
+      {
+        kind: 'createTable',
+        table: {
+          name: 'nums',
+          columns: { id: col({ name: 'id', type: 'serial', nullable: false, primaryKey: true }) },
+          indexes: [],
+          foreignKeys: [],
+          checks: [],
+        },
+      },
+    ]
+    // Inline, with AUTOINCREMENT for serial; no separate PRIMARY KEY clause.
+    expect(emitSqlite(cs)).toBe(
+      'CREATE TABLE "nums" (\n  "id" INTEGER PRIMARY KEY AUTOINCREMENT\n);',
+    )
+  })
+
+  it('inlines foreign keys into CREATE TABLE and skips their addForeignKey change', () => {
+    const cs: ChangeSet = [
+      {
+        kind: 'createTable',
+        table: {
+          name: 'posts',
+          columns: {
+            id: col({ name: 'id', type: 'integer', nullable: false, primaryKey: true }),
+            authorId: col({ name: 'authorId', type: 'integer', nullable: false }),
+          },
+          indexes: [],
+          foreignKeys: [
+            {
+              name: 'posts_author_fk',
+              columns: ['authorId'],
+              refTable: 'users',
+              refColumns: ['id'],
+              onDelete: 'cascade',
+              onUpdate: 'no_action',
+            },
+          ],
+          checks: [],
+        },
+      },
+      // The diff emits this separately for a new table — must be a no-op.
+      {
+        kind: 'addForeignKey',
+        table: 'posts',
+        fk: {
+          name: 'posts_author_fk',
+          columns: ['authorId'],
+          refTable: 'users',
+          refColumns: ['id'],
+          onDelete: 'cascade',
+          onUpdate: 'no_action',
+        },
+      },
+    ]
+    const sql = emitSqlite(cs)
+    expect(sql).toContain('"id" INTEGER PRIMARY KEY')
+    expect(sql).toContain(
+      'FOREIGN KEY ("authorId") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE NO ACTION',
+    )
+    // exactly one statement (the FK change folded in, not a separate ALTER)
+    expect(sql.match(/;/g)?.length).toBe(1)
+  })
+})
+
+describe('emitSqlite — ALTER', () => {
+  it('add / drop / rename column + indexes', () => {
+    expect(
+      emitSqlite([
+        {
+          kind: 'addColumn',
+          table: 'tasks',
+          column: col({ name: 'priority', type: 'integer', nullable: false, default: '0' }),
+        },
+      ]),
+    ).toBe('ALTER TABLE "tasks" ADD COLUMN "priority" INTEGER NOT NULL DEFAULT 0;')
+
+    expect(
+      emitSqlite([{ kind: 'dropColumn', table: 'tasks', column: col({ name: 'priority' }) }]),
+    ).toBe('ALTER TABLE "tasks" DROP COLUMN "priority";')
+
+    expect(emitSqlite([{ kind: 'renameColumn', table: 'tasks', from: 'a', to: 'b' }])).toBe(
+      'ALTER TABLE "tasks" RENAME COLUMN "a" TO "b";',
+    )
+
+    expect(
+      emitSqlite([
+        {
+          kind: 'addIndex',
+          table: 'tasks',
+          index: { name: 'tasks_done_idx', columns: ['done'], unique: false },
+        },
+      ]),
+    ).toBe('CREATE INDEX "tasks_done_idx" ON "tasks" ("done");')
+
+    expect(
+      emitSqlite([
+        {
+          kind: 'dropIndex',
+          table: 'tasks',
+          index: { name: 'tasks_done_idx', columns: ['done'], unique: false },
+        },
+      ]),
+    ).toBe('DROP INDEX "tasks_done_idx";')
+  })
+
+  it('throws SqliteRebuildRequiredError for column alteration', () => {
+    expect(() =>
+      emitSqlite([
+        {
+          kind: 'alterColumn',
+          table: 'tasks',
+          column: 'title',
+          before: col({ name: 'title', type: 'varchar(50)' }),
+          after: col({ name: 'title', type: 'text' }),
+        },
+      ]),
+    ).toThrow(SqliteRebuildRequiredError)
+  })
+
+  it('throws SqliteRebuildRequiredError for FK on an existing table', () => {
+    expect(() =>
+      emitSqlite([
+        {
+          kind: 'addForeignKey',
+          table: 'posts',
+          fk: {
+            name: 'fk',
+            columns: ['x'],
+            refTable: 'u',
+            refColumns: ['id'],
+            onDelete: 'no_action',
+            onUpdate: 'no_action',
+          },
+        },
+      ]),
+    ).toThrow(SqliteRebuildRequiredError)
+  })
+})

--- a/packages/db/src/cli/generate.ts
+++ b/packages/db/src/cli/generate.ts
@@ -8,10 +8,20 @@ import { diff } from '../diff/engine'
 import { invertChanges, hasAmbiguousReverse } from '../diff/invert'
 import { CompositeEnumReferenceError, type CompositeRef } from '../diff/composite-detect'
 import { emitPg } from '../emit/pg'
+import { emitSqlite } from '../emit/sqlite'
 import { appendJournalEntry, computeMigrationHash } from '../migrate/journal'
 import type { DbConfig } from './config'
-import type { SchemaSnapshot } from '../snapshot/types'
+import type { ChangeSet } from '../diff/types'
+import type { Dialect, SchemaSnapshot } from '../snapshot/types'
 import type { Change, RemoveEnumValue } from '../diff/types'
+
+/** Pick the migration SQL emitter for the configured dialect. */
+function emitterFor(dialect: Dialect): (changes: ChangeSet) => string {
+  if (dialect === 'sqlite') return emitSqlite
+  // MySQL has no dedicated emitter yet — it falls back to the Postgres
+  // DDL, which is close but not guaranteed to run. Tracked separately.
+  return emitPg
+}
 
 export interface GenerateOptions {
   name: string
@@ -47,7 +57,10 @@ export interface GenerateResult {
 
 export async function generate(opts: GenerateOptions): Promise<GenerateResult> {
   const migrationsAbs = path.resolve(opts.cwd, opts.config.migrationsDir)
-  const { snapshot: prev, id: previousId } = await readLatestSnapshotEntry(migrationsAbs)
+  const { snapshot: prev, id: previousId } = await readLatestSnapshotEntry(
+    migrationsAbs,
+    opts.config.dialect,
+  )
 
   if (opts.empty) {
     return await writeMigration({
@@ -76,13 +89,14 @@ export async function generate(opts: GenerateOptions): Promise<GenerateResult> {
 
   await assertNoCompositeReferences(changes, opts.detectCompositeRefs)
 
+  const emit = emitterFor(opts.config.dialect)
   return await writeMigration({
     opts,
     migrationsAbs,
     previousId,
     target,
-    upBody: emitPg(changes),
-    downBody: emitPg(invertChanges(changes)),
+    upBody: emit(changes),
+    downBody: emit(invertChanges(changes)),
     changeCount: changes.length,
     draft: hasAmbiguousReverse(changes),
     empty: false,
@@ -161,8 +175,11 @@ interface LatestEntry {
   id: string | null
 }
 
-async function readLatestSnapshotEntry(migrationsDir: string): Promise<LatestEntry> {
-  const empty: SchemaSnapshot = { version: 1, dialect: 'postgres', tables: {} }
+async function readLatestSnapshotEntry(
+  migrationsDir: string,
+  dialect: Dialect,
+): Promise<LatestEntry> {
+  const empty: SchemaSnapshot = { version: 1, dialect, tables: {} }
   if (!existsSync(migrationsDir)) {
     return { snapshot: empty, id: null }
   }

--- a/packages/db/src/emit/sqlite.ts
+++ b/packages/db/src/emit/sqlite.ts
@@ -1,0 +1,210 @@
+import type { Change, ChangeSet } from '../diff/types'
+import type {
+  ColumnSnapshot,
+  ForeignKeySnapshot,
+  IndexSnapshot,
+  TableSnapshot,
+} from '../snapshot/types'
+import { quoteIdent, quoteLiteral } from './identifiers'
+
+/**
+ * Raised when a change set contains a SQLite operation that SQLite's
+ * limited `ALTER TABLE` can't express directly (altering a column's
+ * type/null/default, or adding/dropping a foreign key on an existing
+ * table). Those need the 12-step table-rebuild dance, not yet emitted —
+ * author the migration by hand with `kick db generate --empty` for now.
+ */
+export class SqliteRebuildRequiredError extends Error {
+  constructor(detail: string) {
+    super(
+      `kickjs-db: this change needs a SQLite table rebuild, which the emitter ` +
+        `doesn't generate yet — ${detail}. Author it manually with ` +
+        `\`kick db generate --empty <name>\` (CREATE new table → copy rows → ` +
+        `DROP old → RENAME), or target PostgreSQL for automatic ALTERs.`,
+    )
+    this.name = 'SqliteRebuildRequiredError'
+  }
+}
+
+/**
+ * Emit SQLite DDL for a change set.
+ *
+ * SQLite-specific handling vs the Postgres emitter:
+ * - PG column types are mapped to SQLite type affinities.
+ * - A single integer primary key is emitted **inline** (`INTEGER
+ *   PRIMARY KEY`) so it aliases the rowid (auto-increment); composite
+ *   or non-integer PKs use a table-level `PRIMARY KEY (...)` clause.
+ * - Foreign keys are **inlined into `CREATE TABLE`** — SQLite has no
+ *   `ALTER TABLE ... ADD CONSTRAINT`. The diff emits a new table's FKs
+ *   as separate `addForeignKey` changes; we fold those into the create
+ *   and skip them here.
+ * - `alterColumn`, FK changes on an existing table, and enum changes
+ *   throw {@link SqliteRebuildRequiredError} (or an enum error) rather
+ *   than emit wrong SQL.
+ */
+export function emitSqlite(changes: ChangeSet): string {
+  // Tables created in this change set — their FKs are inlined into the
+  // CREATE TABLE, so the separate `addForeignKey` changes are no-ops.
+  const createdTables = new Set<string>()
+  for (const c of changes) if (c.kind === 'createTable') createdTables.add(c.table.name)
+
+  return changes
+    .map((c) => emitChange(c, createdTables))
+    .filter((s) => s.length > 0)
+    .join('\n')
+}
+
+function emitChange(change: Change, createdTables: Set<string>): string {
+  switch (change.kind) {
+    case 'createTable':
+      return emitCreateTable(change.table)
+    case 'dropTable':
+      return `DROP TABLE ${quoteIdent(change.table.name)};`
+    case 'renameTable':
+      return `ALTER TABLE ${quoteIdent(change.from)} RENAME TO ${quoteIdent(change.to)};`
+    case 'addColumn':
+      return `ALTER TABLE ${quoteIdent(change.table)} ADD COLUMN ${emitColumnDecl(change.column)};`
+    case 'dropColumn':
+      // SQLite 3.35+ supports DROP COLUMN.
+      return `ALTER TABLE ${quoteIdent(change.table)} DROP COLUMN ${quoteIdent(change.column.name)};`
+    case 'renameColumn':
+      // SQLite 3.25+ supports RENAME COLUMN.
+      return `ALTER TABLE ${quoteIdent(change.table)} RENAME COLUMN ${quoteIdent(change.from)} TO ${quoteIdent(change.to)};`
+    case 'addIndex':
+      return emitAddIndex(change.table, change.index)
+    case 'dropIndex':
+      return `DROP INDEX ${quoteIdent(change.index.name)};`
+    case 'addForeignKey':
+      // Inlined into CREATE TABLE for new tables; otherwise impossible
+      // without a rebuild.
+      if (createdTables.has(change.table)) return ''
+      throw new SqliteRebuildRequiredError(
+        `adding foreign key '${change.fk.name}' to existing table '${change.table}'`,
+      )
+    case 'dropForeignKey':
+      throw new SqliteRebuildRequiredError(
+        `dropping foreign key '${change.fk.name}' from table '${change.table}'`,
+      )
+    case 'alterColumn':
+      throw new SqliteRebuildRequiredError(
+        `altering column '${change.column}' on table '${change.table}'`,
+      )
+    case 'createEnum':
+    case 'dropEnum':
+    case 'addEnumValue':
+    case 'removeEnumValue':
+      throw new Error(
+        `kickjs-db: enum changes are PostgreSQL-only and can't be emitted for SQLite. ` +
+          `Model the constrained set with a CHECK constraint or a lookup table instead.`,
+      )
+  }
+}
+
+function emitCreateTable(t: TableSnapshot): string {
+  const columns = Object.values(t.columns)
+  const pkCols = columns.filter((c) => c.primaryKey)
+
+  // A single integer PK becomes the rowid alias only when declared
+  // inline as `INTEGER PRIMARY KEY` — a table-level PRIMARY KEY clause
+  // would not auto-increment. Composite or non-integer PKs use the
+  // table-level clause.
+  const inlinePk =
+    pkCols.length === 1 && sqliteType(pkCols[0].type) === 'INTEGER' ? pkCols[0] : null
+
+  const lines = columns.map((c) => emitColumnDecl(c, c === inlinePk))
+
+  if (!inlinePk && pkCols.length > 0) {
+    lines.push(`PRIMARY KEY (${pkCols.map((c) => quoteIdent(c.name)).join(', ')})`)
+  }
+  for (const fk of t.foreignKeys) lines.push(emitInlineFk(fk))
+
+  return `CREATE TABLE ${quoteIdent(t.name)} (\n  ${lines.join(',\n  ')}\n);`
+}
+
+function emitColumnDecl(c: ColumnSnapshot, inlinePk = false): string {
+  let s = `${quoteIdent(c.name)} ${sqliteType(c.type)}`
+  if (inlinePk) {
+    s += ' PRIMARY KEY'
+    // `serial`/`bigserial` imply an auto-incrementing PK.
+    if (/serial/i.test(c.type)) s += ' AUTOINCREMENT'
+  }
+  if (!c.nullable && !inlinePk) s += ' NOT NULL'
+  if (c.default !== null) s += ` DEFAULT ${sqliteDefault(c.default)}`
+  return s
+}
+
+function emitAddIndex(table: string, i: IndexSnapshot): string {
+  const cols = i.columns.map(quoteIdent).join(', ')
+  return `CREATE${i.unique ? ' UNIQUE' : ''} INDEX ${quoteIdent(i.name)} ON ${quoteIdent(table)} (${cols});`
+}
+
+const FK_ACTIONS: Record<string, string> = {
+  cascade: 'CASCADE',
+  restrict: 'RESTRICT',
+  set_null: 'SET NULL',
+  set_default: 'SET DEFAULT',
+  no_action: 'NO ACTION',
+}
+
+function emitInlineFk(fk: ForeignKeySnapshot): string {
+  const cols = fk.columns.map(quoteIdent).join(', ')
+  const refCols = fk.refColumns.map(quoteIdent).join(', ')
+  return (
+    `FOREIGN KEY (${cols}) REFERENCES ${quoteIdent(fk.refTable)} (${refCols}) ` +
+    `ON DELETE ${FK_ACTIONS[fk.onDelete]} ON UPDATE ${FK_ACTIONS[fk.onUpdate]}`
+  )
+}
+
+/**
+ * Map a Postgres column type string to a SQLite type. SQLite uses
+ * type affinity (only the substring matters), but we emit canonical
+ * names — `INTEGER` / `REAL` / `NUMERIC` / `TEXT` / `BLOB` — so the
+ * generated DDL reads clearly and the right affinity is selected.
+ */
+function sqliteType(pgType: string): string {
+  const base = pgType
+    .toLowerCase()
+    .replace(/\(.*\)/, '') // drop length/precision, e.g. varchar(200)
+    .replace(/\[\]$/, '') // drop array marker (stored as TEXT/JSON)
+    .trim()
+
+  if (/^(serial|bigserial|smallserial|big|small)?int(eger|2|4|8)?$/.test(base)) return 'INTEGER'
+  if (base === 'serial' || base === 'bigserial' || base === 'smallserial') return 'INTEGER'
+  if (base === 'boolean' || base === 'bool') return 'INTEGER'
+  if (/^(real|float4|float8|double precision|float)$/.test(base)) return 'REAL'
+  if (/^(numeric|decimal|money)$/.test(base)) return 'NUMERIC'
+  if (base === 'bytea' || base === 'blob') return 'BLOB'
+  // varchar/char/text/uuid/json/jsonb/citext/xml/inet/cidr/timestamp/date/
+  // time/interval and anything else → TEXT (SQLite stores dates as TEXT).
+  return 'TEXT'
+}
+
+/**
+ * Map a Postgres default expression to its SQLite equivalent.
+ */
+function sqliteDefault(value: unknown): string {
+  if (typeof value === 'boolean') return value ? '1' : '0'
+  if (typeof value === 'number' || typeof value === 'bigint') return String(value)
+  const str = String(value).trim()
+
+  // Booleans → SQLite integer literals.
+  if (/^true$/i.test(str)) return '1'
+  if (/^false$/i.test(str)) return '0'
+
+  // Postgres UUID/`now()` generators → SQLite equivalents.
+  if (/^(gen_random_uuid|uuid_generate_v4)\(\)$/i.test(str)) {
+    // 16 random bytes → 32 hex chars. Not dash-formatted, but unique +
+    // collision-safe; wrap in parens so SQLite treats it as an expression.
+    return '(lower(hex(randomblob(16))))'
+  }
+  if (/^now\(\)$/i.test(str)) return 'CURRENT_TIMESTAMP'
+
+  // SQLite-supported time keywords + plain numerics pass through bare.
+  if (/^(CURRENT_TIMESTAMP|CURRENT_DATE|CURRENT_TIME|NULL)$/i.test(str)) return str.toUpperCase()
+  if (/^-?\d+(\.\d+)?$/.test(str)) return str
+
+  // Any other bare function call (best effort) passes through; everything
+  // else is a string literal.
+  if (/^[a-z_][a-z0-9_]*\s*\([^)]*\)$/i.test(str)) return str
+  return quoteLiteral(str)
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -97,8 +97,10 @@ export {
   type RollbackSummary,
   type StatusEntry,
 } from './migrate/runner'
+export { reviewMigration, type ReviewResult } from './migrate/review'
 
 export { emitPg } from './emit/pg'
+export { emitSqlite, SqliteRebuildRequiredError } from './emit/sqlite'
 
 export { resolveDbConfig, type DbConfig } from './cli/config'
 export { generate } from './cli/generate'

--- a/packages/db/src/migrate/review.ts
+++ b/packages/db/src/migrate/review.ts
@@ -1,0 +1,59 @@
+import path from 'node:path'
+import { readFile, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+
+import { computeMigrationHash } from './journal'
+import type { Journal } from './journal'
+
+export interface ReviewResult {
+  id: string
+  /** True when the migration was already reviewed (no-op). */
+  alreadyReviewed: boolean
+}
+
+/**
+ * Mark a migration as reviewed: flip `meta.json.reviewed` to `true`,
+ * swap the `-- REVIEWED: false` markers in `up.sql` / `down.sql` to
+ * `true`, and recompute the migration's journal hash (the marker swap
+ * changes the file bytes, so the stored hash must follow or the runner's
+ * integrity check would fail).
+ *
+ * This is the single source of truth for "reviewing" — adopters should
+ * never hand-edit `meta.json`, because that leaves the `-- REVIEWED`
+ * markers and the journal hash out of sync.
+ */
+export async function reviewMigration(migrationsDir: string, id: string): Promise<ReviewResult> {
+  const dir = path.join(migrationsDir, id)
+  const metaPath = path.join(dir, 'meta.json')
+  if (!existsSync(metaPath)) {
+    throw new Error(`kickjs-db: migration '${id}' not found under ${migrationsDir}`)
+  }
+
+  const meta = JSON.parse(await readFile(metaPath, 'utf8')) as { reviewed?: boolean }
+  if (meta.reviewed === true) {
+    return { id, alreadyReviewed: true }
+  }
+
+  // 1. Flip the human-facing markers in the SQL files.
+  for (const file of ['up.sql', 'down.sql']) {
+    const p = path.join(dir, file)
+    if (!existsSync(p)) continue
+    const sql = await readFile(p, 'utf8')
+    await writeFile(p, sql.replace(/^-- REVIEWED: false$/m, '-- REVIEWED: true'), 'utf8')
+  }
+
+  // 2. Flip the gate in meta.json (the value the runner actually checks).
+  meta.reviewed = true
+  await writeFile(metaPath, JSON.stringify(meta, null, 2) + '\n', 'utf8')
+
+  // 3. Recompute the journal hash — the marker swap changed up/down.sql.
+  const journalPath = path.join(migrationsDir, '_journal.json')
+  const journal = JSON.parse(await readFile(journalPath, 'utf8')) as Journal
+  const entry = journal.entries.find((e) => e.id === id)
+  if (entry) {
+    entry.hash = await computeMigrationHash(dir)
+    await writeFile(journalPath, JSON.stringify(journal, null, 2) + '\n', 'utf8')
+  }
+
+  return { id, alreadyReviewed: false }
+}


### PR DESCRIPTION
## Why

`kick db generate` emitted **Postgres-only** SQL regardless of `db.dialect` — so SQLite projects couldn't generate migrations from their schema (the adapters + runner were multi-dialect, but the migration *emitter* wasn't). This closes that gap and makes the SQLite story work end-to-end.

## What

- **`emitSqlite`** — IR → SQLite DDL. Maps PG types to affinities (`uuid`→`TEXT`, `boolean`→`INTEGER`, `serial`→`INTEGER PRIMARY KEY AUTOINCREMENT`), normalises defaults (`gen_random_uuid()`→`(lower(hex(randomblob(16))))`, `false`→`0`, `now()`→`CURRENT_TIMESTAMP`), inlines a single integer PK as the rowid alias, and **folds foreign keys into `CREATE TABLE`** (SQLite has no `ALTER ... ADD CONSTRAINT`; the diff emits a new table's FKs as separate changes, which are now folded + skipped). `generate()` dispatches the emitter by dialect. Ops SQLite can't `ALTER` (column type/null/default, FK on an existing table) throw a clear **`SqliteRebuildRequiredError`** instead of wrong SQL.

- **`kick db migrate review <id>`** — the missing review command. Flips `meta.json.reviewed`, swaps the `-- REVIEWED:` markers in `up.sql`/`down.sql`, and recomputes the journal hash so all three stay in sync. (Previously the only way to review was hand-editing `meta.json`, which left the SQL marker + hash stale — the runner gates on `meta.reviewed`, not the comment.)

- **Drift skipped for SQLite/MySQL** — only the PG adapter implements `introspect()`, so `kick db migrate` no longer fails with "introspection not supported" on those dialects.

## Verified end-to-end

Against a real `better-sqlite3` DB, 3 migrations — `create_tasks` (CREATE TABLE), `add_priority` (ADD COLUMN), `add_done_index` (CREATE INDEX) — generate, `migrate review`, then `up`/`down`/`up`:

```
status → 3 applied
down ×3 → drop index → drop column → drop table   (DB verified each step)
up   ×3 → table → column → index                  (final state restored)
```

db: **409** tests (incl. new `emit-sqlite` suite). CLI builds clean.

## Still PG-only (follow-ups)
`emitMysql` (MySQL falls back to PG emit), SQLite/MySQL `introspect()` (drift), and the SQLite 12-step table-rebuild for `alterColumn` / FK-on-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
