### PR TITLE
feat(db): dialect-normalized drift detection for SQLite + MySQL

### DIFF
--- a/.changeset/db-normalized-drift.md
+++ b/.changeset/db-normalized-drift.md
@@ -1,0 +1,11 @@
+---
+'@forinda/kickjs-db': minor
+---
+
+Drift detection now works for SQLite and MySQL — `kick db migrate` catches out-of-band schema changes on all three dialects.
+
+SQLite/MySQL introspection is lossy against a code-first snapshot (a `uuid()` column reads back as `text` / `char(36)`, defaults normalise, SQLite drops FK names), so a raw comparison flagged drift on every migration. `checkDrift` now **canonicalises both sides** before diffing: column types run through the emit type-mapper (so `uuid` ≡ `text`), defaults are dropped, and FK names become a structural key. This catches the drift that matters — tables/columns added or removed, type/nullability/PK changes, indexes — without false positives. PostgreSQL still compares raw (faithful round-trip) and keeps default-level drift detection.
+
+**Behaviour change**: SQLite/MySQL `migrate` previously skipped drift entirely (it had no `introspect()`); it now defaults to `'error'` like Postgres. Tune it with the new `db.driftCheck` option (`'error'` | `'warn'` | `'ignore'`) in `kick.config.ts` / `kickjs-db.config.ts`.
+
+Verified end-to-end: a clean SQLite migrate passes the drift check (no false positive on lossy types), while an out-of-band `ALTER TABLE ... ADD COLUMN` is caught ("Schema drift detected: 1 added").

--- a/packages/db/__tests__/unit/drift-normalize.test.ts
+++ b/packages/db/__tests__/unit/drift-normalize.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { checkDrift } from '@forinda/kickjs-db'
+import type { SchemaSnapshot } from '@forinda/kickjs-db'
+
+const col = (over: Partial<import('@forinda/kickjs-db').ColumnSnapshot>) => ({
+  name: 'c',
+  type: 'text',
+  nullable: true,
+  default: null,
+  primaryKey: false,
+  ...over,
+})
+
+// Stored snapshot — code-first DSL types + defaults.
+const stored: SchemaSnapshot = {
+  version: 1,
+  dialect: 'sqlite',
+  tables: {
+    tasks: {
+      name: 'tasks',
+      columns: {
+        id: col({
+          name: 'id',
+          type: 'uuid',
+          nullable: false,
+          primaryKey: true,
+          default: 'gen_random_uuid()',
+        }),
+        title: col({ name: 'title', type: 'varchar(200)', nullable: false }),
+        done: col({ name: 'done', type: 'boolean', nullable: false, default: 'false' }),
+      },
+      indexes: [{ name: 'tasks_done_idx', columns: ['done'], unique: false }],
+      foreignKeys: [],
+      checks: [],
+    },
+  },
+}
+
+// Live snapshot — what introspectSqlite reads back from the same DB.
+const live: SchemaSnapshot = {
+  version: 1,
+  dialect: 'sqlite',
+  tables: {
+    tasks: {
+      name: 'tasks',
+      columns: {
+        id: col({
+          name: 'id',
+          type: 'text',
+          nullable: false,
+          primaryKey: true,
+          default: 'lower(hex(randomblob(16)))',
+        }),
+        title: col({ name: 'title', type: 'text', nullable: false }),
+        done: col({ name: 'done', type: 'integer', nullable: false, default: '0' }),
+      },
+      indexes: [{ name: 'tasks_done_idx', columns: ['done'], unique: false }],
+      foreignKeys: [],
+      checks: [],
+    },
+  },
+}
+
+describe('checkDrift — dialect normalization (sqlite)', () => {
+  it('does NOT flag drift between a DSL snapshot and its lossy introspection', async () => {
+    // uuid↔text, varchar(200)↔text, boolean↔integer, gen_random_uuid()↔
+    // randomblob, false↔0 all collapse under normalization → no drift.
+    await expect(checkDrift(live, stored, 'error')).resolves.toBeUndefined()
+  })
+
+  it('still flags a real structural drift (live gained a column)', async () => {
+    const drifted: SchemaSnapshot = {
+      ...live,
+      tables: {
+        tasks: {
+          ...live.tables.tasks,
+          columns: { ...live.tables.tasks.columns, sneaky: col({ name: 'sneaky', type: 'text' }) },
+        },
+      },
+    }
+    await expect(checkDrift(drifted, stored, 'error')).rejects.toThrow(/drift/i)
+  })
+
+  it('flags a type change that survives normalization (text → integer)', async () => {
+    const typeChanged: SchemaSnapshot = {
+      ...live,
+      tables: {
+        tasks: {
+          ...live.tables.tasks,
+          columns: {
+            ...live.tables.tasks.columns,
+            title: col({ name: 'title', type: 'integer', nullable: false }),
+          },
+        },
+      },
+    }
+    // stored title is varchar→text; live now integer → real drift.
+    await expect(checkDrift(typeChanged, stored, 'error')).rejects.toThrow(/drift/i)
+  })
+})

--- a/packages/db/src/cli.ts
+++ b/packages/db/src/cli.ts
@@ -38,6 +38,7 @@ import {
 } from './index'
 import type { Dialect } from './snapshot/types'
 import type { MigrationAdapterFactory } from './cli/config'
+import type { DriftBehavior } from './migrate/drift'
 
 /**
  * Authoring shape for the db config — every field optional, defaults
@@ -51,6 +52,12 @@ export interface KickDbConfigInput {
   dialect?: Dialect
   connectionString?: string
   adapter?: MigrationAdapterFactory
+  /**
+   * How `migrate` reacts to out-of-band schema (drift): `'error'`
+   * (default), `'warn'`, or `'ignore'`. The check is dialect-normalised,
+   * so SQLite/MySQL's lossy introspection doesn't false-positive.
+   */
+  driftCheck?: DriftBehavior
 }
 
 /**
@@ -83,6 +90,7 @@ export function resolveKickDbConfig(block: KickDbConfigInput | undefined): DbCon
     dialect: db.dialect ?? 'postgres',
     connectionString: db.connectionString ?? process.env.DATABASE_URL,
     adapter: db.adapter,
+    driftCheck: db.driftCheck,
   }
 }
 
@@ -122,19 +130,6 @@ async function resolveAdapter(config: DbConfig): Promise<{
       await pool.end()
     },
   }
-}
-
-/**
- * Drift detection introspects the live DB and compares it to the last
- * applied snapshot. All three adapters now implement `introspect()`, but
- * SQLite / MySQL introspection is lossy against a code-first snapshot (a
- * `uuid()` column reads back as `text` / `char(36)`), so comparing raw
- * would false-positive. Until a dialect-normalised compare lands, drift
- * stays off for those dialects; PostgreSQL (faithful round-trip) keeps
- * the default `'error'`.
- */
-function driftCheckFor(config: DbConfig): 'ignore' | undefined {
-  return (config.dialect ?? 'postgres') === 'postgres' ? undefined : 'ignore'
 }
 
 interface PgQueryRunnerProbe {
@@ -238,8 +233,8 @@ export function registerDbCommands(parent: Command, getConfig: DbConfigResolver)
         const r = await migrateLatest({
           adapter,
           migrationsDir: config.migrationsDir,
+          driftCheck: config.driftCheck,
           confirmEnumDrop: opts.confirmEnumDrop,
-          driftCheck: driftCheckFor(config),
         })
         console.log(
           r.applied.length === 0
@@ -266,8 +261,8 @@ export function registerDbCommands(parent: Command, getConfig: DbConfigResolver)
         const r = await migrateUp({
           adapter,
           migrationsDir: config.migrationsDir,
+          driftCheck: config.driftCheck,
           confirmEnumDrop: opts.confirmEnumDrop,
-          driftCheck: driftCheckFor(config),
         })
         console.log(
           r.applied.length === 0
@@ -289,7 +284,7 @@ export function registerDbCommands(parent: Command, getConfig: DbConfigResolver)
         const r = await migrateDown({
           adapter,
           migrationsDir: config.migrationsDir,
-          driftCheck: driftCheckFor(config),
+          driftCheck: config.driftCheck,
         })
         console.log(r.reversed ? `Reversed ${r.reversed}.` : 'Nothing to reverse.')
       } finally {
@@ -307,7 +302,7 @@ export function registerDbCommands(parent: Command, getConfig: DbConfigResolver)
         const r = await migrateRollback({
           adapter,
           migrationsDir: config.migrationsDir,
-          driftCheck: driftCheckFor(config),
+          driftCheck: config.driftCheck,
         })
         console.log(
           r.reversed.length === 0

--- a/packages/db/src/cli/config.ts
+++ b/packages/db/src/cli/config.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import type { Dialect } from '../snapshot/types'
 import type { MigrationAdapter } from '../migrate/adapter'
+import type { DriftBehavior } from '../migrate/drift'
 
 export type MigrationAdapterFactory = () => MigrationAdapter | Promise<MigrationAdapter>
 
@@ -9,6 +10,14 @@ export interface DbConfig {
   schemaPath: string
   migrationsDir: string
   dialect: Dialect
+  /**
+   * How `kick db migrate` reacts when the live DB has schema not recorded
+   * in the migrations (someone ran DDL out of band): `'error'` (default —
+   * refuse), `'warn'` (log + continue), `'ignore'` (skip the check). The
+   * check is dialect-normalised, so SQLite/MySQL's lossy introspection
+   * doesn't false-positive.
+   */
+  driftCheck?: DriftBehavior
   /**
    * Postgres connection string for the built-in pgAdapter path. Read from
    * `db.connectionString` in kick.config.ts, or falls back to the
@@ -35,5 +44,6 @@ export async function resolveDbConfig(opts: { configPath: string }): Promise<DbC
     dialect: db.dialect ?? 'postgres',
     connectionString: db.connectionString ?? process.env.DATABASE_URL,
     adapter: db.adapter,
+    driftCheck: db.driftCheck,
   }
 }

--- a/packages/db/src/emit/mysql.ts
+++ b/packages/db/src/emit/mysql.ts
@@ -126,7 +126,7 @@ function emitAddFk(table: string, fk: ForeignKeySnapshot): string {
 /**
  * Map a Postgres column type string to a MySQL type.
  */
-function mysqlType(pgType: string): string {
+export function mysqlType(pgType: string): string {
   const lower = pgType.toLowerCase().trim()
   const base = lower
     .replace(/\(.*\)/, '')

--- a/packages/db/src/emit/sqlite.ts
+++ b/packages/db/src/emit/sqlite.ts
@@ -223,7 +223,7 @@ function emitInlineFk(fk: ForeignKeySnapshot): string {
 }
 
 /** Map a Postgres column type string to a SQLite affinity type. */
-function sqliteType(pgType: string): string {
+export function sqliteType(pgType: string): string {
   const base = pgType
     .toLowerCase()
     .replace(/\(.*\)/, '')

--- a/packages/db/src/migrate/drift.ts
+++ b/packages/db/src/migrate/drift.ts
@@ -1,7 +1,62 @@
 import { diff } from '../diff/engine'
 import type { Change } from '../diff/types'
-import type { SchemaSnapshot } from '../snapshot/types'
+import type {
+  ColumnSnapshot,
+  Dialect,
+  ForeignKeySnapshot,
+  SchemaSnapshot,
+  TableSnapshot,
+} from '../snapshot/types'
+import { sqliteType } from '../emit/sqlite'
+import { mysqlType } from '../emit/mysql'
 import { MigrationDriftError, type SchemaDiffSummary } from './errors'
+
+/**
+ * SQLite and MySQL introspection is lossy against a code-first snapshot: a
+ * `uuid()` column reads back as `text` / `char(36)`, default expressions
+ * store in a normalised form, and SQLite doesn't preserve FK names.
+ * Comparing the raw snapshots would flag drift on every migration.
+ *
+ * To get meaningful drift on those dialects we canonicalise BOTH sides
+ * into the same shape before diffing: column types run through the emit
+ * type-mapper (so `uuid` and `text` collapse together), defaults are
+ * dropped (too divergent to align reliably), and FK names become a
+ * structural key. This still catches the drift that matters — tables /
+ * columns added or removed, type / nullability / PK changes, indexes —
+ * without false positives. PostgreSQL round-trips faithfully, so it is
+ * compared raw and keeps default-level drift detection.
+ */
+function normalizeForDrift(snap: SchemaSnapshot): SchemaSnapshot {
+  if (snap.dialect === 'postgres') return snap
+
+  const tables: Record<string, TableSnapshot> = {}
+  for (const [name, t] of Object.entries(snap.tables)) {
+    const columns: Record<string, ColumnSnapshot> = {}
+    for (const [cn, c] of Object.entries(t.columns)) {
+      columns[cn] = { ...c, type: canonicalType(c.type, snap.dialect), default: null }
+    }
+    tables[name] = { ...t, columns, foreignKeys: t.foreignKeys.map(canonicalFk) }
+  }
+  return { ...snap, tables }
+}
+
+function canonicalType(type: string, dialect: Dialect): string {
+  if (dialect === 'sqlite') return sqliteType(type).toLowerCase()
+  if (dialect === 'mysql') return mysqlType(type).toLowerCase()
+  return type
+}
+
+/** Replace the FK name with a structural key (SQLite synthesizes names). */
+function canonicalFk(fk: ForeignKeySnapshot): ForeignKeySnapshot {
+  return {
+    name: `${fk.columns.join(',')}=>${fk.refTable}(${fk.refColumns.join(',')})`,
+    columns: fk.columns,
+    refTable: fk.refTable,
+    refColumns: fk.refColumns,
+    onDelete: fk.onDelete,
+    onUpdate: fk.onUpdate,
+  }
+}
 
 export type DriftBehavior = 'error' | 'warn' | 'ignore'
 
@@ -18,8 +73,9 @@ export async function checkDrift(
   if (behavior === 'ignore') return
   // diff(prev, next) reads expected as `prev` and live as `next` so 'added'
   // means "live has it but the snapshot doesn't" — i.e. someone ran DDL
-  // outside the migration runner.
-  const changes = diff(expectedSnapshot, liveSnapshot)
+  // outside the migration runner. Both sides are canonicalised first so
+  // SQLite/MySQL's lossy introspection doesn't flag phantom drift.
+  const changes = diff(normalizeForDrift(expectedSnapshot), normalizeForDrift(liveSnapshot))
   if (changes.length === 0) return
 
   const summary = summarize(changes)


### PR DESCRIPTION
## Why

Drift detection (catching schema changed out-of-band, outside the migration runner) was Postgres-only. SQLite/MySQL `migrate` skipped it entirely — they had no `introspect()` until recently, and even with it, their introspection is **lossy** against a code-first snapshot (`uuid()` → `text` / `char(36)`, defaults normalise, SQLite drops FK names), so a raw comparison flags drift on *every* migration. This makes drift work on all three dialects.

## What

`checkDrift` now **canonicalises both sides** before diffing (for non-PG dialects):

- column **types** run through the emit type-mapper (`uuid` and `text` collapse to the same thing);
- **defaults** are dropped (too divergent to align: `(lower(...))` vs `lower(...)`, `false` vs `0`);
- **FK names** become a structural key (SQLite synthesizes names).

What survives the normalization still catches the drift that matters: tables/columns **added or removed**, **type / nullability / PK** changes, **indexes**. PostgreSQL round-trips faithfully → compared raw, keeping default-level drift.

New `db.driftCheck` config option (`'error'` default | `'warn'` | `'ignore'`) on `kick.config.ts` / `kickjs-db.config.ts` to tune it.

## Behaviour change

SQLite/MySQL `migrate` previously skipped drift; it now defaults to `'error'` like Postgres.

## Verified

- **Unit** (`drift-normalize`, 3): a DSL snapshot vs its lossy introspection → **no drift**; a real added column → drift; a real type change (`text`→`integer`) → drift.
- **End-to-end** on a live `dev.db`: clean `migrate up` passes the drift check (no false positive on uuid↔text / boolean↔integer); an out-of-band `ALTER TABLE tasks ADD COLUMN rogue` → **"Schema drift detected: 1 added"**.

db **429** tests.

## db engine — complete
emit ✅ · introspect ✅ · drift ✅ — all three across postgres / sqlite / mysql.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `db.driftCheck` configuration option to control how SQLite and MySQL migrations handle detected schema drift ('error', 'warn', or 'ignore').

* **Bug Fixes**
  * Enhanced drift detection for SQLite and MySQL by comparing introspected schemas and normalizing type and default differences to reduce false positives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->