### PR TITLE
feat(vite,cli): typegen-on-save for bare vite boots + eager re-warm surfaces errors on save

### DIFF
--- a/.changeset/vite-typegen-and-rewarm.md
+++ b/.changeset/vite-typegen-and-rewarm.md
@@ -1,0 +1,10 @@
+---
+'@forinda/kickjs-vite': minor
+'@forinda/kickjs-cli': minor
+---
+
+Two dev-loop fixes:
+
+**Typegen-on-save for bare `vite` boots.** The vite plugin array now includes `kickjs:typegen`, which wires the same debounced typegen watcher `kick dev` uses — so projects (or tools) that boot Vite directly no longer run with silently frozen `.kickjs/types`. The engine is the CLI's new exported `createTypegenDevWatcher()`; the plugin resolves `@forinda/kickjs-cli` from the project root at runtime (optional peer — manifest-walk resolution, since the ESM-only exports map defeats `require.resolve`) and quietly stands down when the CLI is absent or when `kick dev` has claimed ownership via `TYPEGEN_OWNER_KEY` (no double-running). A startup catch-up pass covers edits made while no dev server was running.
+
+**Errors now surface on save, not on the next request.** The app module was re-evaluated lazily after HMR/module-discovery invalidation, so a broken save (syntax error, failed import, bootstrap throw) stayed silent until an HTTP request arrived. Both invalidation paths now eagerly re-warm `virtual:kickjs/app` and log the failure (with fixed stacktraces) the moment the save lands — matching the eager startup behavior.

--- a/packages/cli/__tests__/typegen-dev-watcher.test.ts
+++ b/packages/cli/__tests__/typegen-dev-watcher.test.ts
@@ -47,7 +47,10 @@ describe('createTypegenDevWatcher', () => {
 
     expect(pipeline.runTypegen).toHaveBeenCalledTimes(1)
     const delta = pipeline.runTypegen.mock.calls[0][0].changedFiles
-    expect(delta.changed.sort()).toEqual(['/proj/src/a.controller.ts', '/proj/src/b.service.ts'])
+    expect(delta.changed.toSorted()).toEqual([
+      '/proj/src/a.controller.ts',
+      '/proj/src/b.service.ts',
+    ])
     expect(delta.removed).toEqual(['/proj/src/gone.ts'])
     expect(pipeline.runAllPluginTypegens).toHaveBeenCalledTimes(1)
   })
@@ -90,6 +93,23 @@ describe('createTypegenDevWatcher', () => {
       changed: [],
       removed: [],
     })
+  })
+
+  it('asset detection survives mixed path separators (Windows chokidar)', async () => {
+    const config = { assetMap: { mails: { src: 'src/templates/mails' } } } as unknown as KickConfig
+    const { watcher, pipeline } = makeWatcher(config)
+    // Simulate a native-separator chokidar event against the resolved root.
+    const winStyle = `${watcher.assetSrcRoots[0].replaceAll('/', '\\')}\\welcome.ejs`
+    watcher.handleWatchEvent('change', winStyle)
+    await vi.advanceTimersByTimeAsync(150)
+    expect(pipeline.buildAssets).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not filter files merely named like .kickjs', async () => {
+    const { watcher, pipeline } = makeWatcher()
+    watcher.handleWatchEvent('change', '/proj/src/my.kickjs.backup.ts')
+    await vi.advanceTimersByTimeAsync(150)
+    expect(pipeline.runTypegen).toHaveBeenCalledTimes(1)
   })
 
   it('reports failures once and re-arms after success', async () => {

--- a/packages/cli/__tests__/typegen-dev-watcher.test.ts
+++ b/packages/cli/__tests__/typegen-dev-watcher.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { createTypegenDevWatcher, type TypegenDevPipeline } from '../src/typegen/dev-watcher'
+import type { KickConfig } from '../src/config'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function makePipeline() {
+  return {
+    runTypegen: vi.fn(async () => []),
+    runAllPluginTypegens: vi.fn(async () => []),
+    writeTypegenArtifacts: vi.fn(async () => []),
+    buildAssets: vi.fn(async () => undefined),
+  } as unknown as TypegenDevPipeline & {
+    runTypegen: ReturnType<typeof vi.fn>
+    runAllPluginTypegens: ReturnType<typeof vi.fn>
+    buildAssets: ReturnType<typeof vi.fn>
+  }
+}
+
+function makeWatcher(config: KickConfig | null = null, pipeline = makePipeline()) {
+  const emitWarning = vi.fn()
+  const onPassComplete = vi.fn()
+  const watcher = createTypegenDevWatcher({
+    cwd: '/proj',
+    config,
+    emitWarning,
+    onPassComplete,
+    pipeline,
+  })
+  return { watcher, pipeline, emitWarning, onPassComplete }
+}
+
+describe('createTypegenDevWatcher', () => {
+  it('batches events in one debounce window into a single precise delta', async () => {
+    const { watcher, pipeline } = makeWatcher()
+    watcher.handleWatchEvent('change', '/proj/src/a.controller.ts')
+    watcher.handleWatchEvent('add', '/proj/src/b.service.ts')
+    watcher.handleWatchEvent('unlink', '/proj/src/gone.ts')
+    await vi.advanceTimersByTimeAsync(150)
+
+    expect(pipeline.runTypegen).toHaveBeenCalledTimes(1)
+    const delta = pipeline.runTypegen.mock.calls[0][0].changedFiles
+    expect(delta.changed.sort()).toEqual(['/proj/src/a.controller.ts', '/proj/src/b.service.ts'])
+    expect(delta.removed).toEqual(['/proj/src/gone.ts'])
+    expect(pipeline.runAllPluginTypegens).toHaveBeenCalledTimes(1)
+  })
+
+  it('unlink supersedes a pending change for the same file (and vice versa)', async () => {
+    const { watcher, pipeline } = makeWatcher()
+    watcher.handleWatchEvent('change', '/proj/src/x.ts')
+    watcher.handleWatchEvent('unlink', '/proj/src/x.ts')
+    await vi.advanceTimersByTimeAsync(150)
+    const delta = pipeline.runTypegen.mock.calls[0][0].changedFiles
+    expect(delta.changed).toEqual([])
+    expect(delta.removed).toEqual(['/proj/src/x.ts'])
+  })
+
+  it('unlinkDir forces a full scan (undefined delta)', async () => {
+    const { watcher, pipeline } = makeWatcher()
+    watcher.handleWatchEvent('change', '/proj/src/a.ts')
+    watcher.handleWatchEvent('unlinkDir', '/proj/src/modules/old')
+    await vi.advanceTimersByTimeAsync(150)
+    expect(pipeline.runTypegen.mock.calls[0][0].changedFiles).toBeUndefined()
+  })
+
+  it('ignores .kickjs output and .d.ts files', async () => {
+    const { watcher, pipeline } = makeWatcher()
+    watcher.handleWatchEvent('change', '/proj/.kickjs/types/kick__routes.ts')
+    watcher.handleWatchEvent('change', '/proj/src/generated.d.ts')
+    await vi.advanceTimersByTimeAsync(150)
+    expect(pipeline.runTypegen).not.toHaveBeenCalled()
+  })
+
+  it('asset changes trigger buildAssets only when an assetMap is configured', async () => {
+    const config = { assetMap: { mails: { src: 'src/templates/mails' } } } as unknown as KickConfig
+    const { watcher, pipeline } = makeWatcher(config)
+    expect(watcher.assetSrcRoots.length).toBe(1)
+    watcher.handleWatchEvent('change', `${watcher.assetSrcRoots[0]}/welcome.ejs`)
+    await vi.advanceTimersByTimeAsync(150)
+    expect(pipeline.buildAssets).toHaveBeenCalledTimes(1)
+    // Asset-only window — the scan delta carries no .ts files.
+    expect(pipeline.runTypegen.mock.calls[0][0].changedFiles).toEqual({
+      changed: [],
+      removed: [],
+    })
+  })
+
+  it('reports failures once and re-arms after success', async () => {
+    const pipeline = makePipeline()
+    pipeline.runTypegen
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue([])
+    const { watcher, emitWarning } = makeWatcher(null, pipeline)
+
+    watcher.handleWatchEvent('change', '/proj/src/a.ts')
+    await vi.advanceTimersByTimeAsync(150)
+    watcher.handleWatchEvent('change', '/proj/src/a.ts')
+    await vi.advanceTimersByTimeAsync(150)
+    expect(emitWarning).toHaveBeenCalledTimes(1) // identical failure deduped
+
+    watcher.handleWatchEvent('change', '/proj/src/a.ts') // success → clears
+    await vi.advanceTimersByTimeAsync(150)
+    pipeline.runTypegen.mockRejectedValueOnce(new Error('boom'))
+    watcher.handleWatchEvent('change', '/proj/src/a.ts')
+    await vi.advanceTimersByTimeAsync(150)
+    expect(emitWarning).toHaveBeenCalledTimes(2) // re-armed
+  })
+
+  it('runs onPassComplete after the plugin chain settles', async () => {
+    const { watcher, onPassComplete } = makeWatcher()
+    watcher.handleWatchEvent('change', '/proj/src/a.ts')
+    await vi.advanceTimersByTimeAsync(150)
+    expect(onPassComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('runOnce fires an immediate full pass', async () => {
+    const { watcher, pipeline } = makeWatcher()
+    watcher.runOnce()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(pipeline.runTypegen).toHaveBeenCalledTimes(1)
+    expect(pipeline.runTypegen.mock.calls[0][0].changedFiles).toBeUndefined()
+  })
+
+  it('dispose cancels the pending window and blocks further work', async () => {
+    const { watcher, pipeline } = makeWatcher()
+    watcher.handleWatchEvent('change', '/proj/src/a.ts')
+    watcher.dispose()
+    await vi.advanceTimersByTimeAsync(300)
+    watcher.runOnce()
+    expect(pipeline.runTypegen).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -7,7 +7,7 @@ import { loadKickConfig } from '../config'
 import { runTypegen, writeTypegenArtifacts } from '../typegen'
 import { runAllPluginTypegens } from '../typegen/run-plugins'
 import { buildAssets } from '../asset-manager/build'
-import { createTypegenErrorReporter } from './typegen-error-reporter'
+import { createTypegenDevWatcher, TYPEGEN_OWNER_KEY } from '../typegen/dev-watcher'
 import {
   createDevTypechecker,
   formatTypecheckOutput,
@@ -98,6 +98,11 @@ async function startDevServer(
   const vitePath = require.resolve('vite')
   const { createServer } = await import(pathToFileURL(vitePath).href)
 
+  // Claim typegen ownership BEFORE booting Vite — the kickjs:typegen
+  // vite plugin checks this marker (same process) and stands down, so
+  // the pipeline never double-runs under `kick dev`.
+  ;(globalThis as Record<string, unknown>)[TYPEGEN_OWNER_KEY] = 'kick-dev'
+
   const server = await createServer({
     configFile: resolve('vite.config.ts'),
     server: {
@@ -113,49 +118,6 @@ async function startDevServer(
     },
   })
 
-  // Resolve the absolute paths of every assetMap.<ns>.src directory so
-  // the watcher can treat any file change beneath them as an asset
-  // change — regardless of extension, since adopters drop .ejs / .html
-  // / .json / .md / .pug / etc. into a templates folder.
-  const assetSrcRoots: readonly string[] = devConfig?.assetMap
-    ? Object.values(devConfig.assetMap)
-        .map((entry) => entry?.src)
-        .filter((src): src is string => typeof src === 'string' && src.length > 0)
-        .map((src) => resolve(cwd, src))
-    : []
-  const isAssetFile = (file: string): boolean =>
-    assetSrcRoots.some((root) => file === root || file.startsWith(`${root}/`))
-
-  // Re-run typegen whenever a source file changes. Vite already
-  // owns a chokidar watcher, so we piggy-back on it instead of
-  // adding our own — same files, no extra fd cost.
-  //
-  // Two trigger paths share one debounced run:
-  //   1. .ts/.tsx/.mts/.cts changes → controllers / services / @Asset
-  //      keys re-discovered, registry + augmentation files refresh.
-  //   2. anything inside an `assetMap.<ns>.src` dir → KickAssets
-  //      augmentation refreshes so TypeScript sees newly added templates.
-  // Runtime resolution of new templates is handled in @forinda/kickjs
-  // itself — the dev-mode resolver skips its module-level cache so each
-  // `assets.x.y()` call re-walks. No Vite full-reload needed.
-  // Batch every watcher event in the debounce window into one precise
-  // delta. Vite tells us EXACTLY which files changed, so we feed that to
-  // the incremental scanner — it re-extracts only those files and skips
-  // the directory walk entirely (see `scanProjectIncremental`). The
-  // previous code passed only the last file to a full re-scan; batching
-  // a `changed`/`removed` set both fixes that and unlocks the fast path.
-  // Surface watch-mode typegen failures. Deduped so a broken schema
-  // doesn't spam a warning on every save; broadcast as a custom HMR
-  // event so DevTools / overlays can subscribe (same pattern as the
-  // `kickjs:hmr` event in @forinda/kickjs-vite).
-  const typegenErrors = createTypegenErrorReporter((message) => {
-    console.warn(message)
-    server.hot.send({
-      type: 'custom',
-      event: 'kickjs:typegen-error',
-      data: { message, timestamp: Date.now() },
-    })
-  })
   // Optional dev-time typecheck worker (--typecheck / dev.typecheck in
   // kick.config). Runs the PROJECT's own checker after each debounced
   // typegen pass so diagnostics are computed against fresh .kickjs/types.
@@ -197,104 +159,33 @@ async function startDevServer(
       })
     }
   }
-  let typegenTimer: ReturnType<typeof setTimeout> | null = null
-  const pendingChanged = new Set<string>()
-  const pendingRemoved = new Set<string>()
-  // A directory removal can't be expressed as a precise file delta —
-  // chokidar may emit a single `unlinkDir` instead of per-file `unlink`
-  // events, so we can't know which cached files vanished. When that
-  // happens we fall back to a full walk-based re-scan for this window,
-  // which is always correct (it simply won't find the deleted files).
-  let forceFullScan = false
-  // Set when a file under an `assetMap.<ns>.src` dir changes — drives an
-  // incremental `buildAssets` so the dist copies + manifest stay fresh
-  // without re-copying every asset on every save (buildAssets skips
-  // up-to-date files). Only meaningful when an assetMap is configured.
-  let assetDirty = false
-  const hasAssetMap = !!devConfig?.assetMap && Object.keys(devConfig.assetMap).length > 0
-  const scheduleTypegen = (event: 'add' | 'change' | 'unlink' | 'unlinkDir', file: string) => {
-    if (file.includes('.kickjs')) return
-    if (event === 'unlinkDir') {
-      // Only meaningful if the removed dir could have held scanned
-      // sources or watched assets; cheap to just force a full scan.
-      forceFullScan = true
-      if (hasAssetMap) assetDirty = true
-    } else {
-      if (file.endsWith('.d.ts')) return
-      const isTs = /\.(ts|tsx|mts|cts)$/.test(file)
-      const isAsset = isAssetFile(file)
-      if (!isTs && !isAsset) return
-      if (isAsset && hasAssetMap) assetDirty = true
-      // Only `.ts` files participate in the source scan delta. Asset-only
-      // changes still trigger the pass (so the asset plugin re-emits) but
-      // contribute nothing to the scan — an empty `.ts` delta makes the
-      // incremental scan a near-instant cache replay.
-      if (isTs) {
-        if (event === 'unlink') {
-          pendingRemoved.add(file)
-          pendingChanged.delete(file)
-        } else {
-          pendingChanged.add(file)
-          pendingRemoved.delete(file)
-        }
-      }
-    }
-    if (typegenTimer) clearTimeout(typegenTimer)
-    typegenTimer = setTimeout(() => {
-      // `undefined` delta → full scan (the `unlinkDir` correctness path).
-      const delta = forceFullScan
-        ? undefined
-        : { changed: [...pendingChanged], removed: [...pendingRemoved] }
-      const rebuildAssets = assetDirty
-      pendingChanged.clear()
-      pendingRemoved.clear()
-      forceFullScan = false
-      assetDirty = false
-      runTypegen({
-        cwd,
-        silent: true,
-        allowDuplicates: true,
-        schemaValidator,
-        envFile,
-        srcDir: devConfig?.typegen?.srcDir,
-        outDir: devConfig?.typegen?.outDir,
-        assetMap: devConfig?.assetMap,
-        changedFiles: delta,
-        // Plugin pipeline runs separately just below; opting out here
-        // avoids double-running it on every debounced trigger.
-        runPlugins: false,
+  // Typegen-on-save — shared engine (typegen/dev-watcher.ts) piggy-
+  // backing on Vite's chokidar. Failures surface as deduplicated
+  // warnings + the `kickjs:typegen-error` custom HMR event.
+  const typegenWatcher = createTypegenDevWatcher({
+    cwd,
+    config: devConfig,
+    emitWarning: (message) => {
+      console.warn(message)
+      server.hot.send({
+        type: 'custom',
+        event: 'kickjs:typegen-error',
+        data: { message, timestamp: Date.now() },
       })
-        .then(() => typegenErrors.clear('scan'))
-        .catch((err) => typegenErrors.report('scan', err))
-      // Plugin typegens piggy-back on the same debounce — they re-emit
-      // their `kick__*` files when sources (or templates) change. silent
-      // so the dev console stays quiet; artifacts (.gitignore + sweep)
-      // run after the pass.
-      runAllPluginTypegens({ cwd, config: devConfig, silent: true, changedFiles: delta })
-        .then((r) => writeTypegenArtifacts(typesOutDir, r, true))
-        .then(() => typegenErrors.clear('plugins'))
-        .catch((err) => typegenErrors.report('plugins', err))
-        // Typecheck AFTER the plugin pass settles (success or failure) so
-        // the checker sees the freshest .kickjs/types this window produced.
-        .finally(() => typechecker?.schedule())
-      // Incrementally refresh the dist asset copies + manifest, but only
-      // when an asset file actually changed this window. buildAssets
-      // skips up-to-date files, so this is a cheap stat sweep + the
-      // occasional changed-file copy — not a full re-copy every save.
-      if (rebuildAssets) {
-        buildAssets(devConfig, { cwd, silent: true }).catch(() => {})
-      }
-    }, 100)
-  }
-  server.watcher.on('add', (f: string) => scheduleTypegen('add', f))
-  server.watcher.on('unlink', (f: string) => scheduleTypegen('unlink', f))
-  server.watcher.on('change', (f: string) => scheduleTypegen('change', f))
-  server.watcher.on('unlinkDir', (d: string) => scheduleTypegen('unlinkDir', d))
+    },
+    // Typecheck AFTER each pass settles so the checker sees the
+    // freshest .kickjs/types the window produced.
+    onPassComplete: () => typechecker?.schedule(),
+  })
+  server.watcher.on('add', (f: string) => typegenWatcher.handleWatchEvent('add', f))
+  server.watcher.on('unlink', (f: string) => typegenWatcher.handleWatchEvent('unlink', f))
+  server.watcher.on('change', (f: string) => typegenWatcher.handleWatchEvent('change', f))
+  server.watcher.on('unlinkDir', (d: string) => typegenWatcher.handleWatchEvent('unlinkDir', d))
   // Vite's default watcher ignores extensions it doesn't compile;
   // explicitly subscribe asset src dirs so .ejs / .html changes land
   // in the typegen pipeline.
-  if (assetSrcRoots.length > 0) {
-    server.watcher.add(assetSrcRoots)
+  if (typegenWatcher.assetSrcRoots.length > 0) {
+    server.watcher.add([...typegenWatcher.assetSrcRoots])
   }
 
   await server.listen()
@@ -316,7 +207,7 @@ async function startDevServer(
   const shutdown = async () => {
     if (shuttingDown) return
     shuttingDown = true
-    if (typegenTimer) clearTimeout(typegenTimer)
+    typegenWatcher.dispose()
     typechecker?.dispose()
     try {
       await (

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,17 @@ export { defineCliPlugin, KickPluginConflictError } from './plugin/types'
 export type { TypegenPlugin, TypegenContext, TypegenPluginResult } from './typegen/plugin'
 export { defineTypegen } from './typegen/plugin'
 
+// Typegen-on-save engine — consumed by @forinda/kickjs-vite so plain
+// `vite` boots get the same watcher `kick dev` wires (the CLI claims
+// ownership via TYPEGEN_OWNER_KEY when it boots Vite itself).
+export {
+  createTypegenDevWatcher,
+  TYPEGEN_OWNER_KEY,
+  type TypegenDevWatcher,
+  type TypegenDevWatcherOptions,
+  type TypegenWatchEvent,
+} from './typegen/dev-watcher'
+
 // Plugin Generator Extension API (architecture.md §21.2.3)
 // Plugins ship `kick g <name>` generators via `kickjs.generators` in
 // their package.json — see `defineGenerator` for the manifest shape.

--- a/packages/cli/src/typegen/dev-watcher.ts
+++ b/packages/cli/src/typegen/dev-watcher.ts
@@ -110,8 +110,15 @@ export function createTypegenDevWatcher(opts: TypegenDevWatcherOptions): Typegen
         .map((src) => path.resolve(cwd, src))
     : []
   const hasAssetMap = !!config?.assetMap && Object.keys(config.assetMap).length > 0
-  const isAssetFile = (file: string): boolean =>
-    assetSrcRoots.some((root) => file === root || file.startsWith(`${root}/`))
+  // Normalize BOTH sides to forward slashes before comparing — chokidar
+  // emits native separators on Windows while `path.resolve` produces
+  // backslash roots, so a raw startsWith would miss either direction.
+  const toPosix = (p: string): string => p.replaceAll('\\', '/')
+  const assetRootsPosix = assetSrcRoots.map(toPosix)
+  const isAssetFile = (file: string): boolean => {
+    const posix = toPosix(file)
+    return assetRootsPosix.some((root) => posix === root || posix.startsWith(`${root}/`))
+  }
 
   const reporter = createTypegenErrorReporter(opts.emitWarning)
 
@@ -172,7 +179,9 @@ export function createTypegenDevWatcher(opts: TypegenDevWatcherOptions): Typegen
 
     handleWatchEvent(event, file) {
       if (disposed) return
-      if (file.includes('.kickjs')) return
+      // Typegen's own output directory — separator-aware so a file
+      // merely NAMED like `my.kickjs.backup.ts` isn't filtered.
+      if (toPosix(file).includes('/.kickjs/')) return
       if (event === 'unlinkDir') {
         // Only meaningful if the removed dir could have held scanned
         // sources or watched assets; cheap to just force a full scan.

--- a/packages/cli/src/typegen/dev-watcher.ts
+++ b/packages/cli/src/typegen/dev-watcher.ts
@@ -1,0 +1,216 @@
+/**
+ * Debounced typegen-on-save watcher — the engine behind `kick dev`'s
+ * file-change handling, extracted so `@forinda/kickjs-vite` can run the
+ * SAME pipeline when the adopter boots plain `vite` (or any other
+ * Vite-embedding tool) instead of `kick dev`.
+ *
+ * Behaviour (verbatim from the original inline implementation):
+ *  - Watcher events batch into one debounced pass (default 100ms).
+ *  - `.ts/.tsx/.mts/.cts` changes feed a precise `{changed, removed}`
+ *    delta to the incremental scanner; `unlinkDir` forces a full walk
+ *    (a dir removal can't be expressed as a per-file delta).
+ *  - Files under an `assetMap.<ns>.src` dir mark the pass asset-dirty,
+ *    driving an incremental `buildAssets` sweep.
+ *  - `.kickjs/**` and `.d.ts` events are ignored (typegen's own output).
+ *  - Failures surface through a deduplicating reporter (one warning per
+ *    NEW failure message per source; quiet on repeats; re-arms after a
+ *    successful pass).
+ *
+ * Exactly one watcher should own typegen per dev process. `kick dev`
+ * claims ownership via {@link TYPEGEN_OWNER_KEY} on `globalThis` before
+ * booting Vite; the vite plugin checks the marker and stands down.
+ */
+import path from 'node:path'
+
+import type { KickConfig } from '../config'
+import type { runTypegen, writeTypegenArtifacts } from './index'
+import type { runAllPluginTypegens } from './run-plugins'
+import type { buildAssets } from '../asset-manager/build'
+import { createTypegenErrorReporter } from '../commands/typegen-error-reporter'
+import type { ScanDelta } from './scanner'
+
+/**
+ * `globalThis` key claiming typegen ownership for the current process.
+ * Set by `kick dev` (which boots Vite in-process) so the vite plugin's
+ * own watcher never double-runs the pipeline.
+ */
+export const TYPEGEN_OWNER_KEY = '__kickjs_typegen_owner'
+
+export type TypegenWatchEvent = 'add' | 'change' | 'unlink' | 'unlinkDir'
+
+/** Injectable pipeline — production uses the real functions. */
+export interface TypegenDevPipeline {
+  runTypegen: typeof runTypegen
+  runAllPluginTypegens: typeof runAllPluginTypegens
+  writeTypegenArtifacts: typeof writeTypegenArtifacts
+  buildAssets: typeof buildAssets
+}
+
+export interface TypegenDevWatcherOptions {
+  cwd: string
+  /** Pre-loaded kick.config.ts (null when the project has none). */
+  config: KickConfig | null
+  /**
+   * Warning sink — wired by the caller to `console.warn` plus whatever
+   * HMR broadcast it has (e.g. the `kickjs:typegen-error` custom event).
+   */
+  emitWarning: (message: string) => void
+  /**
+   * Invoked after each pass's plugin chain settles (success or failure).
+   * `kick dev` uses it to schedule the `--typecheck` worker against
+   * fresh `.kickjs/types`.
+   */
+  onPassComplete?: () => void
+  /** Debounce window in ms. @default 100 */
+  debounceMs?: number
+  /** Test seam — defaults to the real typegen pipeline. */
+  pipeline?: TypegenDevPipeline
+}
+
+export interface TypegenDevWatcher {
+  /** Feed a chokidar-style watcher event into the debounce window. */
+  handleWatchEvent(event: TypegenWatchEvent, file: string): void
+  /**
+   * Run one full (non-incremental) pass immediately — startup catch-up
+   * for callers that didn't run typegen before the server booted.
+   */
+  runOnce(): void
+  /**
+   * Absolute `assetMap.<ns>.src` roots. Vite's default watcher ignores
+   * extensions it doesn't compile, so callers should `watcher.add(...)`
+   * these to receive template-file events at all.
+   */
+  assetSrcRoots: readonly string[]
+  /** Cancel any pending debounced pass. */
+  dispose(): void
+}
+
+export function createTypegenDevWatcher(opts: TypegenDevWatcherOptions): TypegenDevWatcher {
+  const { cwd, config } = opts
+  const debounceMs = opts.debounceMs ?? 100
+  // Default pipeline resolves lazily — a static import would drag the
+  // whole generator/typegen graph (including dist-layout-only module
+  // initializers) into every consumer of this module.
+  const pipeline: TypegenDevPipeline = opts.pipeline ?? {
+    runTypegen: async (o) => (await import('./index')).runTypegen(o),
+    runAllPluginTypegens: async (o) => (await import('./run-plugins')).runAllPluginTypegens(o),
+    writeTypegenArtifacts: async (dir, results, silent) =>
+      (await import('./index')).writeTypegenArtifacts(dir, results, silent),
+    buildAssets: async (cfg, o) => (await import('../asset-manager/build')).buildAssets(cfg, o),
+  }
+
+  const schemaValidator = config?.typegen?.schemaValidator ?? 'zod'
+  const envFile = config?.typegen?.envFile
+  const typesOutDir = path.resolve(cwd, config?.typegen?.outDir ?? '.kickjs/types')
+
+  const assetSrcRoots: readonly string[] = config?.assetMap
+    ? Object.values(config.assetMap)
+        .map((entry) => entry?.src)
+        .filter((src): src is string => typeof src === 'string' && src.length > 0)
+        .map((src) => path.resolve(cwd, src))
+    : []
+  const hasAssetMap = !!config?.assetMap && Object.keys(config.assetMap).length > 0
+  const isAssetFile = (file: string): boolean =>
+    assetSrcRoots.some((root) => file === root || file.startsWith(`${root}/`))
+
+  const reporter = createTypegenErrorReporter(opts.emitWarning)
+
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let disposed = false
+  const pendingChanged = new Set<string>()
+  const pendingRemoved = new Set<string>()
+  let forceFullScan = false
+  let assetDirty = false
+
+  function firePass(delta: ScanDelta | undefined, rebuildAssets: boolean): void {
+    pipeline
+      .runTypegen({
+        cwd,
+        silent: true,
+        allowDuplicates: true,
+        schemaValidator,
+        envFile,
+        srcDir: config?.typegen?.srcDir,
+        outDir: config?.typegen?.outDir,
+        assetMap: config?.assetMap,
+        changedFiles: delta,
+        // Plugin pipeline runs separately just below; opting out here
+        // avoids double-running it on every debounced trigger.
+        runPlugins: false,
+      })
+      .then(() => reporter.clear('scan'))
+      .catch((err) => reporter.report('scan', err))
+    pipeline
+      .runAllPluginTypegens({ cwd, config, silent: true, changedFiles: delta })
+      .then((r) => pipeline.writeTypegenArtifacts(typesOutDir, r, true))
+      .then(() => reporter.clear('plugins'))
+      .catch((err) => reporter.report('plugins', err))
+      // Post-pass hook AFTER the plugin chain settles so consumers (the
+      // --typecheck worker) see the freshest .kickjs/types this window
+      // produced.
+      .finally(() => opts.onPassComplete?.())
+    if (rebuildAssets && config) {
+      pipeline.buildAssets(config, { cwd, silent: true }).catch(() => {})
+    }
+  }
+
+  function flush(): void {
+    // `undefined` delta → full scan (the `unlinkDir` correctness path).
+    const delta = forceFullScan
+      ? undefined
+      : { changed: [...pendingChanged], removed: [...pendingRemoved] }
+    const rebuildAssets = assetDirty
+    pendingChanged.clear()
+    pendingRemoved.clear()
+    forceFullScan = false
+    assetDirty = false
+    firePass(delta, rebuildAssets)
+  }
+
+  return {
+    assetSrcRoots,
+
+    handleWatchEvent(event, file) {
+      if (disposed) return
+      if (file.includes('.kickjs')) return
+      if (event === 'unlinkDir') {
+        // Only meaningful if the removed dir could have held scanned
+        // sources or watched assets; cheap to just force a full scan.
+        forceFullScan = true
+        if (hasAssetMap) assetDirty = true
+      } else {
+        if (file.endsWith('.d.ts')) return
+        const isTs = /\.(ts|tsx|mts|cts)$/.test(file)
+        const isAsset = isAssetFile(file)
+        if (!isTs && !isAsset) return
+        if (isAsset && hasAssetMap) assetDirty = true
+        // Only `.ts` files participate in the source scan delta. Asset-
+        // only changes still trigger the pass (so the asset plugin
+        // re-emits) but contribute nothing to the scan — an empty `.ts`
+        // delta makes the incremental scan a near-instant cache replay.
+        if (isTs) {
+          if (event === 'unlink') {
+            pendingRemoved.add(file)
+            pendingChanged.delete(file)
+          } else {
+            pendingChanged.add(file)
+            pendingRemoved.delete(file)
+          }
+        }
+      }
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(flush, debounceMs)
+    },
+
+    runOnce() {
+      if (disposed) return
+      firePass(undefined, hasAssetMap)
+    },
+
+    dispose() {
+      disposed = true
+      if (timer) clearTimeout(timer)
+      timer = null
+    },
+  }
+}

--- a/packages/vite/__tests__/typegen-plugin.test.ts
+++ b/packages/vite/__tests__/typegen-plugin.test.ts
@@ -1,0 +1,98 @@
+import { EventEmitter } from 'node:events'
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import { kickjsTypegenPlugin, type TypegenCliModule } from '../src/typegen-plugin'
+
+const OWNER_KEY = '__kickjs_typegen_owner'
+
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>)[OWNER_KEY]
+})
+
+function makeFakeServer() {
+  const watcher = new EventEmitter() as EventEmitter & { add: ReturnType<typeof vi.fn> }
+  watcher.add = vi.fn()
+  const httpServer = new EventEmitter()
+  return {
+    config: {
+      root: '/proj',
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    },
+    watcher,
+    hot: { send: vi.fn() },
+    httpServer,
+  }
+}
+
+function makeFakeCli() {
+  const watcher = {
+    handleWatchEvent: vi.fn(),
+    runOnce: vi.fn(),
+    assetSrcRoots: [] as string[],
+    dispose: vi.fn(),
+  }
+  const cli: TypegenCliModule = {
+    loadKickConfig: vi.fn(async () => ({})),
+    createTypegenDevWatcher: vi.fn(() => watcher),
+  }
+  return { cli, watcher }
+}
+
+async function runConfigureServer(plugin: ReturnType<typeof kickjsTypegenPlugin>, server: unknown) {
+  const hook = plugin.configureServer
+  const fn = typeof hook === 'function' ? hook : hook!.handler
+  await fn.call({} as never, server as never)
+}
+
+describe('kickjsTypegenPlugin', () => {
+  it('stands down when kick dev owns typegen', async () => {
+    ;(globalThis as Record<string, unknown>)[OWNER_KEY] = 'kick-dev'
+    const { cli } = makeFakeCli()
+    const server = makeFakeServer()
+    await runConfigureServer(kickjsTypegenPlugin({ loadCli: async () => cli }), server)
+    expect(cli.createTypegenDevWatcher).not.toHaveBeenCalled()
+  })
+
+  it('no-ops with a notice when the CLI is not resolvable', async () => {
+    const server = makeFakeServer()
+    await runConfigureServer(kickjsTypegenPlugin({ loadCli: async () => null }), server)
+    expect(server.config.logger.info).toHaveBeenCalledTimes(1)
+    expect(server.config.logger.info.mock.calls[0][0]).toContain('typegen-on-save disabled')
+  })
+
+  it('wires the watcher: startup pass, watch events, dispose on close', async () => {
+    const { cli, watcher } = makeFakeCli()
+    const server = makeFakeServer()
+    await runConfigureServer(kickjsTypegenPlugin({ loadCli: async () => cli }), server)
+
+    expect(watcher.runOnce).toHaveBeenCalledTimes(1)
+
+    server.watcher.emit('change', '/proj/src/a.controller.ts')
+    server.watcher.emit('add', '/proj/src/b.ts')
+    server.watcher.emit('unlink', '/proj/src/c.ts')
+    server.watcher.emit('unlinkDir', '/proj/src/old')
+    expect(watcher.handleWatchEvent.mock.calls).toEqual([
+      ['change', '/proj/src/a.controller.ts'],
+      ['add', '/proj/src/b.ts'],
+      ['unlink', '/proj/src/c.ts'],
+      ['unlinkDir', '/proj/src/old'],
+    ])
+
+    server.httpServer.emit('close')
+    expect(watcher.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('broadcasts warnings on the kickjs:typegen-error channel', async () => {
+    const { cli } = makeFakeCli()
+    const server = makeFakeServer()
+    await runConfigureServer(kickjsTypegenPlugin({ loadCli: async () => cli }), server)
+
+    const opts = (cli.createTypegenDevWatcher as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    opts.emitWarning('types may be stale')
+    expect(server.config.logger.warn).toHaveBeenCalledWith('types may be stale')
+    expect(server.hot.send).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'kickjs:typegen-error' }),
+    )
+  })
+})

--- a/packages/vite/__tests__/vite-plugin.test.ts
+++ b/packages/vite/__tests__/vite-plugin.test.ts
@@ -1,4 +1,4 @@
-﻿import 'reflect-metadata'
+import 'reflect-metadata'
 import { describe, it, expect, beforeEach } from 'vitest'
 import { kickjsVitePlugin } from '@forinda/kickjs-vite'
 import type { Plugin } from 'vite'
@@ -109,7 +109,7 @@ describe('kickjsVitePlugin()', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Tests: kickjs:core plugin â€” config hook
+// Tests: kickjs:core plugin — config hook
 // ---------------------------------------------------------------------------
 
 describe('kickjs:core plugin', () => {
@@ -215,7 +215,7 @@ describe('kickjs:core plugin', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Tests: kickjs:virtual-modules plugin â€” resolveId + load
+// Tests: kickjs:virtual-modules plugin — resolveId + load
 // ---------------------------------------------------------------------------
 
 describe('kickjs:virtual-modules plugin', () => {
@@ -279,7 +279,7 @@ describe('kickjs:virtual-modules plugin', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Tests: kickjs:hmr plugin â€” decorator detection & transform
+// Tests: kickjs:hmr plugin — decorator detection & transform
 // ---------------------------------------------------------------------------
 
 describe('kickjs:hmr plugin', () => {
@@ -290,7 +290,7 @@ describe('kickjs:hmr plugin', () => {
     expect(hmrPlugin).toBeDefined()
   })
 
-  describe('transform() â€” decorator detection', () => {
+  describe('transform() — decorator detection', () => {
     it('returns null (does not transform code)', () => {
       const code = `
 @Service()
@@ -425,7 +425,7 @@ export class RepoB {}
 
     it('still handles project source files without kickjs patterns', () => {
       // Plain helper / utility / side-effect modules don't carry decorators
-      // or v4 factories, but they're imported by the running app â€” a change
+      // or v4 factories, but they're imported by the running app — a change
       // to one MUST invalidate the virtual app or HMR silently misses it.
       // Returning [] tells Vite "we handled it" and our debounced flush
       // will invalidate the virtual:kickjs/app module.
@@ -468,7 +468,7 @@ const Load = defineContextDecorator({ key: 'x', resolve: () => 1 })
 
     it('handles decorator with arguments on same line as class', () => {
       const code = `@Controller() export class UserController {}`
-      // The regex expects newline/whitespace between decorator and class â€” this
+      // The regex expects newline/whitespace between decorator and class — this
       // may or may not match depending on exact formatting. We verify it does
       // not crash either way.
       const result = simulateTransformAndHmr(code, '/src/inline.controller.ts')
@@ -479,7 +479,7 @@ const Load = defineContextDecorator({ key: 'x', resolve: () => 1 })
 })
 
 // ---------------------------------------------------------------------------
-// Tests: kickjs:module-discovery plugin â€” transform
+// Tests: kickjs:module-discovery plugin — transform
 // ---------------------------------------------------------------------------
 
 describe('kickjs:module-discovery plugin', () => {
@@ -512,7 +512,7 @@ describe('kickjs:module-discovery plugin', () => {
     it('processes .module.ts files', () => {
       const code = `export class UserModule {}`
       const result = callTransform(discoveryPlugin, code, '/src/user.module.ts')
-      expect(result).toBeNull() // still null â€” discovery only observes
+      expect(result).toBeNull() // still null — discovery only observes
     })
 
     it('processes .module.js files', () => {
@@ -524,7 +524,7 @@ describe('kickjs:module-discovery plugin', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Tests: kickjs:dev-server plugin â€” structure
+// Tests: kickjs:dev-server plugin — structure
 // ---------------------------------------------------------------------------
 
 describe('kickjs:dev-server plugin', () => {

--- a/packages/vite/__tests__/vite-plugin.test.ts
+++ b/packages/vite/__tests__/vite-plugin.test.ts
@@ -1,4 +1,4 @@
-import 'reflect-metadata'
+﻿import 'reflect-metadata'
 import { describe, it, expect, beforeEach } from 'vitest'
 import { kickjsVitePlugin } from '@forinda/kickjs-vite'
 import type { Plugin } from 'vite'
@@ -82,23 +82,23 @@ describe('kickjsVitePlugin()', () => {
     expect(names).toContain('kickjs:devtools-flag')
   })
 
-  it('returns exactly 7 sub-plugins (default config registers the devtools flag)', () => {
-    expect(plugins).toHaveLength(8)
+  it('returns exactly 9 sub-plugins (default config registers the devtools flag)', () => {
+    expect(plugins).toHaveLength(9)
   })
 
   it('accepts a custom entry option', () => {
     const custom = kickjsVitePlugin({ entry: 'app/server.ts' })
-    expect(custom).toHaveLength(8)
+    expect(custom).toHaveLength(9)
   })
 
   it('accepts empty options', () => {
     const noArgs = kickjsVitePlugin({})
-    expect(noArgs).toHaveLength(8)
+    expect(noArgs).toHaveLength(9)
   })
 
   it('drops the devtools flag + strip plugins when devtools: false', () => {
     const stripped = kickjsVitePlugin({ devtools: false })
-    expect(stripped).toHaveLength(6)
+    expect(stripped).toHaveLength(7)
     expect(stripped.map((p) => p.name)).not.toContain('kickjs:devtools-flag')
     expect(stripped.map((p) => p.name)).not.toContain('kickjs:devtools-strip')
   })
@@ -109,7 +109,7 @@ describe('kickjsVitePlugin()', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Tests: kickjs:core plugin — config hook
+// Tests: kickjs:core plugin â€” config hook
 // ---------------------------------------------------------------------------
 
 describe('kickjs:core plugin', () => {
@@ -215,7 +215,7 @@ describe('kickjs:core plugin', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Tests: kickjs:virtual-modules plugin — resolveId + load
+// Tests: kickjs:virtual-modules plugin â€” resolveId + load
 // ---------------------------------------------------------------------------
 
 describe('kickjs:virtual-modules plugin', () => {
@@ -279,7 +279,7 @@ describe('kickjs:virtual-modules plugin', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Tests: kickjs:hmr plugin — decorator detection & transform
+// Tests: kickjs:hmr plugin â€” decorator detection & transform
 // ---------------------------------------------------------------------------
 
 describe('kickjs:hmr plugin', () => {
@@ -290,7 +290,7 @@ describe('kickjs:hmr plugin', () => {
     expect(hmrPlugin).toBeDefined()
   })
 
-  describe('transform() — decorator detection', () => {
+  describe('transform() â€” decorator detection', () => {
     it('returns null (does not transform code)', () => {
       const code = `
 @Service()
@@ -425,7 +425,7 @@ export class RepoB {}
 
     it('still handles project source files without kickjs patterns', () => {
       // Plain helper / utility / side-effect modules don't carry decorators
-      // or v4 factories, but they're imported by the running app — a change
+      // or v4 factories, but they're imported by the running app â€” a change
       // to one MUST invalidate the virtual app or HMR silently misses it.
       // Returning [] tells Vite "we handled it" and our debounced flush
       // will invalidate the virtual:kickjs/app module.
@@ -468,7 +468,7 @@ const Load = defineContextDecorator({ key: 'x', resolve: () => 1 })
 
     it('handles decorator with arguments on same line as class', () => {
       const code = `@Controller() export class UserController {}`
-      // The regex expects newline/whitespace between decorator and class — this
+      // The regex expects newline/whitespace between decorator and class â€” this
       // may or may not match depending on exact formatting. We verify it does
       // not crash either way.
       const result = simulateTransformAndHmr(code, '/src/inline.controller.ts')
@@ -479,7 +479,7 @@ const Load = defineContextDecorator({ key: 'x', resolve: () => 1 })
 })
 
 // ---------------------------------------------------------------------------
-// Tests: kickjs:module-discovery plugin — transform
+// Tests: kickjs:module-discovery plugin â€” transform
 // ---------------------------------------------------------------------------
 
 describe('kickjs:module-discovery plugin', () => {
@@ -512,7 +512,7 @@ describe('kickjs:module-discovery plugin', () => {
     it('processes .module.ts files', () => {
       const code = `export class UserModule {}`
       const result = callTransform(discoveryPlugin, code, '/src/user.module.ts')
-      expect(result).toBeNull() // still null — discovery only observes
+      expect(result).toBeNull() // still null â€” discovery only observes
     })
 
     it('processes .module.js files', () => {
@@ -524,7 +524,7 @@ describe('kickjs:module-discovery plugin', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Tests: kickjs:dev-server plugin — structure
+// Tests: kickjs:dev-server plugin â€” structure
 // ---------------------------------------------------------------------------
 
 describe('kickjs:dev-server plugin', () => {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -45,7 +45,7 @@
     "vite": ">=6.0.0",
     "express": "^5.1.0",
     "@forinda/kickjs": ">=5.14.0-alpha.0",
-    "@forinda/kickjs-cli": ">=6.1.0"
+    "@forinda/kickjs-cli": ">=6.0.0"
   },
   "devDependencies": {
     "@forinda/kickjs": "workspace:*",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -44,7 +44,8 @@
   "peerDependencies": {
     "vite": ">=6.0.0",
     "express": "^5.1.0",
-    "@forinda/kickjs": ">=5.14.0-alpha.0"
+    "@forinda/kickjs": ">=5.14.0-alpha.0",
+    "@forinda/kickjs-cli": ">=6.1.0"
   },
   "devDependencies": {
     "@forinda/kickjs": "workspace:*",
@@ -73,5 +74,9 @@
   "bugs": {
     "url": "https://github.com/forinda/kick-js/issues"
   },
-  "peerDependenciesMeta": {}
+  "peerDependenciesMeta": {
+    "@forinda/kickjs-cli": {
+      "optional": true
+    }
+  }
 }

--- a/packages/vite/src/hmr-plugin.ts
+++ b/packages/vite/src/hmr-plugin.ts
@@ -40,6 +40,7 @@
 import type { Plugin, ViteDevServer } from 'vite'
 import type { HmrOptions, PluginContext } from './types'
 import { RESOLVED_APP } from './virtual-modules'
+import { rewarmApp } from './warm'
 
 /**
  * Test whether a watcher event refers to a file we should react to.
@@ -294,6 +295,11 @@ function flushInvalidation(
   if (vmod) {
     server.moduleGraph.invalidateModule(vmod)
   }
+  // 2b. Re-warm immediately — without this, re-evaluation waits for the
+  //     next HTTP request, so a broken save (syntax error, boot throw)
+  //     stays SILENT until something hits the server. Mirrors the eager
+  //     startup warm in dev-server.ts.
+  rewarmApp(server, `HMR invalidation (${batch.length} token${batch.length === 1 ? '' : 's'})`)
 
   // 3. Send ONE custom HMR event with the full batch
   //    DevTools dashboard, Swagger UI, and other dev tools can listen:

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -76,6 +76,7 @@ import { kickjsModuleDiscoveryPlugin } from './module-discovery'
 import { kickjsHmrPlugin } from './hmr-plugin'
 import { devtoolsFlagPlugin } from './devtools-flag-plugin'
 import { devtoolsStripPlugin } from './devtools-strip-plugin'
+import { kickjsTypegenPlugin } from './typegen-plugin'
 
 /**
  * Create the KickJS Vite plugin array.
@@ -131,6 +132,9 @@ export function kickjsVitePlugin(options: KickJSPluginOptions = {}): Plugin[] {
     kickjsHmrPlugin(ctx, options.hmr),
     kickjsVirtualModulesPlugin(ctx),
     kickjsDevServerPlugin(ctx),
+    // Typegen-on-save for bare `vite` boots — no-op under `kick dev`
+    // (which claims ownership) or when @forinda/kickjs-cli is absent.
+    kickjsTypegenPlugin(),
   ]
   // Register the devtools flag plugin by default. Adopters who don't
   // gate their devtools imports get a harmless no-op; adopters who do
@@ -157,6 +161,11 @@ export type {
 
 // Standalone plugins users can compose alongside `kickjsVitePlugin()`
 export { envWatchPlugin } from './env-watch-plugin'
+export {
+  kickjsTypegenPlugin,
+  type TypegenPluginOptions,
+  type TypegenCliModule,
+} from './typegen-plugin'
 export {
   devtoolsFlagPlugin,
   resolveDevtoolsFlag,

--- a/packages/vite/src/module-discovery.ts
+++ b/packages/vite/src/module-discovery.ts
@@ -32,6 +32,7 @@
 import type { Plugin, ViteDevServer } from 'vite'
 import type { PluginContext } from './types'
 import { RESOLVED_APP } from './virtual-modules'
+import { rewarmApp } from './warm'
 
 /** Regex to detect exported module classes in source files */
 const MODULE_CLASS_REGEX =
@@ -165,6 +166,9 @@ function invalidateVirtualApp(server: ViteDevServer): void {
   if (mod) {
     server.moduleGraph.invalidateModule(mod)
   }
+  // Re-warm immediately so a broken module file surfaces its error on
+  // save instead of on the next HTTP request (see warm.ts).
+  rewarmApp(server, 'module discovery change')
 }
 
 /**

--- a/packages/vite/src/typegen-plugin.ts
+++ b/packages/vite/src/typegen-plugin.ts
@@ -1,0 +1,159 @@
+/**
+ * kickjs:typegen — typegen-on-save for plain `vite` boots.
+ *
+ * `kick dev` owns the typegen watcher when it boots Vite (it claims
+ * ownership on `globalThis` before `createServer`). But adopters who
+ * run bare `vite` (the pre-fix scaffold default, or any Vite-embedding
+ * tool) historically got working HMR with silently frozen
+ * `.kickjs/types` — new routes lost their typing until a manual
+ * `kick typegen`.
+ *
+ * This plugin closes that gap: when nothing has claimed ownership, it
+ * dynamically loads the PROJECT's `@forinda/kickjs-cli` (optional peer
+ * — resolved from the project root, never bundled) and wires the same
+ * `createTypegenDevWatcher` engine `kick dev` uses, plus one startup
+ * catch-up pass. No CLI installed → quiet no-op with a one-line notice.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import type { Plugin, ViteDevServer } from 'vite'
+
+/** Mirror of the CLI's TYPEGEN_OWNER_KEY — string-duplicated so this
+ * module never needs the CLI at import time. */
+const OWNER_KEY = '__kickjs_typegen_owner'
+
+/** Structural slice of the CLI surface this plugin consumes. */
+export interface TypegenCliModule {
+  loadKickConfig(cwd: string): Promise<unknown>
+  createTypegenDevWatcher(opts: {
+    cwd: string
+    config: unknown
+    emitWarning: (message: string) => void
+  }): {
+    handleWatchEvent(event: 'add' | 'change' | 'unlink' | 'unlinkDir', file: string): void
+    runOnce(): void
+    assetSrcRoots: readonly string[]
+    dispose(): void
+  }
+}
+
+/**
+ * Resolve `@forinda/kickjs-cli` from the PROJECT root (not from this
+ * package — under pnpm's strict layout the vite plugin can't see the
+ * CLI through its own node_modules). Walks `node_modules` upward and
+ * reads the manifest directly with fs: the CLI is ESM-only (no
+ * `require` condition in its exports map), so `createRequire().resolve`
+ * throws ERR_PACKAGE_PATH_NOT_EXPORTED and can't be used here.
+ * Returns null when not installed or too old to export the watcher
+ * engine.
+ */
+function resolveCliEntry(root: string): string | null {
+  let dir = root
+  for (;;) {
+    const pkgDir = join(dir, 'node_modules', '@forinda', 'kickjs-cli')
+    const manifestPath = join(pkgDir, 'package.json')
+    if (existsSync(manifestPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+          exports?: Record<string, unknown>
+          module?: string
+          main?: string
+        }
+        const dot = pkg.exports?.['.'] as string | Record<string, unknown> | undefined
+        const fromExports =
+          typeof dot === 'string'
+            ? dot
+            : typeof dot?.import === 'string'
+              ? dot.import
+              : typeof (dot?.import as Record<string, unknown> | undefined)?.default === 'string'
+                ? ((dot!.import as Record<string, unknown>).default as string)
+                : typeof dot?.default === 'string'
+                  ? (dot.default as string)
+                  : undefined
+        const entryRel = fromExports ?? pkg.module ?? pkg.main
+        if (typeof entryRel === 'string') return join(pkgDir, entryRel)
+      } catch {
+        // Unreadable manifest — keep walking up.
+      }
+    }
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
+async function loadCliFromProject(root: string): Promise<TypegenCliModule | null> {
+  try {
+    const entry = resolveCliEntry(root)
+    if (!entry || !existsSync(entry)) return null
+    const mod = (await import(pathToFileURL(entry).href)) as Partial<TypegenCliModule>
+    if (
+      typeof mod.createTypegenDevWatcher === 'function' &&
+      typeof mod.loadKickConfig === 'function'
+    ) {
+      return mod as TypegenCliModule
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+export interface TypegenPluginOptions {
+  /** Test seam — defaults to project-root resolution of the real CLI. */
+  loadCli?: (root: string) => Promise<TypegenCliModule | null>
+}
+
+export function kickjsTypegenPlugin(opts: TypegenPluginOptions = {}): Plugin {
+  const loadCli = opts.loadCli ?? loadCliFromProject
+  return {
+    name: 'kickjs:typegen',
+    apply: 'serve',
+
+    async configureServer(server: ViteDevServer) {
+      // `kick dev` boots Vite in-process and runs its own watcher —
+      // stand down so the pipeline never double-runs.
+      if ((globalThis as Record<string, unknown>)[OWNER_KEY]) return
+
+      const root = server.config.root
+      const cli = await loadCli(root)
+      if (!cli) {
+        server.config.logger.info(
+          '[kickjs] typegen-on-save disabled — @forinda/kickjs-cli not resolvable from the ' +
+            'project (install it, or run `kick dev`).',
+        )
+        return
+      }
+
+      const config = await cli.loadKickConfig(root).catch(() => null)
+      const watcher = cli.createTypegenDevWatcher({
+        cwd: root,
+        config,
+        emitWarning: (message) => {
+          server.config.logger.warn(message)
+          server.hot.send({
+            type: 'custom',
+            event: 'kickjs:typegen-error',
+            data: { message, timestamp: Date.now() },
+          })
+        },
+      })
+
+      // Startup catch-up — bare `vite` has no pre-server typegen pass
+      // (kick dev runs one before createServer), so types may be stale
+      // from edits made while no dev server was running.
+      watcher.runOnce()
+
+      server.watcher.on('add', (f: string) => watcher.handleWatchEvent('add', f))
+      server.watcher.on('change', (f: string) => watcher.handleWatchEvent('change', f))
+      server.watcher.on('unlink', (f: string) => watcher.handleWatchEvent('unlink', f))
+      server.watcher.on('unlinkDir', (d: string) => watcher.handleWatchEvent('unlinkDir', d))
+      if (watcher.assetSrcRoots.length > 0) {
+        server.watcher.add([...watcher.assetSrcRoots])
+      }
+      server.httpServer?.once('close', () => watcher.dispose())
+    },
+  }
+}

--- a/packages/vite/src/typegen-plugin.ts
+++ b/packages/vite/src/typegen-plugin.ts
@@ -153,7 +153,13 @@ export function kickjsTypegenPlugin(opts: TypegenPluginOptions = {}): Plugin {
       if (watcher.assetSrcRoots.length > 0) {
         server.watcher.add([...watcher.assetSrcRoots])
       }
-      server.httpServer?.once('close', () => watcher.dispose())
+      if (server.httpServer) {
+        server.httpServer.once('close', () => watcher.dispose())
+      } else {
+        // Middleware mode — no httpServer; tie disposal to the chokidar
+        // watcher's own close so the debounce timer can't leak.
+        server.watcher.once('close', () => watcher.dispose())
+      }
     },
   }
 }

--- a/packages/vite/src/warm.ts
+++ b/packages/vite/src/warm.ts
@@ -1,0 +1,30 @@
+/**
+ * Eager app re-warm after an invalidation.
+ *
+ * The dev server evaluates `virtual:kickjs/app` lazily — after a save
+ * invalidates it, re-evaluation waits for the NEXT HTTP request. A
+ * broken file (syntax error, failed import, boot throw) was therefore
+ * silent until something hit the server, even though startup surfaced
+ * the same class of error eagerly. Re-warming right after invalidation
+ * pushes transform/bootstrap errors into the dev console the moment
+ * the save lands.
+ *
+ * Errors are logged (with fixed stacktraces) but never thrown — the
+ * dev loop must survive a mid-edit broken state; the next successful
+ * save heals it.
+ */
+import type { ViteDevServer } from 'vite'
+
+import { VIRTUAL_APP } from './virtual-modules'
+
+export function rewarmApp(server: ViteDevServer, reason: string): void {
+  server.ssrLoadModule(VIRTUAL_APP).catch((err: unknown) => {
+    if (err instanceof Error) server.ssrFixStacktrace(err)
+    server.config.logger.error(
+      `[kickjs] app failed to reload after ${reason}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      { timestamp: true },
+    )
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -701,6 +701,9 @@ importers:
       '@babel/core':
         specifier: ^7.29.7
         version: 7.29.7
+      '@forinda/kickjs-cli':
+        specifier: '>=6.0.0'
+        version: 6.0.1(@forinda/kickjs-devtools-kit@6.0.0(@forinda/kickjs@packages+kickjs))(better-sqlite3@12.10.0)(dotenv@17.4.2)(express@5.2.1)(multer@2.1.1)(mysql2@3.22.5(@types/node@25.9.2))(pg@8.21.0)(valibot@1.4.1(typescript@6.0.3))(yup@1.7.1)(zod@4.4.3)
     devDependencies:
       '@forinda/kickjs':
         specifier: workspace:*
@@ -1324,6 +1327,77 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@forinda/kickjs-cli-kit@0.1.1':
+    resolution: {integrity: sha512-4bO7HOKa6kQVJmPMJDOhzZEwslMWt9qPcN6HDDPDsLnfRIRVYUJG3TumpPogylJxPU11x6cz4vfWbNyj61Xy3w==}
+    engines: {node: '>=20.0'}
+    peerDependencies:
+      commander: '>=12.0.0'
+
+  '@forinda/kickjs-cli@6.0.1':
+    resolution: {integrity: sha512-Px7Zy2DlKCgjZGvq+hGg/qxXho5sjPaCTAXhUECjRuynj+tC6kGiJ7aECFAT1DNYrlsgwlZqfix/8/aSHLrzrg==}
+    engines: {node: '>=20.0'}
+    hasBin: true
+
+  '@forinda/kickjs-db@6.1.1':
+    resolution: {integrity: sha512-FHMJfXrKRRQaL0tfv0k9l09SEvAnBUV+D52Y1mMLRYgunbcCc/2wOnhZ69yPQEh6BYrbb8rzAuCVzKyJYiulgw==}
+    engines: {node: '>=20.0'}
+    hasBin: true
+    peerDependencies:
+      '@forinda/kickjs': '>=5.14.0-alpha.0'
+      '@forinda/kickjs-devtools-kit': '>=6.0.0-alpha.0'
+      better-sqlite3: '>=12.0.0'
+      mysql2: '>=3.0.0'
+      pg: '>=8.11.0'
+    peerDependenciesMeta:
+      '@forinda/kickjs-devtools-kit':
+        optional: true
+      better-sqlite3:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+
+  '@forinda/kickjs-devtools-kit@6.0.0':
+    resolution: {integrity: sha512-7ovfcS4f7Ajx9uORixwHgENhqYniy0JoEKU1Ea7WtM3BA9+VrTkAqCJ93sNWdkIwYubrdATxqSRoORSbCdw5Og==}
+    engines: {node: '>=20.0'}
+    peerDependencies:
+      '@forinda/kickjs': '>=5.14.0-alpha.0'
+    peerDependenciesMeta:
+      '@forinda/kickjs':
+        optional: true
+
+  '@forinda/kickjs-schema@0.1.2':
+    resolution: {integrity: sha512-FjhHtGjjYfbS2Ny8BhjaTIfj+ZXjMZTggu86GvmFgPhvWwqvk8wUqMUDxHmYwQ0wD6YazNoAZ/oWBkrYOf/RYQ==}
+    engines: {node: '>=20.0'}
+    peerDependencies:
+      valibot: '>=1.0.0'
+      yup: '>=1.0.0'
+      zod: '>=3.23.0'
+    peerDependenciesMeta:
+      valibot:
+        optional: true
+      yup:
+        optional: true
+      zod:
+        optional: true
+
+  '@forinda/kickjs@5.16.0':
+    resolution: {integrity: sha512-/Y9rWX3YwRtUsEBG2G3C4na6KsE2sH/nryW2/dliKWfwR7jVQT+5IiCf76sBdagwLc7oodpP5g4rSnDVXiSwuw==}
+    engines: {node: '>=20.0'}
+    peerDependencies:
+      dotenv: ^17.0.0
+      express: ^5.1.0
+      multer: ^2.0.0
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      dotenv:
+        optional: true
+      multer:
+        optional: true
+      zod:
+        optional: true
 
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
@@ -6624,6 +6698,77 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.4':
     optional: true
+
+  '@forinda/kickjs-cli-kit@0.1.1(commander@14.0.3)':
+    dependencies:
+      commander: 14.0.3
+
+  '@forinda/kickjs-cli-kit@0.1.1(commander@15.0.0)':
+    dependencies:
+      commander: 15.0.0
+
+  '@forinda/kickjs-cli@6.0.1(@forinda/kickjs-devtools-kit@6.0.0(@forinda/kickjs@packages+kickjs))(better-sqlite3@12.10.0)(dotenv@17.4.2)(express@5.2.1)(multer@2.1.1)(mysql2@3.22.5(@types/node@25.9.2))(pg@8.21.0)(valibot@1.4.1(typescript@6.0.3))(yup@1.7.1)(zod@4.4.3)':
+    dependencies:
+      '@clack/prompts': 1.5.1
+      '@forinda/kickjs': 5.16.0(dotenv@17.4.2)(express@5.2.1)(multer@2.1.1)(valibot@1.4.1(typescript@6.0.3))(yup@1.7.1)(zod@4.4.3)
+      '@forinda/kickjs-cli-kit': 0.1.1(commander@15.0.0)
+      '@forinda/kickjs-db': 6.1.1(@forinda/kickjs-devtools-kit@6.0.0(@forinda/kickjs@packages+kickjs))(@forinda/kickjs@5.16.0(dotenv@17.4.2)(express@5.2.1)(multer@2.1.1)(valibot@1.4.1(typescript@6.0.3))(yup@1.7.1)(zod@4.4.3))(better-sqlite3@12.10.0)(mysql2@3.22.5(@types/node@25.9.2))(pg@8.21.0)
+      commander: 15.0.0
+      glob: 13.0.6
+      jiti: 2.7.0
+      oxfmt: 0.54.0
+      picocolors: 1.1.1
+      pluralize: 8.0.0
+    transitivePeerDependencies:
+      - '@forinda/kickjs-devtools-kit'
+      - better-sqlite3
+      - dotenv
+      - express
+      - multer
+      - mysql2
+      - pg
+      - svelte
+      - valibot
+      - vite-plus
+      - yup
+      - zod
+
+  '@forinda/kickjs-db@6.1.1(@forinda/kickjs-devtools-kit@6.0.0(@forinda/kickjs@packages+kickjs))(@forinda/kickjs@5.16.0(dotenv@17.4.2)(express@5.2.1)(multer@2.1.1)(valibot@1.4.1(typescript@6.0.3))(yup@1.7.1)(zod@4.4.3))(better-sqlite3@12.10.0)(mysql2@3.22.5(@types/node@25.9.2))(pg@8.21.0)':
+    dependencies:
+      '@forinda/kickjs': 5.16.0(dotenv@17.4.2)(express@5.2.1)(multer@2.1.1)(valibot@1.4.1(typescript@6.0.3))(yup@1.7.1)(zod@4.4.3)
+      '@forinda/kickjs-cli-kit': 0.1.1(commander@14.0.3)
+      commander: 14.0.3
+      jiti: 2.7.0
+      kysely: 0.29.2
+    optionalDependencies:
+      '@forinda/kickjs-devtools-kit': 6.0.0(@forinda/kickjs@packages+kickjs)
+      better-sqlite3: 12.10.0
+      mysql2: 3.22.5(@types/node@25.9.2)
+      pg: 8.21.0
+
+  '@forinda/kickjs-devtools-kit@6.0.0(@forinda/kickjs@packages+kickjs)':
+    optionalDependencies:
+      '@forinda/kickjs': link:packages/kickjs
+    optional: true
+
+  '@forinda/kickjs-schema@0.1.2(valibot@1.4.1(typescript@6.0.3))(yup@1.7.1)(zod@4.4.3)':
+    optionalDependencies:
+      valibot: 1.4.1(typescript@6.0.3)
+      yup: 1.7.1
+      zod: 4.4.3
+
+  '@forinda/kickjs@5.16.0(dotenv@17.4.2)(express@5.2.1)(multer@2.1.1)(valibot@1.4.1(typescript@6.0.3))(yup@1.7.1)(zod@4.4.3)':
+    dependencies:
+      '@forinda/kickjs-schema': 0.1.2(valibot@1.4.1(typescript@6.0.3))(yup@1.7.1)(zod@4.4.3)
+      express: 5.2.1
+      reflect-metadata: 0.2.2
+    optionalDependencies:
+      dotenv: 17.4.2
+      multer: 2.1.1
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - valibot
+      - yup
 
   '@grpc/grpc-js@1.14.4':
     dependencies:


### PR DESCRIPTION
﻿## Why

Two related dev-loop gaps, both reported from live use:

1. Bare `vite` boots (the pre-#357 scaffold default, and any Vite-embedding tool) had no typegen-on-save — the watcher lived only in `kick dev`.
2. Errors surfaced only at startup: the app module re-evaluates lazily after invalidation, so breaking a TS file once the app was booted produced **silence** until the next HTTP request.

## What

**`kickjs:typegen` plugin (Option B from the dev-script discussion)**
- `kick dev`'s inline watcher extracted into the CLI's exported `createTypegenDevWatcher()` — single engine, behavior verbatim (debounced precise deltas, unlinkDir full-scan fallback, assetMap handling, deduplicating error reporter). `kick dev` refactored onto it.
- The vite plugin loads the project's `@forinda/kickjs-cli` at runtime (new optional peer). Resolution walks `node_modules` manifests directly — the CLI is ESM-only, so `createRequire().resolve` throws `ERR_PACKAGE_PATH_NOT_EXPORTED` (found in E2E).
- Ownership: `kick dev` sets `TYPEGEN_OWNER_KEY` on `globalThis` before booting Vite; the plugin stands down — never double-runs. CLI absent → one-line notice, quiet no-op.
- Startup catch-up pass covers edits made while no server was running.

**Eager re-warm after invalidation**
- Both invalidation paths (HMR token flush, module discovery) now re-warm `virtual:kickjs/app` immediately and log failures with fixed stacktraces — mirroring the eager startup warm. A broken save prints `[kickjs] app failed to reload after HMR invalidation (…): <error>` the moment it lands.

## Verification

- 13 new unit tests: watcher engine (9 — delta batching, unlink supersedence, full-scan fallback, ignore rules, asset gating, dedupe/re-arm reporting, pass hook, runOnce, dispose) + vite plugin (4 — ownership stand-down, missing-CLI notice, event wiring/dispose, error broadcast). Plugin-count pins updated.
- Live E2E on a bare `vite` boot: CLI resolved (0 disabled notices), new route landed in `kick__routes.ts` on save, broken save surfaced the syntax error in the console with no request. Bonus: the probe was appended outside the class (unparseable) and the AST→regex fallback still extracted the route.
- CLI targeted suites + both package builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled type generation on file save for Vite projects, with optional support for projects using `kick dev`.
  * Asset file changes are now automatically detected and rebuild when configured.

* **Bug Fixes**
  * Errors are now reported immediately on save instead of waiting for the next HTTP request.
  * Improved error stack traces for faster debugging.

* **Tests**
  * Added comprehensive test coverage for type generation watcher and plugin.
  * Updated test expectations for plugin initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->