### PR TITLE
docs(db): reflect multi-dialect emit / introspect / drift completion

### DIFF
--- a/docs/db/architecture.md
+++ b/docs/db/architecture.md
@@ -808,6 +808,15 @@ The original roadmap (M0–M7) was time-ordered around a v6.0.0 GA cut. M0–M5 
 
 API reference docs for the whole db family (db + db-pg + db-sqlite + db-mysql) shipped at the same time as the M5 line. Three guide pages live in `docs/guide/` (schema types, relational queries, extensions).
 
+#### Post-M5 — multi-dialect migration completion (5.x minors)
+
+The migration engine is now symmetric across all three node dialects:
+
+- **SQL emit** — `kick db generate` emits dialect-correct DDL for PostgreSQL, SQLite (incl. the safe **table rebuild** for column alters / FK changes SQLite's `ALTER TABLE` can't express), and MySQL (`MODIFY COLUMN`, `DROP FOREIGN KEY`, backtick idents). Dispatched by dialect in `generate()`.
+- **Introspection** — `introspect()` implemented for all three (`information_schema` for PG/MySQL, `sqlite_master` + `PRAGMA` for SQLite), powering `kick db introspect`.
+- **Drift detection** — works on all three. SQLite/MySQL introspection is lossy vs a code-first schema, so `checkDrift` canonicalises both sides (types through the emit mapper, defaults dropped, FK names structural) before diffing — meaningful drift, no false positives. Tunable via `db.driftCheck`.
+- **CLI surface** — the `kick db` commands + db typegen ship from `@forinda/kickjs-db/cli` (`dbCliPlugin`) on the `@forinda/kickjs-cli-kit` contract, plus a standalone `kickjs-db` bin and `defineKickDbConfig` (mergeable config). `kick db migrate review <id>` keeps the REVIEWED markers + journal hash in sync.
+
 ### Remaining work, in priority order
 
 The order is the **adoption-blocker ranking** from the post-M5 gap audit. Each item is sized + sequenced so it can ship as a standalone minor on 5.x.

--- a/docs/guide/database/cli.md
+++ b/docs/guide/database/cli.md
@@ -70,12 +70,25 @@ export default defineKickDbConfig({
   schemaPath: 'src/db/schema.ts',
   migrationsDir: 'db/migrations',
   adapter: () => sqliteAdapter({ database: new Database('dev.db') }),
+  // How `migrate` reacts to out-of-band schema changes (drift):
+  // 'error' (default) | 'warn' | 'ignore'.
+  driftCheck: 'error',
 })
 ```
 
 `defineKickDbConfig` is the same shape as the `kick.config.ts` `db` block,
 so a config authored once drops into either place. `.ts` configs load via
 jiti; `.js` / `.mjs` / `.json` work without it.
+
+### Drift detection
+
+`kick db migrate` introspects the live database and compares it to the
+last applied snapshot — if someone ran DDL out of band, it stops (`'error'`)
+or logs (`'warn'`). It works on all three dialects; SQLite/MySQL
+introspection is lossy against a code-first schema (`uuid()` reads back as
+`text` / `char(36)`), so the comparison normalises both sides and never
+false-positives on the type difference. Set `driftCheck: 'ignore'` to skip
+it entirely.
 
 ## Config helpers
 

--- a/docs/guide/database/drivers.md
+++ b/docs/guide/database/drivers.md
@@ -74,7 +74,8 @@ Both factories take a `better-sqlite3` handle (or any structurally compatible ru
 Notes:
 
 - `db.query.X.findMany({ with })` works. SQLite returns JSON aggregation as TEXT; `createDbClient` transparently parses it back into JS objects, so you never see the encoded form.
-- **`introspect()` is not implemented in v1** — it throws `KickDbError` with code `KICK_DB_INTROSPECT_NOT_SUPPORTED`. Set `driftCheck: 'off'` (or `'ignore'`) on the runner until a follow-up lands.
+- **`introspect()` works** — `kick db introspect` reverse-engineers the live database into a schema file, and `kick db migrate` runs dialect-normalised drift detection. Introspected types reflect SQLite affinities (a `uuid()` column reads back as `text`), so introspection is best for reverse-engineering; drift comparison normalises both sides to avoid false positives.
+- **`kick db generate` emits SQLite DDL** — including the safe table-rebuild for column alters / FK changes SQLite's `ALTER TABLE` can't express.
 - The built-in CLI adapter only resolves Postgres from `connectionString`. For SQLite migrations, supply an `adapter` factory in the `db:` block (see [Migrations → Non-Postgres dialects](./migrations#non-postgres-dialects)).
 
 ## MySQL / MariaDB — `@forinda/kickjs-db/mysql`
@@ -111,13 +112,14 @@ Notes:
 - **MySQL 8.0+ / MariaDB 10.5+ required.** The relational query layer compiles to `JSON_ARRAYAGG`, which shipped in those versions. `mysqlAdapter()` checks the version lazily on first connection and throws `KickDbError` (`KICK_DB_RELATIONAL_NOT_SUPPORTED`) on older servers. The version parser detects MariaDB vs MySQL and applies the correct floor.
 - Like SQLite, JSON aggregation returns TEXT and is parsed back transparently.
 - **Multi-statement migrations** — mysql2's default `query()` rejects multi-statement SQL. The adapter splits generated migration blobs at top-level `;` boundaries (respecting string literals and comments) so they apply against default mysql2 settings.
-- **`introspect()` is not implemented in v1** — throws `KICK_DB_INTROSPECT_NOT_SUPPORTED`. Set `driftCheck: 'off'`.
+- **`introspect()` works** — `kick db introspect` reverse-engineers the live database (via `information_schema`) and `kick db migrate` runs dialect-normalised drift detection. Introspected types reflect the declared MySQL types (`uuid()` reads back as `char(36)`).
+- **`kick db generate` emits MySQL DDL** — backtick identifiers, `MODIFY COLUMN` alters, `DROP FOREIGN KEY`, MySQL type mapping.
 - The package exports helpers for custom tooling: `parseMysqlVersion(version)`, `parseMysqlMajorVersion(version)`, and `splitMysqlStatements(sql)`.
 
 ## Choosing a dialect
 
 - **PostgreSQL** — the default and most complete. Choose it unless you have a specific reason not to: full introspection / drift detection, the richest column-type set (enums, vectors, full-text), and the built-in CLI path.
-- **SQLite** — zero-dependency local / embedded use, fast tests (`:memory:`). Relational queries work; introspection / drift detection don't yet.
+- **SQLite** — zero-dependency local / embedded use, fast tests (`:memory:`). Full migration support including `generate` (with table rebuilds), `introspect`, and drift detection.
 - **MySQL / MariaDB** — when your infrastructure is already MySQL. Mind the 8.0 / 10.5 floor for relational queries.
 
 ## Capability summary
@@ -127,6 +129,9 @@ Notes:
 | Query builder (`selectFrom`, …) |    ✅    |   ✅    |       ✅        |
 | Transactions + savepoints       |    ✅    |   ✅    |       ✅        |
 | Relational `db.query`           |    ✅    |   ✅    | ✅ (8.0+/10.5+) |
+| `kick db generate` (SQL emit)   |    ✅    |   ✅    |       ✅        |
 | Built-in CLI migrate adapter    |    ✅    | factory |     factory     |
-| `introspect()` / drift          |    ✅    |   ❌    |       ❌        |
+| `introspect()` + drift          |    ✅    |   ✅¹   |       ✅¹       |
 | `@forinda/kickjs-db/pg` types   |    ✅    |    —    |        —        |
+
+¹ SQLite/MySQL introspection is lossy against a code-first schema (`uuid()` → `text` / `char(36)`); drift comparison normalises both sides so it doesn't false-positive.

--- a/docs/guide/database/migrations.md
+++ b/docs/guide/database/migrations.md
@@ -155,8 +155,10 @@ kick db introspect --out src/db/schema.ts
 kick db introspect --json
 ```
 
-::: warning Postgres-only introspection in v1
-`introspect()` is implemented for Postgres. SQLite and MySQL throw `KickDbError` with code `KICK_DB_INTROSPECT_NOT_SUPPORTED` — set `driftCheck: 'off'` (or `'ignore'`) on those dialects until a follow-up lands the introspection walk.
+`introspect()` is implemented for all three dialects (Postgres via `information_schema`, SQLite via `sqlite_master` + `PRAGMA`, MySQL via `information_schema`).
+
+::: tip Lossy types on SQLite / MySQL
+SQLite and MySQL don't preserve the code-first type (a `uuid()` column reads back as `text` / `char(36)`), so introspection is best for **reverse-engineering** an existing database. Drift detection accounts for this — it normalises both sides before comparing, so it never false-positives on the type difference. Tune it per-project with `db.driftCheck` (`'error'` default, `'warn'`, or `'ignore'`).
 :::
 
 ## Non-Postgres dialects


### PR DESCRIPTION
## Why

This session completed the db migration engine for all three dialects (SQLite/MySQL emit, introspect ×3, SQLite table-rebuild, normalized drift — #332–#339). The docs still claimed `introspect()` was "not implemented in v1" and told users to set `driftCheck: 'off'` for SQLite/MySQL. This brings them current.

## What

- **drivers.md** — SQLite + MySQL `introspect()` now work (was "not implemented in v1 — throws `KICK_DB_INTROSPECT_NOT_SUPPORTED`"); `kick db generate` emits dialect DDL; capability table updated (`introspect` + drift ✅ for all three, with a lossy-types footnote); "Choosing a dialect" no longer says SQLite drift "doesn't work yet".
- **migrations.md** — replaced the "Postgres-only introspection in v1" warning with the all-dialect reality + the lossy-types / `db.driftCheck` note.
- **cli.md** — documented drift detection + the new `db.driftCheck` option (`'error'` | `'warn'` | `'ignore'`).
- **architecture.md** — added a post-M5 note recording the symmetric multi-dialect engine (emit, introspect, drift, the `@forinda/kickjs-db/cli` surface + standalone bin + `defineKickDbConfig`).

No stale `not implemented in v1` / `driftCheck: 'off'` / `INTROSPECT_NOT_SUPPORTED` claims remain in the db docs. `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
