### PR TITLE
fix(db): kick/db typegen honours db.schemaPath from kick.config

### DIFF
--- a/.changeset/db-typegen-schema-path.md
+++ b/.changeset/db-typegen-schema-path.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-db': patch
+---
+
+`kick/db` typegen now honours `db.schemaPath` from kick.config, matching `kick db generate`. Previously a custom schema path produced working migrations but a silently untyped client (the typegen only probed the default `src/db/schema*` candidates). A configured-but-missing path falls back to the default candidates instead of emitting a broken import.

--- a/packages/db/__tests__/unit/cli-typegen-schema-path.test.ts
+++ b/packages/db/__tests__/unit/cli-typegen-schema-path.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+import { kickDbTypegen } from '../../src/cli-typegen'
+
+let project: string
+
+beforeEach(() => {
+  project = mkdtempSync(join(tmpdir(), 'kick-db-tg-'))
+})
+
+afterEach(() => {
+  rmSync(project, { recursive: true, force: true })
+})
+
+function writeSchema(relPath: string): void {
+  const abs = join(project, relPath)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, 'export const users = {}\n')
+}
+
+describe('kickDbTypegen schema resolution', () => {
+  it('honours db.schemaPath from kick.config (parity with `kick db generate`)', async () => {
+    writeSchema('src/database/my-schema.ts')
+    const out = await kickDbTypegen().generate({
+      cwd: project,
+      config: { db: { schemaPath: 'src/database/my-schema.ts' } },
+    })
+    expect(out).not.toBeNull()
+    expect(out).toContain("from '../../src/database/my-schema'")
+  })
+
+  it('falls back to the default candidates when no config path is set', async () => {
+    writeSchema('src/db/schema.ts')
+    const out = await kickDbTypegen().generate({ cwd: project, config: {} })
+    expect(out).not.toBeNull()
+    expect(out).toContain("from '../../src/db/schema'")
+  })
+
+  it('configured path missing → falls back to candidates rather than emitting a broken import', async () => {
+    writeSchema('src/db/schema.ts')
+    const out = await kickDbTypegen().generate({
+      cwd: project,
+      config: { db: { schemaPath: 'src/nowhere/schema.ts' } },
+    })
+    expect(out).not.toBeNull()
+    expect(out).toContain("from '../../src/db/schema'")
+  })
+
+  it('returns null when nothing resolves', async () => {
+    const out = await kickDbTypegen().generate({ cwd: project, config: {} })
+    expect(out).toBeNull()
+  })
+})

--- a/packages/db/src/cli-typegen.ts
+++ b/packages/db/src/cli-typegen.ts
@@ -29,8 +29,13 @@ const DEFAULT_SCHEMA_PATHS = [
 export const kickDbTypegen = (): CliTypegen => ({
   id: 'kick/db',
   inputs: ['src/db/schema.ts', 'src/db/schema/**/*.ts'],
-  async generate(ctx: { cwd: string }) {
-    const schemaAbs = resolveSchema(ctx.cwd)
+  async generate(ctx: { cwd: string; config?: { db?: { schemaPath?: string } } }) {
+    // Parity with `kick db generate` (cli/config.ts resolveDbConfig):
+    // an adopter-configured `db.schemaPath` must drive BOTH the
+    // migration engine and this augmentation — previously only the
+    // default candidates were probed, so a custom path produced
+    // working migrations but a silently untyped client.
+    const schemaAbs = resolveSchema(ctx.cwd, ctx.config?.db?.schemaPath)
     if (!schemaAbs) return null
 
     // Strip the `.ts` extension and any trailing `/index` so the import
@@ -61,7 +66,16 @@ export const kickDbTypegen = (): CliTypegen => ({
   },
 })
 
-function resolveSchema(cwd: string): string | null {
+function resolveSchema(cwd: string, configuredPath?: string): string | null {
+  // kick.config `db.schemaPath` wins when the file exists; a configured-
+  // but-missing path falls through to the candidates rather than
+  // emitting an augmentation with a broken import specifier.
+  if (configuredPath) {
+    const abs = path.resolve(cwd, configuredPath)
+    if (existsSync(abs)) return abs
+    const idx = path.join(abs, 'index.ts')
+    if (existsSync(idx)) return idx
+  }
   for (const candidate of DEFAULT_SCHEMA_PATHS) {
     const abs = path.resolve(cwd, candidate)
     if (candidate.endsWith('.ts')) {


### PR DESCRIPTION
Parity fix: \kick db generate\ reads \db.schemaPath\ from kick.config but the \kick/db\ typegen only probed the default \src/db/schema*\ candidates - a custom path produced working migrations with a silently untyped client. The typegen now resolves the configured path first (falling back to the candidates when it does not exist, rather than emitting a broken import). 4 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)