### PR TITLE
docs: BYO-first auth guides + dev/CLI workflow documentation refresh

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -1,5 +1,9 @@
 # @forinda/kickjs-auth
 
+::: warning Deprecated
+Auth has moved to BYO (bring-your-own) — compose `@LoadAuthUser` / `@RequireRole` / `@Public` from `defineContextDecorator` and `defineAdapter`. See the [BYO Auth recipe](../guide/byo-recipes.md#auth) and the [Authentication guide](../guide/authentication.md). This package still installs (with a one-time runtime warning) and will be removed in a future major.
+:::
+
 Pluggable authentication — JWT, API key, OAuth, and Passport.js bridge.
 
 ## AuthStrategy

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -60,6 +60,8 @@ cd packages/cli && pnpm link --global
 
 - `-e, --entry <file>` -- Entry file (default: `src/index.ts`)
 - `-p, --port <port>` -- Port number
+- `--polling` -- Force chokidar polling (Docker bind mounts / WSL / NFS)
+- `--typecheck` -- Run the project's checker (`tsgo`/`tsc --noEmit`) after each change; also via `dev.typecheck` in kick.config
 
 **kick g module**
 

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -1,8 +1,79 @@
 # Authentication
 
-KickJS provides pluggable authentication through `@forinda/kickjs-auth`. Use decorators to protect routes, and swap strategies (JWT, API key, custom) without changing your controllers.
+::: warning `@forinda/kickjs-auth` is deprecated
+Auth has moved to **BYO (bring-your-own)**: you compose `@LoadAuthUser` / `@RequireRole` / `@Public` from the framework's own primitives — `defineContextDecorator` and `defineAdapter` — in ~200 lines of code you own end-to-end. No framework upgrade can silently change your auth surface again.
 
-## Installation
+The package still installs (`kick add auth` prints a deprecation warning) and the [legacy reference below](#legacy-forindakickjs-auth-deprecated) stays until removal in a future major. New projects should start from the recipe.
+:::
+
+## The BYO approach
+
+Authentication is just **typed, ordered context population** — exactly what [context decorators](context-decorators.md) do. The full walkthrough lives in the [BYO Auth recipe](byo-recipes.md#auth); the shape:
+
+```ts
+// 1. Declare what `ctx.get('user')` returns — once, globally.
+declare module '@forinda/kickjs' {
+  interface ContextMeta {
+    user: AuthUser | null
+  }
+}
+
+// 2. A strategy is a function: ctx in, user-or-null out. You own the
+//    credential handling (JWT verify, API-key lookup, session read).
+export function jwtStrategy(opts: { secret: string }): AuthStrategy {
+  /* … */
+}
+
+// 3. `@LoadAuthUser` is a parameterised contributor — resolves the user
+//    before the handler runs, throws 401 unless `on401: 'allow'`.
+export const LoadAuthUser = defineHttpContextDecorator<'user', Deps, { on401: 'allow' | 'reject' }>(
+  {
+    key: 'user',
+    deps: { strategies: AUTH_STRATEGIES },
+    paramDefaults: { on401: 'reject' },
+    resolve: async (ctx, { strategies }, params) => {
+      /* try strategies in order */
+    },
+  },
+)
+
+// 4. `@Public` is sugar: LoadAuthUser({ on401: 'allow' }).
+export const Public = LoadAuthUser({ on401: 'allow' })
+
+// 5. AuthAdapter (defineAdapter) registers the strategy list in DI and
+//    ships LoadAuthUser as a GLOBAL contributor when defaultPolicy is
+//    'protected' — every route requires a user unless marked @Public.
+```
+
+Usage reads the same as the old package:
+
+```ts
+@Controller()
+export class UsersController {
+  @Public
+  @Get('/health')
+  health(ctx: RequestContext) {
+    ctx.json({ ok: true })
+  }
+
+  @RequireRole({ roles: ['admin'] })
+  @Delete('/:id')
+  remove(ctx: RequestContext) {
+    const actor = ctx.get('user') // typed AuthUser — never null here
+    // …
+  }
+}
+```
+
+Follow the [recipe](byo-recipes.md#auth) for the complete, copy-paste-ready eight steps (strategies, role checks, adapter, bootstrap, migration checklist). Authorization patterns (roles, policies) live in [Authorization](authorization.md).
+
+---
+
+## Legacy: `@forinda/kickjs-auth` (deprecated)
+
+Everything below documents the deprecated package for existing projects. It keeps working until removal in a future major; imports print a one-time warning (suppress with `KICKJS_SUPPRESS_DEPRECATION=1`).
+
+### Installation
 
 ```bash
 pnpm add @forinda/kickjs-auth
@@ -11,7 +82,7 @@ pnpm add @forinda/kickjs-auth
 pnpm add jsonwebtoken @types/jsonwebtoken
 ```
 
-Or via CLI:
+Or via CLI (prints the deprecation warning):
 
 ```bash
 kick add auth

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -26,16 +26,17 @@ export function jwtStrategy(opts: { secret: string }): AuthStrategy {
 
 // 3. `@LoadAuthUser` is a parameterised contributor — resolves the user
 //    before the handler runs, throws 401 unless `on401: 'allow'`.
-export const LoadAuthUser = defineHttpContextDecorator<'user', Deps, { on401: 'allow' | 'reject' }>(
-  {
-    key: 'user',
-    deps: { strategies: AUTH_STRATEGIES },
-    paramDefaults: { on401: 'reject' },
-    resolve: async (ctx, { strategies }, params) => {
-      /* try strategies in order */
-    },
+//    Only the params shape is spelled; key + deps types are inferred.
+export const LoadAuthUser = defineHttpContextDecorator.withParams<{
+  on401: 'allow' | 'reject'
+}>()({
+  key: 'user',
+  deps: { strategies: AUTH_STRATEGIES },
+  paramDefaults: { on401: 'reject' },
+  resolve: async (ctx, { strategies }, params) => {
+    /* try strategies in order */
   },
-)
+})
 
 // 4. `@Public` is sugar: LoadAuthUser({ on401: 'allow' }).
 export const Public = LoadAuthUser({ on401: 'allow' })

--- a/docs/guide/authorization.md
+++ b/docs/guide/authorization.md
@@ -130,7 +130,7 @@ declare module '@forinda/kickjs-auth' {
 
 Apps that don't augment `AuthUser['roles']` get the loose `string[]` fallback — full backwards compatibility.
 
-## Policy-Based Authorization
+## Legacy: Policy-Based Authorization (deprecated)
 
 For resource-level permissions ("can this user edit THIS post?"), use policies.
 
@@ -266,7 +266,7 @@ class PostService {
 
 Missing policy or missing action both result in denial (deny by default).
 
-## Combining Roles and Policies
+## Legacy: Combining Roles and Policies (deprecated)
 
 You can use `@Roles()` and `@Can()` together. Roles are checked first:
 
@@ -279,7 +279,7 @@ remove(ctx) { ... }
 
 ## Guards (Custom Middleware)
 
-`kick g guard <name>` generates a middleware function for custom authorization logic that doesn't fit `@Roles()` or `@Can()`. Guards are raw Express middleware applied via `@Middleware()`.
+`kick g guard <name>` generates a middleware function for authorization logic that needs to short-circuit the response or run before route matching — the cases [context decorators deliberately don't cover](context-decorators.md). For value-producing checks, prefer a contributor; reach for a guard when you need raw Express middleware semantics.
 
 ```bash
 kick g guard ip-whitelist

--- a/docs/guide/authorization.md
+++ b/docs/guide/authorization.md
@@ -1,7 +1,7 @@
 # Authorization
 
-::: warning `@forinda/kickjs-auth` is deprecated
-Authorization, like authentication, is now **BYO** — composed from [context decorators](context-decorators.md) you own. The patterns below show the BYO shapes first; the [legacy package reference](#legacy-role-based-access-control-deprecated) follows for existing projects.
+::: warning `@forinda/kickjs-auth` is deprecated — and there is no built-in authorization layer anymore
+The framework ships **no roles system and no policy engine**. `@Roles`, `@Policy`, `@Can`, `AuthorizationService`, and the policy registry were features of the deprecated package and have no first-party replacement. Authorization is **your code**: the sections below show the recommended shapes to compose from [context decorators](context-decorators.md). The [legacy package reference](#legacy-role-based-access-control-deprecated) follows for existing projects.
 :::
 
 ## BYO role checks — `@RequireRole`
@@ -37,28 +37,47 @@ dashboard(ctx: RequestContext) { /* ctx.get('user') is non-null here */ }
 
 Because `roles` is your own `AuthUser` type, literal-union role names give you compile-time typo checking with zero augmentation machinery — you declared the type yourself in Step 1.
 
-## BYO policies — resource-level checks
+## Policies — bring your own engine via DI
 
-A policy is the same pattern one level deeper: a contributor (or a plain service the contributor calls) that loads the resource and compares it against the user. Sketch:
+There is no first-party `@Policy` / `@Can` to migrate to — but nothing about a policy engine needs framework support. Context decorators have everything required to compose one: **`deps` injects any DI token** (your engine service), **`dependsOn` orders it after `user`**, and **parameterised decorators carry the action**. The engine is just a service you register:
 
 ```ts
-export const CanEditPost = defineHttpContextDecorator({
-  key: 'post', // doubles as the loaded resource for the handler
-  dependsOn: ['user'],
-  deps: { posts: POSTS_REPO },
-  resolve: async (ctx, { posts }) => {
-    const post = await posts.findById(ctx.params.id)
-    if (!post) throw withStatus(new Error('Not Found'), 404)
-    const user = ctx.get('user')!
-    if (post.authorId !== user.id && !user.roles.includes('admin')) {
+// 1. Your engine — any shape you want. Registered in DI like any service.
+export interface PolicyEngine {
+  can(user: AuthUser, action: string, resource: unknown): boolean | Promise<boolean>
+}
+export const POLICY_ENGINE = createToken<PolicyEngine>('app/auth/policyEngine')
+
+// 2. `@Can` is a parameterised contributor: engine via deps (DI), user
+//    via dependsOn ordering, action via params.
+export const Can = defineHttpContextDecorator<
+  'authorized',
+  { engine: typeof POLICY_ENGINE; posts: typeof POSTS_REPO },
+  { action: string }
+>({
+  key: 'authorized',
+  dependsOn: ['user'], // topologically ordered — user resolves first
+  deps: { engine: POLICY_ENGINE, posts: POSTS_REPO },
+  paramDefaults: { action: 'read' },
+  resolve: async (ctx, { engine, posts }, params) => {
+    const user = ctx.get('user')
+    if (!user) throw withStatus(new Error('Unauthorized'), 401)
+    const resource = await posts.findById(ctx.params.id)
+    if (!resource) throw withStatus(new Error('Not Found'), 404)
+    if (!(await engine.can(user, params.action, resource))) {
       throw withStatus(new Error('Forbidden'), 403)
     }
-    return post // handler reads ctx.get('post') — already authorized
+    return true
   },
 })
+
+// Usage — same ergonomics the old @Can had, but the engine is yours:
+@Can({ action: 'post.delete' })
+@Delete('/:id')
+remove(ctx: RequestContext) { /* … */ }
 ```
 
-The load-and-authorize-in-one-contributor shape replaces `@Policy`/`@Can`: the handler never sees an unauthorized resource, and the policy logic lives in one named, testable unit.
+Swap the engine implementation (CASL, a rules table, hardcoded checks) by re-binding `POLICY_ENGINE` — controllers never change. For simpler cases, fold the load-and-authorize into one contributor that returns the resource itself (`key: 'post'`), so the handler reads `ctx.get('post')` already authorized.
 
 ---
 

--- a/docs/guide/authorization.md
+++ b/docs/guide/authorization.md
@@ -1,13 +1,70 @@
 # Authorization
 
-KickJS provides two levels of authorization:
+::: warning `@forinda/kickjs-auth` is deprecated
+Authorization, like authentication, is now **BYO** — composed from [context decorators](context-decorators.md) you own. The patterns below show the BYO shapes first; the [legacy package reference](#legacy-role-based-access-control-deprecated) follows for existing projects.
+:::
 
-- **Role-based** — `@Roles('admin')` checks string roles on the user
-- **Policy-based** — `@Policy` + `@Can` checks resource-level permissions
+## BYO role checks — `@RequireRole`
 
-Both work through `@forinda/kickjs-auth` and are enforced by `AuthAdapter` middleware.
+A role check is a contributor that depends on the auth user and throws 401/403. The full implementation is Step 4 of the [BYO Auth recipe](byo-recipes.md#auth):
 
-## Role-Based Access Control
+```ts
+export const RequireRole = defineHttpContextDecorator<
+  'roleCheck',
+  Record<string, never>,
+  { roles: readonly string[]; mode?: 'all' | 'any' }
+>({
+  key: 'roleCheck',
+  dependsOn: ['user'], // strict ordering — @LoadAuthUser resolves first
+  paramDefaults: { roles: [], mode: 'any' },
+  resolve: (ctx, _deps, params) => {
+    const user = ctx.get('user')
+    if (!user) throw withStatus(new Error('Unauthorized'), 401)
+    const owned = new Set(user.roles)
+    const hits = params.roles.filter((r) => owned.has(r))
+    const ok = params.mode === 'all' ? hits.length === params.roles.length : hits.length > 0
+    if (!ok) throw withStatus(new Error('Forbidden'), 403)
+    return true
+  },
+})
+
+// Usage — params are typed, ordering is topological, typos in
+// `dependsOn` keys are caught by `kick typegen`'s ContextKeys registry.
+@RequireRole({ roles: ['admin', 'manager'] })
+@Get('/dashboard')
+dashboard(ctx: RequestContext) { /* ctx.get('user') is non-null here */ }
+```
+
+Because `roles` is your own `AuthUser` type, literal-union role names give you compile-time typo checking with zero augmentation machinery — you declared the type yourself in Step 1.
+
+## BYO policies — resource-level checks
+
+A policy is the same pattern one level deeper: a contributor (or a plain service the contributor calls) that loads the resource and compares it against the user. Sketch:
+
+```ts
+export const CanEditPost = defineHttpContextDecorator({
+  key: 'post', // doubles as the loaded resource for the handler
+  dependsOn: ['user'],
+  deps: { posts: POSTS_REPO },
+  resolve: async (ctx, { posts }) => {
+    const post = await posts.findById(ctx.params.id)
+    if (!post) throw withStatus(new Error('Not Found'), 404)
+    const user = ctx.get('user')!
+    if (post.authorId !== user.id && !user.roles.includes('admin')) {
+      throw withStatus(new Error('Forbidden'), 403)
+    }
+    return post // handler reads ctx.get('post') — already authorized
+  },
+})
+```
+
+The load-and-authorize-in-one-contributor shape replaces `@Policy`/`@Can`: the handler never sees an unauthorized resource, and the policy logic lives in one named, testable unit.
+
+---
+
+## Legacy: Role-Based Access Control (deprecated)
+
+Everything below documents the deprecated `@forinda/kickjs-auth` package for existing projects.
 
 `@Roles()` checks that the authenticated user has at least one of the required roles:
 

--- a/docs/guide/authorization.md
+++ b/docs/guide/authorization.md
@@ -9,11 +9,10 @@ The framework ships **no roles system and no policy engine**. `@Roles`, `@Policy
 A role check is a contributor that depends on the auth user and throws 401/403. The full implementation is Step 4 of the [BYO Auth recipe](byo-recipes.md#auth):
 
 ```ts
-export const RequireRole = defineHttpContextDecorator<
-  'roleCheck',
-  Record<string, never>,
-  { roles: readonly string[]; mode?: 'all' | 'any' }
->({
+export const RequireRole = defineHttpContextDecorator.withParams<{
+  roles: readonly string[]
+  mode?: 'all' | 'any'
+}>()({
   key: 'roleCheck',
   dependsOn: ['user'], // strict ordering — @LoadAuthUser resolves first
   paramDefaults: { roles: [], mode: 'any' },
@@ -49,12 +48,9 @@ export interface PolicyEngine {
 export const POLICY_ENGINE = createToken<PolicyEngine>('app/auth/policyEngine')
 
 // 2. `@Can` is a parameterised contributor: engine via deps (DI), user
-//    via dependsOn ordering, action via params.
-export const Can = defineHttpContextDecorator<
-  'authorized',
-  { engine: typeof POLICY_ENGINE; posts: typeof POSTS_REPO },
-  { action: string }
->({
+//    via dependsOn ordering, action via params. Only the params shape
+//    is spelled — `key` and the deps types are inferred from the spec.
+export const Can = defineHttpContextDecorator.withParams<{ action: string }>()({
   key: 'authorized',
   dependsOn: ['user'], // topologically ordered — user resolves first
   deps: { engine: POLICY_ENGINE, posts: POSTS_REPO },

--- a/docs/guide/byo-recipes.md
+++ b/docs/guide/byo-recipes.md
@@ -139,11 +139,7 @@ type LoadAuthUserParams = {
   on401: 'allow' | 'reject'
 }
 
-export const LoadAuthUser = defineHttpContextDecorator<
-  'user',
-  { strategies: typeof AUTH_STRATEGIES },
-  LoadAuthUserParams
->({
+export const LoadAuthUser = defineHttpContextDecorator.withParams<LoadAuthUserParams>()({
   key: 'user',
   deps: { strategies: AUTH_STRATEGIES },
   paramDefaults: { on401: 'reject' },
@@ -168,11 +164,7 @@ import { defineHttpContextDecorator } from '@forinda/kickjs'
 
 type RequireRoleParams = { roles: readonly string[]; mode?: 'all' | 'any' }
 
-export const RequireRole = defineHttpContextDecorator<
-  'roleCheck',
-  Record<string, never>,
-  RequireRoleParams
->({
+export const RequireRole = defineHttpContextDecorator.withParams<RequireRoleParams>()({
   key: 'roleCheck',
   // Strict precedence — auth user must resolve before we check roles.
   dependsOn: ['user'],

--- a/docs/guide/cli-commands.md
+++ b/docs/guide/cli-commands.md
@@ -166,7 +166,7 @@ Changes to your source files are picked up instantly — database connections, W
 
 Opt in via the flag or `dev: { typecheck: true }` in `kick.config.ts`. After each debounced change (and once at startup), `kick dev` runs the **project's own** checker — `tsgo` (`@typescript/native-preview`) preferred, `tsc` fallback — with `--noEmit`, timed after the typegen pass so diagnostics always see fresh `.kickjs/types`:
 
-```
+```text
   kick typecheck (tsgo, 412ms):
     src/modules/users/users.controller.ts(14,9): error TS2322: …
 ```
@@ -358,7 +358,7 @@ kick info
 
 Output — the CLI's own version, plus every `@forinda/kickjs*` dependency the nearest project declares with the version actually installed in `node_modules` (declared range shown when not installed). Packages the `kick add` catalog marks as deprecated are flagged:
 
-```
+```text
   KickJS CLI v6.1.0
 
   System:

--- a/docs/guide/cli-commands.md
+++ b/docs/guide/cli-commands.md
@@ -146,12 +146,32 @@ kick dev -e src/main.ts
 kick dev -p 4000
 ```
 
-| Flag                 | Description | Default                |
-| -------------------- | ----------- | ---------------------- |
-| `-e, --entry <file>` | Entry file  | `src/index.ts`         |
-| `-p, --port <port>`  | Port number | `3000` (or `PORT` env) |
+| Flag                 | Description                                                                         | Default                |
+| -------------------- | ----------------------------------------------------------------------------------- | ---------------------- |
+| `-e, --entry <file>` | Entry file                                                                          | `src/index.ts`         |
+| `-p, --port <port>`  | Port number                                                                         | `3000` (or `PORT` env) |
+| `--polling`          | Force chokidar polling (Docker bind mounts / WSL / NFS where fs events get dropped) | off                    |
+| `--typecheck`        | Run the project's TypeScript checker after each change (see below)                  | off                    |
 
 Changes to your source files are picked up instantly — database connections, WebSocket state, and port bindings survive reloads.
+
+### Errors surface on save
+
+`kick dev` reports problems the moment a save lands, without waiting for a request:
+
+- **Runtime/transform errors** — a broken file (syntax error, failed import, bootstrap throw) prints `[kickjs] app failed to reload after HMR invalidation: …` with a fixed stacktrace.
+- **Typegen failures** — a scan or plugin pass that fails prints a deduplicated `kick typegen: … — types in .kickjs/types may be stale` warning (quiet on repeats of the same error; re-arms after a successful pass) and broadcasts a `kickjs:typegen-error` custom HMR event for DevTools/overlays.
+
+### `--typecheck` — dev-time type checking
+
+Opt in via the flag or `dev: { typecheck: true }` in `kick.config.ts`. After each debounced change (and once at startup), `kick dev` runs the **project's own** checker — `tsgo` (`@typescript/native-preview`) preferred, `tsc` fallback — with `--noEmit`, timed after the typegen pass so diagnostics always see fresh `.kickjs/types`:
+
+```
+  kick typecheck (tsgo, 412ms):
+    src/modules/users/users.controller.ts(14,9): error TS2322: …
+```
+
+A healthy project stays quiet; the first clean run after an error prints `kick typecheck: clean again`. In-flight checks are killed when a new save lands, and the full output rides the `kickjs:typecheck` HMR event.
 
 ## kick dev:debug
 
@@ -336,20 +356,23 @@ Print system and framework information:
 kick info
 ```
 
-Output:
+Output — the CLI's own version, plus every `@forinda/kickjs*` dependency the nearest project declares with the version actually installed in `node_modules` (declared range shown when not installed). Packages the `kick add` catalog marks as deprecated are flagged:
 
 ```
-  KickJS CLI
+  KickJS CLI v6.1.0
 
   System:
     OS:       linux 6.x.x (x64)
-    Node:     v20.x.x
+    Node:     v22.x.x
 
   Packages:
-    @forinda/kickjs           workspace
-    @forinda/kickjs-vite      workspace
-    @forinda/kickjs-cli       workspace
+    @forinda/kickjs          5.16.0
+    @forinda/kickjs-cli      6.1.0
+    @forinda/kickjs-prisma   6.0.1  [DEPRECATED — see `kick add --list --all`]
+    @forinda/kickjs-vite     6.1.0
 ```
+
+`kick --version` / `-V` / `-v` print just the CLI version.
 
 ## kick list
 
@@ -382,11 +405,13 @@ Add KickJS packages with their required peer dependencies automatically resolved
 
 ```bash
 kick add swagger          # installs @forinda/kickjs-swagger
-kick add db auth          # installs multiple packages at once
+kick add db ai            # installs multiple packages at once
 kick add queue:bullmq     # installs queue package + bullmq + ioredis
 kick add --list           # show core packages (alias: kick list)
 kick add --list --all     # full optional catalog
 ```
+
+Deprecated catalog entries (`auth`, `drizzle`, `prisma`) still install but print a migration warning first, and `--list --all` flags them with `[DEPRECATED — …]` plus the recommended replacement (BYO auth via context decorators; `@forinda/kickjs-db` for the early-adoption ORM adapters).
 
 ### Core packages
 

--- a/docs/guide/hmr.md
+++ b/docs/guide/hmr.md
@@ -56,7 +56,7 @@ The `kick dev` command uses Vite's Environment Runner which reads this config au
 
 After an invalidation (a token change or a module-file add/remove), the dev server eagerly re-evaluates `virtual:kickjs/app` instead of waiting for the next HTTP request. A broken save — syntax error, failed import, bootstrap throw — prints immediately:
 
-```
+```text
 [vite] [kickjs] app failed to reload after HMR invalidation (1 token): x Expected ',', got ':'
 ```
 

--- a/docs/guide/hmr.md
+++ b/docs/guide/hmr.md
@@ -52,6 +52,32 @@ export default defineConfig({
 
 The `kick dev` command uses Vite's Environment Runner which reads this config automatically. No additional HMR configuration is needed.
 
+## Errors Surface on Save
+
+After an invalidation (a token change or a module-file add/remove), the dev server eagerly re-evaluates `virtual:kickjs/app` instead of waiting for the next HTTP request. A broken save — syntax error, failed import, bootstrap throw — prints immediately:
+
+```
+[vite] [kickjs] app failed to reload after HMR invalidation (1 token): x Expected ',', got ':'
+```
+
+The next successful save heals it; the dev loop never dies mid-edit.
+
+## Custom HMR Events
+
+Dev tools (the DevTools dashboard, Swagger UI, custom overlays) can subscribe to the channel KickJS broadcasts on:
+
+| Event                  | Payload                      | Fired when                                                      |
+| ---------------------- | ---------------------------- | --------------------------------------------------------------- |
+| `kickjs:hmr`           | `{ tokens, timestamp }`      | A batch of DI tokens was invalidated                            |
+| `kickjs:typegen-error` | `{ message, timestamp }`     | A watch-mode typegen pass failed (types may be stale)           |
+| `kickjs:typecheck`     | `{ ok, output, durationMs }` | A `kick dev --typecheck` run finished (full diagnostics inside) |
+
+```ts
+import.meta.hot?.on('kickjs:typecheck', (data) => {
+  if (!data.ok) overlay.show(data.output)
+})
+```
+
 ## Graceful Shutdown
 
 When the process receives `SIGINT` or `SIGTERM`, `bootstrap()` calls `app.shutdown()` which:

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -49,13 +49,12 @@ Request In
   ├─ ▸ beforeRoutes adapters
   │   └─ Example: AuthAdapter
   │       ├─ Resolve controller + method from URL
-  │       ├─ @Public() → skip auth, next()
-  │       ├─ Try strategies (JWT → API Key → Session)
-  │       │   ├─ No user → onAuthFailed event, 401
-  │       │   └─ User found → ctx.set('user', user), onAuthenticated event
-  │       ├─ @Roles() check          → 403 on missing role
-  │       ├─ @Can(action, resource)  → 403 on policy deny
-  │       ├─ @RateLimit() check      → 429 + RateLimit-* headers
+  │       ├─ @Public → LoadAuthUser({ on401: 'allow' }), user may be null
+  │       ├─ @LoadAuthUser → try strategies in order (BYO)
+  │       │   ├─ No user → throw, 401
+  │       │   └─ User found → ctx.set('user', user)
+  │       ├─ @RequireRole check (BYO) → 403 on missing role
+  │       ├─ @Can / policy engine via DI (BYO) → 403 on deny
   │       └─ CSRF check (cookie auth + mutating method)
   │
   ├─ Express Router matches route
@@ -166,7 +165,7 @@ Services that don't hold a `ctx` reference read the same bag via `getRequestValu
 - [Adapters](./adapters.md) — writing custom adapters with `defineAdapter()`
 - [Plugins](./plugins.md) — bundling modules + adapters + middleware via `definePlugin()`
 - [Context Decorators](./context-decorators.md) — typed per-request values + contributor pipeline
-- [Authentication](./authentication.md) — AuthAdapter strategies and decorators
-- [Authorization](./authorization.md) — @Policy, @Can, @Roles
+- [Authentication](./authentication.md) — BYO auth via context decorators
+- [Authorization](./authorization.md) — BYO role checks + policy engine via DI
 - [Multi-Tenancy](./multi-tenancy.md) — TenantAdapter and database switching
 - [Middleware](./middleware.md) — custom middleware

--- a/docs/guide/typegen.md
+++ b/docs/guide/typegen.md
@@ -75,17 +75,22 @@ export class UserController {
 
 ## Running typegen
 
-| Command                 | When it runs                                                     |
-| ----------------------- | ---------------------------------------------------------------- |
-| `kick typegen`          | One-shot — runs the scan and writes the types                    |
-| `kick typegen --watch`  | Re-runs on every source file change (Ctrl-C to exit)             |
-| `kick dev`              | Runs once at startup, then re-runs whenever Vite's watcher fires |
-| `kick g module ...`     | Runs after the new files are written                             |
-| `kick g controller ...` | Runs after the new file is written                               |
-| `kick g scaffold ...`   | Runs after the new files are written                             |
-| `kick init`             | Runs once after the project is scaffolded                        |
+| Command                 | When it runs                                                                 |
+| ----------------------- | ---------------------------------------------------------------------------- |
+| `kick typegen`          | One-shot — runs the scan and writes the types                                |
+| `kick typegen --watch`  | Re-runs on every source file change (Ctrl-C to exit)                         |
+| `kick dev`              | Runs once at startup, then re-runs whenever Vite's watcher fires             |
+| bare `vite`             | The `kickjs:typegen` vite plugin wires the same watcher + a startup catch-up |
+| `kick g module ...`     | Runs after the new files are written                                         |
+| `kick g controller ...` | Runs after the new file is written                                           |
+| `kick g scaffold ...`   | Runs after the new files are written                                         |
+| `kick init`             | Runs once after the project is scaffolded                                    |
 
-You almost never need to run it manually — `kick dev` keeps `.kickjs/types/` up to date for you.
+You almost never need to run it manually — the dev loop keeps `.kickjs/types/` up to date for you. (`kick dev` is the recommended entry; if something boots Vite directly, the `@forinda/kickjs-vite` plugin runs the identical watcher, resolving `@forinda/kickjs-cli` from your project — exactly one of the two ever owns the pipeline per process.)
+
+### Watch-mode failure surfacing
+
+A failing scan or plugin pass in watch mode prints a deduplicated warning (`kick typegen: <source> pass failed (<error>) — types in .kickjs/types may be stale`) and broadcasts a `kickjs:typegen-error` custom HMR event. Repeated identical failures stay quiet until the message changes or a pass succeeds. Separately, a route whose wired `body`/`query`/`params` schema can't be statically resolved warns with the controller, method, and schema identifier instead of silently emitting `unknown`.
 
 ## How `params` is typed
 


### PR DESCRIPTION
Catch-up documentation for this cycle's shipped features, plus the auth rewrite:

- **authentication.md / authorization.md rewritten BYO-first**: deprecation banners, distilled context-decorator shapes (LoadAuthUser / Public / RequireRole / load-and-authorize policies) linking the full byo-recipes.md walkthrough; legacy package reference demoted below a clear heading. api/auth.md gets the banner too.
- **cli-commands.md**: kick dev gains --polling/--typecheck docs + errors-surface-on-save section; kick info example replaced (was the old hardcoded 'workspace' output); kick add deprecation-warning behavior; version flag aliases.
- **typegen.md**: bare-vite watcher row + single-owner note; watch-mode failure surfacing section (dedupe semantics, kickjs:typegen-error, route schema fallback warnings).
- **hmr.md**: eager re-warm error surfacing + custom HMR events table (kickjs:hmr / typegen-error / typecheck) with subscription example.
- **api/cli.md**: kick dev flag list completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced bring-your-own (BYO) authentication approach with composable context decorators and adapters
  * Deprecated `@forinda/kickjs-auth` package with migration guidance for existing projects
  * Added `--polling` and `--typecheck` flags to the dev command with detailed documentation
  * Enhanced documentation for error surfacing, HMR event listeners, and typegen failure handling
  * Updated authorization patterns to support context decorators and policy-based dependency injection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->