### PR TITLE
fix: typegen/type-safety hardening (db array brands, dev error surfacing, route fallback warnings, deprecations)

### DIFF
--- a/.changeset/cli-add-catalog-refresh.md
+++ b/.changeset/cli-add-catalog-refresh.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+Refresh the `kick add` catalog. `ai` (`@forinda/kickjs-ai` + zod) and `auth` (`@forinda/kickjs-auth` + jsonwebtoken) are now resolvable — `kick add auth` previously reported "Unknown packages" despite the help text suggesting it. Deprecated entries (`auth` → BYO auth via context contributors, `drizzle`/`prisma` → `@forinda/kickjs-db`) still install but print a migration warning and are flagged in `kick add --list --all`. Catalog resolution is exposed as a pure `planAddPackages()` helper with a drift-guard test that fails if an entry stops matching a published workspace package.

--- a/.changeset/cli-dev-typegen-error-surfacing.md
+++ b/.changeset/cli-dev-typegen-error-surfacing.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+`kick dev` no longer silently swallows typegen failures in watch mode. A failed scan or plugin pass now prints a deduplicated console warning ("types in .kickjs/types may be stale") and broadcasts a `kickjs:typegen-error` custom HMR event for DevTools/overlays. Repeated identical failures stay quiet until the error changes or a pass succeeds again.

--- a/.changeset/cli-info-real-versions.md
+++ b/.changeset/cli-info-real-versions.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+`kick info` now reports real data instead of a hardcoded three-package "workspace" list: the CLI's own version, plus every `@forinda/kickjs*` dependency the project declares with the version actually installed in `node_modules` (falling back to the declared range when not installed) and a `[DEPRECATED]` flag for packages the `kick add` catalog marks as deprecated. `kick -v` now works as an alias for `-V` / `--version`.

--- a/.changeset/cli-route-schema-fallback-warnings.md
+++ b/.changeset/cli-route-schema-fallback-warnings.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+`kick typegen` now warns when a route decorator's wired `body`/`query`/`params` schema cannot be statically resolved and the generated `KickRoutes` type silently falls back to `unknown` (or URL-pattern params). The warning names the controller, method, route, and schema identifier, and suggests exporting the schema with a static import specifier. No warning is emitted when no schema is wired or when `typegen.schemaValidator` is `false`.

--- a/.changeset/db-array-brand-preservation.md
+++ b/.changeset/db-array-brand-preservation.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-db': patch
+---
+
+Preserve `.notNull()` / `.primaryKey()` / `.default()` brands through `.array()`. Previously `integer().notNull().array()` silently dropped the NOT NULL marker, so `SchemaToTypes` emitted `number[] | null` for a NOT NULL column (and `.default(...).array()` lost the `Generated<T>` insert-optionality wrapper). Brand-last chains (`.array().notNull()`) were and remain correct.

--- a/.changeset/deprecate-auth.md
+++ b/.changeset/deprecate-auth.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-auth': patch
+---
+
+Mark the package as deprecated — auth is moving to BYO (bring-your-own): compose `@LoadAuthUser` / `@RequireRole` / `@Public` from `defineContextDecorator` and `defineAdapter` (see the BYO Auth recipe in the docs). Importing the package now prints a one-time console warning (suppress with `KICKJS_SUPPRESS_DEPRECATION=1`) and the entry module carries `@deprecated` JSDoc. The package will be removed in a future major.

--- a/.changeset/deprecate-prisma-drizzle.md
+++ b/.changeset/deprecate-prisma-drizzle.md
@@ -3,4 +3,4 @@
 '@forinda/kickjs-drizzle': patch
 ---
 
-Mark both packages as deprecated in favor of `@forinda/kickjs-db`. Importing either now prints a one-time console warning (suppress with `KICKJS_SUPPRESS_DEPRECATION=1`) and the entry modules carry `@deprecated` JSDoc so editors flag usages. Both packages will be removed in a future major.
+Mark both packages as deprecated. They were early-adoption adapters and are no longer maintained — `@forinda/kickjs-db` is the supported DB layer going forward. Importing either now prints a one-time console warning (suppress with `KICKJS_SUPPRESS_DEPRECATION=1`) and the entry modules carry `@deprecated` JSDoc so editors flag usages. Both packages will be removed in a future major.

--- a/.changeset/deprecate-prisma-drizzle.md
+++ b/.changeset/deprecate-prisma-drizzle.md
@@ -3,4 +3,4 @@
 '@forinda/kickjs-drizzle': patch
 ---
 
-Mark both packages as deprecated. They were early-adoption adapters and are no longer maintained — `@forinda/kickjs-db` is the supported DB layer going forward. Importing either now prints a one-time console warning (suppress with `KICKJS_SUPPRESS_DEPRECATION=1`) and the entry modules carry `@deprecated` JSDoc so editors flag usages. Both packages will be removed in a future major.
+Mark both packages as deprecated. They were early-adoption adapters and are no longer maintained — wire the ORM directly in your app (BYO), or use `@forinda/kickjs-db`, the built-in Kick ORM, if you prefer to skip external ORMs. Importing either now prints a one-time console warning (suppress with `KICKJS_SUPPRESS_DEPRECATION=1`) and the entry modules carry `@deprecated` JSDoc so editors flag usages. Both packages will be removed in a future major.

--- a/.changeset/deprecate-prisma-drizzle.md
+++ b/.changeset/deprecate-prisma-drizzle.md
@@ -1,0 +1,6 @@
+---
+'@forinda/kickjs-prisma': patch
+'@forinda/kickjs-drizzle': patch
+---
+
+Mark both packages as deprecated in favor of `@forinda/kickjs-db`. Importing either now prints a one-time console warning (suppress with `KICKJS_SUPPRESS_DEPRECATION=1`) and the entry modules carry `@deprecated` JSDoc so editors flag usages. Both packages will be removed in a future major.

--- a/.changeset/vite-hmr-typed-global.md
+++ b/.changeset/vite-hmr-typed-global.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-vite': patch
+---
+
+Type the `globalThis.__kickjs_container` access in the HMR plugin instead of casting through `any`. No runtime behavior change.

--- a/packages/auth/__tests__/deprecation.test.ts
+++ b/packages/auth/__tests__/deprecation.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import { warnDeprecated } from '../src/deprecation'
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('deprecation warning', () => {
+  it('warns by default and points at the BYO auth recipe', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(warnDeprecated({})).toBe(true)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0][0]).toContain('deprecated')
+    expect(spy.mock.calls[0][0]).toContain('BYO')
+    expect(spy.mock.calls[0][0]).toContain('defineContextDecorator')
+  })
+
+  it('is suppressed via KICKJS_SUPPRESS_DEPRECATION=1 or =true', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(warnDeprecated({ KICKJS_SUPPRESS_DEPRECATION: '1' })).toBe(false)
+    expect(warnDeprecated({ KICKJS_SUPPRESS_DEPRECATION: 'true' })).toBe(false)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('still warns when KICKJS_SUPPRESS_DEPRECATION=0', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(warnDeprecated({ KICKJS_SUPPRESS_DEPRECATION: '0' })).toBe(true)
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/auth/src/deprecation.ts
+++ b/packages/auth/src/deprecation.ts
@@ -1,7 +1,7 @@
 /**
  * One-time runtime deprecation notice. Lives in its own module (rather
  * than inline in index.ts) so it is unit-testable without importing the
- * adapters, which pull the optional `@prisma/client` peer.
+ * strategies, which pull optional peers (jsonwebtoken, argon2, bcrypt).
  */
 export function warnDeprecated(env: NodeJS.ProcessEnv = process.env): boolean {
   // Match the documented contract (`=1`) plus the repo-wide env-flag
@@ -10,9 +10,9 @@ export function warnDeprecated(env: NodeJS.ProcessEnv = process.env): boolean {
   const flag = env.KICKJS_SUPPRESS_DEPRECATION
   if (flag === '1' || flag === 'true') return false
   console.warn(
-    '[kickjs] @forinda/kickjs-prisma is deprecated. It was an early-adoption adapter and ' +
-      'is no longer maintained — wire Prisma directly in your app (BYO), or use ' +
-      '@forinda/kickjs-db, the built-in Kick ORM, if you prefer to skip external ORMs. ' +
+    '[kickjs] @forinda/kickjs-auth is deprecated — auth is moving to BYO (bring-your-own): ' +
+      'compose @LoadAuthUser / @RequireRole / @Public from defineContextDecorator and ' +
+      'defineAdapter (see the BYO Auth recipe in the KickJS docs). ' +
       'This package will be removed in a future major. ' +
       'Set KICKJS_SUPPRESS_DEPRECATION=1 to silence this warning.',
   )

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,4 +1,17 @@
+/**
+ * @deprecated `@forinda/kickjs-auth` is deprecated — auth is moving to
+ * BYO (bring-your-own). Compose `@LoadAuthUser` / `@RequireRole` /
+ * `@Public` from `defineContextDecorator` and `defineAdapter` (see the
+ * BYO Auth recipe in the KickJS docs). This package will be removed in
+ * a future major.
+ *
+ * @module @forinda/kickjs-auth
+ */
 import 'reflect-metadata'
+
+import { warnDeprecated } from './deprecation'
+
+warnDeprecated()
 
 // Types & interfaces
 export {

--- a/packages/cli/__tests__/add-registry.test.ts
+++ b/packages/cli/__tests__/add-registry.test.ts
@@ -1,0 +1,105 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+import { describe, it, expect } from 'vitest'
+
+import { PACKAGE_REGISTRY, planAddPackages } from '../src/commands/add'
+
+const WORKSPACE_PACKAGES_DIR = resolve(__dirname, '../..')
+
+/** name → package.json for every workspace package under packages/ */
+function workspaceManifests(): Map<string, { name: string; private?: boolean }> {
+  const out = new Map<string, { name: string; private?: boolean }>()
+  for (const dir of readdirSync(WORKSPACE_PACKAGES_DIR)) {
+    const p = join(WORKSPACE_PACKAGES_DIR, dir, 'package.json')
+    if (!existsSync(p)) continue
+    const manifest = JSON.parse(readFileSync(p, 'utf-8'))
+    out.set(manifest.name, manifest)
+  }
+  return out
+}
+
+describe('PACKAGE_REGISTRY catalog health', () => {
+  const manifests = workspaceManifests()
+
+  it('covers auth and ai', () => {
+    expect(PACKAGE_REGISTRY.auth?.pkg).toBe('@forinda/kickjs-auth')
+    expect(PACKAGE_REGISTRY.ai?.pkg).toBe('@forinda/kickjs-ai')
+  })
+
+  it('marks drizzle and prisma as deprecated with a kickjs-db migration hint', () => {
+    expect(PACKAGE_REGISTRY.drizzle?.deprecated).toContain('@forinda/kickjs-db')
+    expect(PACKAGE_REGISTRY.prisma?.deprecated).toContain('@forinda/kickjs-db')
+  })
+
+  it('marks auth as deprecated with the BYO migration hint', () => {
+    expect(PACKAGE_REGISTRY.auth?.deprecated).toContain('BYO')
+  })
+
+  it('every first-party entry points at an existing, non-private workspace package', () => {
+    for (const [name, entry] of Object.entries(PACKAGE_REGISTRY)) {
+      if (!entry.pkg.startsWith('@forinda/')) continue
+      const manifest = manifests.get(entry.pkg)
+      expect(
+        manifest,
+        `registry entry '${name}' → ${entry.pkg} not found in workspace`,
+      ).toBeDefined()
+      expect(manifest?.private ?? false, `registry entry '${name}' → ${entry.pkg} is private`).toBe(
+        false,
+      )
+    }
+  })
+
+  it('never offers the merged db-* dialect shims or internal support packages', () => {
+    const offered = new Set(Object.values(PACKAGE_REGISTRY).map((e) => e.pkg))
+    for (const shim of [
+      '@forinda/kickjs-db-pg',
+      '@forinda/kickjs-db-mysql',
+      '@forinda/kickjs-db-sqlite',
+      '@forinda/kickjs-cli-kit',
+      '@forinda/kickjs-devtools-kit',
+    ]) {
+      expect(offered.has(shim), `${shim} should not be in the catalog`).toBe(false)
+    }
+  })
+})
+
+describe('planAddPackages', () => {
+  it('resolves a known package with its peers', () => {
+    const plan = planAddPackages(['ws'], false)
+    expect(plan.prodDeps).toContain('@forinda/kickjs-ws')
+    expect(plan.prodDeps).toContain('socket.io')
+    expect(plan.unknown).toEqual([])
+    expect(plan.warnings).toEqual([])
+  })
+
+  it('auth still installs (with jsonwebtoken) but carries a deprecation warning', () => {
+    const plan = planAddPackages(['auth'], false)
+    expect(plan.prodDeps).toContain('@forinda/kickjs-auth')
+    expect(plan.prodDeps).toContain('jsonwebtoken')
+    expect(plan.warnings.length).toBe(1)
+    expect(plan.warnings[0]).toContain('BYO')
+  })
+
+  it('collects unknown names without dropping known ones', () => {
+    const plan = planAddPackages(['nope', 'swagger'], false)
+    expect(plan.unknown).toEqual(['nope'])
+    expect(plan.prodDeps).toContain('@forinda/kickjs-swagger')
+  })
+
+  it('warns when adding a deprecated package but still installs it', () => {
+    const plan = planAddPackages(['prisma'], false)
+    expect(plan.prodDeps).toContain('@forinda/kickjs-prisma')
+    expect(plan.warnings.length).toBe(1)
+    expect(plan.warnings[0]).toContain('prisma')
+    expect(plan.warnings[0]).toContain('@forinda/kickjs-db')
+  })
+
+  it('honours the dev flag and per-entry dev defaults', () => {
+    const devForced = planAddPackages(['swagger'], true)
+    expect(devForced.devDeps).toContain('@forinda/kickjs-swagger')
+
+    const devByDefault = planAddPackages(['testing'], false)
+    expect(devByDefault.devDeps).toContain('@forinda/kickjs-testing')
+  })
+})

--- a/packages/cli/__tests__/info-packages.test.ts
+++ b/packages/cli/__tests__/info-packages.test.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+import { resolveInstalledKickPackages } from '../src/commands/info'
+
+let project: string
+
+beforeEach(() => {
+  project = mkdtempSync(join(tmpdir(), 'kick-info-'))
+})
+
+afterEach(() => {
+  rmSync(project, { recursive: true, force: true })
+})
+
+function writeManifest(dir: string, manifest: object): void {
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'package.json'), JSON.stringify(manifest, null, 2))
+}
+
+describe('resolveInstalledKickPackages', () => {
+  it('lists @forinda/kickjs* deps with installed versions from node_modules', () => {
+    writeManifest(project, {
+      name: 'app',
+      dependencies: { '@forinda/kickjs': '^5.16.0', express: '^5.1.0' },
+      devDependencies: { '@forinda/kickjs-cli': '^6.0.1' },
+    })
+    writeManifest(join(project, 'node_modules', '@forinda', 'kickjs'), {
+      name: '@forinda/kickjs',
+      version: '5.16.0',
+    })
+
+    const pkgs = resolveInstalledKickPackages(project)
+    expect(pkgs.map((p) => p.name)).toEqual(['@forinda/kickjs', '@forinda/kickjs-cli'])
+
+    const kickjs = pkgs.find((p) => p.name === '@forinda/kickjs')!
+    expect(kickjs.installed).toBe('5.16.0')
+    expect(kickjs.declared).toBe('^5.16.0')
+
+    // cli not present in node_modules — falls back to declared range only
+    const cli = pkgs.find((p) => p.name === '@forinda/kickjs-cli')!
+    expect(cli.installed).toBeNull()
+    expect(cli.declared).toBe('^6.0.1')
+  })
+
+  it('flags deprecated packages from the kick add catalog', () => {
+    writeManifest(project, {
+      name: 'app',
+      dependencies: {
+        '@forinda/kickjs-prisma': '^6.0.0',
+        '@forinda/kickjs-db': '^6.1.1',
+      },
+    })
+
+    const pkgs = resolveInstalledKickPackages(project)
+    expect(pkgs.find((p) => p.name === '@forinda/kickjs-prisma')?.deprecated).toBe(true)
+    expect(pkgs.find((p) => p.name === '@forinda/kickjs-db')?.deprecated).toBe(false)
+  })
+
+  it('returns empty outside a project', () => {
+    expect(resolveInstalledKickPackages(join(project, 'does-not-exist'))).toEqual([])
+  })
+
+  it('ignores non-kickjs scoped packages', () => {
+    writeManifest(project, {
+      name: 'app',
+      dependencies: { '@forinda/other-lib': '^1.0.0', zod: '^4.0.0' },
+    })
+    expect(resolveInstalledKickPackages(project)).toEqual([])
+  })
+})

--- a/packages/cli/__tests__/render-routes-warnings.test.ts
+++ b/packages/cli/__tests__/render-routes-warnings.test.ts
@@ -39,6 +39,24 @@ describe('renderRoutes fallback warnings', () => {
     expect(onWarn.mock.calls[0][0]).toContain('createTaskSchema')
   })
 
+  it('query fallback warning names the @ApiQueryParams-derived shape when one exists', () => {
+    const onWarn = vi.fn()
+    renderRoutes(
+      [
+        route({
+          querySchema: { identifier: 'listTasksQuery', source: null },
+          queryFilterable: ['status'],
+        }),
+      ],
+      OUT,
+      'zod',
+      { onWarn },
+    )
+    expect(onWarn).toHaveBeenCalledTimes(1)
+    expect(onWarn.mock.calls[0][0]).toContain('@ApiQueryParams')
+    expect(onWarn.mock.calls[0][0]).not.toContain("'unknown'")
+  })
+
   it('does not warn when no schema is wired', () => {
     const onWarn = vi.fn()
     renderRoutes([route({})], OUT, 'zod', { onWarn })

--- a/packages/cli/__tests__/render-routes-warnings.test.ts
+++ b/packages/cli/__tests__/render-routes-warnings.test.ts
@@ -1,0 +1,70 @@
+import path from 'node:path'
+
+import { describe, it, expect, vi } from 'vitest'
+
+import { renderRoutes } from '../src/typegen/render/routes'
+import type { DiscoveredRoute } from '../src/typegen/scanner'
+
+const OUT = path.resolve('.kickjs/types/kick__routes.ts')
+
+const route = (overrides: Partial<DiscoveredRoute>): DiscoveredRoute => ({
+  controller: 'TaskController',
+  method: 'create',
+  httpMethod: 'POST',
+  path: '/',
+  pathParams: [],
+  queryFilterable: null,
+  querySortable: null,
+  querySearchable: null,
+  bodySchema: null,
+  querySchema: null,
+  paramsSchema: null,
+  filePath: path.resolve('src/modules/tasks/task.controller.ts'),
+  relativePath: 'modules/tasks/task.controller.ts',
+  ...overrides,
+})
+
+describe('renderRoutes fallback warnings', () => {
+  it('warns when a wired body schema has an unresolvable source', () => {
+    const onWarn = vi.fn()
+    const src = renderRoutes(
+      [route({ bodySchema: { identifier: 'createTaskSchema', source: null } })],
+      OUT,
+      'zod',
+      { onWarn },
+    )
+    expect(src).toContain('body: unknown')
+    expect(onWarn).toHaveBeenCalledTimes(1)
+    expect(onWarn.mock.calls[0][0]).toContain('TaskController.create')
+    expect(onWarn.mock.calls[0][0]).toContain('createTaskSchema')
+  })
+
+  it('does not warn when no schema is wired', () => {
+    const onWarn = vi.fn()
+    renderRoutes([route({})], OUT, 'zod', { onWarn })
+    expect(onWarn).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when the schema validator is disabled', () => {
+    const onWarn = vi.fn()
+    renderRoutes(
+      [route({ bodySchema: { identifier: 'createTaskSchema', source: null } })],
+      OUT,
+      false,
+      { onWarn },
+    )
+    expect(onWarn).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when the schema resolves (same-file source)', () => {
+    const onWarn = vi.fn()
+    const src = renderRoutes(
+      [route({ bodySchema: { identifier: 'createTaskSchema', source: '' } })],
+      OUT,
+      'zod',
+      { onWarn },
+    )
+    expect(src).toContain('infer<typeof _S0>')
+    expect(onWarn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/__tests__/typegen-error-reporter.test.ts
+++ b/packages/cli/__tests__/typegen-error-reporter.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { createTypegenErrorReporter } from '../src/commands/typegen-error-reporter'
+
+describe('createTypegenErrorReporter', () => {
+  it('emits on first failure, message includes source and error', () => {
+    const emit = vi.fn()
+    const r = createTypegenErrorReporter(emit)
+    r.report('scan', new Error('boom'))
+    expect(emit).toHaveBeenCalledTimes(1)
+    expect(emit.mock.calls[0][0]).toContain('scan')
+    expect(emit.mock.calls[0][0]).toContain('boom')
+  })
+
+  it('suppresses repeats of the same message for the same source', () => {
+    const emit = vi.fn()
+    const r = createTypegenErrorReporter(emit)
+    r.report('scan', new Error('boom'))
+    r.report('scan', new Error('boom'))
+    expect(emit).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-emits when the message changes', () => {
+    const emit = vi.fn()
+    const r = createTypegenErrorReporter(emit)
+    r.report('scan', new Error('boom'))
+    r.report('scan', new Error('different'))
+    expect(emit).toHaveBeenCalledTimes(2)
+  })
+
+  it('clear() re-arms so an identical failure emits again', () => {
+    const emit = vi.fn()
+    const r = createTypegenErrorReporter(emit)
+    r.report('scan', new Error('boom'))
+    r.clear('scan')
+    r.report('scan', new Error('boom'))
+    expect(emit).toHaveBeenCalledTimes(2)
+  })
+
+  it('tracks sources independently', () => {
+    const emit = vi.fn()
+    const r = createTypegenErrorReporter(emit)
+    r.report('scan', new Error('boom'))
+    r.report('plugins', new Error('boom'))
+    expect(emit).toHaveBeenCalledTimes(2)
+  })
+
+  it('stringifies non-Error rejection values', () => {
+    const emit = vi.fn()
+    const r = createTypegenErrorReporter(emit)
+    r.report('scan', 'string failure')
+    expect(emit.mock.calls[0][0]).toContain('string failure')
+  })
+})

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -58,7 +58,10 @@ async function main() {
 
   program.showHelpAfterError()
 
-  await program.parseAsync(process.argv)
+  // Commander registers a single short flag for version (`-V`); accept
+  // the lowercase `-v` people type by reflex as an alias.
+  const argv = process.argv.map((arg) => (arg === '-v' ? '--version' : arg))
+  await program.parseAsync(argv)
 }
 
 main().catch((err) => {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -122,14 +122,14 @@ export const PACKAGE_REGISTRY: Record<string, PackageEntry> = {
     peers: ['drizzle-orm'],
     description: 'Drizzle ORM adapter + query builder',
     deprecated:
-      'early-adoption adapter, no longer maintained — @forinda/kickjs-db is the supported DB layer (`kick add db` / pg / sqlite / mysql)',
+      'early-adoption adapter, no longer maintained — wire Drizzle directly (BYO), or use @forinda/kickjs-db, the built-in Kick ORM (`kick add db` / pg / sqlite / mysql)',
   },
   prisma: {
     pkg: '@forinda/kickjs-prisma',
     peers: ['@prisma/client'],
     description: 'Prisma adapter + query builder',
     deprecated:
-      'early-adoption adapter, no longer maintained — @forinda/kickjs-db is the supported DB layer (`kick add db` / pg / sqlite / mysql)',
+      'early-adoption adapter, no longer maintained — wire Prisma directly (BYO), or use @forinda/kickjs-db, the built-in Kick ORM (`kick add db` / pg / sqlite / mysql)',
   },
 
   // Real-time

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -15,10 +15,16 @@ interface PackageEntry {
    * future package-removal flows refuse to drop them.
    */
   core?: boolean
+  /**
+   * Set when the package still installs but should no longer be the
+   * default choice. The string is the migration hint shown both in
+   * `kick add --list --all` and as a warning when the package is added.
+   */
+  deprecated?: string
 }
 
 /** Registry of KickJS packages and their required peer dependencies */
-const PACKAGE_REGISTRY: Record<string, PackageEntry> = {
+export const PACKAGE_REGISTRY: Record<string, PackageEntry> = {
   // Core (always installed by kick new — required for the framework to run)
   kickjs: {
     pkg: '@forinda/kickjs',
@@ -64,6 +70,24 @@ const PACKAGE_REGISTRY: Record<string, PackageEntry> = {
     description: 'Yup schema validation — wrap with fromYup()',
   },
 
+  // Auth — deprecated in favour of BYO (bring-your-own) auth composed
+  // from context contributors. Still installable for existing projects;
+  // JWT is the common path, so it co-installs jsonwebtoken.
+  auth: {
+    pkg: '@forinda/kickjs-auth',
+    peers: ['jsonwebtoken'],
+    description: 'JWT, API key, OAuth strategies, @Public, @Roles (+ optional argon2/bcryptjs)',
+    deprecated:
+      'auth is moving to BYO — compose @LoadAuthUser/@RequireRole/@Public from defineContextDecorator (see the BYO Auth recipe in the docs)',
+  },
+
+  // AI — requires zod (^4) for tool/schema definitions.
+  ai: {
+    pkg: '@forinda/kickjs-ai',
+    peers: ['zod'],
+    description: 'AI toolkit — LLM providers, tool definitions from controllers',
+  },
+
   // API
   swagger: {
     pkg: '@forinda/kickjs-swagger',
@@ -97,11 +121,15 @@ const PACKAGE_REGISTRY: Record<string, PackageEntry> = {
     pkg: '@forinda/kickjs-drizzle',
     peers: ['drizzle-orm'],
     description: 'Drizzle ORM adapter + query builder',
+    deprecated:
+      'early-adoption adapter, no longer maintained — @forinda/kickjs-db is the supported DB layer (`kick add db` / pg / sqlite / mysql)',
   },
   prisma: {
     pkg: '@forinda/kickjs-prisma',
     peers: ['@prisma/client'],
     description: 'Prisma adapter + query builder',
+    deprecated:
+      'early-adoption adapter, no longer maintained — @forinda/kickjs-db is the supported DB layer (`kick add db` / pg / sqlite / mysql)',
   },
 
   // Real-time
@@ -271,7 +299,8 @@ export function printPackageList(all = false): void {
   const formatRow = ([name, info]: [string, PackageEntry]): string => {
     const padded = name.padEnd(maxName + 2)
     const peers = info.peers.length ? ` (+ ${info.peers.join(', ')})` : ''
-    return `    ${padded} ${info.description}${peers}`
+    const deprecated = info.deprecated ? ` [DEPRECATED — ${info.deprecated}]` : ''
+    return `    ${padded} ${info.description}${peers}${deprecated}`
   }
 
   console.log('\n  Core packages (always installed by `kick new`):\n')
@@ -285,9 +314,48 @@ export function printPackageList(all = false): void {
     console.log('  Run `kick add --list --all` for the full catalog.')
   }
 
-  console.log('\n  Usage: kick add auth drizzle swagger')
+  console.log('\n  Usage: kick add ai db swagger')
   console.log('         kick add queue:bullmq')
   console.log()
+}
+
+export interface AddPlan {
+  prodDeps: string[]
+  devDeps: string[]
+  unknown: string[]
+  /** Deprecation notices for requested entries — print, then install anyway. */
+  warnings: string[]
+}
+
+/**
+ * Pure resolution step for `kick add` — maps requested catalog names to
+ * the npm packages (plus peers) to install, split prod/dev. Kept free
+ * of I/O so the catalog rules (dev defaults, deprecations, unknown
+ * handling) are unit-testable without spawning a package manager.
+ */
+export function planAddPackages(packages: string[], forceDev: boolean): AddPlan {
+  const prodDeps = new Set<string>()
+  const devDeps = new Set<string>()
+  const unknown: string[] = []
+  const warnings: string[] = []
+
+  for (const name of packages) {
+    const entry = PACKAGE_REGISTRY[name]
+    if (!entry) {
+      unknown.push(name)
+      continue
+    }
+    if (entry.deprecated) {
+      warnings.push(`'${name}' (${entry.pkg}) is deprecated — ${entry.deprecated}`)
+    }
+    const target = forceDev || entry.dev ? devDeps : prodDeps
+    target.add(entry.pkg)
+    for (const peer of entry.peers) {
+      target.add(peer)
+    }
+  }
+
+  return { prodDeps: [...prodDeps], devDeps: [...devDeps], unknown, warnings }
 }
 
 export function registerListCommand(program: Command): void {
@@ -318,33 +386,21 @@ export function registerAddCommand(program: Command): void {
 
       const { pm, source } = await resolvePackageManagerWithSource(opts.pm)
       console.log(`\n  Using ${pm} (resolved from ${source})`)
-      const forceDevFlag = opts.dev
-      const prodDeps = new Set<string>()
-      const devDeps = new Set<string>()
-      const unknown: string[] = []
+      const { prodDeps, devDeps, unknown, warnings } = planAddPackages(packages, Boolean(opts.dev))
 
-      for (const name of packages) {
-        const entry = PACKAGE_REGISTRY[name]
-        if (!entry) {
-          unknown.push(name)
-          continue
-        }
-        const target = forceDevFlag || entry.dev ? devDeps : prodDeps
-        target.add(entry.pkg)
-        for (const peer of entry.peers) {
-          target.add(peer)
-        }
+      for (const warning of warnings) {
+        console.warn(`\n  WARNING: ${warning}`)
       }
 
       if (unknown.length > 0) {
         console.log(`\n  Unknown packages: ${unknown.join(', ')}`)
         console.log('  Run "kick add --list" to see available packages.\n')
-        if (prodDeps.size === 0 && devDeps.size === 0) return
+        if (prodDeps.length === 0 && devDeps.length === 0) return
       }
 
       // Install production dependencies
-      if (prodDeps.size > 0) {
-        const deps = Array.from(prodDeps)
+      if (prodDeps.length > 0) {
+        const deps = prodDeps
         const cmd = `${pm} add ${deps.join(' ')}`
         console.log(`\n  Installing ${deps.length} dependency(ies):`)
         for (const dep of deps) console.log(`    + ${dep}`)
@@ -357,8 +413,8 @@ export function registerAddCommand(program: Command): void {
       }
 
       // Install dev dependencies
-      if (devDeps.size > 0) {
-        const deps = Array.from(devDeps)
+      if (devDeps.length > 0) {
+        const deps = devDeps
         const cmd = `${pm} add -D ${deps.join(' ')}`
         console.log(`\n  Installing ${deps.length} dev dependency(ies):`)
         for (const dep of deps) console.log(`    + ${dep} (dev)`)

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -1,22 +1,127 @@
+import { existsSync, readFileSync } from 'node:fs'
 import { platform, release, arch } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import type { Command } from 'commander'
+
+import { PACKAGE_REGISTRY } from './add'
+
+/**
+ * The CLI's own version, read from its package.json — same pattern as
+ * cli.ts (`__dirname/../package.json` resolves from dist/ to the
+ * package root in both the bundled and source layouts).
+ */
+function ownVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const pkg = JSON.parse(readFileSync(join(here, '..', 'package.json'), 'utf-8'))
+    return pkg.version ?? 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+/** npm package names the `kick add` catalog marks as deprecated. */
+const DEPRECATED_PKGS = new Set(
+  Object.values(PACKAGE_REGISTRY)
+    .filter((entry) => entry.deprecated)
+    .map((entry) => entry.pkg),
+)
+
+export interface InstalledPackage {
+  name: string
+  /** Version actually installed in node_modules, if resolvable */
+  installed: string | null
+  /** Range declared in the project's package.json */
+  declared: string | null
+  /** Deprecated per the `kick add` catalog */
+  deprecated: boolean
+}
+
+/**
+ * Collect every `@forinda/kickjs*` dependency the project declares,
+ * pairing the declared range with the version actually installed in
+ * `node_modules` (null when not installed — e.g. before the first
+ * install, or a hoisted/virtual-store layout we can't see through).
+ */
+export function resolveInstalledKickPackages(projectDir: string): InstalledPackage[] {
+  const manifestPath = join(projectDir, 'package.json')
+  if (!existsSync(manifestPath)) return []
+  let manifest: { dependencies?: Record<string, string>; devDependencies?: Record<string, string> }
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+  } catch {
+    return []
+  }
+  const declared: Record<string, string> = {
+    ...manifest.dependencies,
+    ...manifest.devDependencies,
+  }
+  return Object.keys(declared)
+    .filter((name) => name === '@forinda/kickjs' || name.startsWith('@forinda/kickjs-'))
+    .toSorted()
+    .map((name) => {
+      let installed: string | null = null
+      const installedManifest = join(projectDir, 'node_modules', ...name.split('/'), 'package.json')
+      if (existsSync(installedManifest)) {
+        try {
+          installed = JSON.parse(readFileSync(installedManifest, 'utf-8')).version ?? null
+        } catch {
+          // unreadable — fall back to the declared range
+        }
+      }
+      return {
+        name,
+        installed,
+        declared: declared[name] ?? null,
+        deprecated: DEPRECATED_PKGS.has(name),
+      }
+    })
+}
+
+/** Nearest ancestor directory (including `fromDir`) with a package.json. */
+function findProjectRoot(fromDir: string): string | null {
+  let dir = fromDir
+  while (true) {
+    if (existsSync(join(dir, 'package.json'))) return dir
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
 
 export function registerInfoCommand(program: Command): void {
   program
     .command('info')
     .description('Print system and framework info')
     .action(() => {
-      console.log(`
-  KickJS CLI
+      const lines: string[] = [
+        '',
+        `  KickJS CLI v${ownVersion()}`,
+        '',
+        '  System:',
+        `    OS:       ${platform()} ${release()} (${arch()})`,
+        `    Node:     ${process.version}`,
+      ]
 
-  System:
-    OS:       ${platform()} ${release()} (${arch()})
-    Node:     ${process.version}
+      const projectRoot = findProjectRoot(process.cwd())
+      const packages = projectRoot ? resolveInstalledKickPackages(projectRoot) : []
 
-  Packages:
-    @forinda/kickjs          workspace
-    @forinda/kickjs-vite     workspace
-    @forinda/kickjs-cli      workspace
-`)
+      if (!projectRoot) {
+        lines.push('', '  Packages:  (not inside a project — no package.json found)')
+      } else if (packages.length === 0) {
+        lines.push('', `  Packages:  (no @forinda/kickjs* dependencies in ${projectRoot})`)
+      } else {
+        lines.push('', '  Packages:')
+        const width = Math.max(...packages.map((p) => p.name.length))
+        for (const pkg of packages) {
+          const version = pkg.installed ?? `${pkg.declared ?? '?'} (declared — not installed)`
+          const flag = pkg.deprecated ? '  [DEPRECATED — see `kick add --list --all`]' : ''
+          lines.push(`    ${pkg.name.padEnd(width + 2)} ${version}${flag}`)
+        }
+      }
+
+      lines.push('')
+      console.log(lines.join('\n'))
     })
 }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -7,6 +7,7 @@ import { loadKickConfig } from '../config'
 import { runTypegen, writeTypegenArtifacts } from '../typegen'
 import { runAllPluginTypegens } from '../typegen/run-plugins'
 import { buildAssets } from '../asset-manager/build'
+import { createTypegenErrorReporter } from './typegen-error-reporter'
 
 /**
  * Start the Vite dev server with @forinda/kickjs-vite plugin.
@@ -137,6 +138,18 @@ async function startDevServer(
   // the directory walk entirely (see `scanProjectIncremental`). The
   // previous code passed only the last file to a full re-scan; batching
   // a `changed`/`removed` set both fixes that and unlocks the fast path.
+  // Surface watch-mode typegen failures. Deduped so a broken schema
+  // doesn't spam a warning on every save; broadcast as a custom HMR
+  // event so DevTools / overlays can subscribe (same pattern as the
+  // `kickjs:hmr` event in @forinda/kickjs-vite).
+  const typegenErrors = createTypegenErrorReporter((message) => {
+    console.warn(message)
+    server.hot.send({
+      type: 'custom',
+      event: 'kickjs:typegen-error',
+      data: { message, timestamp: Date.now() },
+    })
+  })
   let typegenTimer: ReturnType<typeof setTimeout> | null = null
   const pendingChanged = new Set<string>()
   const pendingRemoved = new Set<string>()
@@ -203,14 +216,17 @@ async function startDevServer(
         // Plugin pipeline runs separately just below; opting out here
         // avoids double-running it on every debounced trigger.
         runPlugins: false,
-      }).catch(() => {})
+      })
+        .then(() => typegenErrors.clear('scan'))
+        .catch((err) => typegenErrors.report('scan', err))
       // Plugin typegens piggy-back on the same debounce — they re-emit
       // their `kick__*` files when sources (or templates) change. silent
       // so the dev console stays quiet; artifacts (.gitignore + sweep)
       // run after the pass.
       runAllPluginTypegens({ cwd, config: devConfig, silent: true, changedFiles: delta })
         .then((r) => writeTypegenArtifacts(typesOutDir, r, true))
-        .catch(() => {})
+        .then(() => typegenErrors.clear('plugins'))
+        .catch((err) => typegenErrors.report('plugins', err))
       // Incrementally refresh the dist asset copies + manifest, but only
       // when an asset file actually changed this window. buildAssets
       // skips up-to-date files, so this is a cheap stat sweep + the

--- a/packages/cli/src/commands/typegen-error-reporter.ts
+++ b/packages/cli/src/commands/typegen-error-reporter.ts
@@ -1,0 +1,31 @@
+/**
+ * Deduplicating reporter for typegen failures in `kick dev` watch mode.
+ *
+ * The watch pipeline used to swallow errors entirely (`.catch(() => {})`),
+ * which left adopters debugging stale `.kickjs/types` with no signal.
+ * This reporter warns on every NEW failure message per source, stays
+ * quiet for repeats of the same message (each save in a broken state
+ * would otherwise re-print it), and re-arms once the source succeeds
+ * again so a recurring failure after a fix re-warns.
+ */
+export interface TypegenErrorReporter {
+  /** Report a failure for `source`; emits only if the message changed. */
+  report(source: string, err: unknown): void
+  /** Mark `source` healthy — the next failure emits even if identical. */
+  clear(source: string): void
+}
+
+export function createTypegenErrorReporter(emit: (message: string) => void): TypegenErrorReporter {
+  const lastMessage = new Map<string, string>()
+  return {
+    report(source, err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (lastMessage.get(source) === msg) return
+      lastMessage.set(source, msg)
+      emit(`  kick typegen: ${source} pass failed (${msg}) — types in .kickjs/types may be stale`)
+    },
+    clear(source) {
+      lastMessage.delete(source)
+    },
+  }
+}

--- a/packages/cli/src/typegen/builtin/routes.ts
+++ b/packages/cli/src/typegen/builtin/routes.ts
@@ -40,7 +40,9 @@ export const kickRoutesTypegen = (): TypegenPlugin => ({
     // hoisted-import path computation inside renderRoutes needs the
     // absolute target so it can re-relativise schema imports.
     const outFile = path.resolve(ctx.cwd, '.kickjs/types/kick__routes.ts')
-    return renderRoutes(scan.routes, outFile, schemaValidator)
+    return renderRoutes(scan.routes, outFile, schemaValidator, {
+      onWarn: (msg) => ctx.log.warn(msg),
+    })
   },
 })
 

--- a/packages/cli/src/typegen/render/routes.ts
+++ b/packages/cli/src/typegen/render/routes.ts
@@ -79,10 +79,19 @@ export {}
       // type silently degrades, so say so. A disabled validator is an
       // intentional opt-out and stays quiet.
       if (schema && schemaValidator !== false) {
+        // Name the ACTUAL fallback per field: params → URL-pattern params,
+        // query → the @ApiQueryParams-derived shape when one exists
+        // (renderQueryShape), otherwise 'unknown'.
+        const fallback =
+          field === 'params'
+            ? 'URL-pattern params'
+            : field === 'query' && m.queryFilterable !== null
+              ? 'the @ApiQueryParams-derived query shape'
+              : `'unknown'`
         opts.onWarn?.(
           `route ${m.controller}.${m.method} (${m.httpMethod} ${m.path}): ` +
             `${field} schema '${schema.identifier}' could not be statically resolved — ` +
-            `falling back to ${field === 'params' ? 'URL-pattern params' : `'unknown'`}. ` +
+            `falling back to ${fallback}. ` +
             `Export the schema from the controller file or import it with a static specifier.`,
         )
       }

--- a/packages/cli/src/typegen/render/routes.ts
+++ b/packages/cli/src/typegen/render/routes.ts
@@ -33,6 +33,7 @@ export function renderRoutes(
   routes: DiscoveredRoute[],
   routesOutFile: string,
   schemaValidator: 'zod' | 'kickjs-schema' | false,
+  opts: { onWarn?: (msg: string) => void } = {},
 ): string {
   if (routes.length === 0) {
     return `${ROUTES_HEADER}
@@ -63,16 +64,30 @@ export {}
 
   const renderField = (
     schema: { identifier: string; source: string | null } | null,
-    routeFilePath: string,
+    m: DiscoveredRoute,
+    field: 'body' | 'query' | 'params',
   ): string | null => {
     const alias = planSchemaImport(
       schema,
-      routeFilePath,
+      m.filePath,
       routesOutFile,
       schemaValidator,
       schemaImports,
     )
-    if (!alias) return null
+    if (!alias) {
+      // The adopter wired a schema but we couldn't link it — the emitted
+      // type silently degrades, so say so. A disabled validator is an
+      // intentional opt-out and stays quiet.
+      if (schema && schemaValidator !== false) {
+        opts.onWarn?.(
+          `route ${m.controller}.${m.method} (${m.httpMethod} ${m.path}): ` +
+            `${field} schema '${schema.identifier}' could not be statically resolved — ` +
+            `falling back to ${field === 'params' ? 'URL-pattern params' : `'unknown'`}. ` +
+            `Export the schema from the controller file or import it with a static specifier.`,
+        )
+      }
+      return null
+    }
     if (schemaValidator === 'kickjs-schema') {
       return `import('@forinda/kickjs-schema').InferSchemaOutput<typeof ${alias}>`
     }
@@ -92,9 +107,9 @@ export {}
 
       // Schema-driven types win over the URL-pattern / `unknown` defaults
       // when the user has wired a schema in the route decorator.
-      const bodySchemaType = renderField(m.bodySchema, m.filePath)
-      const querySchemaType = renderField(m.querySchema, m.filePath)
-      const paramsSchemaType = renderField(m.paramsSchema, m.filePath)
+      const bodySchemaType = renderField(m.bodySchema, m, 'body')
+      const querySchemaType = renderField(m.querySchema, m, 'query')
+      const paramsSchemaType = renderField(m.paramsSchema, m, 'params')
 
       const paramsType = paramsSchemaType ?? urlParamsType
       const bodyType = bodySchemaType ?? 'unknown'

--- a/packages/db/__tests__/unit/columns-array-brands.test-d.ts
+++ b/packages/db/__tests__/unit/columns-array-brands.test-d.ts
@@ -1,0 +1,40 @@
+// Type-level companion to columns-array-brands.test.ts. Lives in a
+// `.test-d.ts` file because vitest only enforces expectTypeOf assertions
+// under `--typecheck`, whose include list is `**/*.test-d.ts`.
+//
+// Run: vitest run --typecheck --typecheck.ignoreSourceErrors \
+//        __tests__/unit/columns-array-brands.test-d.ts
+import { describe, it, expectTypeOf } from 'vitest'
+import type { Generated } from 'kysely'
+
+import { integer, varchar, uuid, table } from '../../src/index'
+import type { SchemaToTypes } from '../../src/index'
+
+describe('array() brand preservation (type-level)', () => {
+  it('notNull().array() keeps NOT NULL in the row type', () => {
+    const tags = table('tags', {
+      id: uuid().primaryKey().defaultRandom(),
+      names: varchar(64).notNull().array(),
+      maybe: integer().array(), // no brands — stays nullable
+    })
+    const schema = { tags }
+    type DB = SchemaToTypes<typeof schema>
+
+    expectTypeOf<DB['tags']>().toEqualTypeOf<{
+      id: Generated<string>
+      names: string[]
+      maybe: number[] | null
+    }>()
+  })
+
+  it('default().array() keeps the Generated wrapper', () => {
+    const t = table('t', {
+      id: uuid().primaryKey().defaultRandom(),
+      counts: integer().notNull().default(0).array(),
+    })
+    const schema = { t }
+    type DB = SchemaToTypes<typeof schema>
+
+    expectTypeOf<DB['t']['counts']>().toEqualTypeOf<Generated<number[]>>()
+  })
+})

--- a/packages/db/__tests__/unit/columns-array-brands.test.ts
+++ b/packages/db/__tests__/unit/columns-array-brands.test.ts
@@ -1,0 +1,14 @@
+// Runtime companion to columns-array-brands.test-d.ts — the type-level
+// assertions live there because vitest only enforces them under
+// `--typecheck` (include: `**/*.test-d.ts`).
+import { describe, it, expect } from 'vitest'
+
+import { integer } from '../../src/index'
+
+describe('array() brand preservation (runtime)', () => {
+  it('notNull().array() keeps [] suffix and NOT NULL state', () => {
+    const snap = integer().notNull().array().toJSON('xs')
+    expect(snap.type).toBe('integer[]')
+    expect(snap.nullable).toBe(false)
+  })
+})

--- a/packages/db/src/dsl/columns/types.ts
+++ b/packages/db/src/dsl/columns/types.ts
@@ -77,6 +77,19 @@ export const KICK_NOT_NULL = Symbol.for('@forinda/kickjs-db/NotNull')
 export type NotNullBrand = { readonly [KICK_NOT_NULL]?: true }
 
 /**
+ * Re-attach the nullability / generated brands after a transform that
+ * must return a *new* builder type (e.g. `.array()` widening `T` to
+ * `T[]`). Without this, `integer().notNull().array()` silently dropped
+ * `NotNullBrand` and the row type regressed to `number[] | null`.
+ *
+ * Uses the same `extends` checks as `SchemaToTypes` (client/schema-types.ts)
+ * so detection stays consistent in both directions.
+ */
+export type PreserveBrands<Self, Out> = Out &
+  (Self extends NotNullBrand ? NotNullBrand : unknown) &
+  (Self extends GeneratedBrand ? GeneratedBrand : unknown)
+
+/**
  * Phantom-typed column builder. The `T` generic carries the column's TS
  * value type (number / string / Date / etc.); nullability is tracked via
  * the `NotNullBrand` intersection rather than a class generic so chain
@@ -119,9 +132,9 @@ export class ColumnBuilder<T = unknown> {
     return this
   }
 
-  array(): ColumnBuilder<T[]> {
+  array(): PreserveBrands<this, ColumnBuilder<T[]>> {
     this.state.type = `${this.state.type}[]`
-    return this as unknown as ColumnBuilder<T[]>
+    return this as unknown as PreserveBrands<this, ColumnBuilder<T[]>>
   }
 
   references(

--- a/packages/db/tsconfig.test.json
+++ b/packages/db/tsconfig.test.json
@@ -2,14 +2,13 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
-    "baseUrl": ".",
     "types": [],
     "paths": {
       "@forinda/kickjs": ["../kickjs/src/index.ts"],
       "@forinda/kickjs/*": ["../kickjs/src/*"],
-      "@forinda/kickjs-db": ["src/index.ts"],
-      "@forinda/kickjs-db/pg": ["src/dsl/columns/pg.ts"],
-      "@forinda/kickjs-db/*": ["src/*"]
+      "@forinda/kickjs-db": ["./src/index.ts"],
+      "@forinda/kickjs-db/pg": ["./src/dsl/columns/pg.ts"],
+      "@forinda/kickjs-db/*": ["./src/*"]
     }
   },
   "include": ["src", "__tests__"]

--- a/packages/drizzle/__tests__/deprecation.test.ts
+++ b/packages/drizzle/__tests__/deprecation.test.ts
@@ -13,9 +13,16 @@ describe('deprecation warning', () => {
     expect(spy.mock.calls[0][0]).toContain('deprecated')
   })
 
-  it('is suppressed via KICKJS_SUPPRESS_DEPRECATION', () => {
+  it('is suppressed via KICKJS_SUPPRESS_DEPRECATION=1 or =true', () => {
     const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     expect(warnDeprecated({ KICKJS_SUPPRESS_DEPRECATION: '1' })).toBe(false)
+    expect(warnDeprecated({ KICKJS_SUPPRESS_DEPRECATION: 'true' })).toBe(false)
     expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('still warns when KICKJS_SUPPRESS_DEPRECATION=0', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(warnDeprecated({ KICKJS_SUPPRESS_DEPRECATION: '0' })).toBe(true)
+    expect(spy).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/drizzle/__tests__/deprecation.test.ts
+++ b/packages/drizzle/__tests__/deprecation.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import { warnDeprecated } from '../src/deprecation'
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('deprecation warning', () => {
+  it('warns by default and points at @forinda/kickjs-db', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(warnDeprecated({})).toBe(true)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0][0]).toContain('@forinda/kickjs-db')
+    expect(spy.mock.calls[0][0]).toContain('deprecated')
+  })
+
+  it('is suppressed via KICKJS_SUPPRESS_DEPRECATION', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(warnDeprecated({ KICKJS_SUPPRESS_DEPRECATION: '1' })).toBe(false)
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/drizzle/src/deprecation.ts
+++ b/packages/drizzle/src/deprecation.ts
@@ -4,7 +4,11 @@
  * adapters, which pull the optional `drizzle-orm` peer.
  */
 export function warnDeprecated(env: NodeJS.ProcessEnv = process.env): boolean {
-  if (env.KICKJS_SUPPRESS_DEPRECATION) return false
+  // Match the documented contract (`=1`) plus the repo-wide env-flag
+  // convention (run.ts resolvePolling) — a bare truthy check would make
+  // `KICKJS_SUPPRESS_DEPRECATION=0` suppress too.
+  const flag = env.KICKJS_SUPPRESS_DEPRECATION
+  if (flag === '1' || flag === 'true') return false
   console.warn(
     '[kickjs] @forinda/kickjs-drizzle is deprecated. It was an early-adoption adapter and ' +
       'is no longer maintained — @forinda/kickjs-db (schema DSL + client, dialect subpaths ' +

--- a/packages/drizzle/src/deprecation.ts
+++ b/packages/drizzle/src/deprecation.ts
@@ -6,8 +6,9 @@
 export function warnDeprecated(env: NodeJS.ProcessEnv = process.env): boolean {
   if (env.KICKJS_SUPPRESS_DEPRECATION) return false
   console.warn(
-    '[kickjs] @forinda/kickjs-drizzle is deprecated — the DB layer is consolidated ' +
-      'into @forinda/kickjs-db (schema DSL + client, dialect subpaths /pg /mysql /sqlite). ' +
+    '[kickjs] @forinda/kickjs-drizzle is deprecated. It was an early-adoption adapter and ' +
+      'is no longer maintained — @forinda/kickjs-db (schema DSL + client, dialect subpaths ' +
+      '/pg /mysql /sqlite) is the supported DB layer going forward. ' +
       'This package will be removed in a future major. ' +
       'Set KICKJS_SUPPRESS_DEPRECATION=1 to silence this warning.',
   )

--- a/packages/drizzle/src/deprecation.ts
+++ b/packages/drizzle/src/deprecation.ts
@@ -11,8 +11,8 @@ export function warnDeprecated(env: NodeJS.ProcessEnv = process.env): boolean {
   if (flag === '1' || flag === 'true') return false
   console.warn(
     '[kickjs] @forinda/kickjs-drizzle is deprecated. It was an early-adoption adapter and ' +
-      'is no longer maintained — @forinda/kickjs-db (schema DSL + client, dialect subpaths ' +
-      '/pg /mysql /sqlite) is the supported DB layer going forward. ' +
+      'is no longer maintained — wire Drizzle directly in your app (BYO), or use ' +
+      '@forinda/kickjs-db, the built-in Kick ORM, if you prefer to skip external ORMs. ' +
       'This package will be removed in a future major. ' +
       'Set KICKJS_SUPPRESS_DEPRECATION=1 to silence this warning.',
   )

--- a/packages/drizzle/src/deprecation.ts
+++ b/packages/drizzle/src/deprecation.ts
@@ -1,0 +1,15 @@
+/**
+ * One-time runtime deprecation notice. Lives in its own module (rather
+ * than inline in index.ts) so it is unit-testable without importing the
+ * adapters, which pull the optional `drizzle-orm` peer.
+ */
+export function warnDeprecated(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.KICKJS_SUPPRESS_DEPRECATION) return false
+  console.warn(
+    '[kickjs] @forinda/kickjs-drizzle is deprecated — the DB layer is consolidated ' +
+      'into @forinda/kickjs-db (schema DSL + client, dialect subpaths /pg /mysql /sqlite). ' +
+      'This package will be removed in a future major. ' +
+      'Set KICKJS_SUPPRESS_DEPRECATION=1 to silence this warning.',
+  )
+  return true
+}

--- a/packages/drizzle/src/index.ts
+++ b/packages/drizzle/src/index.ts
@@ -1,3 +1,15 @@
+/**
+ * @deprecated `@forinda/kickjs-drizzle` is deprecated — the DB layer is
+ * consolidated into `@forinda/kickjs-db`. Migrate to the unified schema
+ * DSL + client (`@forinda/kickjs-db`, dialect subpaths `/pg`, `/mysql`,
+ * `/sqlite`). This package will be removed in a future major.
+ *
+ * @module @forinda/kickjs-drizzle
+ */
+import { warnDeprecated } from './deprecation'
+
+warnDeprecated()
+
 export { DrizzleAdapter } from './drizzle.adapter'
 export { DrizzleTenantAdapter } from './drizzle-tenant.adapter'
 export { DrizzleQueryAdapter, toQueryFieldConfig } from './query-adapter'

--- a/packages/drizzle/src/index.ts
+++ b/packages/drizzle/src/index.ts
@@ -1,8 +1,9 @@
 /**
- * @deprecated `@forinda/kickjs-drizzle` is deprecated — the DB layer is
- * consolidated into `@forinda/kickjs-db`. Migrate to the unified schema
- * DSL + client (`@forinda/kickjs-db`, dialect subpaths `/pg`, `/mysql`,
- * `/sqlite`). This package will be removed in a future major.
+ * @deprecated `@forinda/kickjs-drizzle` is deprecated. It was an
+ * early-adoption adapter and is no longer maintained —
+ * `@forinda/kickjs-db` (schema DSL + client, dialect subpaths `/pg`,
+ * `/mysql`, `/sqlite`) is the supported DB layer going forward. This
+ * package will be removed in a future major.
  *
  * @module @forinda/kickjs-drizzle
  */

--- a/packages/drizzle/src/index.ts
+++ b/packages/drizzle/src/index.ts
@@ -1,8 +1,8 @@
 /**
  * @deprecated `@forinda/kickjs-drizzle` is deprecated. It was an
- * early-adoption adapter and is no longer maintained —
- * `@forinda/kickjs-db` (schema DSL + client, dialect subpaths `/pg`,
- * `/mysql`, `/sqlite`) is the supported DB layer going forward. This
+ * early-adoption adapter and is no longer maintained — wire Drizzle
+ * directly in your app (BYO), or use `@forinda/kickjs-db`, the
+ * built-in Kick ORM, if you prefer to skip external ORMs. This
  * package will be removed in a future major.
  *
  * @module @forinda/kickjs-drizzle

--- a/packages/prisma/__tests__/deprecation.test.ts
+++ b/packages/prisma/__tests__/deprecation.test.ts
@@ -13,9 +13,16 @@ describe('deprecation warning', () => {
     expect(spy.mock.calls[0][0]).toContain('deprecated')
   })
 
-  it('is suppressed via KICKJS_SUPPRESS_DEPRECATION', () => {
+  it('is suppressed via KICKJS_SUPPRESS_DEPRECATION=1 or =true', () => {
     const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     expect(warnDeprecated({ KICKJS_SUPPRESS_DEPRECATION: '1' })).toBe(false)
+    expect(warnDeprecated({ KICKJS_SUPPRESS_DEPRECATION: 'true' })).toBe(false)
     expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('still warns when KICKJS_SUPPRESS_DEPRECATION=0', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(warnDeprecated({ KICKJS_SUPPRESS_DEPRECATION: '0' })).toBe(true)
+    expect(spy).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/prisma/__tests__/deprecation.test.ts
+++ b/packages/prisma/__tests__/deprecation.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import { warnDeprecated } from '../src/deprecation'
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('deprecation warning', () => {
+  it('warns by default and points at @forinda/kickjs-db', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(warnDeprecated({})).toBe(true)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0][0]).toContain('@forinda/kickjs-db')
+    expect(spy.mock.calls[0][0]).toContain('deprecated')
+  })
+
+  it('is suppressed via KICKJS_SUPPRESS_DEPRECATION', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(warnDeprecated({ KICKJS_SUPPRESS_DEPRECATION: '1' })).toBe(false)
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/prisma/src/deprecation.ts
+++ b/packages/prisma/src/deprecation.ts
@@ -1,0 +1,15 @@
+/**
+ * One-time runtime deprecation notice. Lives in its own module (rather
+ * than inline in index.ts) so it is unit-testable without importing the
+ * adapters, which pull the optional `@prisma/client` peer.
+ */
+export function warnDeprecated(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.KICKJS_SUPPRESS_DEPRECATION) return false
+  console.warn(
+    '[kickjs] @forinda/kickjs-prisma is deprecated — the DB layer is consolidated ' +
+      'into @forinda/kickjs-db (schema DSL + client, dialect subpaths /pg /mysql /sqlite). ' +
+      'This package will be removed in a future major. ' +
+      'Set KICKJS_SUPPRESS_DEPRECATION=1 to silence this warning.',
+  )
+  return true
+}

--- a/packages/prisma/src/deprecation.ts
+++ b/packages/prisma/src/deprecation.ts
@@ -6,8 +6,9 @@
 export function warnDeprecated(env: NodeJS.ProcessEnv = process.env): boolean {
   if (env.KICKJS_SUPPRESS_DEPRECATION) return false
   console.warn(
-    '[kickjs] @forinda/kickjs-prisma is deprecated — the DB layer is consolidated ' +
-      'into @forinda/kickjs-db (schema DSL + client, dialect subpaths /pg /mysql /sqlite). ' +
+    '[kickjs] @forinda/kickjs-prisma is deprecated. It was an early-adoption adapter and ' +
+      'is no longer maintained — @forinda/kickjs-db (schema DSL + client, dialect subpaths ' +
+      '/pg /mysql /sqlite) is the supported DB layer going forward. ' +
       'This package will be removed in a future major. ' +
       'Set KICKJS_SUPPRESS_DEPRECATION=1 to silence this warning.',
   )

--- a/packages/prisma/src/deprecation.ts
+++ b/packages/prisma/src/deprecation.ts
@@ -4,7 +4,11 @@
  * adapters, which pull the optional `@prisma/client` peer.
  */
 export function warnDeprecated(env: NodeJS.ProcessEnv = process.env): boolean {
-  if (env.KICKJS_SUPPRESS_DEPRECATION) return false
+  // Match the documented contract (`=1`) plus the repo-wide env-flag
+  // convention (run.ts resolvePolling) — a bare truthy check would make
+  // `KICKJS_SUPPRESS_DEPRECATION=0` suppress too.
+  const flag = env.KICKJS_SUPPRESS_DEPRECATION
+  if (flag === '1' || flag === 'true') return false
   console.warn(
     '[kickjs] @forinda/kickjs-prisma is deprecated. It was an early-adoption adapter and ' +
       'is no longer maintained — @forinda/kickjs-db (schema DSL + client, dialect subpaths ' +

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -1,8 +1,9 @@
 /**
- * @deprecated `@forinda/kickjs-prisma` is deprecated — the DB layer is
- * consolidated into `@forinda/kickjs-db`. Migrate to the unified schema
- * DSL + client (`@forinda/kickjs-db`, dialect subpaths `/pg`, `/mysql`,
- * `/sqlite`). This package will be removed in a future major.
+ * @deprecated `@forinda/kickjs-prisma` is deprecated. It was an
+ * early-adoption adapter and is no longer maintained —
+ * `@forinda/kickjs-db` (schema DSL + client, dialect subpaths `/pg`,
+ * `/mysql`, `/sqlite`) is the supported DB layer going forward. This
+ * package will be removed in a future major.
  *
  * @module @forinda/kickjs-prisma
  */

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -1,3 +1,15 @@
+/**
+ * @deprecated `@forinda/kickjs-prisma` is deprecated — the DB layer is
+ * consolidated into `@forinda/kickjs-db`. Migrate to the unified schema
+ * DSL + client (`@forinda/kickjs-db`, dialect subpaths `/pg`, `/mysql`,
+ * `/sqlite`). This package will be removed in a future major.
+ *
+ * @module @forinda/kickjs-prisma
+ */
+import { warnDeprecated } from './deprecation'
+
+warnDeprecated()
+
 export { PrismaAdapter } from './prisma.adapter'
 export { PrismaTenantAdapter } from './prisma-tenant.adapter'
 export { PrismaQueryAdapter } from './query-adapter'

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -1,8 +1,8 @@
 /**
  * @deprecated `@forinda/kickjs-prisma` is deprecated. It was an
- * early-adoption adapter and is no longer maintained —
- * `@forinda/kickjs-db` (schema DSL + client, dialect subpaths `/pg`,
- * `/mysql`, `/sqlite`) is the supported DB layer going forward. This
+ * early-adoption adapter and is no longer maintained — wire Prisma
+ * directly in your app (BYO), or use `@forinda/kickjs-db`, the
+ * built-in Kick ORM, if you prefer to skip external ORMs. This
  * package will be removed in a future major.
  *
  * @module @forinda/kickjs-prisma

--- a/packages/vite/src/hmr-plugin.ts
+++ b/packages/vite/src/hmr-plugin.ts
@@ -249,6 +249,18 @@ export function kickjsHmrPlugin(ctx: PluginContext, hmrOptions: HmrOptions = {})
 }
 
 /**
+ * Shape of the reactive-container handle the KickJS runtime publishes on
+ * `globalThis` for dev-mode HMR. Optional all the way down — the container
+ * only exists after the app has bootstrapped at least once, and older
+ * runtime versions may not expose `invalidate`.
+ */
+interface KickHmrGlobal {
+  __kickjs_container?: {
+    invalidate?: (token: string) => void
+  }
+}
+
+/**
  * Flush accumulated token invalidations.
  *
  * Called after the debounce window closes. Performs:
@@ -270,7 +282,7 @@ function flushInvalidation(
 
   // 1. Invalidate tokens in the reactive container (if available)
   //    container.invalidate() walks the dependency graph and notifies subscribers
-  const container = (globalThis as any).__kickjs_container
+  const container = (globalThis as typeof globalThis & KickHmrGlobal).__kickjs_container
   if (container && typeof container.invalidate === 'function') {
     for (const token of batch) {
       container.invalidate(token)


### PR DESCRIPTION
## Why

Audit of the typegen / dev-workflow type-safety surface found five real gaps. Each is fixed in its own commit with a paired changeset.

## What

- **fix(db):** `.notNull()` / `.default()` brands now survive `.array()` — `integer().notNull().array()` previously typed as `number[] | null` in `SchemaToTypes`. Also fixed `tsconfig.test.json` (`baseUrl` is fatal under TS6), which had been silently disabling the package's vitest typecheck program; the new type assertions live in a `.test-d.ts` file where `vitest --typecheck` enforces them.
- **refactor(vite):** typed the `globalThis.__kickjs_container` HMR access (was `as any`). No runtime change.
- **fix(cli):** `kick dev` watch mode no longer swallows typegen failures — deduplicated console warning + `kickjs:typegen-error` custom HMR event (same pattern as `kickjs:hmr`).
- **feat(cli):** `kick typegen` warns when a wired route schema can't be statically resolved and the generated `KickRoutes` type silently falls back to `unknown`.
- **chore(prisma, drizzle):** runtime + JSDoc deprecation (suppress with `KICKJS_SUPPRESS_DEPRECATION=1`).

## CLI catalog + info (follow-up commits in this PR)

- **feat(cli):** `kick add` catalog refreshed — `ai` and `auth` resolvable (previously "Unknown packages" despite the help text), deprecated entries (`auth` → BYO auth recipe, `drizzle`/`prisma` → early-adoption adapters superseded by `@forinda/kickjs-db`) still install but warn and are flagged in `--list --all`. Pure `planAddPackages()` + drift-guard test (catalog entry must match a published, non-private workspace package).
- **fix(prisma, drizzle):** deprecation wording corrected — they were early-adoption adapters, not merged into kickjs-db.
- **fix(cli):** `kick info` reports the CLI version and real installed `@forinda/kickjs*` versions from node_modules (with declared-range fallback and `[DEPRECATED]` flags) instead of a hardcoded "workspace" list. `kick -v` now aliases `-V`/`--version`.

## Not included (audit items verified already done)

- Branded DI tokens — `createToken<T>()` already phantom-typed via `InjectionToken<T>`.
- `@Value` key constraint — already constrained via `KickEnv` / `ValueKey<K>`.
- Startup typegen error surfacing — already warns; only the watch path was silent.

## Findings surfaced during this work (follow-ups, not addressed here)

- With `tsconfig.test.json` fixed, `vitest --typecheck` reveals ~30 pre-existing type errors across other `packages/db` test files (e.g. `register.test.ts`) that were never enforced. Worth a dedicated cleanup pass, then enabling `--typecheck` in the db test script.
- `packages/cli` has 77 test failures on Windows hosts only (fixture helpers shell out to `ln -sf`; some assertions assume `/` path separators). Linux CI is unaffected.

## Testing

- New unit tests: db array-brand preservation (runtime + `.test-d.ts` type assertions, verified red→green), CLI error reporter (6 cases), route fallback warnings (4 cases, red→green), add-catalog registry + planner (10 cases), kick info package resolution (4 cases), deprecation warnings (2 × 2 cases).
- Per-package `build` + `test` green at every commit for db, vite, prisma, drizzle, and the touched CLI suites. CLI suite otherwise green except the pre-existing Windows-only failures above (verified identical without these changes via `git stash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
