### PR TITLE
docs(cli-kit): add README + LICENSE; changeset to re-sync publish

### DIFF
--- a/.changeset/cli-kit-readme.md
+++ b/.changeset/cli-kit-readme.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-cli-kit': patch
+---
+
+Add a README and bundle the LICENSE in the published package. (0.1.0 was published manually without provenance; this re-syncs the package with the changesets release flow so the next publish ships the docs + a provenance attestation.)

--- a/packages/cli-kit/LICENSE
+++ b/packages/cli-kit/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Felix Orinda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli-kit/README.md
+++ b/packages/cli-kit/README.md
@@ -79,16 +79,16 @@ export default [
 
 ## Contract surface
 
-| Export                   | Purpose                                                                   |
-| ------------------------ | ------------------------------------------------------------------------- |
-| `defineCliPlugin(p)`     | Declare a CLI plugin: `name` + `register()` / `commands` / `typegens` / `generators`. |
-| `defineGenerator(spec)`  | Declare a `kick g <name>` scaffolder (returns the spec, typed).            |
-| `KickCliPlugin<TConfig>` | The plugin shape. `TConfig` is the host config type (`ctx.config`).       |
-| `KickCliPluginContext`   | What `register()` receives: `cwd`, `projectRoot`, `config`, `log`.        |
-| `GeneratorSpec` + co.    | `GeneratorContext` / `GeneratorFile` / `GeneratorArg` / `GeneratorFlag`.  |
-| `KickCommandDefinition`  | A declarative shell-handler command (the `commands` field shape).         |
-| `CliTypegen`             | Structural typegen shape (the CLI's `TypegenPlugin` satisfies it).        |
-| `KickPluginConflictError`| Thrown on duplicate plugin / command / typegen / generator ids.           |
+| Export                    | Purpose                                                                               |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| `defineCliPlugin(p)`      | Declare a CLI plugin: `name` + `register()` / `commands` / `typegens` / `generators`. |
+| `defineGenerator(spec)`   | Declare a `kick g <name>` scaffolder (returns the spec, typed).                       |
+| `KickCliPlugin<TConfig>`  | The plugin shape. `TConfig` is the host config type (`ctx.config`).                   |
+| `KickCliPluginContext`    | What `register()` receives: `cwd`, `projectRoot`, `config`, `log`.                    |
+| `GeneratorSpec` + co.     | `GeneratorContext` / `GeneratorFile` / `GeneratorArg` / `GeneratorFlag`.              |
+| `KickCommandDefinition`   | A declarative shell-handler command (the `commands` field shape).                     |
+| `CliTypegen`              | Structural typegen shape (the CLI's `TypegenPlugin` satisfies it).                    |
+| `KickPluginConflictError` | Thrown on duplicate plugin / command / typegen / generator ids.                       |
 
 ## License
 

--- a/packages/cli-kit/README.md
+++ b/packages/cli-kit/README.md
@@ -1,0 +1,95 @@
+# @forinda/kickjs-cli-kit
+
+The shared CLI-plugin contract for KickJS. Defines the types and helpers a package implements to ship `kick`-compatible commands, generators, and typegens — without depending on the full `@forinda/kickjs-cli`.
+
+This is a tiny, dependency-free package (one `commander` peer). You only need it if you're **building** a CLI plugin; app authors never import it directly.
+
+## Why this package exists
+
+The kick CLI mounts first-party plugins (the database tooling, for example). If those packages imported `defineCliPlugin` from `@forinda/kickjs-cli` to describe their commands, that would form a dependency cycle — the CLI already depends on them. Hoisting the **contract** into a standalone package both sides import breaks the cycle:
+
+```
+@forinda/kickjs-cli  ─┐
+                      ├─►  @forinda/kickjs-cli-kit   (contract only)
+@forinda/kickjs-db   ─┘
+```
+
+`@forinda/kickjs-cli` re-exports the whole contract, so `import { defineCliPlugin } from '@forinda/kickjs-cli'` keeps working for app-side `kick.config.ts` plugins.
+
+## Install
+
+```bash
+pnpm add @forinda/kickjs-cli-kit commander
+```
+
+`commander` is a peer dependency (the host CLI provides the `Command` your plugin registers against).
+
+## Quick start
+
+### A CLI plugin
+
+```ts
+import { defineCliPlugin } from '@forinda/kickjs-cli-kit'
+
+export const helloPlugin = defineCliPlugin({
+  name: 'my-org/hello',
+  register(program, ctx) {
+    program
+      .command('hello <name>')
+      .description('Say hello')
+      .action((name: string) => {
+        console.log(`Hello, ${name}! (project: ${ctx.projectRoot})`)
+      })
+  },
+})
+```
+
+Mount it in `kick.config.ts`:
+
+```ts
+import { defineConfig } from '@forinda/kickjs-cli'
+import { helloPlugin } from './tools/hello-plugin'
+
+export default defineConfig({ plugins: [helloPlugin] })
+```
+
+```bash
+kick hello world
+```
+
+### A `kick g <name>` generator
+
+```ts
+import { defineGenerator } from '@forinda/kickjs-cli-kit'
+
+export default [
+  defineGenerator({
+    name: 'widget',
+    description: 'Scaffold a widget',
+    args: [{ name: 'name', required: true }],
+    files: (ctx) => [
+      {
+        path: `src/widgets/${ctx.kebab}.ts`,
+        content: `export class ${ctx.pascal}Widget {}\n`,
+      },
+    ],
+  }),
+]
+```
+
+## Contract surface
+
+| Export                   | Purpose                                                                   |
+| ------------------------ | ------------------------------------------------------------------------- |
+| `defineCliPlugin(p)`     | Declare a CLI plugin: `name` + `register()` / `commands` / `typegens` / `generators`. |
+| `defineGenerator(spec)`  | Declare a `kick g <name>` scaffolder (returns the spec, typed).            |
+| `KickCliPlugin<TConfig>` | The plugin shape. `TConfig` is the host config type (`ctx.config`).       |
+| `KickCliPluginContext`   | What `register()` receives: `cwd`, `projectRoot`, `config`, `log`.        |
+| `GeneratorSpec` + co.    | `GeneratorContext` / `GeneratorFile` / `GeneratorArg` / `GeneratorFlag`.  |
+| `KickCommandDefinition`  | A declarative shell-handler command (the `commands` field shape).         |
+| `CliTypegen`             | Structural typegen shape (the CLI's `TypegenPlugin` satisfies it).        |
+| `KickPluginConflictError`| Thrown on duplicate plugin / command / typegen / generator ids.           |
+
+## License
+
+MIT © Felix Orinda

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -20,7 +20,9 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
     "build": "tsdown",


### PR DESCRIPTION
## Why

`@forinda/kickjs-cli-kit@0.1.0` was published **manually** (the automated release failed on a missing `repository.url`, fixed in #341). That manual publish has **no README** on npm and **no provenance attestation** (provenance is OIDC/CI-only).

## What

- **README.md** — house-style docs (why the package exists, install, plugin + generator quick starts, contract surface table).
- **LICENSE** — copy the repo's MIT license into the package, and list `README.md` + `LICENSE` in `files`.
- **Changeset** (patch → `0.1.1`) — so the changesets release flow republishes via OIDC, restoring provenance and shipping the README.

Net: the next release run re-syncs cli-kit with the automated flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)