### PR TITLE
feat(db): MySQL migration emitter

### DIFF
--- a/.changeset/db-mysql-emit.md
+++ b/.changeset/db-mysql-emit.md
@@ -1,0 +1,7 @@
+---
+'@forinda/kickjs-db': minor
+---
+
+`kick db generate` now emits MySQL DDL when `db.dialect: 'mysql'`. Previously MySQL fell back to the Postgres emitter, which produced double-quoted identifiers and Postgres-only types that MySQL rejects.
+
+`emitMysql` mirrors the Postgres emitter's structure (MySQL has full `ALTER TABLE` support, unlike SQLite) with MySQL-specific output: backtick identifiers, PG→MySQL type mapping (`uuid`→`CHAR(36)`, `boolean`→`TINYINT(1)`, `serial`→`INT ... AUTO_INCREMENT`, `jsonb`→`JSON`, `text`→`TEXT`, length-preserving `varchar(n)`→`VARCHAR(n)`), normalised defaults (`gen_random_uuid()`→`(UUID())`, `now()`→`CURRENT_TIMESTAMP`, `false`→`0`), `alterColumn` via `MODIFY COLUMN`, and `dropForeignKey` via `DROP FOREIGN KEY`. The emitter is dispatched by dialect in `generate()`.

--- a/packages/db/__tests__/unit/emit-mysql.test.ts
+++ b/packages/db/__tests__/unit/emit-mysql.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest'
+import { emitMysql } from '@forinda/kickjs-db'
+import type { ChangeSet } from '@forinda/kickjs-db'
+
+const col = (over: Partial<import('@forinda/kickjs-db').ColumnSnapshot> = {}) => ({
+  name: 'c',
+  type: 'text',
+  nullable: true,
+  default: null,
+  primaryKey: false,
+  ...over,
+})
+
+describe('emitMysql — CREATE TABLE', () => {
+  it('maps PG types to MySQL + backtick idents + normalises defaults', () => {
+    const cs: ChangeSet = [
+      {
+        kind: 'createTable',
+        table: {
+          name: 'tasks',
+          columns: {
+            id: col({
+              name: 'id',
+              type: 'uuid',
+              nullable: false,
+              primaryKey: true,
+              default: 'gen_random_uuid()',
+            }),
+            title: col({ name: 'title', type: 'varchar(200)', nullable: false }),
+            done: col({ name: 'done', type: 'boolean', nullable: false, default: 'false' }),
+            createdAt: col({
+              name: 'createdAt',
+              type: 'timestamp',
+              nullable: false,
+              default: 'CURRENT_TIMESTAMP',
+            }),
+          },
+          indexes: [],
+          foreignKeys: [],
+          checks: [],
+        },
+      },
+    ]
+    expect(emitMysql(cs)).toBe(
+      'CREATE TABLE `tasks` (\n' +
+        '  `id` CHAR(36) NOT NULL DEFAULT (UUID()),\n' +
+        '  `title` VARCHAR(200) NOT NULL,\n' +
+        '  `done` TINYINT(1) NOT NULL DEFAULT 0,\n' +
+        '  `createdAt` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,\n' +
+        '  PRIMARY KEY (`id`)\n' +
+        ');',
+    )
+  })
+
+  it('inlines a serial PK as AUTO_INCREMENT PRIMARY KEY', () => {
+    const cs: ChangeSet = [
+      {
+        kind: 'createTable',
+        table: {
+          name: 'nums',
+          columns: { id: col({ name: 'id', type: 'serial', nullable: false, primaryKey: true }) },
+          indexes: [],
+          foreignKeys: [],
+          checks: [],
+        },
+      },
+    ]
+    expect(emitMysql(cs)).toBe(
+      'CREATE TABLE `nums` (\n  `id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY\n);',
+    )
+  })
+})
+
+describe('emitMysql — ALTER (full support)', () => {
+  it('add / drop / rename column', () => {
+    expect(
+      emitMysql([
+        {
+          kind: 'addColumn',
+          table: 'tasks',
+          column: col({ name: 'priority', type: 'integer', nullable: false, default: '0' }),
+        },
+      ]),
+    ).toBe('ALTER TABLE `tasks` ADD COLUMN `priority` INT NOT NULL DEFAULT 0;')
+
+    expect(
+      emitMysql([{ kind: 'dropColumn', table: 'tasks', column: col({ name: 'priority' }) }]),
+    ).toBe('ALTER TABLE `tasks` DROP COLUMN `priority`;')
+
+    expect(emitMysql([{ kind: 'renameColumn', table: 'tasks', from: 'a', to: 'b' }])).toBe(
+      'ALTER TABLE `tasks` RENAME COLUMN `a` TO `b`;',
+    )
+  })
+
+  it('alterColumn restates the column via MODIFY COLUMN', () => {
+    expect(
+      emitMysql([
+        {
+          kind: 'alterColumn',
+          table: 'tasks',
+          column: 'title',
+          before: col({ name: 'title', type: 'varchar(50)', nullable: true }),
+          after: col({ name: 'title', type: 'varchar(200)', nullable: false }),
+        },
+      ]),
+    ).toBe('ALTER TABLE `tasks` MODIFY COLUMN `title` VARCHAR(200) NOT NULL;')
+  })
+
+  it('index + foreign key statements use MySQL syntax', () => {
+    expect(
+      emitMysql([
+        {
+          kind: 'addIndex',
+          table: 'tasks',
+          index: { name: 'tasks_done_idx', columns: ['done'], unique: false },
+        },
+      ]),
+    ).toBe('CREATE INDEX `tasks_done_idx` ON `tasks` (`done`);')
+
+    expect(
+      emitMysql([
+        {
+          kind: 'dropIndex',
+          table: 'tasks',
+          index: { name: 'tasks_done_idx', columns: ['done'], unique: false },
+        },
+      ]),
+    ).toBe('DROP INDEX `tasks_done_idx` ON `tasks`;')
+
+    expect(
+      emitMysql([
+        {
+          kind: 'addForeignKey',
+          table: 'posts',
+          fk: {
+            name: 'posts_author_fk',
+            columns: ['authorId'],
+            refTable: 'users',
+            refColumns: ['id'],
+            onDelete: 'cascade',
+            onUpdate: 'no_action',
+          },
+        },
+      ]),
+    ).toBe(
+      'ALTER TABLE `posts` ADD CONSTRAINT `posts_author_fk` FOREIGN KEY (`authorId`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION;',
+    )
+
+    expect(
+      emitMysql([
+        {
+          kind: 'dropForeignKey',
+          table: 'posts',
+          fk: {
+            name: 'posts_author_fk',
+            columns: ['authorId'],
+            refTable: 'users',
+            refColumns: ['id'],
+            onDelete: 'cascade',
+            onUpdate: 'no_action',
+          },
+        },
+      ]),
+    ).toBe('ALTER TABLE `posts` DROP FOREIGN KEY `posts_author_fk`;')
+  })
+})

--- a/packages/db/src/cli/generate.ts
+++ b/packages/db/src/cli/generate.ts
@@ -9,6 +9,7 @@ import { invertChanges, hasAmbiguousReverse } from '../diff/invert'
 import { CompositeEnumReferenceError, type CompositeRef } from '../diff/composite-detect'
 import { emitPg } from '../emit/pg'
 import { emitSqlite } from '../emit/sqlite'
+import { emitMysql } from '../emit/mysql'
 import { appendJournalEntry, computeMigrationHash } from '../migrate/journal'
 import type { DbConfig } from './config'
 import type { ChangeSet } from '../diff/types'
@@ -17,10 +18,14 @@ import type { Change, RemoveEnumValue } from '../diff/types'
 
 /** Pick the migration SQL emitter for the configured dialect. */
 function emitterFor(dialect: Dialect): (changes: ChangeSet) => string {
-  if (dialect === 'sqlite') return emitSqlite
-  // MySQL has no dedicated emitter yet — it falls back to the Postgres
-  // DDL, which is close but not guaranteed to run. Tracked separately.
-  return emitPg
+  switch (dialect) {
+    case 'sqlite':
+      return emitSqlite
+    case 'mysql':
+      return emitMysql
+    case 'postgres':
+      return emitPg
+  }
 }
 
 export interface GenerateOptions {

--- a/packages/db/src/emit/mysql.ts
+++ b/packages/db/src/emit/mysql.ts
@@ -1,0 +1,180 @@
+import type { Change, ChangeSet } from '../diff/types'
+import type {
+  ColumnSnapshot,
+  ForeignKeySnapshot,
+  IndexSnapshot,
+  TableSnapshot,
+} from '../snapshot/types'
+import { quoteLiteral } from './identifiers'
+
+/** MySQL quotes identifiers with backticks, not double quotes. */
+function ident(name: string): string {
+  return name
+    .split('.')
+    .map((part) => '`' + part.replace(/`/g, '``') + '`')
+    .join('.')
+}
+
+/**
+ * Emit MySQL DDL for a change set.
+ *
+ * MySQL has full `ALTER TABLE` support (unlike SQLite), so this mirrors
+ * the Postgres emitter's structure — column/FK/index changes map to direct
+ * ALTERs. The MySQL-specific bits:
+ * - backtick identifiers + PG→MySQL type mapping;
+ * - a single integer PK is emitted inline as `... AUTO_INCREMENT PRIMARY
+ *   KEY` (MySQL requires an auto-increment column to be a key);
+ * - `alterColumn` uses `MODIFY COLUMN` (MySQL restates the whole column
+ *   definition at once, rather than PG's separate SET TYPE / SET DEFAULT
+ *   / SET NOT NULL clauses);
+ * - `dropForeignKey` uses `DROP FOREIGN KEY` (not `DROP CONSTRAINT`).
+ * - PG `ENUM` type changes are PG-only and throw (MySQL enums are inline
+ *   column types, not standalone objects).
+ */
+export function emitMysql(changes: ChangeSet): string {
+  return changes
+    .map(emitChange)
+    .filter((s) => s.length > 0)
+    .join('\n')
+}
+
+function emitChange(change: Change): string {
+  switch (change.kind) {
+    case 'createTable':
+      return emitCreateTable(change.table)
+    case 'dropTable':
+      return `DROP TABLE ${ident(change.table.name)};`
+    case 'renameTable':
+      return `ALTER TABLE ${ident(change.from)} RENAME TO ${ident(change.to)};`
+    case 'addColumn':
+      return `ALTER TABLE ${ident(change.table)} ADD COLUMN ${emitColumnDecl(change.column)};`
+    case 'dropColumn':
+      return `ALTER TABLE ${ident(change.table)} DROP COLUMN ${ident(change.column.name)};`
+    case 'renameColumn':
+      // MySQL 8.0+ supports RENAME COLUMN.
+      return `ALTER TABLE ${ident(change.table)} RENAME COLUMN ${ident(change.from)} TO ${ident(change.to)};`
+    case 'alterColumn':
+      // MySQL restates the full column definition in one MODIFY clause.
+      return `ALTER TABLE ${ident(change.table)} MODIFY COLUMN ${emitColumnDecl(change.after)};`
+    case 'addIndex':
+      return emitAddIndex(change.table, change.index)
+    case 'dropIndex':
+      return `DROP INDEX ${ident(change.index.name)} ON ${ident(change.table)};`
+    case 'addForeignKey':
+      return emitAddFk(change.table, change.fk)
+    case 'dropForeignKey':
+      return `ALTER TABLE ${ident(change.table)} DROP FOREIGN KEY ${ident(change.fk.name)};`
+    case 'createEnum':
+    case 'dropEnum':
+    case 'addEnumValue':
+    case 'removeEnumValue':
+      throw new Error(
+        `kickjs-db: standalone ENUM type changes are PostgreSQL-only and can't be ` +
+          `emitted for MySQL. Model the column as an inline MySQL ENUM(...) or a ` +
+          `CHECK constraint instead.`,
+      )
+  }
+}
+
+function emitCreateTable(t: TableSnapshot): string {
+  const columns = Object.values(t.columns)
+  const pkCols = columns.filter((c) => c.primaryKey)
+
+  // A single integer PK is emitted inline with AUTO_INCREMENT (when the
+  // column is serial) — MySQL requires an auto-increment column to be the
+  // key, declared on the column itself.
+  const inlinePk = pkCols.length === 1 && /serial/i.test(pkCols[0].type) ? pkCols[0] : null
+
+  const lines = columns.map((c) => emitColumnDecl(c, c === inlinePk))
+  if (!inlinePk && pkCols.length > 0) {
+    lines.push(`PRIMARY KEY (${pkCols.map((c) => ident(c.name)).join(', ')})`)
+  }
+  return `CREATE TABLE ${ident(t.name)} (\n  ${lines.join(',\n  ')}\n);`
+}
+
+function emitColumnDecl(c: ColumnSnapshot, inlinePk = false): string {
+  let s = `${ident(c.name)} ${mysqlType(c.type)}`
+  if (!c.nullable) s += ' NOT NULL'
+  if (c.default !== null) s += ` DEFAULT ${mysqlDefault(c.default)}`
+  if (inlinePk) s += ' AUTO_INCREMENT PRIMARY KEY'
+  return s
+}
+
+function emitAddIndex(table: string, i: IndexSnapshot): string {
+  const cols = i.columns.map(ident).join(', ')
+  return `CREATE${i.unique ? ' UNIQUE' : ''} INDEX ${ident(i.name)} ON ${ident(table)} (${cols});`
+}
+
+const FK_ACTIONS: Record<string, string> = {
+  cascade: 'CASCADE',
+  restrict: 'RESTRICT',
+  set_null: 'SET NULL',
+  set_default: 'SET DEFAULT',
+  no_action: 'NO ACTION',
+}
+
+function emitAddFk(table: string, fk: ForeignKeySnapshot): string {
+  const cols = fk.columns.map(ident).join(', ')
+  const refCols = fk.refColumns.map(ident).join(', ')
+  return (
+    `ALTER TABLE ${ident(table)} ADD CONSTRAINT ${ident(fk.name)} ` +
+    `FOREIGN KEY (${cols}) REFERENCES ${ident(fk.refTable)} (${refCols}) ` +
+    `ON DELETE ${FK_ACTIONS[fk.onDelete]} ON UPDATE ${FK_ACTIONS[fk.onUpdate]};`
+  )
+}
+
+/**
+ * Map a Postgres column type string to a MySQL type.
+ */
+function mysqlType(pgType: string): string {
+  const lower = pgType.toLowerCase().trim()
+  const base = lower
+    .replace(/\(.*\)/, '')
+    .replace(/\[\]$/, '')
+    .trim()
+  // Preserve an explicit length/precision, e.g. varchar(200) → VARCHAR(200).
+  const lenMatch = lower.match(/\(([^)]*)\)/)
+  const len = lenMatch ? `(${lenMatch[1]})` : ''
+
+  if (base === 'serial' || base === 'integer' || base === 'int' || base === 'int4') return 'INT'
+  if (base === 'bigserial' || base === 'bigint' || base === 'int8') return 'BIGINT'
+  if (base === 'smallserial' || base === 'smallint' || base === 'int2') return 'SMALLINT'
+  if (base === 'boolean' || base === 'bool') return 'TINYINT(1)'
+  if (base === 'real' || base === 'float4') return 'FLOAT'
+  if (base === 'double precision' || base === 'float8' || base === 'float') return 'DOUBLE'
+  if (base === 'numeric' || base === 'decimal') return `DECIMAL${len || '(10,0)'}`
+  if (base === 'money') return 'DECIMAL(19,4)'
+  if (base === 'uuid') return 'CHAR(36)'
+  if (base === 'varchar' || base === 'character varying') return `VARCHAR${len || '(255)'}`
+  if (base === 'char' || base === 'character' || base === 'bpchar') return `CHAR${len || '(1)'}`
+  if (base === 'text' || base === 'citext') return 'TEXT'
+  if (base === 'json' || base === 'jsonb') return 'JSON'
+  if (base === 'timestamp' || base === 'timestamptz') return 'TIMESTAMP'
+  if (base === 'date') return 'DATE'
+  if (base === 'time' || base === 'timetz') return 'TIME'
+  if (base === 'bytea' || base === 'blob') return 'BLOB'
+  // Pass anything else through uppercased with its length (best effort).
+  return base.toUpperCase() + len
+}
+
+/**
+ * Map a Postgres default expression to its MySQL equivalent.
+ */
+function mysqlDefault(value: unknown): string {
+  if (typeof value === 'boolean') return value ? '1' : '0'
+  if (typeof value === 'number' || typeof value === 'bigint') return String(value)
+  const str = String(value).trim()
+
+  if (/^true$/i.test(str)) return '1'
+  if (/^false$/i.test(str)) return '0'
+
+  // Postgres UUID/`now()` generators → MySQL equivalents.
+  if (/^(gen_random_uuid|uuid_generate_v4)\(\)$/i.test(str)) return '(UUID())'
+  if (/^now\(\)$/i.test(str)) return 'CURRENT_TIMESTAMP'
+  if (/^(CURRENT_TIMESTAMP|CURRENT_DATE|CURRENT_TIME|NULL)$/i.test(str)) return str.toUpperCase()
+  if (/^-?\d+(\.\d+)?$/.test(str)) return str
+
+  // Other bare function calls pass through; everything else is a literal.
+  if (/^[a-z_][a-z0-9_]*\s*\([^)]*\)$/i.test(str)) return str
+  return quoteLiteral(str)
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -101,6 +101,7 @@ export { reviewMigration, type ReviewResult } from './migrate/review'
 
 export { emitPg } from './emit/pg'
 export { emitSqlite, SqliteRebuildRequiredError } from './emit/sqlite'
+export { emitMysql } from './emit/mysql'
 
 export { resolveDbConfig, type DbConfig } from './cli/config'
 export { generate } from './cli/generate'


### PR DESCRIPTION
## Why

`kick db generate` with `db.dialect: 'mysql'` fell back to the **Postgres** emitter — double-quoted identifiers + PG-only types that MySQL rejects. This adds a real MySQL emitter so MySQL projects can generate runnable migrations from their schema.

## What

`emitMysql` translates the change-set IR to MySQL DDL. MySQL has full `ALTER TABLE` support (unlike SQLite), so it mirrors `emitPg`'s structure rather than the SQLite rebuild dance — with MySQL-specific output:

- **Backtick identifiers** (`` `col` ``), not double quotes.
- **Type mapping**: `uuid`→`CHAR(36)`, `boolean`→`TINYINT(1)`, `serial`→`INT ... AUTO_INCREMENT`, `bigint`→`BIGINT`, `jsonb`/`json`→`JSON`, `text`→`TEXT`, length-preserving `varchar(200)`→`VARCHAR(200)`, `timestamp`→`TIMESTAMP`, `bytea`→`BLOB`.
- **Defaults**: `gen_random_uuid()`→`(UUID())`, `now()`→`CURRENT_TIMESTAMP`, `false`→`0`.
- **Single serial PK** inlined as `... AUTO_INCREMENT PRIMARY KEY` (MySQL requires the auto-increment column to be a key).
- **`alterColumn`** via `MODIFY COLUMN` (MySQL restates the whole column at once).
- **`dropForeignKey`** via `DROP FOREIGN KEY` (not `DROP CONSTRAINT`); **`addForeignKey`** via `ADD CONSTRAINT ... FOREIGN KEY`.
- Standalone PG `ENUM` type changes throw (MySQL enums are inline column types).

`generate()` dispatches the emitter by dialect via a `switch` (exhaustive over `postgres | sqlite | mysql`).

## Verified

New `emit-mysql` suite (5 tests) covers CREATE TABLE type mapping + backticks + defaults, AUTO_INCREMENT PK, add/drop/rename column, `MODIFY COLUMN`, index + FK syntax. db **418** tests.

## Remaining db gaps
SQLite/MySQL `introspect()` (re-enables drift), and the SQLite 12-step table-rebuild for `alterColumn` / FK-on-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
