### PR TITLE
chore: gitignore tutorials/ (keep local-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ superpowers/
 # `**/` so the rule fires inside any nested project, not just root.
 **/.kickjs/
 examples/
+# Tutorials + generated thumbnails — authored locally, not tracked
+tutorials/


### PR DESCRIPTION
Keep the `tutorials/` folder + generated thumbnails local (content/marketing assets), not tracked in the repo. Supersedes #346.