### PR TITLE
fix(db): clear test-suite type errors and enforce vitest --typecheck

### DIFF
--- a/.changeset/db-sqlite-introspect-compat.md
+++ b/.changeset/db-sqlite-introspect-compat.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-db': patch
+---
+
+`SqliteIntrospectDb.prepare(...).all` is no longer method-generic. better-sqlite3 v12's own `Statement.all(...params): Result[]` is non-generic, so the previous generic signature made a real `Database` instance structurally incompatible with `introspectSqlite(db)` — adopters had to cast. Row typing now happens inside the introspector; passing a better-sqlite3 `Database` directly type-checks.

--- a/packages/db/__tests__/unit/abort-signal-unit.test.ts
+++ b/packages/db/__tests__/unit/abort-signal-unit.test.ts
@@ -62,7 +62,7 @@ interface ExecuteCall {
   signal: AbortSignal | undefined
 }
 
-function patchExecuteToObserve(client: { qb: Kysely<unknown> }) {
+function patchExecuteToObserve(client: { qb: Kysely<any> }) {
   const calls: ExecuteCall[] = []
   const original = (client.qb as any).executeQuery
   ;(client.qb as any).executeQuery = vi.fn(async (compiled: any, opts?: any) => {
@@ -77,7 +77,7 @@ function patchExecuteToObserve(client: { qb: Kysely<unknown> }) {
   }
 }
 
-function patchExecuteToReject(client: { qb: Kysely<unknown> }, err: unknown) {
+function patchExecuteToReject(client: { qb: Kysely<any> }, err: unknown) {
   const original = (client.qb as any).executeQuery
   ;(client.qb as any).executeQuery = vi.fn(async () => {
     throw err

--- a/packages/db/__tests__/unit/default-preservation.test.ts
+++ b/packages/db/__tests__/unit/default-preservation.test.ts
@@ -184,12 +184,12 @@ describe('M5.A.1 — diff guard against removed-value-as-default', () => {
     })
 
     const changes = diff(prev, next)
-    const removeChange = changes.find((c) => c.kind === 'removeEnumValue')
+    const removeChange = changes.find(
+      (c): c is Extract<(typeof changes)[number], { kind: 'removeEnumValue' }> =>
+        c.kind === 'removeEnumValue',
+    )
     expect(removeChange).toBeDefined()
-    expect(
-      (removeChange as { affectedColumns: { default: string | null }[] }).affectedColumns[0]
-        ?.default,
-    ).toBe(`'active'::"status"`)
+    expect(removeChange?.affectedColumns[0]?.default).toBe(`'active'::"status"`)
   })
 
   it('does NOT throw when the column has no default', () => {

--- a/packages/db/__tests__/unit/query-builder.test.ts
+++ b/packages/db/__tests__/unit/query-builder.test.ts
@@ -94,7 +94,7 @@ function makeMysqlDialect(): KyselyDialect {
  * Patch `executeQuery` on the underlying Kysely so we can capture
  * the SQL the namespace emits and feed back canned rows.
  */
-function patchExecute(client: { qb: Kysely<unknown> }, rows: unknown[]) {
+function patchExecute(client: { qb: Kysely<any> }, rows: unknown[]) {
   const calls: { sql: string; parameters: readonly unknown[] }[] = []
   const original = (client.qb as unknown as { executeQuery: unknown }).executeQuery
   ;(

--- a/packages/db/__tests__/unit/query-types.test.ts
+++ b/packages/db/__tests__/unit/query-types.test.ts
@@ -2,11 +2,11 @@
  * Type-level coverage for `db.query.X.findMany({ with })` —
  * spec-relational-query.md §3.3 expectTypeOf matrix.
  *
- * The test file owns the global `KickDbRegister` +
- * `KickDbRelationsRegister` augmentations for this run: a 4-table
- * fixture (users / posts / comments / categories) declared inline
- * here and augmented onto both registries. Runtime asserts only —
- * no DB connection, no schema instance.
+ * The test file owns the global `KickDbRelationsRegister` augmentation
+ * for this run: a 4-table fixture (users / posts / comments /
+ * categories) declared inline here. (`KickDbRegister` is owned by
+ * register.test.ts — see the note above the augmentation below.)
+ * Runtime asserts only — no DB connection, no schema instance.
  */
 
 import { describe, expectTypeOf, it } from 'vitest'
@@ -38,13 +38,13 @@ interface FixtureDB {
   }
 }
 
-// ── Augment both registries ─────────────────────────────────────────────
-declare module '../../src/client/register' {
-  interface KickDbRegister {
-    db: { qb: import('kysely').Kysely<FixtureDB> }
-  }
-}
-
+// ── Augment the relations registry ──────────────────────────────────────
+// NOTE: deliberately NOT augmenting `KickDbRegister` here — register.test.ts
+// owns that global augmentation (`db: KickDbClient<AppDB>`), and a second
+// conflicting `db` declaration breaks the whole-program typecheck
+// ("Subsequent property declarations must have the same type"). Every
+// assertion below passes `FixtureDB` explicitly, so the column-shape
+// registry is not needed.
 declare module '../../src/query/types' {
   interface KickDbRelationsRegister {
     db: {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -56,7 +56,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run --typecheck --passWithNoTests",
     "typecheck": "tsgo --noEmit",
     "clean": "rm -rf dist .wireit",
     "lint": "tsc --noEmit"

--- a/packages/db/src/migrate/introspect-sqlite.ts
+++ b/packages/db/src/migrate/introspect-sqlite.ts
@@ -9,9 +9,17 @@ import type {
 
 const DEFAULT_EXCLUDED = ['kick_migrations', 'kick_migrations_lock']
 
-/** Minimal better-sqlite3 surface introspection needs (sync `.all()`). */
+/**
+ * Minimal better-sqlite3 surface introspection needs (sync `.all()`).
+ *
+ * `all` is deliberately NOT method-generic: better-sqlite3 v12's own
+ * `Statement.all(...params): Result[]` is non-generic, so a generic
+ * method here would make a real `Database` instance structurally
+ * incompatible (callers had to cast). Row typing happens inside this
+ * module via per-call assertions instead.
+ */
 export interface SqliteIntrospectDb {
-  prepare(sql: string): { all<R = unknown>(...params: unknown[]): R[] }
+  prepare(sql: string): { all(...params: unknown[]): unknown[] }
 }
 
 export interface IntrospectSqliteOptions {
@@ -72,7 +80,7 @@ export function introspectSqlite(
        WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
        ORDER BY name`,
     )
-    .all<{ name: string }>()
+    .all() as { name: string }[]
 
   const tables: Record<string, TableSnapshot> = {}
   for (const { name } of tableRows) {
@@ -89,7 +97,7 @@ export function introspectSqlite(
 }
 
 function readColumns(db: SqliteIntrospectDb, table: string): Record<string, ColumnSnapshot> {
-  const rows = db.prepare(`PRAGMA table_info(${quote(table)})`).all<TableInfoRow>()
+  const rows = db.prepare(`PRAGMA table_info(${quote(table)})`).all() as TableInfoRow[]
   const out: Record<string, ColumnSnapshot> = {}
   for (const r of rows) {
     out[r.name] = {
@@ -104,15 +112,13 @@ function readColumns(db: SqliteIntrospectDb, table: string): Record<string, Colu
 }
 
 function readIndexes(db: SqliteIntrospectDb, table: string): IndexSnapshot[] {
-  const list = db.prepare(`PRAGMA index_list(${quote(table)})`).all<IndexListRow>()
+  const list = db.prepare(`PRAGMA index_list(${quote(table)})`).all() as IndexListRow[]
   const out: IndexSnapshot[] = []
   for (const idx of list) {
     // Skip auto-indexes SQLite creates for UNIQUE / PK constraints — those
     // belong to the column/constraint definitions, not standalone indexes.
     if (idx.origin !== 'c') continue
-    const cols = db
-      .prepare(`PRAGMA index_info(${quote(idx.name)})`)
-      .all<IndexInfoRow>()
+    const cols = (db.prepare(`PRAGMA index_info(${quote(idx.name)})`).all() as IndexInfoRow[])
       .filter((c) => c.name !== null)
       .map((c) => c.name as string)
     out.push({ name: idx.name, columns: cols, unique: idx.unique === 1 })
@@ -121,7 +127,7 @@ function readIndexes(db: SqliteIntrospectDb, table: string): IndexSnapshot[] {
 }
 
 function readForeignKeys(db: SqliteIntrospectDb, table: string): ForeignKeySnapshot[] {
-  const rows = db.prepare(`PRAGMA foreign_key_list(${quote(table)})`).all<FkListRow>()
+  const rows = db.prepare(`PRAGMA foreign_key_list(${quote(table)})`).all() as FkListRow[]
   // Group multi-column FKs by their `id`.
   const byId = new Map<number, FkListRow[]>()
   for (const r of rows) {


### PR DESCRIPTION
﻿## Why

Fixing `tsconfig.test.json` in #348 revealed that the db package's whole-program typecheck had never actually run (a fatal `baseUrl` config error aborted it before checking a single file). Running it surfaced 28 latent type errors across the test suite, and one real source-level incompatibility.

## What

**Source fix** (the one real product issue, changeset included):
- `SqliteIntrospectDb.prepare(...).all` de-genericized — better-sqlite3 v12's `Statement.all` is non-generic, so the old method-generic signature made a real `Database` structurally incompatible with `introspectSqlite(db)`. Row typing moved to per-call assertions inside the introspector. Passing a better-sqlite3 `Database` now type-checks without casts (the 4 errors in `introspect-sqlite.test.ts` were exactly this friction).

**Test-side fixes:**
- `abort-signal-unit` / `query-builder` helpers: `{ qb: Kysely<unknown> }` → `{ qb: Kysely<any> }` (Kysely's generic is invariant via `fn.any`; the helpers already cast internals). 20 errors.
- `query-types.test.ts`: removed its `KickDbRegister.db` augmentation — it conflicted with `register.test.ts`'s augmentation of the same global interface ("Subsequent property declarations must have the same type"); every assertion in the file passes `FixtureDB` explicitly so the registry was unused. Ownership documented in both files. 3 errors.
- `default-preservation.test.ts`: unsafe widening cast over `RemoveEnumValue | undefined` replaced with a type-guard `find` narrow. 1 error.

**Enforcement:**
- db `test` script is now `vitest run --typecheck --passWithNoTests` — `expectTypeOf` assertions in this package are enforced on every test run instead of being runtime no-ops.

## Result

`pnpm --filter @forinda/kickjs-db test`: 72 files, 432 tests, **Type Errors: no errors** (previously 28 unhandled source errors when typecheck was forced on). Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
