### PR TITLE
fix(db): prune redundant FK/index drops from inverted migrations (sqlite first-migration fix)

### DIFF
--- a/.changeset/db-invert-redundant-drops.md
+++ b/.changeset/db-invert-redundant-drops.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-db': patch
+---
+
+`kick db generate` no longer fails on SQLite for FK-bearing schemas. Inverting a migration now prunes `dropForeignKey` / `dropIndex` entries for tables the same down-set drops outright — `DROP TABLE` removes both, and on SQLite those drops compile to a table rebuild against the post-state snapshot, which no longer contains the table. Every first migration of a schema with foreign keys previously died with `SqliteRebuildRequiredError: no resolved snapshot for table 'X'` while emitting down.sql. Postgres/MySQL down migrations also lose the redundant pre-drop statements.

--- a/.changeset/db-invert-redundant-drops.md
+++ b/.changeset/db-invert-redundant-drops.md
@@ -3,3 +3,5 @@
 ---
 
 `kick db generate` no longer fails on SQLite for FK-bearing schemas. Inverting a migration now prunes `dropForeignKey` / `dropIndex` entries for tables the same down-set drops outright — `DROP TABLE` removes both, and on SQLite those drops compile to a table rebuild against the post-state snapshot, which no longer contains the table. Every first migration of a schema with foreign keys previously died with `SqliteRebuildRequiredError: no resolved snapshot for table 'X'` while emitting down.sql. Postgres/MySQL down migrations also lose the redundant pre-drop statements.
+
+Additionally, the sqlite adapter's `SqliteStatement.all`/`get` are no longer method-generic, so a real better-sqlite3 v12 `Database` passes `sqliteAdapter` / `sqliteDialect` without casts (same fix as `SqliteIntrospectDb`).

--- a/packages/db/__tests__/unit/cli-generate.test.ts
+++ b/packages/db/__tests__/unit/cli-generate.test.ts
@@ -45,9 +45,9 @@ describe('generate()', () => {
     // Forward only adds — per spec §5, the reverse is clean (no DRAFT marker).
     expect(downSql).not.toContain('-- DRAFT')
     expect(downSql).toContain('DROP TABLE "users"')
-    expect(downSql).toContain('DROP INDEX "users_email_unique"')
-    // Order: drop index before drop table.
-    expect(downSql.indexOf('DROP INDEX')).toBeLessThan(downSql.indexOf('DROP TABLE'))
+    // The index lives on a table the down drops outright — its DROP INDEX
+    // is pruned as redundant (see invert-redundant-drops.test.ts).
+    expect(downSql).not.toContain('DROP INDEX "users_email_unique"')
 
     const meta = JSON.parse(
       await readFile(path.join(cfg.migrationsDir, subdirs[0], 'meta.json'), 'utf8'),

--- a/packages/db/__tests__/unit/invert-redundant-drops.test.ts
+++ b/packages/db/__tests__/unit/invert-redundant-drops.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Inverting a fresh-schema migration (createTable + addIndex +
+ * addForeignKey) must NOT emit dropForeignKey / dropIndex for tables the
+ * same inverted set drops outright — DROP TABLE removes both, and on
+ * SQLite the FK/index drop compiles to a table rebuild against the
+ * post-state snapshot, which no longer contains the table. This was the
+ * `SqliteRebuildRequiredError: no resolved snapshot for table 'X'`
+ * failure on every first `kick db generate` for an FK-bearing schema.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { invertChanges } from '../../src/diff/invert'
+import type { ChangeSet } from '../../src/diff/types'
+import type { ForeignKeySnapshot, TableSnapshot } from '../../src/snapshot/types'
+
+function tableSnap(name: string): TableSnapshot {
+  return { name, columns: {}, indexes: [], foreignKeys: [], checks: [] }
+}
+
+const FK: ForeignKeySnapshot = {
+  name: 'tasks_projectId_fk',
+  columns: ['projectId'],
+  refTable: 'projects',
+  refColumns: ['id'],
+  onDelete: 'cascade',
+  onUpdate: 'no_action',
+}
+
+describe('invertChanges — redundant teardown pruning', () => {
+  it('drops FK/index inversions for tables the inverted set drops', () => {
+    const forward: ChangeSet = [
+      { kind: 'createTable', table: tableSnap('projects') },
+      { kind: 'createTable', table: tableSnap('tasks') },
+      {
+        kind: 'addIndex',
+        table: 'tasks',
+        index: { name: 'tasks_done_idx', columns: ['done'], unique: false },
+      },
+      { kind: 'addForeignKey', table: 'tasks', fk: FK },
+    ]
+
+    const down = invertChanges(forward)
+    expect(down.map((c) => c.kind)).toEqual(['dropTable', 'dropTable'])
+  })
+
+  it('keeps FK/index drops for tables that survive', () => {
+    const forward: ChangeSet = [
+      { kind: 'createTable', table: tableSnap('projects') },
+      // tasks pre-exists — only its FK is added this migration.
+      { kind: 'addForeignKey', table: 'tasks', fk: FK },
+    ]
+
+    const down = invertChanges(forward)
+    expect(down.map((c) => c.kind)).toEqual(['dropForeignKey', 'dropTable'])
+  })
+})

--- a/packages/db/__tests__/unit/invert.test.ts
+++ b/packages/db/__tests__/unit/invert.test.ts
@@ -53,16 +53,20 @@ describe('invertChanges()', () => {
   })
 
   it('reverses the order so teardown matches dependencies', () => {
+    // Index/FK live on a table that SURVIVES the inversion ('other'),
+    // so their drops are kept and ordered before the dropTable. When
+    // they belong to a table the inverted set drops, they're pruned
+    // outright — see invert-redundant-drops.test.ts.
     const fwd: ChangeSet = [
       { kind: 'createTable', table: usersTable },
-      { kind: 'addIndex', table: 'users', index: { name: 'i', columns: ['id'], unique: false } },
+      { kind: 'addIndex', table: 'other', index: { name: 'i', columns: ['id'], unique: false } },
       {
         kind: 'addForeignKey',
-        table: 'users',
+        table: 'other',
         fk: {
           name: 'fk',
           columns: ['id'],
-          refTable: 'other',
+          refTable: 'users',
           refColumns: ['id'],
           onDelete: 'cascade',
           onUpdate: 'no_action',

--- a/packages/db/src/adapters/sqlite/adapter.ts
+++ b/packages/db/src/adapters/sqlite/adapter.ts
@@ -17,10 +17,17 @@ import { introspectSqlite } from '../../migrate/introspect-sqlite'
  * to match the `MigrationAdapter` contract. No I/O actually awaits;
  * the wrapping is for shape compatibility.
  */
+/**
+ * `all` / `get` are deliberately NOT method-generic: better-sqlite3
+ * v12's own `Statement` methods are non-generic, so generic signatures
+ * here would make a real `Database` instance structurally incompatible
+ * (callers had to cast — same fix as `SqliteIntrospectDb`). Row typing
+ * happens at the call sites via assertions instead.
+ */
 export interface SqliteStatement {
   run(...params: readonly unknown[]): { changes: number; lastInsertRowid: number | bigint }
-  all<R = unknown>(...params: readonly unknown[]): R[]
-  get<R = unknown>(...params: readonly unknown[]): R | undefined
+  all(...params: readonly unknown[]): unknown[]
+  get(...params: readonly unknown[]): unknown
 }
 
 export interface SqliteDatabaseLike {
@@ -75,14 +82,14 @@ export function sqliteAdapter(opts: SqliteAdapterOptions): MigrationAdapter {
            FROM kick_migrations
            ORDER BY applied_at ASC, id ASC`,
         )
-        .all<{
-          id: string
-          name: string
-          hash: string
-          batch: number
-          applied_at: string
-          direction: 'up' | 'down'
-        }>()
+        .all() as {
+        id: string
+        name: string
+        hash: string
+        batch: number
+        applied_at: string
+        direction: 'up' | 'down'
+      }[]
       return rows.map((row) => ({
         id: row.id,
         name: row.name,

--- a/packages/db/src/diff/invert.ts
+++ b/packages/db/src/diff/invert.ts
@@ -20,7 +20,24 @@ export function invertChanges(forward: ChangeSet): ChangeSet {
   for (const change of forward) {
     reversed.push(invert(change))
   }
-  return reversed.toReversed()
+  const ordered = reversed.toReversed()
+
+  // Prune redundant teardown: when the inverted set drops a table
+  // outright, its dropForeignKey / dropIndex entries are no-ops — the
+  // DROP TABLE removes both. On SQLite they're actively fatal: FK/index
+  // drops compile to a table rebuild against the post-state snapshot,
+  // which no longer contains the table when the inversion of a
+  // createTable is in the same set (every first migration of an
+  // FK-bearing schema hit `SqliteRebuildRequiredError`).
+  const droppedTables = new Set(
+    ordered.filter((c) => c.kind === 'dropTable').map((c) => c.table.name),
+  )
+  return ordered.filter((c) => {
+    if (c.kind === 'dropForeignKey' || c.kind === 'dropIndex') {
+      return !droppedTables.has(c.table)
+    }
+    return true
+  })
 }
 
 function invert(change: Change): Change {


### PR DESCRIPTION
Found by live E2E: every first \kick db generate\ on SQLite for an FK-bearing schema died with \SqliteRebuildRequiredError: no resolved snapshot for table 'X'\ while emitting down.sql. The inverted change set ordered \dropForeignKey\/\dropIndex\ before \dropTable\ for the same tables; on SQLite those compile to a table rebuild against the post-state snapshot - which is empty when the down fully reverts a first migration. \invertChanges()\ now prunes FK/index drops for tables the same set drops outright (DROP TABLE removes both); drops on surviving tables keep the existing ordering. PG/MySQL down migrations also lose the redundant statements. 2 new tests + 2 expectation updates; full db suite 434 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `kick db generate` command failing on SQLite databases with schemas containing foreign keys
  * Improved migration inversion to eliminate redundant drop statements that could cause errors

* **Tests**
  * Added and updated unit tests for migration inversion behavior with constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->