### PR TITLE
feat(db,cli): ship db CLI from @forinda/kickjs-db/cli (plugin + standalone bin)

### DIFF
--- a/.changeset/db-cli-plugin.md
+++ b/.changeset/db-cli-plugin.md
@@ -1,0 +1,24 @@
+---
+'@forinda/kickjs-db': minor
+'@forinda/kickjs-cli': minor
+---
+
+Ship the database CLI from `@forinda/kickjs-db/cli` — a mountable plugin **and** a standalone `kickjs-db` bin — so you can use the db tooling without (or alongside) `@forinda/kickjs-cli`.
+
+**New: `@forinda/kickjs-db/cli`**
+
+- `dbCliPlugin` — a CLI plugin (`@forinda/kickjs-cli-kit` contract). Mount it in `kick.config.ts` to get `kick db generate | migrate latest|up|down|rollback|status|review | introspect`. It reads config from the same `kick.config.ts` `db` block (via `ctx.config`, no re-parse).
+- `defineKickDbConfig` / `mergeKickDbConfig` / `resolveKickDbConfig` — vite-style config helpers. Author a standalone `kickjs-db.config.ts` (`export default defineKickDbConfig({ ... })`) or reuse the `kick.config.ts` `db` block; the two merge (later wins).
+- Standalone **`kickjs-db` bin** — `npx kickjs-db migrate latest` runs the whole command tree without kickjs-cli, loading `kickjs-db.config.ts` (or a `kick.config.ts` `db` block) through jiti.
+
+**Breaking (`@forinda/kickjs-cli`): `kick db` is now opt-in.**
+The `kick db` commands are no longer built into kickjs-cli. Add the plugin to your config:
+
+```ts
+import { defineConfig } from '@forinda/kickjs-cli'
+import { dbCliPlugin } from '@forinda/kickjs-db/cli'
+
+export default defineConfig({ plugins: [dbCliPlugin] })
+```
+
+Zero-config **db type generation is unchanged** — it stays a built-in typegen (`kick typegen` still emits `.kickjs/types` for your schema). Only the `kick db` _commands_ moved.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -92,6 +92,7 @@ const guideSidebar = [
       { text: 'Schema', link: '/guide/database/schema' },
       { text: 'Queries', link: '/guide/database/queries' },
       { text: 'Migrations', link: '/guide/database/migrations' },
+      { text: 'CLI', link: '/guide/database/cli' },
       { text: 'Drivers', link: '/guide/database/drivers' },
       { text: 'Repositories', link: '/guide/database/repositories' },
     ],

--- a/docs/guide/database/cli.md
+++ b/docs/guide/database/cli.md
@@ -1,0 +1,87 @@
+# Database CLI
+
+The `kick db` command tree (migrations, schema generation, introspection)
+ships from **`@forinda/kickjs-db/cli`**. Use it two ways: mounted as a
+plugin inside the `kick` CLI, or as the standalone `kickjs-db` binary —
+no `@forinda/kickjs-cli` required.
+
+## Commands
+
+| Command               | Does                                                                                                           |
+| --------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `generate <name>`     | Diff the schema against the last snapshot, emit `up.sql` / `down.sql`. `-e/--empty` for a hand-authored shell. |
+| `migrate latest`      | Apply all pending migrations in one batch.                                                                     |
+| `migrate up` / `down` | Apply / reverse a single migration.                                                                            |
+| `migrate rollback`    | Reverse the entire last batch.                                                                                 |
+| `migrate status`      | Print applied + pending migrations.                                                                            |
+| `migrate review <id>` | Mark a migration reviewed (flips `meta.json` + the `-- REVIEWED` markers + the journal hash).                  |
+| `introspect`          | Generate a TypeScript schema file from a live database.                                                        |
+
+## Option A — as a `kick` CLI plugin
+
+Mount `dbCliPlugin` in `kick.config.ts`. It reads config from the same
+file's `db` block, so there's nothing to wire twice:
+
+```ts
+import { defineConfig } from '@forinda/kickjs-cli'
+import { dbCliPlugin } from '@forinda/kickjs-db/cli'
+
+export default defineConfig({
+  plugins: [dbCliPlugin],
+  db: {
+    schemaPath: 'src/db/schema.ts',
+    migrationsDir: 'db/migrations',
+    dialect: 'sqlite',
+    adapter: () => sqliteAdapter({ database: new Database('dev.db') }),
+  },
+})
+```
+
+```bash
+kick db generate add_users
+kick db migrate review 20260610_..._add_users
+kick db migrate latest
+```
+
+> The `db` commands are **opt-in** — they are not built into `kick` until
+> you add `dbCliPlugin`. (Zero-config db _type generation_ stays built-in;
+> only the commands are gated.)
+
+## Option B — standalone `kickjs-db`
+
+Run the same tree without installing `@forinda/kickjs-cli`:
+
+```bash
+npx kickjs-db migrate latest
+npx kickjs-db generate add_users
+```
+
+Config resolves from a standalone `kickjs-db.config.ts` (or a
+`kick.config.ts` `db` block — the two merge, later wins):
+
+```ts
+// kickjs-db.config.ts
+import { defineKickDbConfig } from '@forinda/kickjs-db/cli'
+import Database from 'better-sqlite3'
+import { sqliteAdapter } from '@forinda/kickjs-db/sqlite'
+
+export default defineKickDbConfig({
+  dialect: 'sqlite',
+  schemaPath: 'src/db/schema.ts',
+  migrationsDir: 'db/migrations',
+  adapter: () => sqliteAdapter({ database: new Database('dev.db') }),
+})
+```
+
+`defineKickDbConfig` is the same shape as the `kick.config.ts` `db` block,
+so a config authored once drops into either place. `.ts` configs load via
+jiti; `.js` / `.mjs` / `.json` work without it.
+
+## Config helpers
+
+| Helper                                  | Purpose                                                                       |
+| --------------------------------------- | ----------------------------------------------------------------------------- |
+| `defineKickDbConfig(cfg)`               | Typed identity helper (vite's `defineConfig` spirit).                         |
+| `mergeKickDbConfig(...cfgs)`            | Shallow-merge config layers, later wins.                                      |
+| `resolveKickDbConfig(block)`            | Apply defaults → a resolved `DbConfig`.                                       |
+| `registerDbCommands(parent, getConfig)` | Attach the command tree to any commander command (used to build custom bins). |

--- a/packages/cli/src/plugin/builtins.ts
+++ b/packages/cli/src/plugin/builtins.ts
@@ -21,7 +21,6 @@ import { registerRemoveCommand } from '../commands/remove'
 import { registerTypegenCommand } from '../commands/typegen'
 import { registerCheckCommand } from '../commands/check'
 import { registerDoctorCommand } from '../commands/doctor'
-import { registerDbCommands } from '../commands/db'
 import { registerCodemodCommands } from '../commands/codemod'
 import { kickDbTypegen } from '../typegen/builtin/db'
 import { kickAssetsTypegen } from '../typegen/builtin/assets'
@@ -51,7 +50,10 @@ export const builtinCliPlugins: readonly KickCliPlugin[] = [
   defineCliPlugin({ name: 'kick/typegen', register: registerTypegenCommand }),
   defineCliPlugin({ name: 'kick/check', register: registerCheckCommand }),
   defineCliPlugin({ name: 'kick/doctor', register: registerDoctorCommand }),
-  defineCliPlugin({ name: 'kick/db', register: registerDbCommands, typegens: [kickDbTypegen()] }),
+  // DB type generation stays built-in (zero-config `.kickjs/types`); the
+  // `kick db` *commands* now ship from `@forinda/kickjs-db/cli` as the
+  // opt-in `dbCliPlugin` — add it to `kick.config.ts` `plugins: []`.
+  defineCliPlugin({ name: 'kick/db-typegen', typegens: [kickDbTypegen()] }),
   defineCliPlugin({ name: 'kick/codemod', register: registerCodemodCommands }),
   // Typegen-only built-ins. Each owns one `.kickjs/types/kick__*` file
   // via the TypegenPlugin contract; together they replace the entire

--- a/packages/db/__tests__/unit/cli-config.test.ts
+++ b/packages/db/__tests__/unit/cli-config.test.ts
@@ -1,29 +1,53 @@
 import { describe, it, expect } from 'vitest'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { resolveDbConfig } from '../../src/cli/config'
+import {
+  defineKickDbConfig,
+  mergeKickDbConfig,
+  resolveKickDbConfig,
+  dbCliPlugin,
+} from '../../src/cli'
 
-const here = path.dirname(fileURLToPath(import.meta.url))
-const fixtures = path.resolve(here, '../fixtures')
+describe('defineKickDbConfig', () => {
+  it('returns the config verbatim (identity helper)', () => {
+    const cfg = defineKickDbConfig({ dialect: 'sqlite', schemaPath: 'x.ts' })
+    expect(cfg).toEqual({ dialect: 'sqlite', schemaPath: 'x.ts' })
+  })
+})
 
-describe('resolveDbConfig', () => {
-  it('reads schemaPath/migrationsDir/dialect from config', async () => {
-    const cfg = await resolveDbConfig({
-      configPath: path.join(fixtures, 'kick.config.demo.ts'),
-    })
-    expect(cfg).toEqual({
-      schemaPath: './packages/db/__tests__/fixtures/schema.demo.ts',
-      migrationsDir: './packages/db/__tests__/fixtures/migrations',
+describe('mergeKickDbConfig', () => {
+  it('shallow-merges with later sources winning', () => {
+    expect(
+      mergeKickDbConfig({ dialect: 'postgres', schemaPath: 'base.ts' }, undefined, {
+        schemaPath: 'override.ts',
+        migrationsDir: 'm',
+      }),
+    ).toEqual({ dialect: 'postgres', schemaPath: 'override.ts', migrationsDir: 'm' })
+  })
+
+  it('ignores undefined sources', () => {
+    expect(mergeKickDbConfig(undefined, { dialect: 'mysql' })).toEqual({ dialect: 'mysql' })
+  })
+})
+
+describe('resolveKickDbConfig', () => {
+  it('applies defaults for an empty / missing block', () => {
+    expect(resolveKickDbConfig(undefined)).toMatchObject({
+      schemaPath: 'src/db/schema.ts',
+      migrationsDir: 'db/migrations',
       dialect: 'postgres',
     })
   })
 
-  it('returns sensible defaults when absent', async () => {
-    const cfg = await resolveDbConfig({
-      configPath: path.join(fixtures, 'kick.config.empty.ts'),
-    })
-    expect(cfg.dialect).toBe('postgres')
-    expect(cfg.schemaPath).toBe('src/db/schema.ts')
-    expect(cfg.migrationsDir).toBe('db/migrations')
+  it('honours explicit fields over defaults', () => {
+    const r = resolveKickDbConfig({ dialect: 'sqlite', migrationsDir: 'custom/mig' })
+    expect(r.dialect).toBe('sqlite')
+    expect(r.migrationsDir).toBe('custom/mig')
+    expect(r.schemaPath).toBe('src/db/schema.ts')
+  })
+})
+
+describe('dbCliPlugin', () => {
+  it('is a kick/db CLI plugin with a register hook', () => {
+    expect(dbCliPlugin.name).toBe('kick/db')
+    expect(typeof dbCliPlugin.register).toBe('function')
   })
 })

--- a/packages/db/bin/kickjs-db.mjs
+++ b/packages/db/bin/kickjs-db.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Standalone `kickjs-db` CLI — run the database command tree without
+ * installing `@forinda/kickjs-cli`.
+ *
+ *   npx kickjs-db migrate latest
+ *   npx kickjs-db generate add_users
+ *
+ * Config resolution (later wins, vite-style merge):
+ *   1. `kick.config.{ts,js,mjs,json}` → its `db` block, if present.
+ *   2. `kickjs-db.config.{ts,js,mjs,json}` → its default export.
+ *
+ * `.ts` / `.mjs` configs load through jiti; `.json` is read directly.
+ */
+import path from 'node:path'
+import { existsSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+import { Command } from 'commander'
+
+import { registerDbCommands, resolveKickDbConfig, mergeKickDbConfig } from '../dist/cli.mjs'
+
+const CONFIG_EXTS = ['ts', 'mts', 'js', 'mjs', 'json']
+
+function findConfig(baseName, cwd) {
+  for (const ext of CONFIG_EXTS) {
+    const p = path.join(cwd, `${baseName}.${ext}`)
+    if (existsSync(p)) return p
+  }
+  return null
+}
+
+async function importConfig(file) {
+  if (file.endsWith('.json')) {
+    const { readFile } = await import('node:fs/promises')
+    return JSON.parse(await readFile(file, 'utf8'))
+  }
+  if (file.endsWith('.ts') || file.endsWith('.mts')) {
+    // jiti handles extensionless relative TS imports a config may use.
+    const { createJiti } = await import('jiti').catch(() => {
+      throw new Error(
+        `kickjs-db: reading a TypeScript config (${path.basename(file)}) needs jiti. ` +
+          `Install it (\`npm i -D jiti\`) or use a .js/.mjs/.json config.`,
+      )
+    })
+    const jiti = createJiti(import.meta.url)
+    return await jiti.import(file, { default: true })
+  }
+  const mod = await import(pathToFileURL(file).href)
+  return mod.default ?? mod
+}
+
+async function resolveConfig() {
+  const cwd = process.cwd()
+
+  const kickConfigFile = findConfig('kick.config', cwd)
+  const dbConfigFile = findConfig('kickjs-db.config', cwd)
+
+  let kickDbBlock
+  if (kickConfigFile) {
+    const cfg = await importConfig(kickConfigFile)
+    kickDbBlock = cfg?.db
+  }
+  let standaloneBlock
+  if (dbConfigFile) {
+    standaloneBlock = await importConfig(dbConfigFile)
+  }
+
+  if (!kickDbBlock && !standaloneBlock) {
+    throw new Error(
+      'kickjs-db: no config found — add a `kickjs-db.config.ts` (export default ' +
+        'defineKickDbConfig({...})) or a `db` block to `kick.config.ts`.',
+    )
+  }
+  // Standalone config layers over the kick.config db block.
+  return resolveKickDbConfig(mergeKickDbConfig(kickDbBlock, standaloneBlock))
+}
+
+const program = new Command()
+program.name('kickjs-db').description('KickJS database CLI (standalone)')
+
+registerDbCommands(program, resolveConfig)
+
+program.showHelpAfterError()
+program.parseAsync(process.argv).catch((err) => {
+  console.error(err instanceof Error ? err.message : err)
+  process.exitCode = 1
+})

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -37,13 +37,21 @@
       "import": "./dist/mysql.mjs",
       "types": "./dist/mysql.d.mts"
     },
+    "./cli": {
+      "import": "./dist/cli.mjs",
+      "types": "./dist/cli.d.mts"
+    },
     "./devtools-events": {
       "import": "./dist/devtools-events.mjs",
       "types": "./dist/devtools-events.d.mts"
     }
   },
+  "bin": {
+    "kickjs-db": "./bin/kickjs-db.mjs"
+  },
   "files": [
-    "dist"
+    "dist",
+    "bin"
   ],
   "scripts": {
     "build": "tsdown",
@@ -54,6 +62,9 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
+    "@forinda/kickjs-cli-kit": "workspace:*",
+    "commander": "^14.0.2",
+    "jiti": "^2.4.2",
     "kysely": "0.29.2"
   },
   "peerDependencies": {

--- a/packages/db/src/cli.ts
+++ b/packages/db/src/cli.ts
@@ -1,7 +1,23 @@
-import path from 'node:path'
-import type { Command } from 'commander'
+/**
+ * `@forinda/kickjs-db/cli` — the database command tree as a mountable CLI
+ * plugin + the building blocks for a standalone `kickjs-db` bin.
+ *
+ * Two ways to use it:
+ *  1. **As a kickjs-cli plugin** — add `dbCliPlugin` to `kick.config.ts`
+ *     `plugins: []`. The host CLI calls `register(program, ctx)` and the
+ *     db config is read from `ctx.config.db` (already loaded — no re-parse).
+ *  2. **Standalone** — the `kickjs-db` bin builds a commander program,
+ *     resolves config from `kickjs-db.config.ts` (or a `kick.config.ts`
+ *     `db` block), and calls {@link registerDbCommands} directly. Lets
+ *     `npx kickjs-db migrate latest` work without installing kickjs-cli.
+ *
+ * @module @forinda/kickjs-db/cli
+ */
 
 import { writeFile } from 'node:fs/promises'
+import type { Command } from 'commander'
+
+import { defineCliPlugin, type KickCliPlugin } from '@forinda/kickjs-cli-kit'
 
 import {
   detectCompositeReferences,
@@ -16,43 +32,62 @@ import {
   type CompositeQueryRunner,
   type DbConfig,
   type MigrationAdapter,
-} from '@forinda/kickjs-db'
-import { loadKickConfig } from '../config'
+} from './index'
+import type { Dialect } from './snapshot/types'
+import type { MigrationAdapterFactory } from './cli/config'
 
-interface BaseOpts {
-  config: string
+/**
+ * Authoring shape for the db config — every field optional, defaults
+ * applied by {@link resolveKickDbConfig}. This is the same shape as the
+ * `db` block in `kick.config.ts`, so a config authored with
+ * `defineKickDbConfig` drops straight into either place.
+ */
+export interface KickDbConfigInput {
+  schemaPath?: string
+  migrationsDir?: string
+  dialect?: Dialect
+  connectionString?: string
+  adapter?: MigrationAdapterFactory
 }
 
 /**
- * Resolve the `db` block from `kick.config.ts` using the CLI's own jiti
- * loader (`loadKickConfig`) rather than `@forinda/kickjs-db`'s
- * `resolveDbConfig`, which does a native `import()` of the config file.
- *
- * Native ESM can't resolve the extensionless, relative TypeScript
- * imports a `kick.config.ts` commonly uses (e.g. `import { toolsPlugin }
- * from './tools/cli-plugin'` to mount a CLI plugin) — so any config that
- * imports local TS broke every `kick db` command with "Cannot find
- * module". jiti handles those exactly like the rest of the CLI does.
+ * Identity helper for type inference — mirrors vite's `defineConfig`.
+ * Use it in a standalone `kickjs-db.config.ts` (`export default
+ * defineKickDbConfig({ ... })`) or as the value of `kick.config.ts`'s
+ * `db` field. Both resolve through {@link resolveKickDbConfig}.
  */
-async function loadConfig(opts: BaseOpts): Promise<DbConfig> {
-  const startDir = path.dirname(path.resolve(process.cwd(), opts.config))
-  const cfg = await loadKickConfig(startDir)
-  const db = cfg?.db ?? {}
+export function defineKickDbConfig(cfg: KickDbConfigInput): KickDbConfigInput {
+  return cfg
+}
+
+/**
+ * Shallow-merge db configs, later wins (vite's `mergeConfig` spirit).
+ * Lets a standalone `kickjs-db.config.ts` layer over a project's
+ * `kick.config.ts` `db` block, or vice versa.
+ */
+export function mergeKickDbConfig(
+  ...configs: (KickDbConfigInput | undefined)[]
+): KickDbConfigInput {
+  return Object.assign({}, ...configs.filter(Boolean))
+}
+
+/** Apply defaults to a {@link KickDbConfigInput}, yielding a resolved {@link DbConfig}. */
+export function resolveKickDbConfig(block: KickDbConfigInput | undefined): DbConfig {
+  const db = block ?? {}
   return {
     schemaPath: db.schemaPath ?? 'src/db/schema.ts',
     migrationsDir: db.migrationsDir ?? 'db/migrations',
     dialect: db.dialect ?? 'postgres',
     connectionString: db.connectionString ?? process.env.DATABASE_URL,
-    adapter: db.adapter as DbConfig['adapter'],
+    adapter: db.adapter,
   }
 }
 
 /**
  * Resolve a MigrationAdapter from config:
  *  1. config.adapter() — explicit factory wins.
- *  2. config.connectionString — built-in pgAdapter path; we dynamically
- *     import @forinda/kickjs-db/pg + pg so the CLI doesn't pull pg into
- *     non-PG workflows.
+ *  2. config.connectionString — built-in pgAdapter path; dynamically
+ *     imports `./pg` + `pg` so non-PG workflows don't pull pg.
  */
 async function resolveAdapter(config: DbConfig): Promise<{
   adapter: MigrationAdapter
@@ -64,19 +99,17 @@ async function resolveAdapter(config: DbConfig): Promise<{
   }
   if (!config.connectionString) {
     throw new Error(
-      'kickjs-db: no adapter resolved — set db.connectionString (or DATABASE_URL) in kick.config.ts, or supply db.adapter() factory',
+      'kickjs-db: no adapter resolved — set db.connectionString (or DATABASE_URL), or supply a db.adapter() factory',
     )
   }
   const dialect = config.dialect ?? 'postgres'
   if (dialect !== 'postgres') {
     throw new Error(
-      `kickjs-db: built-in CLI adapter only supports postgres in M1 (dialect=${dialect}); use db.adapter() factory for other dialects`,
+      `kickjs-db: the built-in CLI adapter only supports postgres (dialect=${dialect}); supply a db.adapter() factory for other dialects`,
     )
   }
-  // Dynamic import so the CLI doesn't hard-require pg unless this path runs.
-  // The pg adapter ships from the `@forinda/kickjs-db/pg` subpath; adopters
-  // who use this path install `@forinda/kickjs-db` + `pg` in their own app.
-  const [{ pgAdapter }, pg] = await Promise.all([import('@forinda/kickjs-db/pg'), import('pg')])
+  // Dynamic import so we don't hard-require pg unless this path runs.
+  const [{ pgAdapter }, pg] = await Promise.all([import('./pg'), import('pg')])
   const pool = new pg.default.Pool({ connectionString: config.connectionString })
   const adapter = pgAdapter({ pool })
   return {
@@ -90,10 +123,9 @@ async function resolveAdapter(config: DbConfig): Promise<{
 
 /**
  * Drift detection introspects the live DB and compares it to the last
- * applied snapshot. Only the Postgres adapter implements `introspect()`
- * today, so for SQLite / MySQL we turn drift off (the runner would
- * otherwise throw "introspection not supported"). PostgreSQL keeps the
- * default `'error'` behaviour.
+ * applied snapshot. Only the Postgres adapter implements `introspect()`,
+ * so for SQLite / MySQL we turn drift off (the runner would otherwise
+ * throw "introspection not supported"). PostgreSQL keeps `'error'`.
  */
 function driftCheckFor(config: DbConfig): 'ignore' | undefined {
   return (config.dialect ?? 'postgres') === 'postgres' ? undefined : 'ignore'
@@ -105,16 +137,9 @@ interface PgQueryRunnerProbe {
 }
 
 /**
- * Resolve a pg-protocol-compatible query runner for the M4.C
- * composite-type check at `kick db generate` time. Only fires for the
- * built-in pgAdapter path (dialect=postgres + connection string set):
- * the `db.adapter` factory escape hatch returns an opaque
- * MigrationAdapter, so we skip the check there.
- *
- * Returns null when detection is not wired (non-postgres dialect, no
- * connection string, or the adopter is using a custom adapter
- * factory). Adopters who need detection on a custom factory can call
- * `detectCompositeReferences` directly against their own pool.
+ * Resolve a pg-protocol query runner for the composite-type check at
+ * `generate` time. Only fires for the built-in pgAdapter path
+ * (dialect=postgres + connection string, no custom adapter factory).
  */
 async function tryResolvePgQueryRunner(config: DbConfig): Promise<PgQueryRunnerProbe | null> {
   if (config.adapter) return null
@@ -123,12 +148,7 @@ async function tryResolvePgQueryRunner(config: DbConfig): Promise<PgQueryRunnerP
 
   const pg = await import('pg')
   const pool = new pg.default.Pool({ connectionString: config.connectionString })
-  return {
-    runner: pool,
-    cleanup: async () => {
-      await pool.end()
-    },
-  }
+  return { runner: pool, cleanup: async () => void (await pool.end()) }
 }
 
 function printStatusTable(status: Awaited<ReturnType<typeof migrateStatus>>): void {
@@ -147,39 +167,36 @@ function printStatusTable(status: Awaited<ReturnType<typeof migrateStatus>>): vo
   )
 }
 
-export function registerDbCommands(program: Command): void {
-  const db = program.command('db').description('Database commands (kickjs-db)')
+/** A config source — resolved lazily so each command reads fresh config. */
+export type DbConfigResolver = () => DbConfig | Promise<DbConfig>
 
-  db.command('generate <name>')
+/**
+ * Attach the db commands (`generate`, `migrate *`, `introspect`) onto a
+ * commander command. `parent` is the command they hang off — the plugin
+ * passes a `db` subcommand (so `kick db generate`), the standalone bin
+ * passes the root program (so `kickjs-db generate`). `getConfig` supplies
+ * the resolved {@link DbConfig} — under kickjs-cli from `ctx.config.db`,
+ * standalone from `kickjs-db.config.ts`.
+ */
+export function registerDbCommands(parent: Command, getConfig: DbConfigResolver): void {
+  parent
+    .command('generate <name>')
     .description('Generate a new migration from schema diff')
-    .option('-c, --config <path>', 'Path to kick.config.ts', 'kick.config.ts')
     .option(
       '-e, --empty',
       'Skip schema diff and create an empty migration shell (data migration, seed, freeform SQL)',
     )
-    .action(async (name: string, opts: BaseOpts & { empty?: boolean }) => {
+    .action(async (name: string, opts: { empty?: boolean }) => {
       const cwd = process.cwd()
-      const config = await loadConfig(opts)
+      const config = await getConfig()
 
-      // M4.C — wire composite-type detection when we can resolve a PG pool
-      // ourselves (built-in pgAdapter path, dialect=postgres, connection
-      // string available). When the operator uses the `adapter` factory
-      // escape hatch we skip the check — they can run
-      // `detectCompositeReferences` manually if needed.
       const probe = await tryResolvePgQueryRunner(config)
       const detectCompositeRefs = probe
         ? (enumName: string) => detectCompositeReferences(probe.runner, enumName)
         : undefined
 
       try {
-        const result = await generate({
-          name,
-          config,
-          cwd,
-          empty: opts.empty,
-          detectCompositeRefs,
-        })
-
+        const result = await generate({ name, config, cwd, empty: opts.empty, detectCompositeRefs })
         if (result.status === 'no-changes') {
           console.log('No schema changes detected.')
           return
@@ -198,19 +215,18 @@ export function registerDbCommands(program: Command): void {
     })
 
   // ── migrate runner subcommands ─────────────────────────────────────────
-  const migrate = db.command('migrate').description('Migration runner subcommands')
+  const migrate = parent.command('migrate').description('Migration runner subcommands')
 
   migrate
     .command('latest')
     .description('Apply all pending migrations in a new batch')
-    .option('-c, --config <path>', 'Path to kick.config.ts', 'kick.config.ts')
     .option(
       '--confirm-enum-drop',
       'Allow migrations carrying the `-- KICK ENUM REMOVE` header to apply',
       false,
     )
-    .action(async (opts: BaseOpts & { confirmEnumDrop?: boolean }) => {
-      const config = await loadConfig(opts)
+    .action(async (opts: { confirmEnumDrop?: boolean }) => {
+      const config = await getConfig()
       const { adapter, cleanup } = await resolveAdapter(config)
       try {
         const r = await migrateLatest({
@@ -219,11 +235,11 @@ export function registerDbCommands(program: Command): void {
           confirmEnumDrop: opts.confirmEnumDrop,
           driftCheck: driftCheckFor(config),
         })
-        if (r.applied.length === 0) {
-          console.log('No pending migrations.')
-        } else {
-          console.log(`Applied batch ${r.batch}: ${r.applied.join(', ')}`)
-        }
+        console.log(
+          r.applied.length === 0
+            ? 'No pending migrations.'
+            : `Applied batch ${r.batch}: ${r.applied.join(', ')}`,
+        )
       } finally {
         await cleanup()
       }
@@ -232,14 +248,13 @@ export function registerDbCommands(program: Command): void {
   migrate
     .command('up')
     .description('Apply the next single pending migration')
-    .option('-c, --config <path>', 'Path to kick.config.ts', 'kick.config.ts')
     .option(
       '--confirm-enum-drop',
       'Allow migrations carrying the `-- KICK ENUM REMOVE` header to apply',
       false,
     )
-    .action(async (opts: BaseOpts & { confirmEnumDrop?: boolean }) => {
-      const config = await loadConfig(opts)
+    .action(async (opts: { confirmEnumDrop?: boolean }) => {
+      const config = await getConfig()
       const { adapter, cleanup } = await resolveAdapter(config)
       try {
         const r = await migrateUp({
@@ -248,11 +263,11 @@ export function registerDbCommands(program: Command): void {
           confirmEnumDrop: opts.confirmEnumDrop,
           driftCheck: driftCheckFor(config),
         })
-        if (r.applied.length === 0) {
-          console.log('No pending migrations.')
-        } else {
-          console.log(`Applied ${r.applied[0]} (batch ${r.batch})`)
-        }
+        console.log(
+          r.applied.length === 0
+            ? 'No pending migrations.'
+            : `Applied ${r.applied[0]} (batch ${r.batch})`,
+        )
       } finally {
         await cleanup()
       }
@@ -261,9 +276,8 @@ export function registerDbCommands(program: Command): void {
   migrate
     .command('down')
     .description('Reverse the most recent applied migration')
-    .option('-c, --config <path>', 'Path to kick.config.ts', 'kick.config.ts')
-    .action(async (opts: BaseOpts) => {
-      const config = await loadConfig(opts)
+    .action(async () => {
+      const config = await getConfig()
       const { adapter, cleanup } = await resolveAdapter(config)
       try {
         const r = await migrateDown({
@@ -271,11 +285,7 @@ export function registerDbCommands(program: Command): void {
           migrationsDir: config.migrationsDir,
           driftCheck: driftCheckFor(config),
         })
-        if (!r.reversed) {
-          console.log('Nothing to reverse.')
-        } else {
-          console.log(`Reversed ${r.reversed}.`)
-        }
+        console.log(r.reversed ? `Reversed ${r.reversed}.` : 'Nothing to reverse.')
       } finally {
         await cleanup()
       }
@@ -284,9 +294,8 @@ export function registerDbCommands(program: Command): void {
   migrate
     .command('rollback')
     .description('Reverse the entire last batch as a single unit')
-    .option('-c, --config <path>', 'Path to kick.config.ts', 'kick.config.ts')
-    .action(async (opts: BaseOpts) => {
-      const config = await loadConfig(opts)
+    .action(async () => {
+      const config = await getConfig()
       const { adapter, cleanup } = await resolveAdapter(config)
       try {
         const r = await migrateRollback({
@@ -294,11 +303,11 @@ export function registerDbCommands(program: Command): void {
           migrationsDir: config.migrationsDir,
           driftCheck: driftCheckFor(config),
         })
-        if (r.reversed.length === 0) {
-          console.log('Nothing to roll back.')
-        } else {
-          console.log(`Rolled back batch ${r.batch}: ${r.reversed.join(', ')}`)
-        }
+        console.log(
+          r.reversed.length === 0
+            ? 'Nothing to roll back.'
+            : `Rolled back batch ${r.batch}: ${r.reversed.join(', ')}`,
+        )
       } finally {
         await cleanup()
       }
@@ -307,13 +316,11 @@ export function registerDbCommands(program: Command): void {
   migrate
     .command('status')
     .description('Print applied + pending migrations')
-    .option('-c, --config <path>', 'Path to kick.config.ts', 'kick.config.ts')
-    .action(async (opts: BaseOpts) => {
-      const config = await loadConfig(opts)
+    .action(async () => {
+      const config = await getConfig()
       const { adapter, cleanup } = await resolveAdapter(config)
       try {
-        const status = await migrateStatus({ adapter, migrationsDir: config.migrationsDir })
-        printStatusTable(status)
+        printStatusTable(await migrateStatus({ adapter, migrationsDir: config.migrationsDir }))
       } finally {
         await cleanup()
       }
@@ -322,10 +329,9 @@ export function registerDbCommands(program: Command): void {
   migrate
     .command('review <id>')
     .description('Mark a migration reviewed (flips meta.json + the -- REVIEWED markers)')
-    .option('-c, --config <path>', 'Path to kick.config.ts', 'kick.config.ts')
-    .action(async (id: string, opts: BaseOpts) => {
+    .action(async (id: string) => {
       // No adapter/DB needed — review only touches the migration files.
-      const config = await loadConfig(opts)
+      const config = await getConfig()
       const r = await reviewMigration(config.migrationsDir, id)
       console.log(
         r.alreadyReviewed
@@ -335,13 +341,13 @@ export function registerDbCommands(program: Command): void {
     })
 
   // ── kick db introspect ─────────────────────────────────────────────────
-  db.command('introspect')
+  parent
+    .command('introspect')
     .description('Generate a TypeScript schema file from a live database')
-    .option('-c, --config <path>', 'Path to kick.config.ts', 'kick.config.ts')
     .option('--out <path>', 'Output file (defaults to db.schemaPath from config)')
     .option('--json', 'Print the raw SchemaSnapshot JSON to stdout instead of writing TS source')
-    .action(async (opts: BaseOpts & { out?: string; json?: boolean }) => {
-      const config = await loadConfig(opts)
+    .action(async (opts: { out?: string; json?: boolean }) => {
+      const config = await getConfig()
       const { adapter, cleanup } = await resolveAdapter(config)
       try {
         const snapshot = await adapter.introspect()
@@ -350,12 +356,41 @@ export function registerDbCommands(program: Command): void {
           return
         }
         const out = opts.out ?? config.schemaPath
-        const source = renderSchemaSource(snapshot)
-        await writeFile(out, source, 'utf8')
-        const tableCount = Object.keys(snapshot.tables).length
-        console.log(`Wrote ${out} (${tableCount} table${tableCount === 1 ? '' : 's'}).`)
+        await writeFile(out, renderSchemaSource(snapshot), 'utf8')
+        const n = Object.keys(snapshot.tables).length
+        console.log(`Wrote ${out} (${n} table${n === 1 ? '' : 's'}).`)
       } finally {
         await cleanup()
       }
     })
 }
+
+/**
+ * Read the `db` block off a host CLI config object. The kit types
+ * `ctx.config` as `unknown`; the db block is structurally a
+ * {@link KickDbConfigInput}.
+ */
+function dbBlockOf(config: unknown): KickDbConfigInput | undefined {
+  return (config as { db?: KickDbConfigInput } | null)?.db
+}
+
+/**
+ * The database CLI plugin. Mount it in `kick.config.ts`:
+ *
+ * ```ts
+ * import { defineConfig } from '@forinda/kickjs-cli'
+ * import { dbCliPlugin } from '@forinda/kickjs-db/cli'
+ *
+ * export default defineConfig({ plugins: [dbCliPlugin] })
+ * ```
+ *
+ * `kick db generate|migrate|introspect` then read config from the
+ * `db` block of the same `kick.config.ts`.
+ */
+export const dbCliPlugin: KickCliPlugin = defineCliPlugin({
+  name: 'kick/db',
+  register(program, ctx) {
+    const db = program.command('db').description('Database commands (kickjs-db)')
+    registerDbCommands(db, () => resolveKickDbConfig(dbBlockOf(ctx.config)))
+  },
+})

--- a/packages/db/tsdown.config.ts
+++ b/packages/db/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     pg: 'src/pg.ts',
     sqlite: 'src/sqlite.ts',
     mysql: 'src/mysql.ts',
+    cli: 'src/cli.ts',
     'devtools-events': 'src/devtools-events.ts',
   },
   format: ['esm'],
@@ -26,6 +27,11 @@ export default defineConfig({
     'better-sqlite3',
     'mysql2',
     'mysql2/promise',
+    // CLI subpath deps — kept external so the `./cli` entry + bin resolve
+    // them from the install, never bundled into the ORM entries.
+    '@forinda/kickjs-cli-kit',
+    'commander',
+    'jiti',
     /^node:/,
   ],
   banner: { js: createBanner(pkg.name, pkg.version) },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,15 @@ importers:
 
   packages/db:
     dependencies:
+      '@forinda/kickjs-cli-kit':
+        specifier: workspace:*
+        version: link:../cli-kit
+      commander:
+        specifier: ^14.0.2
+        version: 14.0.3
+      jiti:
+        specifier: ^2.4.2
+        version: 2.7.0
       kysely:
         specifier: 0.29.2
         version: 0.29.2


### PR DESCRIPTION
## Why

The `kick db` command tree was hardwired into `@forinda/kickjs-cli`. This moves it into **`@forinda/kickjs-db/cli`** so the db tooling can be used **without** kickjs-cli (a standalone `kickjs-db` bin) and **plugs into** the plugin ecosystem (a mountable `dbCliPlugin`). Built on the `@forinda/kickjs-cli-kit` contract from #333.

## What

**`@forinda/kickjs-db/cli`** (new subpath):
- **`dbCliPlugin`** — mount in `kick.config.ts` `plugins: []` → `kick db generate | migrate latest|up|down|rollback|status|review | introspect`. Reads config from `ctx.config.db` (already loaded by the host CLI — no re-parse).
- **`defineKickDbConfig` / `mergeKickDbConfig` / `resolveKickDbConfig`** — vite-style mergeable config. Same shape standalone or as the `kick.config.ts` `db` block.
- **`registerDbCommands(parent, getConfig)`** — attach the tree to any commander command (used to build the bin).

**`kickjs-db` bin** — `npx kickjs-db migrate latest` runs the whole tree with no kickjs-cli, loading `kickjs-db.config.ts` (or a `kick.config.ts` `db` block) via jiti.

## Breaking — `kick db` is opt-in now

The `kick db` commands are no longer built into kickjs-cli. Add the plugin:

```ts
import { defineConfig } from '@forinda/kickjs-cli'
import { dbCliPlugin } from '@forinda/kickjs-db/cli'
export default defineConfig({ plugins: [dbCliPlugin] })
```

Zero-config db **type generation is unchanged** — it stays a built-in typegen (renamed `kick/db-typegen` to avoid a name clash with the mounted plugin). Only the *commands* moved.

## Verified end-to-end (SQLite example)

- **Plugin path**: `kick db migrate status` → reads `ctx.config.db`, queries `dev.db`.
- **Standalone bin**: `kickjs-db migrate status` / `generate noop` (→ "No schema changes") / `migrate down` / `migrate up` — all against a real `better-sqlite3` `dev.db`, no kickjs-cli. `kickjs-db --help` shows a clean `generate | migrate | introspect` tree (no redundant `db` prefix).

db **413** tests (+ new `cli-config` suite), cli **381** tests, full build **23/23**.

Guide: `docs/guide/database/cli.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
