### PR TITLE
fix(cli): scaffold dev script runs kick dev so typegen-on-save actually works

### DIFF
--- a/.changeset/cli-scaffold-kick-dev.md
+++ b/.changeset/cli-scaffold-kick-dev.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+Scaffolded projects now get `"dev": "kick dev"` instead of bare `"dev": "vite"`. The typegen-on-save watcher (and the opt-in `--typecheck` worker) live only in `kick dev` — the bare `vite` script gave working HMR with silently frozen `.kickjs/types`, so adding a route or controller required a manual `kick typegen` to refresh its typing. Existing projects: change the `dev` script in package.json to `kick dev`.

--- a/packages/cli/__tests__/scaffold-dev-script.test.ts
+++ b/packages/cli/__tests__/scaffold-dev-script.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Drift guard: the scaffolded `dev` script must go through `kick dev`,
+ * never bare `vite`. The typegen-on-save watcher (and the --typecheck
+ * worker) live ONLY in `kick dev` — a bare `vite` script gives working
+ * HMR with silently frozen `.kickjs/types`, the exact DX failure where
+ * adding a controller path requires a manual `kick typegen`.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { generatePackageJson } from '../src/generators/templates/project-config'
+
+describe('scaffolded package.json scripts', () => {
+  it('dev runs kick dev (typegen watcher), not bare vite', () => {
+    const versions = {
+      '@forinda/kickjs': '^5.16.0',
+      '@forinda/kickjs-schema': '^0.1.2',
+      '@forinda/kickjs-cli': '^6.0.1',
+      '@forinda/kickjs-vite': '^6.0.1',
+    }
+    const pkg = JSON.parse(generatePackageJson('demo-app', 'minimal', versions))
+    expect(pkg.scripts.dev).toBe('kick dev')
+    expect(pkg.scripts['dev:debug']).toBe('kick dev:debug')
+    expect(pkg.scripts.build).toBe('kick build')
+    expect(pkg.scripts.typegen).toBe('kick typegen')
+  })
+})

--- a/packages/cli/src/generators/templates/project-config.ts
+++ b/packages/cli/src/generators/templates/project-config.ts
@@ -91,7 +91,11 @@ export function generatePackageJson(
       version: '0.0.0',
       type: 'module',
       scripts: {
-        dev: 'vite',
+        // `kick dev` (not bare `vite`): it boots Vite itself AND owns the
+        // typegen-on-save watcher. Plain `vite` gives working HMR but
+        // frozen `.kickjs/types` — new routes silently lose their typing
+        // until a manual `kick typegen`.
+        dev: 'kick dev',
         'dev:debug': 'kick dev:debug',
         build: 'kick build',
         start: 'kick start',


### PR DESCRIPTION
Root cause of the "added a controller path, had to rerun typegen" DX failure: the project template scaffolds `"dev": "vite"`, but the entire typegen-on-save pipeline (debounced watcher, incremental scan, error surfacing, `--typecheck` worker) lives only in `kick dev` — the `@forinda/kickjs-vite` plugin has zero typegen logic. Plain `vite` gives working HMR with silently frozen `.kickjs/types`, so every scaffolded project shipped with stale-types-on-save by default.

Template now emits `"dev": "kick dev"` (which boots Vite itself — no other behavior change), with a drift-guard test asserting the kick-owned scripts. Changeset includes the one-line migration note for existing projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
