### PR TITLE
fix(cli-kit): add repository metadata for npm provenance

### DIFF
--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -43,6 +43,15 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/forinda/kick-js.git",
+    "directory": "packages/cli-kit"
+  },
+  "homepage": "https://forinda.github.io/kick-js/",
+  "bugs": {
+    "url": "https://github.com/forinda/kick-js/issues"
+  },
   "license": "MIT",
   "author": "Felix Orinda",
   "engines": {


### PR DESCRIPTION
## Why

`@forinda/kickjs-cli-kit@0.1.0` failed to publish in the release run:

```
E422 422 Unprocessable Entity — Error verifying sigstore provenance bundle:
Failed to validate repository information: package.json: "repository.url" is "",
expected to match "https://github.com/forinda/kick-js" from provenance
```

The new package was scaffolded without the `repository` block, which provenance-backed (OIDC) publishes require.

## What

Add the same `repository` / `homepage` / `bugs` metadata every other `@forinda/kickjs-*` package carries, pointing at `packages/cli-kit`. The other 6 packages in that release published fine (`kickjs@5.16.0`, `kickjs-db@6.1.0`, `kickjs-cli@6.0.0`, `kickjs-db-pg/-sqlite/-mysql`); only cli-kit was blocked. This unblocks future releases. (0.1.0 itself is being published manually with the fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm package metadata with repository information, homepage URL, and issue tracker link for improved package discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->