### PR TITLE
feat(db): SQLite table rebuild for column alters + FK changes

### DIFF
--- a/.changeset/db-sqlite-table-rebuild.md
+++ b/.changeset/db-sqlite-table-rebuild.md
@@ -1,0 +1,11 @@
+---
+'@forinda/kickjs-db': minor
+---
+
+`kick db generate` now emits a SQLite **table rebuild** for changes SQLite's `ALTER TABLE` can't express — column type/null/default alters and foreign-key add/drop on an existing table. Previously these threw `SqliteRebuildRequiredError` and had to be hand-authored.
+
+The emitter follows SQLite's recommended safe procedure: `CREATE TABLE _kick_new_<t>` with the desired shape → `INSERT ... SELECT` the surviving columns (the old/new column intersection, so data is preserved) → `DROP TABLE` → `RENAME` → recreate indexes. Verified end-to-end: a seeded row survives both `migrate up` and `migrate down` of a column-type change, with indexes intact.
+
+To build the new table the emitter needs the resolved before/after schema, so `generate()` now threads both snapshots into the SQLite emitter (`emitSqlite(changes, { from, to })`). Calling `emitSqlite(changes)` bare with a rebuild-requiring change still throws `SqliteRebuildRequiredError`.
+
+Limitation: the rebuild works for tables without **inbound** foreign-key references (the common case). A table that other tables' FKs point at would need `PRAGMA foreign_keys=OFF` outside the migration transaction — still out of scope.

--- a/packages/db-pg/__tests__/integration/abort-signal-pg.test.ts
+++ b/packages/db-pg/__tests__/integration/abort-signal-pg.test.ts
@@ -52,6 +52,16 @@ beforeAll(async () => {
     database: container.getDatabase(),
     max: 4, // big enough for the parallel "is the backend gone" check
   })
+  // The mid-flight cancel test deliberately abandons a `pg_sleep(10)`
+  // backend (Kysely's `'ignore query'` strategy). When `container.stop()`
+  // tears the server down in afterAll, that backend's pooled connection is
+  // terminated server-side (`57P01`), which a `pg.Pool` surfaces as an
+  // async `'error'` on the idle client. Without a listener that becomes an
+  // unhandled error and fails the run even though every test passed — a
+  // pool error handler is mandatory for exactly this teardown race.
+  pool.on('error', () => {
+    // expected idle-client termination during teardown — swallow.
+  })
 }, 90_000)
 
 afterAll(async () => {

--- a/packages/db/__tests__/unit/emit-sqlite.test.ts
+++ b/packages/db/__tests__/unit/emit-sqlite.test.ts
@@ -193,3 +193,127 @@ describe('emitSqlite — ALTER', () => {
     ).toThrow(SqliteRebuildRequiredError)
   })
 })
+
+import type { SchemaSnapshot } from '@forinda/kickjs-db'
+
+const tbl = (
+  name: string,
+  cols: Record<string, Partial<import('@forinda/kickjs-db').ColumnSnapshot>>,
+  indexes: import('@forinda/kickjs-db').IndexSnapshot[] = [],
+) => ({
+  name,
+  columns: Object.fromEntries(Object.entries(cols).map(([n, o]) => [n, col({ name: n, ...o })])),
+  indexes,
+  foreignKeys: [],
+  checks: [],
+})
+
+describe('emitSqlite — table rebuild (alterColumn with snapshots)', () => {
+  it('rebuilds the table: create _kick_new / copy common cols / drop / rename / reindex', () => {
+    const from: SchemaSnapshot = {
+      version: 1,
+      dialect: 'sqlite',
+      tables: {
+        tasks: tbl(
+          'tasks',
+          {
+            id: { type: 'integer', nullable: false, primaryKey: true },
+            title: { type: 'varchar(50)', nullable: true },
+          },
+          [{ name: 'tasks_title_idx', columns: ['title'], unique: false }],
+        ),
+      },
+    }
+    const to: SchemaSnapshot = {
+      version: 1,
+      dialect: 'sqlite',
+      tables: {
+        tasks: tbl(
+          'tasks',
+          {
+            id: { type: 'integer', nullable: false, primaryKey: true },
+            title: { type: 'text', nullable: false }, // type + nullability changed
+          },
+          [{ name: 'tasks_title_idx', columns: ['title'], unique: false }],
+        ),
+      },
+    }
+    const sql = emitSqlite(
+      [
+        {
+          kind: 'alterColumn',
+          table: 'tasks',
+          column: 'title',
+          before: from.tables.tasks.columns.title,
+          after: to.tables.tasks.columns.title,
+        },
+      ],
+      { from, to },
+    )
+    expect(sql).toBe(
+      'CREATE TABLE "_kick_new_tasks" (\n' +
+        '  "id" INTEGER PRIMARY KEY,\n' +
+        '  "title" TEXT NOT NULL\n' +
+        ');\n' +
+        'INSERT INTO "_kick_new_tasks" ("id", "title")\n' +
+        '  SELECT "id", "title" FROM "tasks";\n' +
+        'DROP TABLE "tasks";\n' +
+        'ALTER TABLE "_kick_new_tasks" RENAME TO "tasks";\n' +
+        'CREATE INDEX "tasks_title_idx" ON "tasks" ("title");',
+    )
+  })
+
+  it('copies only the column intersection (a dropped column is not selected)', () => {
+    const from: SchemaSnapshot = {
+      version: 1,
+      dialect: 'sqlite',
+      tables: {
+        t: tbl('t', {
+          id: { type: 'integer', primaryKey: true, nullable: false },
+          gone: { type: 'text' },
+          keep: { type: 'text' },
+        }),
+      },
+    }
+    const to: SchemaSnapshot = {
+      version: 1,
+      dialect: 'sqlite',
+      tables: {
+        t: tbl('t', {
+          id: { type: 'integer', primaryKey: true, nullable: false },
+          keep: { type: 'integer' },
+        }),
+      },
+    }
+    const sql = emitSqlite(
+      [
+        {
+          kind: 'alterColumn',
+          table: 't',
+          column: 'keep',
+          before: from.tables.t.columns.keep,
+          after: to.tables.t.columns.keep,
+        },
+      ],
+      { from, to },
+    )
+    expect(sql).toContain(
+      'INSERT INTO "_kick_new_t" ("id", "keep")\n  SELECT "id", "keep" FROM "t";',
+    )
+    expect(sql).not.toContain('gone')
+  })
+
+  it('still throws when no snapshot is supplied (bare call)', () => {
+    expect(() =>
+      emitSqlite([
+        {
+          kind: 'alterColumn',
+          table: 'tasks',
+          column: 'title',
+          before: col({ name: 'title', type: 'varchar(50)' }),
+          after: col({ name: 'title', type: 'text' }),
+        },
+      ]),
+    ).toThrow(SqliteRebuildRequiredError)
+  })
+})

--- a/packages/db/src/cli/generate.ts
+++ b/packages/db/src/cli/generate.ts
@@ -16,15 +16,25 @@ import type { ChangeSet } from '../diff/types'
 import type { Dialect, SchemaSnapshot } from '../snapshot/types'
 import type { Change, RemoveEnumValue } from '../diff/types'
 
-/** Pick the migration SQL emitter for the configured dialect. */
-function emitterFor(dialect: Dialect): (changes: ChangeSet) => string {
+/**
+ * Emit migration DDL for the dialect. `from`/`to` are the schema snapshots
+ * before/after the changes apply — the SQLite emitter uses them to build
+ * table rebuilds (column alters, FK add/drop) it can't express via
+ * `ALTER TABLE`. Postgres/MySQL ignore them.
+ */
+function emitDdl(
+  dialect: Dialect,
+  changes: ChangeSet,
+  from: SchemaSnapshot,
+  to: SchemaSnapshot,
+): string {
   switch (dialect) {
     case 'sqlite':
-      return emitSqlite
+      return emitSqlite(changes, { from, to })
     case 'mysql':
-      return emitMysql
+      return emitMysql(changes)
     case 'postgres':
-      return emitPg
+      return emitPg(changes)
   }
 }
 
@@ -94,14 +104,15 @@ export async function generate(opts: GenerateOptions): Promise<GenerateResult> {
 
   await assertNoCompositeReferences(changes, opts.detectCompositeRefs)
 
-  const emit = emitterFor(opts.config.dialect)
+  const dialect = opts.config.dialect
   return await writeMigration({
     opts,
     migrationsAbs,
     previousId,
     target,
-    upBody: emit(changes),
-    downBody: emit(invertChanges(changes)),
+    // up: prev -> target. down: invert applied to target -> prev.
+    upBody: emitDdl(dialect, changes, prev, target),
+    downBody: emitDdl(dialect, invertChanges(changes), target, prev),
     changeCount: changes.length,
     draft: hasAmbiguousReverse(changes),
     empty: false,

--- a/packages/db/src/emit/sqlite.ts
+++ b/packages/db/src/emit/sqlite.ts
@@ -3,61 +3,106 @@ import type {
   ColumnSnapshot,
   ForeignKeySnapshot,
   IndexSnapshot,
+  SchemaSnapshot,
   TableSnapshot,
 } from '../snapshot/types'
 import { quoteIdent, quoteLiteral } from './identifiers'
 
 /**
- * Raised when a change set contains a SQLite operation that SQLite's
- * limited `ALTER TABLE` can't express directly (altering a column's
- * type/null/default, or adding/dropping a foreign key on an existing
- * table). Those need the 12-step table-rebuild dance, not yet emitted —
- * author the migration by hand with `kick db generate --empty` for now.
+ * Raised when a change set needs a SQLite table rebuild but the emitter
+ * wasn't given the resolved snapshots to build it from (it only has the
+ * per-change diff). `generate()` always passes the snapshots, so this only
+ * surfaces if `emitSqlite` is called bare with a rebuild-requiring change.
  */
 export class SqliteRebuildRequiredError extends Error {
   constructor(detail: string) {
     super(
-      `kickjs-db: this change needs a SQLite table rebuild, which the emitter ` +
-        `doesn't generate yet — ${detail}. Author it manually with ` +
-        `\`kick db generate --empty <name>\` (CREATE new table → copy rows → ` +
-        `DROP old → RENAME), or target PostgreSQL for automatic ALTERs.`,
+      `kickjs-db: this SQLite change needs a table rebuild and no resolved ` +
+        `schema snapshot was supplied to build it — ${detail}. This is an ` +
+        `internal error; report it (generate() passes the snapshots).`,
     )
     this.name = 'SqliteRebuildRequiredError'
   }
 }
 
 /**
+ * Resolved before/after schema snapshots, threaded in by `generate()` so
+ * the emitter can build the 12-step table-rebuild for changes SQLite's
+ * `ALTER TABLE` can't express (column type/null/default changes, FK
+ * add/drop on an existing table). `to` is the schema *after* the changes
+ * apply; `from` is before — their column intersection drives the
+ * `INSERT ... SELECT` data copy.
+ */
+export interface SqliteEmitContext {
+  from?: SchemaSnapshot
+  to?: SchemaSnapshot
+}
+
+/**
  * Emit SQLite DDL for a change set.
  *
- * SQLite-specific handling vs the Postgres emitter:
- * - PG column types are mapped to SQLite type affinities.
- * - A single integer primary key is emitted **inline** (`INTEGER
- *   PRIMARY KEY`) so it aliases the rowid (auto-increment); composite
- *   or non-integer PKs use a table-level `PRIMARY KEY (...)` clause.
- * - Foreign keys are **inlined into `CREATE TABLE`** — SQLite has no
- *   `ALTER TABLE ... ADD CONSTRAINT`. The diff emits a new table's FKs
- *   as separate `addForeignKey` changes; we fold those into the create
- *   and skip them here.
- * - `alterColumn`, FK changes on an existing table, and enum changes
- *   throw {@link SqliteRebuildRequiredError} (or an enum error) rather
- *   than emit wrong SQL.
+ * Most operations map to a direct statement (CREATE/DROP/RENAME TABLE,
+ * ADD/DROP/RENAME COLUMN, CREATE/DROP INDEX). The ones SQLite can't `ALTER`
+ * directly — `alterColumn`, and foreign-key add/drop on an existing table —
+ * are handled by a **table rebuild**: create a new table with the desired
+ * shape, copy rows, drop the old, rename, recreate indexes. Foreign keys
+ * are folded into `CREATE TABLE` (SQLite has no `ADD CONSTRAINT`).
  */
-export function emitSqlite(changes: ChangeSet): string {
-  // Tables created in this change set — their FKs are inlined into the
-  // CREATE TABLE, so the separate `addForeignKey` changes are no-ops.
+export function emitSqlite(changes: ChangeSet, ctx: SqliteEmitContext = {}): string {
   const createdTables = new Set<string>()
   for (const c of changes) if (c.kind === 'createTable') createdTables.add(c.table.name)
 
-  return changes
-    .map((c) => emitChange(c, createdTables))
-    .filter((s) => s.length > 0)
-    .join('\n')
+  // Tables that need a rebuild (an ALTER SQLite can't express). A table
+  // created in this same change set is never rebuilt — its FKs inline into
+  // CREATE TABLE directly.
+  const rebuildTables = new Set<string>()
+  for (const c of changes) {
+    const t = perTableName(c)
+    if (!t || createdTables.has(t)) continue
+    if (c.kind === 'alterColumn' || c.kind === 'dropForeignKey' || c.kind === 'addForeignKey') {
+      rebuildTables.add(t)
+    }
+  }
+
+  const out: string[] = []
+
+  // 1. Emit every change that isn't subsumed by a rebuild.
+  for (const c of changes) {
+    const t = perTableName(c)
+    if (t && rebuildTables.has(t)) continue // folded into the rebuild below
+    const sql = emitChange(c)
+    if (sql) out.push(sql)
+  }
+
+  // 2. Emit one rebuild per affected table, from the resolved `to` snapshot.
+  for (const table of rebuildTables) {
+    out.push(emitRebuild(table, ctx))
+  }
+
+  return out.join('\n')
 }
 
-function emitChange(change: Change, createdTables: Set<string>): string {
+/** The table a per-table change targets, or null for table-level changes. */
+function perTableName(change: Change): string | null {
+  switch (change.kind) {
+    case 'addColumn':
+    case 'dropColumn':
+    case 'renameColumn':
+    case 'alterColumn':
+    case 'addIndex':
+    case 'dropIndex':
+    case 'addForeignKey':
+    case 'dropForeignKey':
+      return change.table
+    default:
+      return null
+  }
+}
+
+function emitChange(change: Change): string {
   switch (change.kind) {
     case 'createTable':
-      return emitCreateTable(change.table)
+      return emitCreateTable(change.table.name, change.table)
     case 'dropTable':
       return `DROP TABLE ${quoteIdent(change.table.name)};`
     case 'renameTable':
@@ -65,30 +110,20 @@ function emitChange(change: Change, createdTables: Set<string>): string {
     case 'addColumn':
       return `ALTER TABLE ${quoteIdent(change.table)} ADD COLUMN ${emitColumnDecl(change.column)};`
     case 'dropColumn':
-      // SQLite 3.35+ supports DROP COLUMN.
       return `ALTER TABLE ${quoteIdent(change.table)} DROP COLUMN ${quoteIdent(change.column.name)};`
     case 'renameColumn':
-      // SQLite 3.25+ supports RENAME COLUMN.
       return `ALTER TABLE ${quoteIdent(change.table)} RENAME COLUMN ${quoteIdent(change.from)} TO ${quoteIdent(change.to)};`
     case 'addIndex':
       return emitAddIndex(change.table, change.index)
     case 'dropIndex':
       return `DROP INDEX ${quoteIdent(change.index.name)};`
     case 'addForeignKey':
-      // Inlined into CREATE TABLE for new tables; otherwise impossible
-      // without a rebuild.
-      if (createdTables.has(change.table)) return ''
-      throw new SqliteRebuildRequiredError(
-        `adding foreign key '${change.fk.name}' to existing table '${change.table}'`,
-      )
     case 'dropForeignKey':
-      throw new SqliteRebuildRequiredError(
-        `dropping foreign key '${change.fk.name}' from table '${change.table}'`,
-      )
     case 'alterColumn':
-      throw new SqliteRebuildRequiredError(
-        `altering column '${change.column}' on table '${change.table}'`,
-      )
+      // FK add/drop + column alters never emit a standalone statement:
+      // new-table FKs inline into CREATE TABLE, existing-table FK + column
+      // changes are subsumed by the table rebuild.
+      return ''
     case 'createEnum':
     case 'dropEnum':
     case 'addEnumValue':
@@ -100,32 +135,64 @@ function emitChange(change: Change, createdTables: Set<string>): string {
   }
 }
 
-function emitCreateTable(t: TableSnapshot): string {
+/**
+ * The SQLite-recommended safe table mutation: create the new table, copy
+ * the rows that survive (column intersection of old + new), drop the old,
+ * rename, and recreate indexes.
+ *
+ * Works for tables without inbound foreign-key references (the common
+ * case for a column type/default change). Tables referenced by other
+ * tables' FKs would need `PRAGMA foreign_keys=OFF` outside the migration
+ * transaction — out of scope here.
+ */
+function emitRebuild(table: string, ctx: SqliteEmitContext): string {
+  const next = ctx.to?.tables[table]
+  if (!next) {
+    throw new SqliteRebuildRequiredError(`no resolved snapshot for table '${table}'`)
+  }
+  const prev = ctx.from?.tables[table]
+
+  // Copy columns present in BOTH old and new (added columns get their
+  // default; dropped columns are simply not selected).
+  const newCols = Object.keys(next.columns)
+  const common = prev ? newCols.filter((c) => c in prev.columns) : newCols
+  const colList = common.map(quoteIdent).join(', ')
+
+  const tmp = `_kick_new_${table}`
+  const lines: string[] = [
+    emitCreateTable(tmp, next),
+    common.length > 0
+      ? `INSERT INTO ${quoteIdent(tmp)} (${colList})\n  SELECT ${colList} FROM ${quoteIdent(table)};`
+      : `-- (no columns survive the rebuild; nothing to copy)`,
+    `DROP TABLE ${quoteIdent(table)};`,
+    `ALTER TABLE ${quoteIdent(tmp)} RENAME TO ${quoteIdent(table)};`,
+  ]
+  for (const idx of next.indexes) lines.push(emitAddIndex(table, idx))
+  return lines.join('\n')
+}
+
+function emitCreateTable(name: string, t: TableSnapshot): string {
   const columns = Object.values(t.columns)
   const pkCols = columns.filter((c) => c.primaryKey)
 
-  // A single integer PK becomes the rowid alias only when declared
-  // inline as `INTEGER PRIMARY KEY` — a table-level PRIMARY KEY clause
-  // would not auto-increment. Composite or non-integer PKs use the
-  // table-level clause.
+  // A single integer PK becomes the rowid alias only when declared inline
+  // as `INTEGER PRIMARY KEY`; composite/non-integer PKs use a table clause.
   const inlinePk =
     pkCols.length === 1 && sqliteType(pkCols[0].type) === 'INTEGER' ? pkCols[0] : null
 
   const lines = columns.map((c) => emitColumnDecl(c, c === inlinePk))
-
   if (!inlinePk && pkCols.length > 0) {
     lines.push(`PRIMARY KEY (${pkCols.map((c) => quoteIdent(c.name)).join(', ')})`)
   }
   for (const fk of t.foreignKeys) lines.push(emitInlineFk(fk))
 
-  return `CREATE TABLE ${quoteIdent(t.name)} (\n  ${lines.join(',\n  ')}\n);`
+  return `CREATE TABLE ${quoteIdent(name)} (\n  ${lines.join(',\n  ')}\n);`
 }
 
 function emitColumnDecl(c: ColumnSnapshot, inlinePk = false): string {
   let s = `${quoteIdent(c.name)} ${sqliteType(c.type)}`
   if (inlinePk) {
     s += ' PRIMARY KEY'
-    // `serial`/`bigserial` imply an auto-incrementing PK.
     if (/serial/i.test(c.type)) s += ' AUTOINCREMENT'
   }
   if (!c.nullable && !inlinePk) s += ' NOT NULL'
@@ -155,17 +222,12 @@ function emitInlineFk(fk: ForeignKeySnapshot): string {
   )
 }
 
-/**
- * Map a Postgres column type string to a SQLite type. SQLite uses
- * type affinity (only the substring matters), but we emit canonical
- * names — `INTEGER` / `REAL` / `NUMERIC` / `TEXT` / `BLOB` — so the
- * generated DDL reads clearly and the right affinity is selected.
- */
+/** Map a Postgres column type string to a SQLite affinity type. */
 function sqliteType(pgType: string): string {
   const base = pgType
     .toLowerCase()
-    .replace(/\(.*\)/, '') // drop length/precision, e.g. varchar(200)
-    .replace(/\[\]$/, '') // drop array marker (stored as TEXT/JSON)
+    .replace(/\(.*\)/, '')
+    .replace(/\[\]$/, '')
     .trim()
 
   if (/^(serial|bigserial|smallserial|big|small)?int(eger|2|4|8)?$/.test(base)) return 'INTEGER'
@@ -174,37 +236,21 @@ function sqliteType(pgType: string): string {
   if (/^(real|float4|float8|double precision|float)$/.test(base)) return 'REAL'
   if (/^(numeric|decimal|money)$/.test(base)) return 'NUMERIC'
   if (base === 'bytea' || base === 'blob') return 'BLOB'
-  // varchar/char/text/uuid/json/jsonb/citext/xml/inet/cidr/timestamp/date/
-  // time/interval and anything else → TEXT (SQLite stores dates as TEXT).
   return 'TEXT'
 }
 
-/**
- * Map a Postgres default expression to its SQLite equivalent.
- */
+/** Map a Postgres default expression to its SQLite equivalent. */
 function sqliteDefault(value: unknown): string {
   if (typeof value === 'boolean') return value ? '1' : '0'
   if (typeof value === 'number' || typeof value === 'bigint') return String(value)
   const str = String(value).trim()
 
-  // Booleans → SQLite integer literals.
   if (/^true$/i.test(str)) return '1'
   if (/^false$/i.test(str)) return '0'
-
-  // Postgres UUID/`now()` generators → SQLite equivalents.
-  if (/^(gen_random_uuid|uuid_generate_v4)\(\)$/i.test(str)) {
-    // 16 random bytes → 32 hex chars. Not dash-formatted, but unique +
-    // collision-safe; wrap in parens so SQLite treats it as an expression.
-    return '(lower(hex(randomblob(16))))'
-  }
+  if (/^(gen_random_uuid|uuid_generate_v4)\(\)$/i.test(str)) return '(lower(hex(randomblob(16))))'
   if (/^now\(\)$/i.test(str)) return 'CURRENT_TIMESTAMP'
-
-  // SQLite-supported time keywords + plain numerics pass through bare.
   if (/^(CURRENT_TIMESTAMP|CURRENT_DATE|CURRENT_TIME|NULL)$/i.test(str)) return str.toUpperCase()
   if (/^-?\d+(\.\d+)?$/.test(str)) return str
-
-  // Any other bare function call (best effort) passes through; everything
-  // else is a string literal.
   if (/^[a-z_][a-z0-9_]*\s*\([^)]*\)$/i.test(str)) return str
   return quoteLiteral(str)
 }


### PR DESCRIPTION
## Why

SQLite's `ALTER TABLE` can't change a column's type/null/default or add/drop a foreign key on an existing table. `emitSqlite` threw `SqliteRebuildRequiredError` for those, so SQLite users had to hand-author the migration. This emits the rebuild automatically — the last SQLite emit gap.

## What

`emitSqlite` now builds SQLite's recommended safe table mutation for `alterColumn` + existing-table FK add/drop:

```sql
CREATE TABLE "_kick_new_tasks" ( …desired shape, FKs inline… );
INSERT INTO "_kick_new_tasks" ("id","title",…)
  SELECT "id","title",… FROM "tasks";   -- old∩new columns → data preserved
DROP TABLE "tasks";
ALTER TABLE "_kick_new_tasks" RENAME TO "tasks";
CREATE INDEX … ;                          -- indexes recreated
```

To build the new table the emitter needs the resolved before/after schema, so `generate()` threads both snapshots in: `emitSqlite(changes, { from, to })` (up: `prev→target`, down: `target→prev`). The `INSERT ... SELECT` copies the **old∩new column intersection** — added columns get their default, dropped columns aren't selected. Calling `emitSqlite(changes)` bare with a rebuild change still throws `SqliteRebuildRequiredError`.

## Verified end-to-end

Seeded a row, changed a column type, then on the live `dev.db`:

```
migrate up   → rebuild applied; row survives (priority=5), tasks_done_idx intact
migrate down → reverse rebuild;  row still present
```

New unit tests: exact rebuild SQL, column-intersection copy (dropped col excluded), bare-call still throws. db **426** tests.

## Limitation

Works for tables without **inbound** FK references (the common case). A table other tables' FKs point at would need `PRAGMA foreign_keys=OFF` outside the migration transaction — out of scope (documented in the emitter).

## db status
emit ✅ (pg/sqlite/mysql) · introspect ✅ (pg/sqlite/mysql) · SQLite rebuild ✅. Remaining: dialect-normalized **drift** for sqlite/mysql (the one "off" switch left).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
