### PR TITLE
feat(cli): dev-time typecheck worker (kick dev --typecheck)

### DIFF
--- a/.changeset/cli-dev-typecheck-worker.md
+++ b/.changeset/cli-dev-typecheck-worker.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+`kick dev --typecheck` (or `dev.typecheck: true` in kick.config) runs the project's own TypeScript checker after each debounced change and surfaces diagnostics without leaving the dev console. Resolves `tsgo` (`@typescript/native-preview`) from the project's `node_modules/.bin`, falling back to `tsc`; runs `--noEmit` after the typegen pass settles so checks always see fresh `.kickjs/types`. In-flight runs are killed when a new save lands. Failures print a capped diagnostic summary and broadcast a `kickjs:typecheck` HMR event with the full output; a healthy project stays quiet, and the first clean run after an error prints a "clean again" line. Off by default.

--- a/packages/cli/__tests__/dev-typecheck.test.ts
+++ b/packages/cli/__tests__/dev-typecheck.test.ts
@@ -1,0 +1,142 @@
+import { EventEmitter } from 'node:events'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import {
+  resolveTypecheckBin,
+  createDevTypechecker,
+  formatTypecheckOutput,
+} from '../src/commands/dev-typecheck'
+
+// ── resolveTypecheckBin ─────────────────────────────────────────────────
+
+describe('resolveTypecheckBin', () => {
+  let project: string
+
+  beforeEach(() => {
+    project = mkdtempSync(join(tmpdir(), 'kick-tc-'))
+  })
+
+  afterEach(() => {
+    rmSync(project, { recursive: true, force: true })
+  })
+
+  function writeBin(name: string): void {
+    const bin = join(project, 'node_modules', '.bin')
+    mkdirSync(bin, { recursive: true })
+    writeFileSync(join(bin, name), '')
+  }
+
+  it('prefers tsgo over tsc', () => {
+    // Cover both platforms' shim names so the test passes everywhere.
+    writeBin('tsgo')
+    writeBin('tsgo.CMD')
+    writeBin('tsc')
+    writeBin('tsc.CMD')
+    const bin = resolveTypecheckBin(project)
+    expect(bin?.kind).toBe('tsgo')
+    expect(bin?.args).toEqual(['--noEmit'])
+  })
+
+  it('falls back to tsc when tsgo is absent', () => {
+    writeBin('tsc')
+    writeBin('tsc.CMD')
+    expect(resolveTypecheckBin(project)?.kind).toBe('tsc')
+  })
+
+  it('returns null when neither checker is installed', () => {
+    expect(resolveTypecheckBin(project)).toBeNull()
+  })
+})
+
+// ── createDevTypechecker ────────────────────────────────────────────────
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
+  killed = false
+  kill(): boolean {
+    this.killed = true
+    return true
+  }
+}
+
+function makeChecker(onResult: ReturnType<typeof vi.fn>) {
+  const children: FakeChild[] = []
+  const spawnFn = vi.fn(() => {
+    const child = new FakeChild()
+    children.push(child)
+    return child as never
+  })
+  const checker = createDevTypechecker({
+    cwd: '/proj',
+    bin: { cmd: 'tsgo', args: ['--noEmit'], shell: false, kind: 'tsgo' },
+    onResult,
+    spawnFn: spawnFn as never,
+  })
+  return { checker, children, spawnFn }
+}
+
+describe('createDevTypechecker', () => {
+  it('reports ok on exit code 0', () => {
+    const onResult = vi.fn()
+    const { checker, children } = makeChecker(onResult)
+    checker.schedule()
+    children[0].stdout.emit('data', Buffer.from('checked fine\n'))
+    children[0].emit('close', 0)
+    expect(onResult).toHaveBeenCalledTimes(1)
+    expect(onResult.mock.calls[0][0].ok).toBe(true)
+  })
+
+  it('reports failure with captured output on non-zero exit', () => {
+    const onResult = vi.fn()
+    const { checker, children } = makeChecker(onResult)
+    checker.schedule()
+    children[0].stdout.emit('data', Buffer.from('src/a.ts(3,1): error TS2322: nope\n'))
+    children[0].emit('close', 2)
+    expect(onResult.mock.calls[0][0].ok).toBe(false)
+    expect(onResult.mock.calls[0][0].output).toContain('TS2322')
+  })
+
+  it('kills the in-flight run when rescheduled and suppresses its result', () => {
+    const onResult = vi.fn()
+    const { checker, children } = makeChecker(onResult)
+    checker.schedule()
+    checker.schedule() // second save lands while first run is in flight
+    expect(children[0].killed).toBe(true)
+    // The superseded child's close must not produce a (stale) result.
+    children[0].emit('close', 1)
+    expect(onResult).not.toHaveBeenCalled()
+    children[1].emit('close', 0)
+    expect(onResult).toHaveBeenCalledTimes(1)
+    expect(onResult.mock.calls[0][0].ok).toBe(true)
+  })
+
+  it('dispose() kills the in-flight run and stops reporting', () => {
+    const onResult = vi.fn()
+    const { checker, children } = makeChecker(onResult)
+    checker.schedule()
+    checker.dispose()
+    expect(children[0].killed).toBe(true)
+    children[0].emit('close', 0)
+    expect(onResult).not.toHaveBeenCalled()
+  })
+})
+
+// ── formatTypecheckOutput ───────────────────────────────────────────────
+
+describe('formatTypecheckOutput', () => {
+  it('passes short output through trimmed', () => {
+    expect(formatTypecheckOutput('  a\nb  \n')).toBe('a\nb')
+  })
+
+  it('caps long output and reports the overflow', () => {
+    const lines = Array.from({ length: 30 }, (_, i) => `error line ${i}`).join('\n')
+    const out = formatTypecheckOutput(lines, 10)
+    expect(out.split('\n')).toHaveLength(11) // 10 lines + overflow notice
+    expect(out).toContain('… 20 more line(s)')
+  })
+})

--- a/packages/cli/src/commands/dev-typecheck.ts
+++ b/packages/cli/src/commands/dev-typecheck.ts
@@ -1,0 +1,140 @@
+/**
+ * Dev-mode TypeScript check worker for `kick dev --typecheck`.
+ *
+ * After each debounced typegen pass (so `.kickjs/types` is fresh —
+ * checking against stale typegen output would report false positives), the
+ * dev server runs the PROJECT's own checker (`tsgo --noEmit`, falling
+ * back to `tsc --noEmit`) as a detached child process and surfaces
+ * diagnostics in the dev console + a `kickjs:typecheck` HMR event.
+ *
+ * tsgo checks a typical project in well under a second, so this is
+ * cheap enough to run on every save — but it stays opt-in
+ * (`--typecheck` flag or `dev.typecheck` in kick.config) because the
+ * adopter may already have an IDE or separate watch doing the job.
+ */
+import { spawn, type ChildProcess } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+export interface TypecheckBin {
+  cmd: string
+  args: string[]
+  /** `.CMD` shims require a shell on Windows. */
+  shell: boolean
+  kind: 'tsgo' | 'tsc'
+}
+
+/**
+ * Locate the project's checker binary under `node_modules/.bin`,
+ * preferring tsgo (`@typescript/native-preview`) over tsc. Returns
+ * null when neither is installed — callers print a one-time notice
+ * and skip checking rather than failing the dev server.
+ *
+ * On Windows the runnable shim is `<name>.CMD` / `<name>.cmd`; the
+ * extensionless file is a POSIX shell script `spawn` can't launch.
+ */
+export function resolveTypecheckBin(projectDir: string): TypecheckBin | null {
+  const binDir = join(projectDir, 'node_modules', '.bin')
+  const isWin = process.platform === 'win32'
+  for (const kind of ['tsgo', 'tsc'] as const) {
+    const names = isWin ? [`${kind}.CMD`, `${kind}.cmd`, `${kind}.exe`] : [kind]
+    for (const name of names) {
+      const candidate = join(binDir, name)
+      if (existsSync(candidate)) {
+        return { cmd: candidate, args: ['--noEmit'], shell: isWin, kind }
+      }
+    }
+  }
+  return null
+}
+
+export interface TypecheckResult {
+  ok: boolean
+  /** Combined stdout+stderr of the checker run. */
+  output: string
+  durationMs: number
+  kind: 'tsgo' | 'tsc'
+}
+
+export interface DevTypechecker {
+  /** Start a check, killing any in-flight run (its result is dropped). */
+  schedule(): void
+  /** Kill any in-flight run and stop reporting. */
+  dispose(): void
+}
+
+export function createDevTypechecker(opts: {
+  cwd: string
+  bin: TypecheckBin
+  onResult: (result: TypecheckResult) => void
+  /** Injectable for tests — defaults to node:child_process spawn. */
+  spawnFn?: typeof spawn
+}): DevTypechecker {
+  const spawnFn = opts.spawnFn ?? spawn
+  let inflight: ChildProcess | null = null
+  // Generation counter — a superseded or disposed run's `close` event
+  // must not report (rapid saves would otherwise interleave stale
+  // results over fresh ones).
+  let generation = 0
+  let disposed = false
+
+  return {
+    schedule() {
+      if (disposed) return
+      const myGen = ++generation
+      if (inflight) {
+        inflight.kill()
+        inflight = null
+      }
+      const started = Date.now()
+      const child = spawnFn(opts.bin.cmd, opts.bin.args, {
+        cwd: opts.cwd,
+        shell: opts.bin.shell,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      inflight = child
+      let output = ''
+      child.stdout?.on('data', (chunk: Buffer) => {
+        output += chunk.toString()
+      })
+      child.stderr?.on('data', (chunk: Buffer) => {
+        output += chunk.toString()
+      })
+      child.on('error', () => {
+        // Spawn failure (binary vanished mid-session) — treat like a
+        // superseded run; the resolve-time null path already covers
+        // the "not installed" notice.
+        if (myGen === generation) inflight = null
+      })
+      child.on('close', (code: number | null) => {
+        if (disposed || myGen !== generation) return
+        inflight = null
+        opts.onResult({
+          ok: code === 0,
+          output,
+          durationMs: Date.now() - started,
+          kind: opts.bin.kind,
+        })
+      })
+    },
+    dispose() {
+      disposed = true
+      if (inflight) {
+        inflight.kill()
+        inflight = null
+      }
+    },
+  }
+}
+
+/**
+ * Compact a checker's diagnostic dump for the dev console — first
+ * `maxLines` lines plus an overflow note. The full output always goes
+ * out on the `kickjs:typecheck` HMR event for tools that want it.
+ */
+export function formatTypecheckOutput(output: string, maxLines = 12): string {
+  const lines = output.trim().split(/\r?\n/)
+  if (lines.length <= maxLines) return lines.join('\n')
+  const shown = lines.slice(0, maxLines)
+  return `${shown.join('\n')}\n… ${lines.length - maxLines} more line(s)`
+}

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -8,6 +8,12 @@ import { runTypegen, writeTypegenArtifacts } from '../typegen'
 import { runAllPluginTypegens } from '../typegen/run-plugins'
 import { buildAssets } from '../asset-manager/build'
 import { createTypegenErrorReporter } from './typegen-error-reporter'
+import {
+  createDevTypechecker,
+  formatTypecheckOutput,
+  resolveTypecheckBin,
+  type DevTypechecker,
+} from './dev-typecheck'
 
 /**
  * Start the Vite dev server with @forinda/kickjs-vite plugin.
@@ -38,7 +44,7 @@ function resolvePolling(flag: boolean | undefined): boolean {
 async function startDevServer(
   _entry: string,
   port?: string,
-  opts: { polling?: boolean } = {},
+  opts: { polling?: boolean; typecheck?: boolean } = {},
 ): Promise<void> {
   if (port) process.env.PORT = port
   const polling = resolvePolling(opts.polling)
@@ -150,6 +156,47 @@ async function startDevServer(
       data: { message, timestamp: Date.now() },
     })
   })
+  // Optional dev-time typecheck worker (--typecheck / dev.typecheck in
+  // kick.config). Runs the PROJECT's own checker after each debounced
+  // typegen pass so diagnostics are computed against fresh .kickjs/types.
+  // tsgo checks a typical project in well under a second; in-flight runs
+  // are killed when a new save lands, so rapid edits never queue up.
+  const typecheckEnabled = opts.typecheck ?? devConfig?.dev?.typecheck ?? false
+  let typechecker: DevTypechecker | null = null
+  let lastTypecheckOk = true
+  if (typecheckEnabled) {
+    const bin = resolveTypecheckBin(cwd)
+    if (!bin) {
+      console.warn(
+        '  kick dev: --typecheck requested but neither tsgo (@typescript/native-preview) ' +
+          'nor typescript is installed in this project — skipping type checks.',
+      )
+    } else {
+      typechecker = createDevTypechecker({
+        cwd,
+        bin,
+        onResult: (result) => {
+          // Full output always rides the HMR event (DevTools / overlays);
+          // the console gets a capped, indented summary — and only on
+          // failure or on the error→clean transition, so a healthy
+          // project stays quiet.
+          server.hot.send({
+            type: 'custom',
+            event: 'kickjs:typecheck',
+            data: { ok: result.ok, output: result.output, durationMs: result.durationMs },
+          })
+          if (!result.ok) {
+            lastTypecheckOk = false
+            console.warn(`\n  kick typecheck (${result.kind}, ${result.durationMs}ms):`)
+            console.warn(formatTypecheckOutput(result.output).replace(/^/gm, '    '))
+          } else if (!lastTypecheckOk) {
+            lastTypecheckOk = true
+            console.log(`  kick typecheck: clean again (${result.kind}, ${result.durationMs}ms)`)
+          }
+        },
+      })
+    }
+  }
   let typegenTimer: ReturnType<typeof setTimeout> | null = null
   const pendingChanged = new Set<string>()
   const pendingRemoved = new Set<string>()
@@ -227,6 +274,9 @@ async function startDevServer(
         .then((r) => writeTypegenArtifacts(typesOutDir, r, true))
         .then(() => typegenErrors.clear('plugins'))
         .catch((err) => typegenErrors.report('plugins', err))
+        // Typecheck AFTER the plugin pass settles (success or failure) so
+        // the checker sees the freshest .kickjs/types this window produced.
+        .finally(() => typechecker?.schedule())
       // Incrementally refresh the dist asset copies + manifest, but only
       // when an asset file actually changed this window. buildAssets
       // skips up-to-date files, so this is a cheap stat sweep + the
@@ -252,6 +302,10 @@ async function startDevServer(
 
   console.log(`\n  KickJS dev server running (Vite + @forinda/kickjs-vite)\n`)
 
+  // Baseline check on startup — surfaces pre-existing type errors
+  // immediately instead of waiting for the first save.
+  typechecker?.schedule()
+
   // Graceful shutdown — Vite closes the server + all HMR connections.
   // The app suppresses its own signal handlers in dev (Vite owns the
   // lifecycle), so drive its graceful shutdown here: drain in-flight
@@ -263,6 +317,7 @@ async function startDevServer(
     if (shuttingDown) return
     shuttingDown = true
     if (typegenTimer) clearTimeout(typegenTimer)
+    typechecker?.dispose()
     try {
       await (
         globalThis as { __kickjs_app_shutdown?: () => Promise<void> }
@@ -290,9 +345,16 @@ export function registerRunCommands(program: Command): void {
       '--polling',
       'Force chokidar to poll for file changes (Docker / WSL / NFS / older kernels)',
     )
+    .option(
+      '--typecheck',
+      'Run the project TypeScript checker (tsgo/tsc --noEmit) after each change and report diagnostics',
+    )
     .action(async (opts: any) => {
       try {
-        await startDevServer(opts.entry, opts.port, { polling: opts.polling })
+        await startDevServer(opts.entry, opts.port, {
+          polling: opts.polling,
+          typecheck: opts.typecheck,
+        })
       } catch (err: any) {
         if (err.code === 'ERR_MODULE_NOT_FOUND' && err.message?.includes('vite')) {
           console.error('\n  Error: vite is not installed.\n  Run: pnpm add -D vite unplugin-swc\n')

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -428,6 +428,20 @@ export interface KickConfig {
    */
   typegen?: TypegenConfig
   /**
+   * Dev-server (`kick dev`) settings.
+   */
+  dev?: {
+    /**
+     * Run the project's TypeScript checker (`tsgo --noEmit`, falling
+     * back to `tsc --noEmit`) after each debounced change and surface
+     * diagnostics in the dev console + a `kickjs:typecheck` HMR event.
+     * Equivalent to the `kick dev --typecheck` flag.
+     *
+     * @default false
+     */
+    typecheck?: boolean
+  }
+  /**
    * Database settings — schema path, migrations dir, dialect,
    * connection string, optional adapter factory. Consumed by
    * `kick db generate` / `kick db migrate*`. See {@link KickDbConfigBlock}.


### PR DESCRIPTION
﻿## Why

Type errors in a KickJS project are invisible during `kick dev` — the dev loop transpiles with SWC (no checking), so mistakes surface only in the IDE or at the next full build. Measurement on the current toolchain showed `tsgo --noEmit` checks a single project in ~0.4-2s, which makes an on-save checker cheap enough to be practical.

## What

New opt-in dev typecheck worker:

- **`kick dev --typecheck`** flag, or **`dev.typecheck: true`** in `kick.config.ts`. Off by default — adopters may already have an IDE or separate watch doing this.
- Resolves the **project's own checker** from `node_modules/.bin`: `tsgo` (`@typescript/native-preview`) preferred, `tsc` fallback, one-time notice + skip when neither is installed. Windows `.CMD` shim handling included.
- Runs `--noEmit` **after the debounced typegen pass settles**, so diagnostics are always computed against fresh `.kickjs/types` (checking before would report false positives during scaffolding).
- **In-flight runs are killed** when a new save lands; superseded results are dropped (generation counter), so rapid edits never interleave stale diagnostics.
- Reporting: failures print a capped (12-line) indented summary in the dev console; the full output rides a `kickjs:typecheck` custom HMR event (same pattern as `kickjs:hmr` / `kickjs:typegen-error`) for DevTools/overlays. A healthy project stays quiet; the first clean run after an error prints a "clean again" line. Baseline check runs once at startup.
- Worker is disposed on graceful shutdown.

## Testing

- 9 unit tests (`dev-typecheck.test.ts`): bin resolution preference/fallback/absence, ok/fail reporting, in-flight kill + stale-result suppression, dispose semantics, output capping. Spawn is injectable — no real processes in unit tests.
- Live E2E against a real project (examples scratch app, `tsc` fallback path): injected a type error → console showed `src/broken-probe.ts(1,14): error TS2322 ...` ~1.5s after save; removing the file printed `kick typecheck: clean again (tsc, 2379ms)`; healthy saves stayed silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
