### PR TITLE
test(cli): make the CLI test suite pass on Windows

### DIFF
--- a/packages/cli/__tests__/generator-extension.test.ts
+++ b/packages/cli/__tests__/generator-extension.test.ts
@@ -287,7 +287,8 @@ describe('tryDispatchPluginGenerator', () => {
     expect(result).not.toBeNull()
     expect(result!.source).toBe('@my-org/kickjs-cqrs')
     expect(result!.files).toHaveLength(1)
-    expect(result!.files[0]).toMatch(/generated\/create-order\.command\.ts$/)
+    // Normalize — the dispatcher returns OS-native paths (backslashes on Windows).
+    expect(result!.files[0].replaceAll('\\', '/')).toMatch(/generated\/create-order\.command\.ts$/)
   })
 
   it('first-match-wins when two plugins declare the same generator name', async () => {

--- a/packages/cli/__tests__/helpers.ts
+++ b/packages/cli/__tests__/helpers.ts
@@ -14,8 +14,8 @@
  * @module @forinda/kickjs-cli/__tests__/helpers
  */
 
-import { execSync, spawnSync, type SpawnSyncReturns } from 'node:child_process'
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs'
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, symlinkSync } from 'node:fs'
 import { join, resolve, dirname } from 'node:path'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
@@ -94,10 +94,10 @@ export function createFixtureProject(name = 'kick-cli-test'): string {
   // directly (not the dist) to avoid needing a build step in tests.
   mkdirSync(join(dir, 'node_modules', '@forinda'), { recursive: true })
   const kickjsSrc = join(WORKSPACE_ROOT, 'packages', 'kickjs')
-  execSync(`ln -sf "${kickjsSrc}" "${join(dir, 'node_modules', '@forinda', 'kickjs')}"`)
+  linkDir(kickjsSrc, join(dir, 'node_modules', '@forinda', 'kickjs'))
   // Some scaffolds also import from @forinda/kickjs-swagger
   const swaggerSrc = join(WORKSPACE_ROOT, 'packages', 'swagger')
-  execSync(`ln -sf "${swaggerSrc}" "${join(dir, 'node_modules', '@forinda', 'kickjs-swagger')}"`)
+  linkDir(swaggerSrc, join(dir, 'node_modules', '@forinda', 'kickjs-swagger'))
 
   // Symlink @types/node and zod from the workspace so tsc can resolve
   // both the `types: ['node']` reference and any `import { z } from 'zod'`
@@ -137,13 +137,26 @@ function linkWorkspaceDep(fixtureDir: string, pkgName: string): void {
           })()
         : join(fixtureDir, 'node_modules', pkgName)
       try {
-        execSync(`ln -sf "${candidate}" "${target}"`)
+        linkDir(candidate, target)
       } catch {
         // ignore
       }
       return
     }
   }
+}
+
+/**
+ * Cross-platform replacement for `ln -sf <target> <link>` on directories.
+ * `ln` doesn't exist on a stock Windows host, so the previous execSync
+ * shell-out failed every fixture-based test there. `symlinkSync` with
+ * type 'junction' works without admin rights on Windows (junctions are
+ * directory-only, which is all we link); the type argument is ignored
+ * on POSIX. `-f` semantics via the rmSync prelude.
+ */
+function linkDir(target: string, linkPath: string): void {
+  rmSync(linkPath, { recursive: true, force: true })
+  symlinkSync(target, linkPath, 'junction')
 }
 
 /** Recursively delete a fixture directory (best-effort, never throws) */

--- a/packages/cli/__tests__/migrate-modules.test.ts
+++ b/packages/cli/__tests__/migrate-modules.test.ts
@@ -231,7 +231,9 @@ export const modules: AppModuleClass[] = []`,
   })
 
   it('finds all three module-declaration files (current + legacy index)', async () => {
-    const files = await findModuleFiles(join(dir, 'modules'))
+    // findModuleFiles returns OS-native absolute paths — normalize so
+    // the suffix assertions hold on Windows too.
+    const files = (await findModuleFiles(join(dir, 'modules'))).map((f) => f.replaceAll('\\', '/'))
     expect(files.length).toBe(4)
     expect(files.some((f) => f.endsWith('users/user.module.ts'))).toBe(true)
     expect(files.some((f) => f.endsWith('tasks/index.ts'))).toBe(true)
@@ -246,7 +248,9 @@ export const modules: AppModuleClass[] = []`,
   })
 
   it('findStyleDriftModules picks up class form in legacy index.ts files', async () => {
-    const drift = await findStyleDriftModules(join(dir, 'modules'), 'define')
+    const drift = (await findStyleDriftModules(join(dir, 'modules'), 'define')).map((p) =>
+      p.replaceAll('\\', '/'),
+    )
     // Three of the four files actually have a `class … implements AppModule`
     // declaration; the orders/index.ts only re-exports.
     expect(drift.length).toBeGreaterThanOrEqual(2)


### PR DESCRIPTION
﻿## Why

The CLI test suite had 77 failures on Windows hosts — fixture helpers shelled out to `ln -sf` (does not exist on stock Windows), which broke fixture creation and cascaded across 10 test files. Three further tests asserted forward-slash path suffixes against OS-native paths. Linux CI was unaffected; local development on Windows had no usable suite.

## What

- `__tests__/helpers.ts`: replaced the three `execSync('ln -sf ...')` calls with a `linkDir()` helper using `fs.symlinkSync(target, link, 'junction')` — junctions work without admin rights on Windows and the type argument is ignored on POSIX, so behavior on Linux/macOS is unchanged.
- `migrate-modules.test.ts` / `generator-extension.test.ts`: normalize backslashes before suffix/regex assertions (product functions intentionally return OS-native absolute paths used for fs operations — the tests were the inconsistent side).

Test-only change — no changeset (nothing published changes).

## Result

`pnpm --filter @forinda/kickjs-cli test` on Windows 11: **39/39 files, 406/406 tests, 0 failures** (previously 77 failures / 10 files). 114s wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated file path assertions to normalize separators across different operating systems.
  * Improved test fixture setup to use native Node.js APIs for creating symbolic links instead of shell commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->