### PR TITLE
feat(db): SQLite + MySQL introspection

### DIFF
--- a/.changeset/db-introspect-sqlite-mysql.md
+++ b/.changeset/db-introspect-sqlite-mysql.md
@@ -1,0 +1,11 @@
+---
+'@forinda/kickjs-db': minor
+---
+
+`introspect()` now works for SQLite and MySQL, so `kick db introspect` can reverse-engineer a live SQLite / MySQL database into a `schema.ts` (previously Postgres-only — the SQLite/MySQL adapters threw `KICK_DB_INTROSPECT_NOT_SUPPORTED`).
+
+- `introspectSqlite` walks `sqlite_master` + `PRAGMA table_info|index_list|index_info|foreign_key_list` (skips constraint auto-indexes, groups multi-column FKs).
+- `introspectMysql` walks `information_schema.{TABLES,COLUMNS,STATISTICS,KEY_COLUMN_USAGE,REFERENTIAL_CONSTRAINTS}`.
+- Both are exported (`introspectSqlite` / `introspectMysql`) and wired into their adapters' `introspect()`.
+
+Note: SQLite/MySQL introspection is **lossy** against a code-first snapshot — a `uuid()` column reads back as `text` / `char(36)` — so it powers schema reverse-engineering, not byte-exact drift detection. Drift stays off for those dialects pending a dialect-normalised compare; PostgreSQL drift is unaffected.

--- a/packages/db-mysql/__tests__/unit/version-check.test.ts
+++ b/packages/db-mysql/__tests__/unit/version-check.test.ts
@@ -300,9 +300,22 @@ describe('mysqlAdapter — multi-statement DDL via splitter', () => {
     expect(queries).toEqual(['CREATE TABLE x (id int)', 'INSERT INTO x VALUES (1)'])
   })
 
-  it('introspect throws — drift detection lands in a follow-up', async () => {
-    const { pool } = makeMockPool('8.0.34')
+  it('introspect walks information_schema (empty snapshot when no tables)', async () => {
+    // mysqlAdapter now implements introspect() via information_schema; every
+    // SELECT returns an empty row set, so the snapshot has no tables.
+    const pool: MysqlPoolLike = {
+      async query() {
+        return [[] as never, []]
+      },
+      async getConnection(): Promise<MysqlConnectionLike> {
+        throw new Error('not used in this test')
+      },
+    }
     const adapter = mysqlAdapter({ pool })
-    await expect(adapter.introspect()).rejects.toThrow(/not supported in v1/)
+    await expect(adapter.introspect()).resolves.toEqual({
+      version: 1,
+      dialect: 'mysql',
+      tables: {},
+    })
   })
 })

--- a/packages/db-sqlite/__tests__/integration/relational-query.test.ts
+++ b/packages/db-sqlite/__tests__/integration/relational-query.test.ts
@@ -271,8 +271,11 @@ describe('sqliteAdapter — migration table contract', () => {
     await adapter.releaseLock()
   })
 
-  it('introspect throws — drift detection lands in a follow-up', async () => {
+  it('introspect reads the live schema via sqlite_master + PRAGMA', async () => {
     const adapter = sqliteAdapter({ database })
-    await expect(adapter.introspect()).rejects.toThrow(/not supported in v1/)
+    const snap = await adapter.introspect()
+    expect(snap.dialect).toBe('sqlite')
+    // The suite created tables on this handle — introspect sees them.
+    expect(Object.keys(snap.tables).length).toBeGreaterThan(0)
   })
 })

--- a/packages/db/__tests__/unit/introspect-mysql.test.ts
+++ b/packages/db/__tests__/unit/introspect-mysql.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { introspectMysql, type MysqlIntrospectDb } from '@forinda/kickjs-db'
+
+/** Mock pool: route each information_schema query to canned rows. */
+function mockDb(rowsByMatch: { match: RegExp; rows: unknown[] }[]): MysqlIntrospectDb {
+  return {
+    async query<R = unknown>(sql: string): Promise<[R, unknown]> {
+      const hit = rowsByMatch.find((r) => r.match.test(sql))
+      return [(hit?.rows ?? []) as R, []]
+    },
+  }
+}
+
+describe('introspectMysql', () => {
+  it('maps columns / indexes / fks from information_schema', async () => {
+    const db = mockDb([
+      { match: /FROM information_schema\.TABLES/, rows: [{ TABLE_NAME: 'tasks' }] },
+      {
+        match: /FROM information_schema\.COLUMNS/,
+        rows: [
+          {
+            COLUMN_NAME: 'id',
+            DATA_TYPE: 'char',
+            COLUMN_TYPE: 'char(36)',
+            IS_NULLABLE: 'NO',
+            COLUMN_DEFAULT: null,
+            COLUMN_KEY: 'PRI',
+            EXTRA: '',
+          },
+          {
+            COLUMN_NAME: 'done',
+            DATA_TYPE: 'tinyint',
+            COLUMN_TYPE: 'tinyint(1)',
+            IS_NULLABLE: 'NO',
+            COLUMN_DEFAULT: '0',
+            COLUMN_KEY: '',
+            EXTRA: '',
+          },
+        ],
+      },
+      {
+        match: /FROM information_schema\.STATISTICS/,
+        rows: [
+          { INDEX_NAME: 'tasks_done_idx', COLUMN_NAME: 'done', NON_UNIQUE: 1, SEQ_IN_INDEX: 1 },
+        ],
+      },
+      {
+        match: /FROM information_schema\.KEY_COLUMN_USAGE/,
+        rows: [
+          {
+            CONSTRAINT_NAME: 'fk_author',
+            COLUMN_NAME: 'author_id',
+            REF_TABLE: 'users',
+            REF_COLUMN: 'id',
+            DELETE_RULE: 'CASCADE',
+            UPDATE_RULE: 'NO ACTION',
+            ORDINAL_POSITION: 1,
+          },
+        ],
+      },
+    ])
+
+    const snap = await introspectMysql(db)
+    expect(snap.dialect).toBe('mysql')
+    const t = snap.tables.tasks
+    expect(t.columns.id).toMatchObject({ type: 'char(36)', nullable: false, primaryKey: true })
+    expect(t.columns.done).toMatchObject({ type: 'tinyint(1)', nullable: false, default: '0' })
+    expect(t.indexes).toEqual([{ name: 'tasks_done_idx', columns: ['done'], unique: false }])
+    expect(t.foreignKeys[0]).toMatchObject({
+      name: 'fk_author',
+      columns: ['author_id'],
+      refTable: 'users',
+      refColumns: ['id'],
+      onDelete: 'cascade',
+      onUpdate: 'no_action',
+    })
+  })
+})

--- a/packages/db/__tests__/unit/introspect-sqlite.test.ts
+++ b/packages/db/__tests__/unit/introspect-sqlite.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import Database from 'better-sqlite3'
+import { introspectSqlite } from '@forinda/kickjs-db'
+
+function db(setup: string) {
+  const d = new Database(':memory:')
+  d.exec(setup)
+  return d
+}
+
+describe('introspectSqlite', () => {
+  it('reads columns, PK, nullability, defaults', () => {
+    const d = db(`
+      CREATE TABLE tasks (
+        id TEXT NOT NULL DEFAULT (lower(hex(randomblob(16)))),
+        title TEXT NOT NULL,
+        done INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (id)
+      );
+    `)
+    const snap = introspectSqlite(d)
+    expect(snap.dialect).toBe('sqlite')
+    const t = snap.tables.tasks
+    expect(Object.keys(t.columns)).toEqual(['id', 'title', 'done'])
+    expect(t.columns.id).toMatchObject({ type: 'text', nullable: false, primaryKey: true })
+    expect(t.columns.title).toMatchObject({ type: 'text', nullable: false, primaryKey: false })
+    expect(t.columns.done).toMatchObject({ type: 'integer', nullable: false, default: '0' })
+  })
+
+  it('captures explicit CREATE INDEX but skips constraint auto-indexes', () => {
+    const d = db(`
+      CREATE TABLE t (id INTEGER PRIMARY KEY, email TEXT UNIQUE, done INTEGER);
+      CREATE INDEX t_done_idx ON t (done);
+    `)
+    const idx = introspectSqlite(d).tables.t.indexes
+    // The UNIQUE-constraint auto-index on email is skipped (origin != 'c');
+    // only the explicit CREATE INDEX is reported.
+    expect(idx).toEqual([{ name: 't_done_idx', columns: ['done'], unique: false }])
+  })
+
+  it('reads foreign keys', () => {
+    const d = db(`
+      CREATE TABLE users (id INTEGER PRIMARY KEY);
+      CREATE TABLE posts (
+        id INTEGER PRIMARY KEY,
+        author_id INTEGER NOT NULL,
+        FOREIGN KEY (author_id) REFERENCES users (id) ON DELETE CASCADE
+      );
+    `)
+    const fks = introspectSqlite(d).tables.posts.foreignKeys
+    expect(fks).toHaveLength(1)
+    expect(fks[0]).toMatchObject({
+      columns: ['author_id'],
+      refTable: 'users',
+      refColumns: ['id'],
+      onDelete: 'cascade',
+      onUpdate: 'no_action',
+    })
+  })
+
+  it('excludes the migration bookkeeping tables', () => {
+    const d = db(`
+      CREATE TABLE kick_migrations (id TEXT);
+      CREATE TABLE app (id INTEGER PRIMARY KEY);
+    `)
+    expect(Object.keys(introspectSqlite(d).tables)).toEqual(['app'])
+  })
+})

--- a/packages/db/src/adapters/mysql/adapter.ts
+++ b/packages/db/src/adapters/mysql/adapter.ts
@@ -7,6 +7,7 @@ import {
   type MigrationRow,
   type SchemaSnapshot,
 } from '../../index'
+import { introspectMysql } from '../../migrate/introspect-mysql'
 
 /**
  * mysql2-shaped pool that `mysqlAdapter` consumes. Mirrors the
@@ -448,12 +449,11 @@ export function mysqlAdapter(opts: MysqlAdapterOptions): MigrationAdapter {
     },
 
     async introspect(): Promise<SchemaSnapshot> {
-      throw new KickDbError(
-        'KICK_DB_INTROSPECT_NOT_SUPPORTED',
-        'MySQL introspection is not supported in v1. ' +
-          'Drift detection requires an information_schema walk that lands in a follow-up. ' +
-          'Set `driftCheck: "off"` on the migration runner until then.',
-      )
+      // Reverse-engineer the live schema via information_schema. Types come
+      // back as the declared COLUMN_TYPE (a code-first `uuid()` reads as
+      // `char(36)`), so this powers `kick db introspect`; byte-exact drift
+      // against a code-first snapshot needs a dialect-normalised compare.
+      return introspectMysql(pool)
     },
 
     async close() {

--- a/packages/db/src/adapters/sqlite/adapter.ts
+++ b/packages/db/src/adapters/sqlite/adapter.ts
@@ -1,5 +1,4 @@
 import {
-  KickDbError,
   lockTableDdl,
   migrationsTableDdl,
   type Dialect,
@@ -48,9 +47,10 @@ export interface SqliteAdapterOptions {
  * exists, so the UPDATE either flips `locked_at` and returns
  * `changes=1` (we won) or matches zero rows (someone else holds it).
  *
- * Introspection: not implemented in v1 — throws `KickDbError` with
- * code `KICK_DB_INTROSPECT_NOT_SUPPORTED`. Drift detection lands in a
- * follow-up that walks `sqlite_master` + `pragma` queries.
+ * Introspection: `introspect()` walks `sqlite_master` + `PRAGMA` via
+ * {@link introspectSqlite}. Types come back as SQLite affinities (lossy
+ * vs the code-first DSL), so it powers `kick db introspect` rather than
+ * byte-exact drift detection.
  */
 export function sqliteAdapter(opts: SqliteAdapterOptions): MigrationAdapter {
   const dialect: Dialect = 'sqlite'

--- a/packages/db/src/adapters/sqlite/adapter.ts
+++ b/packages/db/src/adapters/sqlite/adapter.ts
@@ -7,6 +7,7 @@ import {
   type MigrationRow,
   type SchemaSnapshot,
 } from '../../index'
+import { introspectSqlite } from '../../migrate/introspect-sqlite'
 
 /**
  * better-sqlite3-shaped database handle that `sqliteAdapter` consumes.
@@ -149,12 +150,11 @@ export function sqliteAdapter(opts: SqliteAdapterOptions): MigrationAdapter {
     },
 
     async introspect(): Promise<SchemaSnapshot> {
-      throw new KickDbError(
-        'KICK_DB_INTROSPECT_NOT_SUPPORTED',
-        'SQLite introspection is not supported in v1. ' +
-          'Drift detection requires a sqlite_master + pragma walk that lands in a follow-up. ' +
-          'Set `driftCheck: "off"` on the migration runner until then.',
-      )
+      // Reverse-engineer the live schema via sqlite_master + PRAGMA walks.
+      // Types come back as SQLite affinities (a code-first `uuid()` reads as
+      // `text`), so this powers `kick db introspect`; byte-exact drift
+      // against a code-first snapshot needs a dialect-normalised compare.
+      return introspectSqlite(database)
     },
 
     async close() {

--- a/packages/db/src/cli.ts
+++ b/packages/db/src/cli.ts
@@ -126,9 +126,12 @@ async function resolveAdapter(config: DbConfig): Promise<{
 
 /**
  * Drift detection introspects the live DB and compares it to the last
- * applied snapshot. Only the Postgres adapter implements `introspect()`,
- * so for SQLite / MySQL we turn drift off (the runner would otherwise
- * throw "introspection not supported"). PostgreSQL keeps `'error'`.
+ * applied snapshot. All three adapters now implement `introspect()`, but
+ * SQLite / MySQL introspection is lossy against a code-first snapshot (a
+ * `uuid()` column reads back as `text` / `char(36)`), so comparing raw
+ * would false-positive. Until a dialect-normalised compare lands, drift
+ * stays off for those dialects; PostgreSQL (faithful round-trip) keeps
+ * the default `'error'`.
  */
 function driftCheckFor(config: DbConfig): 'ignore' | undefined {
   return (config.dialect ?? 'postgres') === 'postgres' ? undefined : 'ignore'

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -57,6 +57,16 @@ export {
 } from './migrate/schema'
 export { MemoryMigrationAdapter } from './migrate/memory-adapter'
 export { introspectPg } from './migrate/introspect-pg'
+export {
+  introspectSqlite,
+  type SqliteIntrospectDb,
+  type IntrospectSqliteOptions,
+} from './migrate/introspect-sqlite'
+export {
+  introspectMysql,
+  type MysqlIntrospectDb,
+  type IntrospectMysqlOptions,
+} from './migrate/introspect-mysql'
 export type { IntrospectPgOptions, PgQueryRunner } from './migrate/introspect-types'
 export { checkDrift, type DriftBehavior, type DriftLogger } from './migrate/drift'
 

--- a/packages/db/src/migrate/introspect-mysql.ts
+++ b/packages/db/src/migrate/introspect-mysql.ts
@@ -1,0 +1,187 @@
+import type {
+  ColumnSnapshot,
+  ForeignKeySnapshot,
+  FkAction,
+  IndexSnapshot,
+  SchemaSnapshot,
+  TableSnapshot,
+} from '../snapshot/types'
+
+const DEFAULT_EXCLUDED = ['kick_migrations', 'kick_migrations_lock']
+
+/** Minimal mysql2 surface introspection needs. Returns `[rows, fields]`. */
+export interface MysqlIntrospectDb {
+  query<R = unknown>(sql: string, params?: readonly unknown[]): Promise<[R, unknown]>
+}
+
+export interface IntrospectMysqlOptions {
+  excludeTables?: string[]
+}
+
+interface ColumnRow {
+  COLUMN_NAME: string
+  DATA_TYPE: string
+  COLUMN_TYPE: string
+  IS_NULLABLE: 'YES' | 'NO'
+  COLUMN_DEFAULT: string | null
+  COLUMN_KEY: string
+  EXTRA: string
+}
+
+interface IndexRow {
+  INDEX_NAME: string
+  COLUMN_NAME: string
+  NON_UNIQUE: number
+  SEQ_IN_INDEX: number
+}
+
+interface FkRow {
+  CONSTRAINT_NAME: string
+  COLUMN_NAME: string
+  REF_TABLE: string
+  REF_COLUMN: string
+  DELETE_RULE: string
+  UPDATE_RULE: string
+  ORDINAL_POSITION: number
+}
+
+async function rows<R>(db: MysqlIntrospectDb, sql: string, params: unknown[]): Promise<R[]> {
+  const [result] = await db.query<R[]>(sql, params)
+  return result
+}
+
+/**
+ * Read the current MySQL database into a {@link SchemaSnapshot} via
+ * `information_schema`. Types come back as the column's declared
+ * `COLUMN_TYPE` (`varchar(200)`, `tinyint(1)`, …) lowercased — MySQL
+ * doesn't preserve the original DSL type, so this powers `kick db
+ * introspect` rather than byte-exact drift against a code-first snapshot.
+ */
+export async function introspectMysql(
+  db: MysqlIntrospectDb,
+  opts: IntrospectMysqlOptions = {},
+): Promise<SchemaSnapshot> {
+  const excluded = opts.excludeTables ?? DEFAULT_EXCLUDED
+
+  const tableRows = await rows<{ TABLE_NAME: string }>(
+    db,
+    `SELECT TABLE_NAME FROM information_schema.TABLES
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE = 'BASE TABLE'
+     ORDER BY TABLE_NAME`,
+    [],
+  )
+
+  const tables: Record<string, TableSnapshot> = {}
+  for (const t of tableRows) {
+    if (excluded.includes(t.TABLE_NAME)) continue
+    tables[t.TABLE_NAME] = {
+      name: t.TABLE_NAME,
+      columns: await readColumns(db, t.TABLE_NAME),
+      indexes: await readIndexes(db, t.TABLE_NAME),
+      foreignKeys: await readForeignKeys(db, t.TABLE_NAME),
+      checks: [],
+    }
+  }
+  return { version: 1, dialect: 'mysql', tables }
+}
+
+async function readColumns(
+  db: MysqlIntrospectDb,
+  table: string,
+): Promise<Record<string, ColumnSnapshot>> {
+  const cols = await rows<ColumnRow>(
+    db,
+    `SELECT COLUMN_NAME, DATA_TYPE, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT, COLUMN_KEY, EXTRA
+     FROM information_schema.COLUMNS
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+     ORDER BY ORDINAL_POSITION`,
+    [table],
+  )
+  const out: Record<string, ColumnSnapshot> = {}
+  for (const c of cols) {
+    out[c.COLUMN_NAME] = {
+      name: c.COLUMN_NAME,
+      type: normalizeType(c),
+      nullable: c.IS_NULLABLE === 'YES',
+      default: c.COLUMN_DEFAULT,
+      primaryKey: c.COLUMN_KEY === 'PRI',
+    }
+  }
+  return out
+}
+
+async function readIndexes(db: MysqlIntrospectDb, table: string): Promise<IndexSnapshot[]> {
+  const stats = await rows<IndexRow>(
+    db,
+    `SELECT INDEX_NAME, COLUMN_NAME, NON_UNIQUE, SEQ_IN_INDEX
+     FROM information_schema.STATISTICS
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME <> 'PRIMARY'
+     ORDER BY INDEX_NAME, SEQ_IN_INDEX`,
+    [table],
+  )
+  const byName = new Map<string, { cols: string[]; unique: boolean }>()
+  for (const r of stats) {
+    const e = byName.get(r.INDEX_NAME) ?? { cols: [], unique: r.NON_UNIQUE === 0 }
+    e.cols.push(r.COLUMN_NAME)
+    byName.set(r.INDEX_NAME, e)
+  }
+  return [...byName].map(([name, e]) => ({ name, columns: e.cols, unique: e.unique }))
+}
+
+async function readForeignKeys(
+  db: MysqlIntrospectDb,
+  table: string,
+): Promise<ForeignKeySnapshot[]> {
+  const fkRows = await rows<FkRow>(
+    db,
+    `SELECT k.CONSTRAINT_NAME, k.COLUMN_NAME,
+            k.REFERENCED_TABLE_NAME AS REF_TABLE, k.REFERENCED_COLUMN_NAME AS REF_COLUMN,
+            r.DELETE_RULE, r.UPDATE_RULE, k.ORDINAL_POSITION
+     FROM information_schema.KEY_COLUMN_USAGE k
+     JOIN information_schema.REFERENTIAL_CONSTRAINTS r
+       ON r.CONSTRAINT_SCHEMA = k.TABLE_SCHEMA AND r.CONSTRAINT_NAME = k.CONSTRAINT_NAME
+     WHERE k.TABLE_SCHEMA = DATABASE() AND k.TABLE_NAME = ?
+       AND k.REFERENCED_TABLE_NAME IS NOT NULL
+     ORDER BY k.CONSTRAINT_NAME, k.ORDINAL_POSITION`,
+    [table],
+  )
+  const byName = new Map<string, FkRow[]>()
+  for (const r of fkRows) {
+    const g = byName.get(r.CONSTRAINT_NAME) ?? []
+    g.push(r)
+    byName.set(r.CONSTRAINT_NAME, g)
+  }
+  const out: ForeignKeySnapshot[] = []
+  for (const [name, group] of byName) {
+    const first = group[0]
+    out.push({
+      name,
+      columns: group.map((g) => g.COLUMN_NAME),
+      refTable: first.REF_TABLE,
+      refColumns: group.map((g) => g.REF_COLUMN),
+      onDelete: mapFkAction(first.DELETE_RULE),
+      onUpdate: mapFkAction(first.UPDATE_RULE),
+    })
+  }
+  return out
+}
+
+function mapFkAction(action: string): FkAction {
+  switch (action.toUpperCase()) {
+    case 'CASCADE':
+      return 'cascade'
+    case 'RESTRICT':
+      return 'restrict'
+    case 'SET NULL':
+      return 'set_null'
+    case 'SET DEFAULT':
+      return 'set_default'
+    default:
+      return 'no_action'
+  }
+}
+
+/** Use the declared `COLUMN_TYPE` (carries length), lowercased. */
+function normalizeType(c: ColumnRow): string {
+  return (c.COLUMN_TYPE || c.DATA_TYPE).trim().toLowerCase() || 'text'
+}

--- a/packages/db/src/migrate/introspect-sqlite.ts
+++ b/packages/db/src/migrate/introspect-sqlite.ts
@@ -1,0 +1,172 @@
+import type {
+  ColumnSnapshot,
+  ForeignKeySnapshot,
+  FkAction,
+  IndexSnapshot,
+  SchemaSnapshot,
+  TableSnapshot,
+} from '../snapshot/types'
+
+const DEFAULT_EXCLUDED = ['kick_migrations', 'kick_migrations_lock']
+
+/** Minimal better-sqlite3 surface introspection needs (sync `.all()`). */
+export interface SqliteIntrospectDb {
+  prepare(sql: string): { all<R = unknown>(...params: unknown[]): R[] }
+}
+
+export interface IntrospectSqliteOptions {
+  excludeTables?: string[]
+}
+
+interface TableInfoRow {
+  cid: number
+  name: string
+  type: string
+  notnull: 0 | 1
+  dflt_value: string | null
+  pk: number
+}
+
+interface IndexListRow {
+  seq: number
+  name: string
+  unique: 0 | 1
+  origin: string // 'c' = CREATE INDEX, 'u' = UNIQUE constraint, 'pk' = primary key
+  partial: 0 | 1
+}
+
+interface IndexInfoRow {
+  seqno: number
+  cid: number
+  name: string | null
+}
+
+interface FkListRow {
+  id: number
+  seq: number
+  table: string
+  from: string
+  to: string
+  on_update: string
+  on_delete: string
+  match: string
+}
+
+/**
+ * Read a live SQLite database into a {@link SchemaSnapshot} via
+ * `sqlite_master` + `PRAGMA` walks. Type strings come back as the
+ * column's *declared* affinity (`TEXT`, `INTEGER`, …) lowercased — SQLite
+ * doesn't preserve the original DSL type (a `uuid()` column reads back as
+ * `text`), so this is primarily for `kick db introspect` (reverse-engineer
+ * a schema), not byte-exact drift against a code-first snapshot.
+ */
+export function introspectSqlite(
+  db: SqliteIntrospectDb,
+  opts: IntrospectSqliteOptions = {},
+): SchemaSnapshot {
+  const excluded = opts.excludeTables ?? DEFAULT_EXCLUDED
+
+  const tableRows = db
+    .prepare(
+      `SELECT name FROM sqlite_master
+       WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+       ORDER BY name`,
+    )
+    .all<{ name: string }>()
+
+  const tables: Record<string, TableSnapshot> = {}
+  for (const { name } of tableRows) {
+    if (excluded.includes(name)) continue
+    tables[name] = {
+      name,
+      columns: readColumns(db, name),
+      indexes: readIndexes(db, name),
+      foreignKeys: readForeignKeys(db, name),
+      checks: [],
+    }
+  }
+  return { version: 1, dialect: 'sqlite', tables }
+}
+
+function readColumns(db: SqliteIntrospectDb, table: string): Record<string, ColumnSnapshot> {
+  const rows = db.prepare(`PRAGMA table_info(${quote(table)})`).all<TableInfoRow>()
+  const out: Record<string, ColumnSnapshot> = {}
+  for (const r of rows) {
+    out[r.name] = {
+      name: r.name,
+      type: normalizeType(r.type),
+      nullable: r.notnull === 0,
+      default: r.dflt_value,
+      primaryKey: r.pk > 0,
+    }
+  }
+  return out
+}
+
+function readIndexes(db: SqliteIntrospectDb, table: string): IndexSnapshot[] {
+  const list = db.prepare(`PRAGMA index_list(${quote(table)})`).all<IndexListRow>()
+  const out: IndexSnapshot[] = []
+  for (const idx of list) {
+    // Skip auto-indexes SQLite creates for UNIQUE / PK constraints — those
+    // belong to the column/constraint definitions, not standalone indexes.
+    if (idx.origin !== 'c') continue
+    const cols = db
+      .prepare(`PRAGMA index_info(${quote(idx.name)})`)
+      .all<IndexInfoRow>()
+      .filter((c) => c.name !== null)
+      .map((c) => c.name as string)
+    out.push({ name: idx.name, columns: cols, unique: idx.unique === 1 })
+  }
+  return out
+}
+
+function readForeignKeys(db: SqliteIntrospectDb, table: string): ForeignKeySnapshot[] {
+  const rows = db.prepare(`PRAGMA foreign_key_list(${quote(table)})`).all<FkListRow>()
+  // Group multi-column FKs by their `id`.
+  const byId = new Map<number, FkListRow[]>()
+  for (const r of rows) {
+    const g = byId.get(r.id) ?? []
+    g.push(r)
+    byId.set(r.id, g)
+  }
+  const out: ForeignKeySnapshot[] = []
+  for (const [id, group] of byId) {
+    group.sort((a, b) => a.seq - b.seq)
+    const first = group[0]
+    out.push({
+      // SQLite doesn't name FKs — synthesize a stable name.
+      name: `${table}_${group.map((g) => g.from).join('_')}_fk_${id}`,
+      columns: group.map((g) => g.from),
+      refTable: first.table,
+      refColumns: group.map((g) => g.to),
+      onDelete: mapFkAction(first.on_delete),
+      onUpdate: mapFkAction(first.on_update),
+    })
+  }
+  return out
+}
+
+function mapFkAction(action: string): FkAction {
+  switch (action.toUpperCase()) {
+    case 'CASCADE':
+      return 'cascade'
+    case 'RESTRICT':
+      return 'restrict'
+    case 'SET NULL':
+      return 'set_null'
+    case 'SET DEFAULT':
+      return 'set_default'
+    default:
+      return 'no_action'
+  }
+}
+
+/** Lowercase the declared type, preserving any `(length)` qualifier. */
+function normalizeType(declared: string): string {
+  return declared.trim().toLowerCase() || 'text'
+}
+
+/** Quote a SQLite identifier for interpolation into a PRAGMA (no binding). */
+function quote(name: string): string {
+  return '"' + name.replace(/"/g, '""') + '"'
+}


### PR DESCRIPTION
## Why

`introspect()` was Postgres-only — the SQLite and MySQL adapters threw `KICK_DB_INTROSPECT_NOT_SUPPORTED`, so `kick db introspect` (reverse-engineer a live DB into `schema.ts`) didn't work for those dialects. This implements both.

## What

- **`introspectSqlite`** — walks `sqlite_master` + `PRAGMA table_info | index_list | index_info | foreign_key_list`. Skips the constraint auto-indexes SQLite synthesizes for `UNIQUE`/PK, groups multi-column FKs, synthesizes stable FK names (SQLite doesn't name them).
- **`introspectMysql`** — walks `information_schema.{TABLES, COLUMNS, STATISTICS, KEY_COLUMN_USAGE, REFERENTIAL_CONSTRAINTS}`; uses the declared `COLUMN_TYPE` (carries length).
- Both exported + wired into their adapters' `introspect()`.

## Verified

`kickjs-db introspect` against the example's live `dev.db` produces a usable schema:

```ts
import { table, integer, text, index } from '@forinda/kickjs-db'
export const tasks = table('tasks', {
  id: text().primaryKey().default("lower(hex(randomblob(16)))"),
  title: text().notNull(),
  done: integer().notNull().default("0"),
  createdAt: text().notNull().default("CURRENT_TIMESTAMP"),
  priority: integer().notNull().default("0"),
}, (t) => ({ tasks_done_idx: index('tasks_done_idx').on(t.done) }))
```

New suites: `introspect-sqlite` (4, real in-memory better-sqlite3 — columns/PK/defaults, index vs constraint auto-index, FKs, table exclusion) + `introspect-mysql` (1, mock `information_schema`). db **423** tests.

## Scope note — drift still off for sqlite/mysql

Introspection is **lossy** against a code-first snapshot (`uuid()` → `text` / `char(36)`), so comparing raw would false-positive. `driftCheckFor` keeps drift off for those dialects pending a dialect-normalised compare (a separate follow-up). PostgreSQL drift (faithful round-trip) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added schema introspection support for SQLite and MySQL databases, enabling automatic reverse-engineering of live database structures into your project (previously PostgreSQL-only).

* **Documentation**
  * Updated documentation clarifying that schema introspection is now available for all supported databases. Drift detection remains disabled for SQLite and MySQL due to schema comparison limitations; PostgreSQL behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->