### PR TITLE
feat(cli): AST-based typegen scanner via oxc-parser with regex fallback

### DIFF
--- a/.changeset/cli-ast-scanner.md
+++ b/.changeset/cli-ast-scanner.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+`kick typegen` per-file extraction is now AST-based (oxc-parser) with the regex extractors kept as a fallback for unparseable mid-edit sources. Accuracy fixes over the regex path: template-literal route paths extract correctly, `@ApiQueryParams` stacked above the HTTP decorator is no longer silently dropped, string literals containing parens/braces can't skew extraction, aliased named imports resolve as schema sources, and const-bound `createToken` declarations are no longer double-emitted. The scan cache version is bumped so stale regex-era entries refresh on first run.

--- a/packages/cli/__tests__/extract-ast.test.ts
+++ b/packages/cli/__tests__/extract-ast.test.ts
@@ -1,0 +1,241 @@
+import { resolve } from 'node:path'
+
+import { describe, it, expect } from 'vitest'
+
+import { extractFileAst } from '../src/typegen/extract-ast'
+import { extractFileRegex } from '../src/typegen/scanner'
+
+const CWD = resolve('/proj')
+const FILE = resolve('/proj/src/modules/users/user.controller.ts')
+const MODULE_FILE = resolve('/proj/src/modules/users/user.module.ts')
+
+/** Run both extractors and assert deep equality (parity harness). */
+function expectParity(source: string, filePath = FILE): void {
+  const ast = extractFileAst(source, filePath, CWD)
+  const regex = extractFileRegex(source, filePath, CWD)
+  expect(ast).not.toBeNull()
+  expect(ast).toEqual(regex)
+}
+
+describe('extractFileAst — parity with the regex extractors', () => {
+  it('decorated classes (export, default export, stacked decorators)', () => {
+    expectParity(`
+import { Controller, Service } from '@forinda/kickjs'
+
+@Service()
+export class UserService {}
+
+@Controller()
+@Deprecated()
+export default class UserController {}
+`)
+  })
+
+  it('AppModule classes and defineModule consts tag as Module', () => {
+    expectParity(`
+import { defineModule, type AppModule, type Container } from '@forinda/kickjs'
+
+export class LegacyModule implements AppModule {
+  register(container: Container) {}
+}
+
+export const UserModule = defineModule({
+  name: 'UserModule',
+  build: () => ({ routes: () => null }),
+})
+`)
+  })
+
+  it('createToken — bare form (const form lives in the fixes section: regex double-emits it)', () => {
+    expectParity(`
+import { createToken } from '@forinda/kickjs'
+container.registerFactory(createToken('app/Loose/token'), () => 1)
+`)
+  })
+
+  it('@Inject literals (property and constructor-param positions)', () => {
+    expectParity(`
+import { Inject, Service } from '@forinda/kickjs'
+
+@Service()
+export class A {
+  @Inject('app/Users/repository') private repo!: unknown
+  constructor(@Inject('app/Cache/redis') private cache: unknown) {}
+}
+`)
+  })
+
+  it('defineAdapter / definePlugin / class-style AppAdapter', () => {
+    expectParity(`
+import { defineAdapter, definePlugin, type AppAdapter } from '@forinda/kickjs'
+
+export const pg = defineAdapter({ name: 'postgres', beforeStart() {} })
+export const audit = definePlugin({ name: 'audit-log' })
+
+export class LegacyAdapter implements AppAdapter {
+  name = 'legacy-adapter'
+}
+`)
+  })
+
+  it('defineAugmentation with and without metadata', () => {
+    expectParity(`
+import { defineAugmentation } from '@forinda/kickjs'
+defineAugmentation('PolicyRegistry')
+defineAugmentation('KickAssets', { description: 'Typed asset paths', example: 'assets.mails.welcome()' })
+`)
+  })
+
+  it('context decorators — direct and curried withParams forms', () => {
+    expectParity(`
+import { defineContextDecorator, defineHttpContextDecorator } from '@forinda/kickjs'
+
+export const LoadTenant = defineContextDecorator({
+  key: 'tenant',
+  resolve: (ctx) => ctx.req.headers['x-tenant-id'],
+})
+
+export const LoadProject = defineHttpContextDecorator.withParams<{ id: string }>()({
+  key: 'project',
+  resolve: () => null,
+})
+`)
+  })
+
+  it('routes — paths, params, schema refs, @ApiQueryParams (regex-visible order)', () => {
+    // NOTE: @ApiQueryParams sits BELOW the HTTP decorator here because
+    // the regex extractor only sees decorators after the route
+    // decorator — the above-order case lives in the fixes section.
+    expectParity(`
+import { Controller, Get, Post, ApiQueryParams } from '@forinda/kickjs'
+import { createUserSchema } from './user.dto'
+const listQuerySchema = z.object({})
+
+@Controller()
+export class UserController {
+  @Get('/:id')
+  getUser(ctx) {}
+
+  @Post('/', { body: createUserSchema, query: listQuerySchema })
+  create(ctx) {}
+
+  @Get('/')
+  @ApiQueryParams({ filterable: ['name', 'age'], sortable: ['name'], searchable: ['name'] })
+  list(ctx) {}
+}
+`)
+  })
+
+  it('module mounts + import.meta.glob patterns in module files', () => {
+    expectParity(
+      `
+import { UserController } from './user.controller'
+
+const contributors = import.meta.glob(['./**/*.controller.ts', '!./**/*.test.ts'], { eager: true })
+
+export class UserModule implements AppModule {
+  routes() {
+    return [
+      { path: '/users', controller: UserController },
+      { path: '/admin/users', controller: AdminUserController },
+    ]
+  }
+}
+`,
+      MODULE_FILE,
+    )
+  })
+})
+
+describe('extractFileAst — fixes over the regex path', () => {
+  it('template-literal route paths extract (no-substitution form)', () => {
+    const source = `
+import { Controller, Get } from '@forinda/kickjs'
+
+@Controller()
+export class UserController {
+  @Get(\`/v1/users/:id\`)
+  getUser(ctx) {}
+}
+`
+    const ast = extractFileAst(source, FILE, CWD)!
+    expect(ast.routes[0]?.path).toBe('/v1/users/:id')
+    expect(ast.routes[0]?.pathParams).toEqual(['id'])
+  })
+
+  it('@ApiQueryParams stacked ABOVE the HTTP decorator is still seen', () => {
+    // The regex extractor only searched the text AFTER the route
+    // decorator, so the natural above-stacking order silently lost the
+    // whitelists. The AST reads all decorators on the method.
+    const source = `
+import { Controller, Get, ApiQueryParams } from '@forinda/kickjs'
+
+@Controller()
+export class UserController {
+  @ApiQueryParams({ filterable: ['name'], sortable: [], searchable: [] })
+  @Get('/')
+  list(ctx) {}
+}
+`
+    const ast = extractFileAst(source, FILE, CWD)!
+    expect(ast.routes[0]?.queryFilterable).toEqual(['name'])
+    const regex = extractFileRegex(source, FILE, CWD)
+    expect(regex.routes[0]?.queryFilterable).toBeNull() // documented regex gap
+  })
+
+  it('const-bound createToken is emitted exactly once (regex double-emits)', () => {
+    const source = `
+import { createToken } from '@forinda/kickjs'
+export const USER_REPO = createToken<UserRepo>('app/Users/repository')
+container.registerFactory(createToken('app/Loose/token'), () => 1)
+`
+    const ast = extractFileAst(source, FILE, CWD)!
+    expect(ast.tokens).toEqual([
+      expect.objectContaining({ name: 'app/Users/repository', variable: 'USER_REPO' }),
+      expect.objectContaining({ name: 'app/Loose/token', variable: null }),
+    ])
+    // Regex emits the const-bound token a second time as a bare call —
+    // harmless downstream (the union dedupes) but documented here.
+    const regex = extractFileRegex(source, FILE, CWD)
+    expect(regex.tokens).toHaveLength(3)
+  })
+
+  it('string literals containing parens do not skew route extraction', () => {
+    const source = `
+import { Controller, Get, ApiOperation } from '@forinda/kickjs'
+
+@Controller()
+export class UserController {
+  @ApiOperation({ summary: 'List (all) users :-)' })
+  @Get('/users')
+  list(ctx) {}
+}
+`
+    const ast = extractFileAst(source, FILE, CWD)!
+    expect(ast.routes).toHaveLength(1)
+    expect(ast.routes[0]?.method).toBe('list')
+    expect(ast.routes[0]?.path).toBe('/users')
+  })
+
+  it('aliased named imports resolve as schema sources', () => {
+    const source = `
+import { Controller, Post } from '@forinda/kickjs'
+import { schema as createUserSchema } from './user.dto'
+
+@Controller()
+export class UserController {
+  @Post('/', { body: createUserSchema })
+  create(ctx) {}
+}
+`
+    const ast = extractFileAst(source, FILE, CWD)!
+    expect(ast.routes[0]?.bodySchema).toEqual({
+      identifier: 'createUserSchema',
+      source: './user.dto',
+    })
+  })
+
+  it('returns null on unparseable source (caller falls back to regex)', () => {
+    expect(extractFileAst('export class {{{', FILE, CWD)).toBeNull()
+  })
+})

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,22 +43,23 @@
   "dependencies": {
     "@clack/prompts": "^1.5.1",
     "@forinda/kickjs": "workspace:*",
+    "@forinda/kickjs-cli-kit": "workspace:*",
     "@forinda/kickjs-db": "workspace:*",
     "commander": "^15.0.0",
     "glob": "^13.0.6",
     "jiti": "^2.7.0",
+    "oxc-parser": "^0.135.0",
     "oxfmt": "^0.54.0",
     "picocolors": "^1.1.1",
-    "pluralize": "^8.0.0",
-    "@forinda/kickjs-cli-kit": "workspace:*"
+    "pluralize": "^8.0.0"
   },
   "devDependencies": {
     "@forinda/kickjs-ai": "workspace:*",
-    "pg": "^8.21.0",
-    "@types/pg": "^8.11.10",
     "@swc/core": "^1.15.40",
     "@types/node": "^25.9.2",
+    "@types/pg": "^8.11.10",
     "@types/pluralize": "^0.0.33",
+    "pg": "^8.21.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.8"

--- a/packages/cli/src/typegen/extract-ast.ts
+++ b/packages/cli/src/typegen/extract-ast.ts
@@ -1,0 +1,656 @@
+/**
+ * AST-based per-file extraction — oxc-parser replacement for the regex
+ * extractors in `scanner.ts`.
+ *
+ * Produces the exact same {@link FileExtract} shape so the scanner's
+ * cache / incremental / cross-file-join machinery is untouched. The
+ * scanner calls {@link extractFileAst} first and falls back to the
+ * regex path when the file doesn't parse (mid-edit syntax errors in
+ * watch mode — regex still salvages partial results there).
+ *
+ * What AST extraction fixes over the regex path (forinda/kick-js#108):
+ *   - template-literal route paths (`@Get(\`/v1/users/:id\`)`) — regex
+ *     silently fell back to `/`
+ *   - nested parens/braces inside stacked decorator args
+ *   - string literals containing `(`/`)`/`{`/`}` skewing the
+ *     balanced-delimiter walkers
+ *   - aliased named imports in schema-ref resolution
+ *
+ * Everything here is pure (depends only on the source text), so results
+ * stay safe to cache by filesystem signature.
+ */
+import { relative, sep } from 'node:path'
+
+import { parseSync } from 'oxc-parser'
+
+import {
+  DECORATOR_NAMES,
+  type DecoratorName,
+  type DiscoveredAugmentation,
+  type DiscoveredClass,
+  type DiscoveredContextKey,
+  type DiscoveredInject,
+  type DiscoveredPluginOrAdapter,
+  type DiscoveredRoute,
+  type DiscoveredToken,
+  type FileExtract,
+  type ModuleMount,
+  type SchemaRef,
+} from './scanner'
+
+// scanner.ts ⇄ extract-ast.ts is an import cycle (scanner calls
+// extractFileAst; we need its DECORATOR_NAMES). Type imports are erased,
+// but reading the DECORATOR_NAMES *value* during this module's init
+// would hit the TDZ while scanner is still evaluating — so the set is
+// built lazily on first extraction instead.
+let decoratorNameSet: Set<string> | null = null
+function getDecoratorNameSet(): Set<string> {
+  decoratorNameSet ??= new Set<string>(DECORATOR_NAMES)
+  return decoratorNameSet
+}
+
+// oxc-parser returns ESTree-shaped plain objects. We walk them
+// structurally; a tiny structural node type keeps us honest without
+// pulling in the full @oxc-project/types surface.
+interface Node {
+  type: string
+  [key: string]: unknown
+}
+
+const HTTP_DECORATORS = new Set(['Get', 'Post', 'Put', 'Delete', 'Patch'])
+
+function isNode(value: unknown): value is Node {
+  return typeof value === 'object' && value !== null && typeof (value as Node).type === 'string'
+}
+
+/** Depth-first walk over every AST node (objects with a string `type`). */
+function walk(node: unknown, visit: (node: Node) => void): void {
+  if (Array.isArray(node)) {
+    for (const item of node) walk(item, visit)
+    return
+  }
+  if (!isNode(node)) return
+  visit(node)
+  for (const key of Object.keys(node)) {
+    if (key === 'type') continue
+    const value = node[key]
+    if (typeof value === 'object' && value !== null) walk(value, visit)
+  }
+}
+
+/** Static string value of a literal / no-substitution template, else null. */
+function stringValue(node: unknown): string | null {
+  if (!isNode(node)) return null
+  if (node.type === 'Literal' && typeof node.value === 'string') return node.value
+  if (node.type === 'TemplateLiteral') {
+    const quasis = node.quasis as Node[] | undefined
+    const expressions = node.expressions as unknown[] | undefined
+    if (quasis?.length === 1 && (expressions?.length ?? 0) === 0) {
+      const cooked = (quasis[0] as { value?: { cooked?: string } }).value?.cooked
+      return typeof cooked === 'string' ? cooked : null
+    }
+  }
+  return null
+}
+
+function identifierName(node: unknown): string | null {
+  return isNode(node) && node.type === 'Identifier' ? (node.name as string) : null
+}
+
+/** Callee name for `name(...)` calls (plain identifier callees only). */
+function calleeName(call: Node): string | null {
+  return identifierName(call.callee)
+}
+
+/** Object-literal property lookup by static key name. */
+function getProp(obj: Node | null, name: string): Node | null {
+  if (!obj || obj.type !== 'ObjectExpression') return null
+  for (const prop of (obj.properties as Node[] | undefined) ?? []) {
+    if (prop.type !== 'Property') continue
+    const key = prop.key as Node
+    const keyName =
+      identifierName(key) ?? (key.type === 'Literal' ? String(key.value) : stringValue(key))
+    if (keyName === name) return prop.value as Node
+  }
+  return null
+}
+
+/** First argument when it's an object literal, else null. */
+function firstObjectArg(call: Node): Node | null {
+  const arg = (call.arguments as Node[] | undefined)?.[0]
+  return isNode(arg) && arg.type === 'ObjectExpression' ? arg : null
+}
+
+function extractStringArrayProp(obj: Node | null, key: string): string[] {
+  const value = getProp(obj, key)
+  if (!isNode(value) || value.type !== 'ArrayExpression') return []
+  const out: string[] = []
+  for (const el of (value.elements as unknown[] | undefined) ?? []) {
+    const s = stringValue(el)
+    if (s !== null) out.push(s)
+  }
+  return out
+}
+
+function toRelative(filePath: string, cwd: string): string {
+  return relative(cwd, filePath).split(sep).join('/')
+}
+
+function extractPathParams(path: string): string[] {
+  const matches = path.match(/:([a-zA-Z_]\w*)/g) ?? []
+  return matches.map((m) => m.slice(1))
+}
+
+/** Mirrors scanner.ts joinMountPath — slash-edge handling for #235 §3. */
+function joinMountPath(mountPath: string, routePath: string): string {
+  const prefix = mountPath.endsWith('/') ? mountPath.slice(0, -1) : mountPath
+  if (!routePath || routePath === '/') return prefix || '/'
+  const suffix = routePath.startsWith('/') ? routePath : '/' + routePath
+  return prefix + suffix || '/'
+}
+
+/** `implements` clause includes `name`? */
+function classImplements(cls: Node, name: string): boolean {
+  for (const impl of (cls.implements as Node[] | undefined) ?? []) {
+    const expr = (impl.expression ?? impl) as Node
+    if (identifierName(expr) === name) return true
+    // Qualified form (`kick.AppModule`) — match the rightmost segment.
+    if (expr.type === 'TSQualifiedName' || expr.type === 'MemberExpression') {
+      const right = (expr.right ?? expr.property) as Node | undefined
+      if (right && identifierName(right) === name) return true
+    }
+  }
+  return false
+}
+
+/** Decorators attached to a class / method / property / param node. */
+function decoratorsOf(node: Node): Node[] {
+  return (node.decorators as Node[] | undefined) ?? []
+}
+
+/** `@Name(...)` decorator → { name, call } (call-expression form only). */
+function decoratorCall(dec: Node): { name: string; call: Node } | null {
+  const expr = dec.expression as Node
+  if (!isNode(expr) || expr.type !== 'CallExpression') return null
+  const name = calleeName(expr)
+  return name ? { name, call: expr } : null
+}
+
+interface ImportBinding {
+  source: string
+}
+
+/**
+ * Per-file context shared by the extract passes: import map (local
+ * binding name → module specifier) and the set of top-level const names
+ * (same-file schema refs resolve to the `''` sentinel).
+ */
+interface FileContext {
+  imports: Map<string, ImportBinding>
+  topLevelConsts: Set<string>
+}
+
+function buildFileContext(program: Node): FileContext {
+  const imports = new Map<string, ImportBinding>()
+  const topLevelConsts = new Set<string>()
+  for (const stmt of (program.body as Node[] | undefined) ?? []) {
+    if (stmt.type === 'ImportDeclaration') {
+      const source = stringValue(stmt.source) ?? ''
+      for (const spec of (stmt.specifiers as Node[] | undefined) ?? []) {
+        const local = identifierName(spec.local)
+        if (local) imports.set(local, { source })
+      }
+      continue
+    }
+    // `const X = ...` / `export const X = ...` at top level
+    const decl =
+      stmt.type === 'VariableDeclaration'
+        ? stmt
+        : stmt.type === 'ExportNamedDeclaration' && isNode(stmt.declaration)
+          ? (stmt.declaration as Node)
+          : null
+    if (isNode(decl) && decl.type === 'VariableDeclaration') {
+      for (const d of (decl.declarations as Node[] | undefined) ?? []) {
+        const name = identifierName(d.id)
+        if (name) topLevelConsts.add(name)
+      }
+    }
+  }
+  return { imports, topLevelConsts }
+}
+
+/**
+ * Mirror of scanner.ts `resolveImportSource` semantics on top of the
+ * AST import map: imported → module specifier, same-file const → `''`
+ * sentinel, otherwise null.
+ */
+function resolveSchemaRef(identifier: string, ctx: FileContext): SchemaRef {
+  const imported = ctx.imports.get(identifier)
+  if (imported) return { identifier, source: imported.source }
+  if (ctx.topLevelConsts.has(identifier)) return { identifier, source: '' }
+  return { identifier, source: null }
+}
+
+/** Schema field (`body:` / `query:` / `params:`) — bare identifiers only. */
+function schemaFieldRef(options: Node | null, field: string, ctx: FileContext): SchemaRef | null {
+  const value = getProp(options, field)
+  const name = identifierName(value)
+  return name ? resolveSchemaRef(name, ctx) : null
+}
+
+interface QueryParamsConfig {
+  filterable: string[]
+  sortable: string[]
+  searchable: string[]
+}
+
+/**
+ * `@ApiQueryParams(...)` on a method — inline object literal or a
+ * same-file const reference. Present-but-opaque (imported config,
+ * column-object map, function call) → empty arrays, mirroring the
+ * regex path's "decorator exists but nothing statically extractable".
+ */
+function extractApiQueryParams(
+  methodDecorators: Node[],
+  topLevelConstInits: Map<string, Node>,
+): QueryParamsConfig | null {
+  for (const dec of methodDecorators) {
+    const dc = decoratorCall(dec)
+    if (!dc || dc.name !== 'ApiQueryParams') continue
+    const arg = (dc.call.arguments as Node[] | undefined)?.[0]
+    let obj: Node | null = null
+    if (isNode(arg) && arg.type === 'ObjectExpression') {
+      obj = arg
+    } else {
+      const refName = identifierName(arg)
+      if (refName) {
+        const init = topLevelConstInits.get(refName)
+        if (init && init.type === 'ObjectExpression') obj = init
+      }
+    }
+    return {
+      filterable: extractStringArrayProp(obj, 'filterable'),
+      sortable: extractStringArrayProp(obj, 'sortable'),
+      searchable: extractStringArrayProp(obj, 'searchable'),
+    }
+  }
+  return null
+}
+
+/**
+ * Parse + extract one source file. Returns `null` when oxc reports
+ * parse errors — the caller falls back to the regex extractors, which
+ * tolerate broken mid-edit sources by matching whatever still looks
+ * right.
+ */
+export function extractFileAst(source: string, filePath: string, cwd: string): FileExtract | null {
+  let program: Node
+  try {
+    const result = parseSync(filePath, source)
+    if (result.errors.length > 0) return null
+    program = result.program as unknown as Node
+  } catch {
+    return null
+  }
+
+  const relPath = toRelative(filePath, cwd)
+  const ctx = buildFileContext(program)
+
+  const classes: DiscoveredClass[] = []
+  const tokens: DiscoveredToken[] = []
+  const injects: DiscoveredInject[] = []
+  const pluginsAndAdapters: DiscoveredPluginOrAdapter[] = []
+  const augmentations: DiscoveredAugmentation[] = []
+  const contextKeys: DiscoveredContextKey[] = []
+  const routes: DiscoveredRoute[] = []
+  const moduleMounts: ModuleMount[] = []
+  const globPatterns: string[] = []
+
+  const seenHelperNames = new Set<string>()
+  const seenContextKeys = new Set<string>()
+  const seenTokenNodes = new Set<Node>()
+  /** Top-level `const X = <init>` map for @ApiQueryParams const refs. */
+  const topLevelConstInits = new Map<string, Node>()
+
+  for (const stmt of (program.body as Node[] | undefined) ?? []) {
+    const decl =
+      stmt.type === 'VariableDeclaration'
+        ? stmt
+        : stmt.type === 'ExportNamedDeclaration' && isNode(stmt.declaration)
+          ? (stmt.declaration as Node)
+          : null
+    if (isNode(decl) && decl.type === 'VariableDeclaration') {
+      for (const d of (decl.declarations as Node[] | undefined) ?? []) {
+        const name = identifierName(d.id)
+        if (name && isNode(d.init)) topLevelConstInits.set(name, d.init as Node)
+      }
+    }
+  }
+
+  // ── Pass 1: top-level statements — classes + defineModule consts ──────
+  const exportedClasses: Array<{ cls: Node; isDefault: boolean }> = []
+  for (const stmt of (program.body as Node[] | undefined) ?? []) {
+    if (stmt.type === 'ExportNamedDeclaration' && isNode(stmt.declaration)) {
+      const d = stmt.declaration as Node
+      if (d.type === 'ClassDeclaration') exportedClasses.push({ cls: d, isDefault: false })
+    } else if (stmt.type === 'ExportDefaultDeclaration' && isNode(stmt.declaration)) {
+      const d = stmt.declaration as Node
+      if (d.type === 'ClassDeclaration') exportedClasses.push({ cls: d, isDefault: true })
+    }
+  }
+
+  for (const { cls, isDefault } of exportedClasses) {
+    const className = identifierName(cls.id)
+    if (!className) continue
+
+    // First call-form decorator whose name is in DECORATOR_NAMES — same
+    // pick as the regex (first in the stack wins).
+    let tagged: DecoratorName | null = null
+    for (const dec of decoratorsOf(cls)) {
+      const dc = decoratorCall(dec)
+      if (dc && getDecoratorNameSet().has(dc.name)) {
+        tagged = dc.name as DecoratorName
+        break
+      }
+    }
+    if (tagged) {
+      classes.push({ className, decorator: tagged, filePath, relativePath: relPath, isDefault })
+    } else if (classImplements(cls, 'AppModule')) {
+      classes.push({
+        className,
+        decorator: 'Module',
+        filePath,
+        relativePath: relPath,
+        isDefault,
+      })
+    }
+  }
+
+  // v4 factory modules: `export const XModule = defineModule({...})`
+  for (const stmt of (program.body as Node[] | undefined) ?? []) {
+    if (stmt.type !== 'ExportNamedDeclaration' || !isNode(stmt.declaration)) continue
+    const d = stmt.declaration as Node
+    if (d.type !== 'VariableDeclaration') continue
+    for (const declarator of (d.declarations as Node[] | undefined) ?? []) {
+      const name = identifierName(declarator.id)
+      const init = declarator.init as Node | undefined
+      if (!name || !isNode(init) || init.type !== 'CallExpression') continue
+      if (calleeName(init) !== 'defineModule') continue
+      if (classes.some((c) => c.className === name)) continue
+      classes.push({
+        className: name,
+        decorator: 'Module',
+        filePath,
+        relativePath: relPath,
+        isDefault: false,
+      })
+    }
+  }
+
+  // ── Pass 2: whole-tree walk — tokens, injects, helpers, globs ─────────
+  walk(program, (node) => {
+    // createToken('name') — const-bound (variable) or bare (null)
+    if (node.type === 'VariableDeclarator') {
+      const init = node.init as Node | undefined
+      if (isNode(init) && init.type === 'CallExpression' && calleeName(init) === 'createToken') {
+        const name = stringValue((init.arguments as Node[] | undefined)?.[0])
+        if (name !== null) {
+          seenTokenNodes.add(init)
+          tokens.push({
+            name,
+            variable: identifierName(node.id),
+            filePath,
+            relativePath: relPath,
+          })
+        }
+      }
+      return
+    }
+
+    if (node.type !== 'CallExpression') {
+      // import.meta.glob handled below (CallExpression); decorators are
+      // reached through their owning class/method nodes, but @Inject can
+      // appear on constructor params too — catch every decorator node.
+      if (node.type === 'Decorator') {
+        const dc = decoratorCall(node)
+        if (dc?.name === 'Inject') {
+          const lit = stringValue((dc.call.arguments as Node[] | undefined)?.[0])
+          if (lit !== null) injects.push({ name: lit, filePath, relativePath: relPath })
+        }
+      }
+      return
+    }
+
+    const callee = node.callee as Node
+    const name = calleeName(node)
+
+    // Bare createToken('name') not consumed by the declarator pass
+    if (name === 'createToken' && !seenTokenNodes.has(node)) {
+      const tokenName = stringValue((node.arguments as Node[] | undefined)?.[0])
+      if (tokenName !== null) {
+        tokens.push({ name: tokenName, variable: null, filePath, relativePath: relPath })
+      }
+      return
+    }
+
+    // defineAdapter({ name }) / definePlugin({ name })
+    if (name === 'defineAdapter' || name === 'definePlugin') {
+      const literal = stringValue(getProp(firstObjectArg(node), 'name'))
+      if (literal !== null) {
+        const kind = name === 'definePlugin' ? 'plugin' : 'adapter'
+        const dedupeKey = `${name}::${literal}::${filePath}`
+        if (!seenHelperNames.has(dedupeKey)) {
+          seenHelperNames.add(dedupeKey)
+          pluginsAndAdapters.push({ kind, name: literal, filePath, relativePath: relPath })
+        }
+      }
+      return
+    }
+
+    // defineAugmentation('Name', { description, example })
+    if (name === 'defineAugmentation') {
+      const args = (node.arguments as Node[] | undefined) ?? []
+      const augName = stringValue(args[0])
+      if (augName !== null) {
+        const meta = isNode(args[1]) && args[1].type === 'ObjectExpression' ? args[1] : null
+        augmentations.push({
+          name: augName,
+          description: stringValue(getProp(meta, 'description')),
+          example: stringValue(getProp(meta, 'example')),
+          filePath,
+          relativePath: relPath,
+        })
+      }
+      return
+    }
+
+    // defineContextDecorator({ key }) / defineHttpContextDecorator({ key })
+    // — direct form
+    if (name === 'defineContextDecorator' || name === 'defineHttpContextDecorator') {
+      const key = stringValue(getProp(firstObjectArg(node), 'key'))
+      if (key !== null && !seenContextKeys.has(key)) {
+        seenContextKeys.add(key)
+        contextKeys.push({ key, filePath, relativePath: relPath })
+      }
+      return
+    }
+
+    // Curried form: define(Http)ContextDecorator.withParams<P>()({ key })
+    // — outer call's callee is the inner `withParams()` call.
+    if (isNode(callee) && callee.type === 'CallExpression') {
+      const innerCallee = callee.callee as Node
+      if (
+        isNode(innerCallee) &&
+        innerCallee.type === 'MemberExpression' &&
+        identifierName(innerCallee.property) === 'withParams'
+      ) {
+        const base = identifierName(innerCallee.object)
+        if (base === 'defineContextDecorator' || base === 'defineHttpContextDecorator') {
+          const key = stringValue(getProp(firstObjectArg(node), 'key'))
+          if (key !== null && !seenContextKeys.has(key)) {
+            seenContextKeys.add(key)
+            contextKeys.push({ key, filePath, relativePath: relPath })
+          }
+        }
+      }
+      return
+    }
+
+    // import.meta.glob('...' | [...]) — module files only (caller gates)
+    if (
+      isNode(callee) &&
+      callee.type === 'MemberExpression' &&
+      identifierName(callee.property) === 'glob'
+    ) {
+      const obj = callee.object as Node
+      if (isNode(obj) && obj.type === 'MetaProperty') {
+        // Flatten every string literal across the args — matches the
+        // regex behaviour (single string + array forms, options object
+        // strings included only if literal; in practice options carry
+        // booleans).
+        walk(node.arguments, (argNode) => {
+          const s = stringValue(argNode)
+          if (s !== null) globPatterns.push(s)
+        })
+      }
+    }
+  })
+
+  // ── Pass 3: class bodies — routes + class-style adapters ─────────────
+  const allClasses: Array<{ cls: Node; className: string }> = []
+  walk(program, (node) => {
+    if (node.type === 'ClassDeclaration' || node.type === 'ClassExpression') {
+      const className = identifierName(node.id)
+      if (className) allClasses.push({ cls: node, className })
+    }
+  })
+
+  for (const { cls, className } of allClasses) {
+    const discovered = classes.find((c) => c.className === className)
+    const body = (cls.body as Node | undefined)?.body as Node[] | undefined
+
+    // Class-style adapters: `class X implements AppAdapter { name = '...' }`
+    if (classImplements(cls, 'AppAdapter')) {
+      for (const member of body ?? []) {
+        if (member.type !== 'PropertyDefinition') continue
+        if (identifierName(member.key) !== 'name') continue
+        const literal = stringValue(member.value)
+        if (literal === null) continue
+        const dedupeKey = `class::${literal}::${filePath}`
+        if (!seenHelperNames.has(dedupeKey)) {
+          seenHelperNames.add(dedupeKey)
+          pluginsAndAdapters.push({
+            kind: 'adapter',
+            name: literal,
+            filePath,
+            relativePath: relPath,
+          })
+        }
+        break
+      }
+    }
+
+    for (const member of body ?? []) {
+      if (member.type !== 'MethodDefinition') continue
+      const methodName = identifierName(member.key)
+      if (!methodName) continue
+
+      // Module mounts: `routes() { ... }` bodies — zip path/controller
+      // pairs in source order (works for the class form; the object-
+      // method form inside defineModule(build) is handled below).
+      if (methodName === 'routes') {
+        collectMounts(member.value as Node, moduleMounts)
+        continue
+      }
+
+      // Route handlers — every HTTP decorator on the method emits one
+      // route (stacked verbs = multiple routes, same as the regex).
+      if (!discovered) continue
+      const decs = decoratorsOf(member)
+      const apiQp = extractApiQueryParams(decs, topLevelConstInits)
+      for (const dec of decs) {
+        const dc = decoratorCall(dec)
+        if (!dc || !HTTP_DECORATORS.has(dc.name)) continue
+        const args = (dc.call.arguments as Node[] | undefined) ?? []
+        const rawPath = stringValue(args[0])
+        const path = rawPath && rawPath.length > 0 ? rawPath : '/'
+        const options = isNode(args[1]) && args[1].type === 'ObjectExpression' ? args[1] : null
+
+        routes.push({
+          controller: className,
+          method: methodName,
+          httpMethod: dc.name.toUpperCase() as DiscoveredRoute['httpMethod'],
+          path,
+          // extractFile contract: own-path params only — the cross-file
+          // join re-applies mount prefixes (scanner.ts joinExtracts).
+          pathParams: extractPathParams(path),
+          queryFilterable: apiQp?.filterable ?? null,
+          querySortable: apiQp?.sortable ?? null,
+          querySearchable: apiQp?.searchable ?? null,
+          bodySchema: schemaFieldRef(options, 'body', ctx),
+          querySchema: schemaFieldRef(options, 'query', ctx),
+          paramsSchema: schemaFieldRef(options, 'params', ctx),
+          filePath,
+          relativePath: relPath,
+        })
+      }
+    }
+  }
+
+  // Object-method `routes()` (defineModule build objects and friends).
+  walk(program, (node) => {
+    if (node.type !== 'Property' || identifierName(node.key) !== 'routes') return
+    const value = node.value as Node
+    if (
+      isNode(value) &&
+      (value.type === 'FunctionExpression' || value.type === 'ArrowFunctionExpression')
+    ) {
+      collectMounts(value, moduleMounts)
+    }
+  })
+
+  return {
+    classes,
+    tokens,
+    injects,
+    pluginsAndAdapters,
+    augmentations,
+    contextKeys,
+    routes,
+    moduleMounts,
+    globPatterns: /\.module\.[mc]?[tj]sx?$/.test(filePath) ? globPatterns : [],
+  }
+}
+
+/**
+ * Collect `{ path: '...', controller: Ident }` pairs from a routes()
+ * function body — zipped in traversal order, shorter list wins, same
+ * as the regex `extractModuleMounts`.
+ */
+function collectMounts(fn: Node, out: ModuleMount[]): void {
+  const paths: string[] = []
+  const controllers: string[] = []
+  walk(fn.body, (node) => {
+    if (node.type !== 'Property') return
+    const key = identifierName(node.key)
+    if (key === 'path') {
+      const s = stringValue(node.value)
+      if (s !== null) paths.push(s)
+    } else if (key === 'controller') {
+      const id = identifierName(node.value)
+      if (id && /^[A-Z]/.test(id)) controllers.push(id)
+    }
+  })
+  const n = Math.min(paths.length, controllers.length)
+  for (let i = 0; i < n; i++) {
+    out.push({ controller: controllers[i], mountPath: paths[i] })
+  }
+}
+
+/**
+ * `joinExtracts` re-derives `pathParams` with the mount prefix — the
+ * scanner needs the same joiner the regex path used; re-exported here
+ * so both implementations share one definition is unnecessary (the
+ * scanner keeps its own). This export exists for tests only.
+ */
+export const __testing = { joinMountPath, extractPathParams }

--- a/packages/cli/src/typegen/scanner-cache.ts
+++ b/packages/cli/src/typegen/scanner-cache.ts
@@ -28,7 +28,10 @@ import { dirname, join } from 'node:path'
 import type { FileExtract } from './scanner'
 
 /** Bump when the shape of `FileExtract` (or any extractor) changes. */
-const CACHE_VERSION = 1
+// v2: per-file extraction switched to AST-first (extract-ast.ts) — v1
+// entries hold regex-era results that can differ (template-literal
+// paths, aliased schema-ref resolution), so they must not be served.
+const CACHE_VERSION = 2
 
 /** The array-valued keys every `FileExtract` must carry. */
 const EXTRACT_ARRAY_KEYS = [

--- a/packages/cli/src/typegen/scanner.ts
+++ b/packages/cli/src/typegen/scanner.ts
@@ -29,6 +29,7 @@ import type { Dirent } from 'node:fs'
 import { readdir, readFile } from 'node:fs/promises'
 import { join, relative, resolve, sep } from 'node:path'
 import { ScanCache } from './scanner-cache'
+import { extractFileAst } from './extract-ast'
 
 /** Decorators that mark a class as DI-managed */
 export const DECORATOR_NAMES = [
@@ -1363,11 +1364,27 @@ export interface FileExtract {
 }
 
 /**
- * Run every per-file extractor over one source string. Pure: depends
- * only on the file's own text, so the result is safe to cache by
- * filesystem signature (see `scanner-cache.ts`).
+ * Run per-file extraction over one source string. Pure: depends only
+ * on the file's own text, so the result is safe to cache by filesystem
+ * signature (see `scanner-cache.ts`).
+ *
+ * AST-first (oxc-parser — exact decorator/argument parsing, template-
+ * literal route paths, no balanced-delimiter heuristics), falling back
+ * to the regex extractors when the file doesn't parse — mid-edit
+ * syntax errors in watch mode still yield partial results that keep
+ * the dev loop alive.
  */
 export function extractFile(source: string, filePath: string, cwd: string): FileExtract {
+  const ast = extractFileAst(source, filePath, cwd)
+  if (ast) return ast
+  return extractFileRegex(source, filePath, cwd)
+}
+
+/**
+ * The original regex extraction pipeline — fallback for unparseable
+ * sources and the parity baseline for the AST extractor's tests.
+ */
+export function extractFileRegex(source: string, filePath: string, cwd: string): FileExtract {
   const classes = extractClassesFromSource(source, filePath, cwd)
   return {
     classes,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
+      oxc-parser:
+        specifier: ^0.135.0
+        version: 0.135.0
       oxfmt:
         specifier: ^0.54.0
         version: 0.54.0
@@ -1610,6 +1613,125 @@ packages:
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
+  '@oxc-parser/binding-android-arm-eabi@0.135.0':
+    resolution: {integrity: sha512-sHeZItACNcA5WRAWqF6ixriR4GkZDyY10gVgnZU7pXku1DjHFATSqnwZM809jl0gXPHxb6fKzYQCK7bNK5cACQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.135.0':
+    resolution: {integrity: sha512-wPte+SzgzWWFgMSF8YZDNM+tBXtJg0AXBi7+tU3yS2z1f2Af9kRLZLKuJojADmuD/cZexmnMHHC3SDItTW77Iw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.135.0':
+    resolution: {integrity: sha512-BmKz3lHIsqVos+9aPcdYCT9MG3APoUyM43KlEFhJMWNVDOGG8FKyiFz81Bc+mGz2o0hpuQ3PfXLfVWJrKXjo2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.135.0':
+    resolution: {integrity: sha512-dM8BS+8+Br1fNvmh2QZbGiHaYttwLebRa6J4Uz9vuFzMNmvsdRYwf7993ptOaV0JTrR63AaoVLjX7nhWbijxjQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.135.0':
+    resolution: {integrity: sha512-xlZnvvJdR9bGu2pOhvR5hMuKPHCE6Sa9owK5A484mzjHdm75VRV5nCs5w/jkmGODMMTFc+KN7EnZqEieM813kw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.135.0':
+    resolution: {integrity: sha512-PSR8LmBK/H/PQRiN8g7RebQgZX/ntVCrdT/JBfNxE5ezdHG1s2i4rbazsRJYD83TTI1MmgTpC0MGL42PLtskQQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.135.0':
+    resolution: {integrity: sha512-I85GJXzfUsigkkk7Ngdz95C217M4FdUi1Z2HrX5UyPmURobwQZ7m2bbUvwFkz4VGZd+lymFGKHvDZ3RQC9qOzA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.135.0':
+    resolution: {integrity: sha512-zqEY0npz0g0aGZj/8a5BclunjVDytsBQHYtIC10Gd26HcrLwbVF6YDbqRQjunMGYdSo97u6xOBl05aTDI2diDQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.135.0':
+    resolution: {integrity: sha512-mWAfprP819gQ2qYst1RxgTI8b/z0b29OpoKfRflIXLHde2dZLihQD4g47Onuvtpo5GPIkMYPRlX9QoeZfs/GnQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.135.0':
+    resolution: {integrity: sha512-gri8c2AOmJKJwOux2KTHFBfUaXoJURuVMKhmKEi/2hTF55cQteTDV2XNfTiE5oCC+Tnem1Y4/MWzcyDadtsSag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.135.0':
+    resolution: {integrity: sha512-Y2tkupCG5wo0SxH2rMLG4d4Kmv6DaM3sBp+GuM5lox0S8Za6VxKgQrY2Mut088QQxKkEE89n/4CCCgmw2o0e3Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.135.0':
+    resolution: {integrity: sha512-xDRJq6i6WTynjeP+ISbDpyH4p9BaJ0wuQcL0lCSDkt9qOXC9dmwpOu1VG/TlwmPI3KpYntmO9nJCuc3TMTsNBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.135.0':
+    resolution: {integrity: sha512-V4MoUuiCRNvihxhIufRxvK+ka013V4joTSK0FAGA1KEjLuNprfH6N/Qw2uxQEVIFuNYMhD/hV6xJ/ptbzlKdHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.135.0':
+    resolution: {integrity: sha512-JCFZ7zM7KXOKoPAbK/ZB4wY0M1jxRECiem2UQuiXLjzGqS9+hno7mtX+qyK2F7HWK2xPhyJb+frpcOtk5DKOtg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-musl@0.135.0':
+    resolution: {integrity: sha512-9jSVS1b3hOV7sdKH4aA2DFfnTz0RgQd0v2BefR+LYbH8yIlmSM22JJZbAAjVeVXmFgUAk3zJQ1tpE/Nd+Vi2YQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-openharmony-arm64@0.135.0':
+    resolution: {integrity: sha512-M857ZLBSdn1Uy/SJJz5zh0qGu67B4P9omCgXGBU2LLqTzraX6ZjVNaKq5yW1PDw/LgJXDXR/dbZfgmB310f11Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.135.0':
+    resolution: {integrity: sha512-2w6DVcntQZX9U5RhXtgiWb3FLWFB5EcwI1U8yr3htOCJUJjagN4BFUHz/Y/d9ZsumndZ6ByxxWEtbUZNE1bfFw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.135.0':
+    resolution: {integrity: sha512-rX1U8+IH2Z37EJjDXKa1iifvUQAdba+vZ4Ewj1iaG5eA/QaSybzclCOwtWa0/5BuUQnnK/T2JHUEFrwhL6Ck2Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.135.0':
+    resolution: {integrity: sha512-9FAisBbH1QICGAjlJobiuKGd/jOuVmyqniWdQMwTa5SkCl6hhuotBCJf1n46B0flYbSOR5TzfV9HZCWSyb3c/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.135.0':
+    resolution: {integrity: sha512-wYF+A2AzJ2n7ul6q+Z2G/ia0S2+8cUp0AgWZzoFvF4WmUcl1P7p+o6se1Gdr5wGnWuF0iAMIkGddrjCarNr2yA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
@@ -1618,6 +1740,9 @@ packages:
 
   '@oxc-project/types@0.134.0':
     resolution: {integrity: sha512-T0xuRRKrQFmocH8y+jGfpmSkGcheaJExY9lEihmR1Gm2aH+75B8CzgU2rABRQSzzDxLjZ15Sc0bRVLj5lVeNXQ==}
+
+  '@oxc-project/types@0.135.0':
+    resolution: {integrity: sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==}
 
   '@oxfmt/binding-android-arm-eabi@0.54.0':
     resolution: {integrity: sha512-NAtpl/SiaeU103e7/OmZw0MvUnsUUopW7hEm/ecegJg7YM0skQaA0IXEZoyTV6NUdiNPupdIUreRqUZTShbn/g==}
@@ -4631,6 +4756,10 @@ packages:
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
+  oxc-parser@0.135.0:
+    resolution: {integrity: sha512-/DaPStu0s2zzNSRRniKyTPM6Z/o+DapOp2JYNKDL8AsgaBGPK2IdZyB87SQjVH+xeQPz+Qr9mrjglfkYgtbVRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   oxfmt@0.54.0:
     resolution: {integrity: sha512-DjnMwn7smSLF+Mc2+pRItnuPftm/dkUFpY/d4+33y9TfKrsHZo8GLhmUg9BrOIUEy94Rlom1Q11N6vuhE+e0oQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6760,11 +6889,77 @@ snapshots:
   '@opentelemetry/api@1.9.1':
     optional: true
 
+  '@oxc-parser/binding-android-arm-eabi@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.135.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.135.0':
+    optional: true
+
   '@oxc-project/types@0.127.0': {}
 
   '@oxc-project/types@0.133.0': {}
 
   '@oxc-project/types@0.134.0': {}
+
+  '@oxc-project/types@0.135.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.54.0':
     optional: true
@@ -9410,6 +9605,31 @@ snapshots:
       regex-recursion: 6.0.2
 
   outdent@0.5.0: {}
+
+  oxc-parser@0.135.0:
+    dependencies:
+      '@oxc-project/types': 0.135.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.135.0
+      '@oxc-parser/binding-android-arm64': 0.135.0
+      '@oxc-parser/binding-darwin-arm64': 0.135.0
+      '@oxc-parser/binding-darwin-x64': 0.135.0
+      '@oxc-parser/binding-freebsd-x64': 0.135.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.135.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.135.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.135.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.135.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.135.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.135.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.135.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.135.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.135.0
+      '@oxc-parser/binding-linux-x64-musl': 0.135.0
+      '@oxc-parser/binding-openharmony-arm64': 0.135.0
+      '@oxc-parser/binding-wasm32-wasi': 0.135.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.135.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.135.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.135.0
 
   oxfmt@0.54.0:
     dependencies:


### PR DESCRIPTION
﻿## Why

The typegen scanner's per-file extraction was regex-based — fast, but with a known accuracy ceiling (forinda/kick-js#108): nested parens in stacked decorator args, template literals, string contents skewing balanced-delimiter walkers, and aliased imports were all invisible or mis-parsed. oxc-parser (Rust, napi) parses a file in ~1ms, so the speed argument for regex no longer holds.

## What

- **New `src/typegen/extract-ast.ts`** — oxc-parser implementation of the full per-file `FileExtract` contract (classes, tokens, injects, plugins/adapters, augmentations, context keys, routes, module mounts, glob patterns). Produces the same shape the cache/incremental/cross-file-join machinery already consumes; none of that changed.
- **`extractFile()` is now AST-first** with the regex pipeline kept as `extractFileRegex()` — the fallback for unparseable mid-edit sources in watch mode (regex still salvages partial results there), and the parity baseline in tests.
- **Scan cache bumped to v2** — regex-era cached extracts can differ and must not be served.

### Accuracy fixes over the regex path (each covered by a test)

- Template-literal route paths (`` @Get(`/v1/users/:id`) ``) extract correctly.
- `@ApiQueryParams` stacked **above** the HTTP decorator was silently dropped by the regex (it only searched text after `@Get`) — now seen regardless of stack order.
- String literals containing parens/braces can no longer skew extraction.
- Aliased named imports (`import { schema as createUserSchema }`) resolve as schema sources.
- Const-bound `createToken` declarations are no longer double-emitted (regex emitted them a second time as a bare call; harmless downstream but wrong).

## Verification

- 15 new tests: parity harness (AST vs regex deep-equal on representative sources covering every extractor) + the five fix cases + parse-failure fallback.
- **Full CLI suite: 41 files, 430 tests, 0 failures** — all scanner suites (cache, incremental, mount-path-params, orphaned-classes, context-keys, env-detection) and the typegen E2E fixtures now run through the AST path unchanged.
- Perf: `kick typegen` on a real project reports 26ms scan (cold), unchanged from the regex era — wall time is node startup, not extraction.
- oxc-parser ships as a regular dependency (napi binary, external in the tsdown bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
