### PR TITLE
feat(kickjs): query-parsing onReject hook, configurable limits, ctx.qs memoization

### DIFF
--- a/.changeset/query-parsing-polish.md
+++ b/.changeset/query-parsing-polish.md
@@ -1,0 +1,9 @@
+---
+'@forinda/kickjs': minor
+---
+
+Query parsing gains an `onReject` hook, configurable limits, and `ctx.qs()` memoization.
+
+- `parseQuery(query, fieldConfig, options?)` accepts a new `ParseQueryOptions` bag: `maxLimit`, `defaultLimit`, `maxSearchLength`, and `onReject`. The historical silent drop of an unknown filter/sort field — or a truncated search string — now fires `onReject({ kind, field, reason })` so callers can warn, count, or return a 400. Fully backward compatible (the 2-arg form is unchanged).
+- `setQueryParsingDefaults({ maxLimit, defaultLimit, maxSearchLength })` replaces the previously hardcoded `MAX_LIMIT = 100` / `MAX_SEARCH_LENGTH = 200` constants with a one-time global override at bootstrap; per-call options still win.
+- `ctx.qs(fieldConfig, options?)` threads the options through, **memoizes** the result per request (repeat calls with the same args skip re-parsing), and by default logs rejected fields via `console.warn` with the request id — pass an explicit `onReject` (e.g. one that throws) to override, or `() => {}` to silence.

--- a/packages/kickjs/__tests__/context-qs.test.ts
+++ b/packages/kickjs/__tests__/context-qs.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import { RequestContext } from '../src/http/context'
+
+function makeCtx(query: Record<string, unknown>): RequestContext {
+  const req = { query, headers: {}, params: {}, body: {} } as never
+  const res = {} as never
+  const next = (() => {}) as never
+  return new RequestContext(req, res, next)
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('RequestContext.qs', () => {
+  it('memoizes repeat calls with the same config reference', () => {
+    const ctx = makeCtx({ filter: 'status:eq:open' })
+    const config = { filterable: ['status'] } as const
+    const a = ctx.qs(config)
+    const b = ctx.qs(config)
+    expect(b).toBe(a) // identical reference — not re-parsed
+  })
+
+  it('re-parses when the config reference changes', () => {
+    const ctx = makeCtx({ filter: 'status:eq:open' })
+    const a = ctx.qs({ filterable: ['status'] })
+    const b = ctx.qs({ filterable: ['status'] })
+    expect(b).not.toBe(a)
+  })
+
+  it('warns by default when a filter field is not whitelisted', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const ctx = makeCtx({ filter: 'secret:eq:x' })
+    const parsed = ctx.qs({ filterable: ['status'] })
+    expect(parsed.filters).toEqual([])
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0][0]).toContain("query filter 'secret' rejected (field-not-allowed)")
+  })
+
+  it('an explicit onReject overrides the default warn (e.g. to throw a 400)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const ctx = makeCtx({ filter: 'secret:eq:x' })
+    expect(() =>
+      ctx.qs(
+        { filterable: ['status'] },
+        {
+          onReject: (r) => {
+            throw new Error(`bad query field: ${r.field}`)
+          },
+        },
+      ),
+    ).toThrow('bad query field: secret')
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('honours per-call limits', () => {
+    const ctx = makeCtx({ limit: '999' })
+    expect(ctx.qs(undefined, { maxLimit: 25 }).pagination.limit).toBe(25)
+  })
+})

--- a/packages/kickjs/__tests__/parse-query.test.ts
+++ b/packages/kickjs/__tests__/parse-query.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 
 import {
   parseQuery,
@@ -8,7 +8,12 @@ import {
   parseSearchQuery,
   setQueryParsingDefaults,
   getQueryParsingDefaults,
+  resetQueryParsingDefaults,
 } from '../src/http/query/parse-query'
+
+// Any test that mutates the module-level defaults restores them here so
+// global state never leaks between tests, even on assertion failure.
+afterEach(() => resetQueryParsingDefaults())
 
 describe('parseFilters — onReject', () => {
   it('reports a filter dropped for an unknown field', () => {
@@ -115,11 +120,23 @@ describe('parseQuery — options threading', () => {
 })
 
 describe('setQueryParsingDefaults', () => {
-  it('overrides the global maxLimit + restores', () => {
+  it('overrides the global maxLimit (afterEach resets)', () => {
     const prev = getQueryParsingDefaults()
     setQueryParsingDefaults({ maxLimit: 5 })
     expect(parsePagination({ page: '1', limit: '999' }).limit).toBe(5)
-    setQueryParsingDefaults({ maxLimit: prev.maxLimit })
-    expect(parsePagination({ page: '1', limit: '999' }).limit).toBe(100)
+    // No manual restore — the afterEach reset guarantees cleanup even if
+    // this assertion throws. Verify the helper round-trips the original.
+    resetQueryParsingDefaults()
+    expect(parsePagination({ page: '1', limit: '999' }).limit).toBe(prev.maxLimit)
+  })
+
+  it('resetQueryParsingDefaults restores every field', () => {
+    setQueryParsingDefaults({ maxLimit: 1, defaultLimit: 1, maxSearchLength: 1 })
+    resetQueryParsingDefaults()
+    expect(getQueryParsingDefaults()).toMatchObject({
+      maxLimit: 100,
+      defaultLimit: 20,
+      maxSearchLength: 200,
+    })
   })
 })

--- a/packages/kickjs/__tests__/parse-query.test.ts
+++ b/packages/kickjs/__tests__/parse-query.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import {
+  parseQuery,
+  parseFilters,
+  parseSort,
+  parsePagination,
+  parseSearchQuery,
+  setQueryParsingDefaults,
+  getQueryParsingDefaults,
+} from '../src/http/query/parse-query'
+
+describe('parseFilters — onReject', () => {
+  it('reports a filter dropped for an unknown field', () => {
+    const onReject = vi.fn()
+    const out = parseFilters(['status:eq:open', 'secret:eq:x'], ['status'], { onReject })
+    expect(out).toHaveLength(1)
+    expect(onReject).toHaveBeenCalledTimes(1)
+    expect(onReject).toHaveBeenCalledWith({
+      kind: 'filter',
+      field: 'secret',
+      reason: 'field-not-allowed',
+    })
+  })
+
+  it('reports a filter dropped for an unknown operator', () => {
+    const onReject = vi.fn()
+    parseFilters(['status:bogus:open'], ['status'], { onReject })
+    expect(onReject).toHaveBeenCalledWith({
+      kind: 'filter',
+      field: 'status',
+      reason: 'unknown-operator',
+    })
+  })
+
+  it('stays silent when every filter is accepted', () => {
+    const onReject = vi.fn()
+    parseFilters(['status:eq:open'], ['status'], { onReject })
+    expect(onReject).not.toHaveBeenCalled()
+  })
+})
+
+describe('parseSort — onReject', () => {
+  it('reports a sort dropped for an unknown field', () => {
+    const onReject = vi.fn()
+    const out = parseSort(['name:asc', 'secret:desc'], ['name'], { onReject })
+    expect(out).toHaveLength(1)
+    expect(onReject).toHaveBeenCalledWith({
+      kind: 'sort',
+      field: 'secret',
+      reason: 'field-not-allowed',
+    })
+  })
+})
+
+describe('parsePagination — configurable limits', () => {
+  it('clamps to a per-call maxLimit', () => {
+    expect(parsePagination({ page: '1', limit: '500' }, { maxLimit: 50 }).limit).toBe(50)
+  })
+
+  it('uses a per-call defaultLimit when limit is absent', () => {
+    expect(parsePagination({ page: '1' }, { defaultLimit: 25 }).limit).toBe(25)
+  })
+
+  it('falls back to the global defaults', () => {
+    expect(parsePagination({ page: '1', limit: '500' }).limit).toBe(100)
+    expect(parsePagination({ page: '1' }).limit).toBe(20)
+  })
+})
+
+describe('parseSearchQuery — truncation reporting', () => {
+  it('truncates to maxSearchLength and reports it', () => {
+    const onReject = vi.fn()
+    const long = 'a'.repeat(300)
+    const out = parseSearchQuery(long, { maxSearchLength: 50, onReject })
+    expect(out).toHaveLength(50)
+    expect(onReject).toHaveBeenCalledWith({
+      kind: 'search',
+      field: 'q',
+      reason: 'truncated',
+    })
+  })
+
+  it('does not report when within length', () => {
+    const onReject = vi.fn()
+    parseSearchQuery('short', { maxSearchLength: 50, onReject })
+    expect(onReject).not.toHaveBeenCalled()
+  })
+})
+
+describe('parseQuery — options threading', () => {
+  it('threads onReject + limits to every sub-parser', () => {
+    const onReject = vi.fn()
+    const parsed = parseQuery(
+      { filter: 'bad:eq:x', sort: 'bad:asc', q: 'y'.repeat(20), page: '1', limit: '999' },
+      { filterable: ['ok'], sortable: ['ok'] },
+      { maxLimit: 10, maxSearchLength: 5, onReject },
+    )
+    expect(parsed.pagination.limit).toBe(10)
+    expect(parsed.search).toHaveLength(5)
+    const reasons = onReject.mock.calls.map((c) => `${c[0].kind}:${c[0].reason}`)
+    expect(reasons).toEqual(
+      expect.arrayContaining([
+        'filter:field-not-allowed',
+        'sort:field-not-allowed',
+        'search:truncated',
+      ]),
+    )
+  })
+
+  it('is backward compatible with the 2-arg form', () => {
+    const parsed = parseQuery({ filter: 'status:eq:open' }, { filterable: ['status'] })
+    expect(parsed.filters).toEqual([{ field: 'status', operator: 'eq', value: 'open' }])
+  })
+})
+
+describe('setQueryParsingDefaults', () => {
+  it('overrides the global maxLimit + restores', () => {
+    const prev = getQueryParsingDefaults()
+    setQueryParsingDefaults({ maxLimit: 5 })
+    expect(parsePagination({ page: '1', limit: '999' }).limit).toBe(5)
+    setQueryParsingDefaults({ maxLimit: prev.maxLimit })
+    expect(parsePagination({ page: '1', limit: '999' }).limit).toBe(100)
+  })
+})

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -5,6 +5,7 @@ import { normalizeProblem, type ProblemDetails, type ValidationError } from '../
 import { requestStore } from './request-store'
 import {
   parseQuery,
+  type ParseQueryOptions,
   type QueryFieldConfig,
   type PaginatedResponse,
   type TypedParsedQuery,
@@ -261,6 +262,14 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
   ) {}
 
   /**
+   * Memo of the most recent {@link qs} call this request. The query
+   * object is immutable for a request's lifetime, so a repeat call with
+   * the same `(fieldConfig, options)` references returns the cached
+   * parse instead of re-walking the filter/sort strings.
+   */
+  private _qsMemo?: { config: unknown; options: unknown; result: unknown }
+
+  /**
    * Read-side accessor for the per-request metadata map.
    *
    * Returns the AsyncLocalStorage map (`requestStore.getStore().values`)
@@ -443,6 +452,10 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
    * config and you get the loose `string` fallback.
    *
    * @param fieldConfig - Optional whitelist for filterable, sortable, and searchable fields
+   * @param options - Limits (`maxLimit`, `defaultLimit`, `maxSearchLength`) and an
+   *   `onReject` hook. By default a rejected/over-broad field is logged via
+   *   `console.warn` with the request id; pass an explicit `onReject` to override
+   *   (e.g. throw to return a 400), or `onReject: () => {}` to silence.
    *
    * @example
    * ```ts
@@ -459,8 +472,33 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
    */
   qs<TConfig extends QueryFieldConfig | undefined = undefined>(
     fieldConfig?: TConfig,
+    options?: ParseQueryOptions,
   ): TypedParsedQuery<TConfig> {
-    return parseQuery<TConfig>(this.req.query as Record<string, any>, fieldConfig)
+    // Cheap per-request memo — repeat calls with the same args (the
+    // common controller pattern) skip re-parsing. `req.query` is fixed
+    // for the request's lifetime, so caching is always sound.
+    const memo = this._qsMemo
+    if (memo && memo.config === fieldConfig && memo.options === options) {
+      return memo.result as TypedParsedQuery<TConfig>
+    }
+    const effective: ParseQueryOptions = {
+      ...options,
+      onReject:
+        options?.onReject ??
+        ((rejection) => {
+          const id = this.requestId ? `[${this.requestId}] ` : ''
+          console.warn(
+            `${id}query ${rejection.kind} '${rejection.field}' rejected (${rejection.reason})`,
+          )
+        }),
+    }
+    const result = parseQuery<TConfig>(
+      this.req.query as Record<string, any>,
+      fieldConfig,
+      effective,
+    )
+    this._qsMemo = { config: fieldConfig, options, result }
+    return result
   }
 
   // ── File Uploads ────────────────────────────────────────────────────

--- a/packages/kickjs/src/http/index.ts
+++ b/packages/kickjs/src/http/index.ts
@@ -46,6 +46,7 @@ export {
   buildQueryParams,
   setQueryParsingDefaults,
   getQueryParsingDefaults,
+  resetQueryParsingDefaults,
   FILTER_OPERATORS,
   type FilterOperator,
   type FilterItem,

--- a/packages/kickjs/src/http/index.ts
+++ b/packages/kickjs/src/http/index.ts
@@ -44,6 +44,8 @@ export {
   parsePagination,
   parseSearchQuery,
   buildQueryParams,
+  setQueryParsingDefaults,
+  getQueryParsingDefaults,
   FILTER_OPERATORS,
   type FilterOperator,
   type FilterItem,
@@ -53,4 +55,7 @@ export {
   type QueryFieldConfig,
   type QueryBuilderAdapter,
   type PaginatedResponse,
+  type ParseQueryOptions,
+  type QueryRejection,
+  type QueryRejectReason,
 } from './query'

--- a/packages/kickjs/src/http/query/index.ts
+++ b/packages/kickjs/src/http/query/index.ts
@@ -7,6 +7,7 @@ export {
   buildQueryParams,
   setQueryParsingDefaults,
   getQueryParsingDefaults,
+  resetQueryParsingDefaults,
 } from './parse-query'
 
 export type { ParseQueryOptions, QueryRejection, QueryRejectReason } from './parse-query'

--- a/packages/kickjs/src/http/query/index.ts
+++ b/packages/kickjs/src/http/query/index.ts
@@ -5,7 +5,11 @@ export {
   parsePagination,
   parseSearchQuery,
   buildQueryParams,
+  setQueryParsingDefaults,
+  getQueryParsingDefaults,
 } from './parse-query'
+
+export type { ParseQueryOptions, QueryRejection, QueryRejectReason } from './parse-query'
 
 export type {
   FilterOperator,

--- a/packages/kickjs/src/http/query/parse-query.ts
+++ b/packages/kickjs/src/http/query/parse-query.ts
@@ -10,10 +10,66 @@ import {
   type TypedParsedQuery,
 } from './types'
 
-const MAX_SEARCH_LENGTH = 200
-const DEFAULT_PAGE = 1
-const DEFAULT_LIMIT = 20
-const MAX_LIMIT = 100
+// ── Configurable defaults ───────────────────────────────────────────────
+
+/**
+ * Why a rejected field/value was dropped. Surfaced through
+ * {@link ParseQueryOptions.onReject} so a caller can warn, count, or
+ * return a 400 instead of the historical silent drop.
+ */
+export type QueryRejectReason = 'field-not-allowed' | 'unknown-operator' | 'truncated'
+
+export interface QueryRejection {
+  kind: 'filter' | 'sort' | 'search'
+  field: string
+  reason: QueryRejectReason
+}
+
+export interface ParseQueryOptions {
+  /** Hard cap on `limit`. Default: global (100, override via {@link setQueryParsingDefaults}). */
+  maxLimit?: number
+  /** `limit` when the query omits one. Default: global (20). */
+  defaultLimit?: number
+  /** Max `q` length before truncation. Default: global (200). */
+  maxSearchLength?: number
+  /**
+   * Called once per dropped filter/sort field or truncated search.
+   * The historical behaviour is a silent drop; wire this to a logger or
+   * a 400 to make over-broad / typo'd queries visible.
+   */
+  onReject?: (rejection: QueryRejection) => void
+}
+
+interface QueryParsingDefaults {
+  maxLimit: number
+  defaultLimit: number
+  maxSearchLength: number
+  defaultPage: number
+}
+
+const defaults: QueryParsingDefaults = {
+  maxLimit: 100,
+  defaultLimit: 20,
+  maxSearchLength: 200,
+  defaultPage: 1,
+}
+
+/**
+ * Globally override the query-parsing limits — call once at bootstrap.
+ * Per-call {@link ParseQueryOptions} still take precedence over these.
+ */
+export function setQueryParsingDefaults(
+  partial: Partial<Omit<QueryParsingDefaults, 'defaultPage'>>,
+): void {
+  if (partial.maxLimit !== undefined) defaults.maxLimit = partial.maxLimit
+  if (partial.defaultLimit !== undefined) defaults.defaultLimit = partial.defaultLimit
+  if (partial.maxSearchLength !== undefined) defaults.maxSearchLength = partial.maxSearchLength
+}
+
+/** Read the current global query-parsing defaults (a copy). */
+export function getQueryParsingDefaults(): Readonly<QueryParsingDefaults> {
+  return { ...defaults }
+}
 
 // ── Individual parsers ──────────────────────────────────────────────────
 
@@ -21,12 +77,14 @@ const MAX_LIMIT = 100
 export function parseFilters(
   filterParam: string | string[] | undefined,
   allowedFields?: string[],
+  options?: Pick<ParseQueryOptions, 'onReject'>,
 ): FilterItem[] {
   if (!filterParam) return []
 
   const items = Array.isArray(filterParam) ? filterParam : [filterParam]
   const results: FilterItem[] = []
   const allowed = allowedFields ? new Set(allowedFields) : null
+  const onReject = options?.onReject
 
   for (const item of items) {
     // Split on first two colons only — value may contain colons (e.g. timestamps)
@@ -41,8 +99,14 @@ export function parseFilters(
     const value = item.slice(secondColon + 1)
 
     if (!field || !value) continue
-    if (!FILTER_OPERATORS.has(operator)) continue
-    if (allowed && !allowed.has(field)) continue
+    if (!FILTER_OPERATORS.has(operator)) {
+      onReject?.({ kind: 'filter', field, reason: 'unknown-operator' })
+      continue
+    }
+    if (allowed && !allowed.has(field)) {
+      onReject?.({ kind: 'filter', field, reason: 'field-not-allowed' })
+      continue
+    }
 
     results.push({ field, operator: operator as FilterOperator, value })
   }
@@ -54,12 +118,14 @@ export function parseFilters(
 export function parseSort(
   sortParam: string | string[] | undefined,
   allowedFields?: string[],
+  options?: Pick<ParseQueryOptions, 'onReject'>,
 ): SortItem[] {
   if (!sortParam) return []
 
   const items = Array.isArray(sortParam) ? sortParam : [sortParam]
   const results: SortItem[] = []
   const allowed = allowedFields ? new Set(allowedFields) : null
+  const onReject = options?.onReject
 
   for (const item of items) {
     // Split on last colon so field names with colons work
@@ -71,7 +137,10 @@ export function parseSort(
 
     if (!field) continue
     if (dir !== 'asc' && dir !== 'desc') continue
-    if (allowed && !allowed.has(field)) continue
+    if (allowed && !allowed.has(field)) {
+      onReject?.({ kind: 'sort', field, reason: 'field-not-allowed' })
+      continue
+    }
 
     results.push({ field, direction: dir })
   }
@@ -80,30 +149,45 @@ export function parseSort(
 }
 
 /** Parse page/limit into pagination with computed offset */
-export function parsePagination(params: {
-  page?: string | number
-  limit?: string | number
-}): PaginationParams {
+export function parsePagination(
+  params: {
+    page?: string | number
+    limit?: string | number
+  },
+  options?: Pick<ParseQueryOptions, 'maxLimit' | 'defaultLimit'>,
+): PaginationParams {
+  const defaultLimit = options?.defaultLimit ?? defaults.defaultLimit
+  const maxLimit = options?.maxLimit ?? defaults.maxLimit
+
   let page =
     typeof params.page === 'string'
       ? Number.parseInt(params.page, 10)
-      : (params.page ?? DEFAULT_PAGE)
+      : (params.page ?? defaults.defaultPage)
   let limit =
     typeof params.limit === 'string'
       ? Number.parseInt(params.limit, 10)
-      : (params.limit ?? DEFAULT_LIMIT)
+      : (params.limit ?? defaultLimit)
 
-  if (Number.isNaN(page) || page < 1) page = DEFAULT_PAGE
-  if (Number.isNaN(limit) || limit < 1) limit = DEFAULT_LIMIT
-  if (limit > MAX_LIMIT) limit = MAX_LIMIT
+  if (Number.isNaN(page) || page < 1) page = defaults.defaultPage
+  if (Number.isNaN(limit) || limit < 1) limit = defaultLimit
+  if (limit > maxLimit) limit = maxLimit
 
   return { page, limit, offset: (page - 1) * limit }
 }
 
 /** Sanitize and truncate search query */
-export function parseSearchQuery(q: string | undefined): string {
+export function parseSearchQuery(
+  q: string | undefined,
+  options?: Pick<ParseQueryOptions, 'maxSearchLength' | 'onReject'>,
+): string {
   if (!q) return ''
-  return q.trim().slice(0, MAX_SEARCH_LENGTH)
+  const maxLen = options?.maxSearchLength ?? defaults.maxSearchLength
+  const trimmed = q.trim()
+  if (trimmed.length > maxLen) {
+    options?.onReject?.({ kind: 'search', field: 'q', reason: 'truncated' })
+    return trimmed.slice(0, maxLen)
+  }
+  return trimmed
 }
 
 // ── Config normalizer ───────────────────────────────────────────────────
@@ -138,6 +222,7 @@ function normalizeFieldConfig(config?: QueryFieldConfig): StringQueryFieldConfig
  * @param fieldConfig - Optional field restrictions (whitelist filterable/sortable/searchable).
  *   Accepts both string-based configs (`{ filterable, sortable, searchable }`) and
  *   column-object configs (`{ columns, sortable, searchColumns }`).
+ * @param options - Limits + an `onReject` hook for dropped/truncated input.
  *
  * @example
  * ```ts
@@ -162,13 +247,15 @@ function normalizeFieldConfig(config?: QueryFieldConfig): StringQueryFieldConfig
 export function parseQuery<TConfig extends QueryFieldConfig | undefined = undefined>(
   query: Record<string, any>,
   fieldConfig?: TConfig,
+  options?: ParseQueryOptions,
 ): TypedParsedQuery<TConfig> {
   const normalized = normalizeFieldConfig(fieldConfig)
+  const rejectOpts = options?.onReject ? { onReject: options.onReject } : undefined
   return {
-    filters: parseFilters(query.filter, normalized?.filterable),
-    sort: parseSort(query.sort, normalized?.sortable),
-    pagination: parsePagination({ page: query.page, limit: query.limit }),
-    search: parseSearchQuery(query.q),
+    filters: parseFilters(query.filter, normalized?.filterable, rejectOpts),
+    sort: parseSort(query.sort, normalized?.sortable, rejectOpts),
+    pagination: parsePagination({ page: query.page, limit: query.limit }, options),
+    search: parseSearchQuery(query.q, options),
   } as TypedParsedQuery<TConfig>
 }
 

--- a/packages/kickjs/src/http/query/parse-query.ts
+++ b/packages/kickjs/src/http/query/parse-query.ts
@@ -47,12 +47,14 @@ interface QueryParsingDefaults {
   defaultPage: number
 }
 
-const defaults: QueryParsingDefaults = {
+const BUILTIN_DEFAULTS: QueryParsingDefaults = {
   maxLimit: 100,
   defaultLimit: 20,
   maxSearchLength: 200,
   defaultPage: 1,
 }
+
+const defaults: QueryParsingDefaults = { ...BUILTIN_DEFAULTS }
 
 /**
  * Globally override the query-parsing limits — call once at bootstrap.
@@ -69,6 +71,16 @@ export function setQueryParsingDefaults(
 /** Read the current global query-parsing defaults (a copy). */
 export function getQueryParsingDefaults(): Readonly<QueryParsingDefaults> {
   return { ...defaults }
+}
+
+/**
+ * Restore the built-in query-parsing defaults (maxLimit 100, defaultLimit
+ * 20, maxSearchLength 200). Useful in test teardown after a
+ * {@link setQueryParsingDefaults} override so global state can't leak
+ * between tests.
+ */
+export function resetQueryParsingDefaults(): void {
+  Object.assign(defaults, BUILTIN_DEFAULTS)
 }
 
 // ── Individual parsers ──────────────────────────────────────────────────

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -71,6 +71,8 @@ export {
   parsePagination,
   parseSearchQuery,
   buildQueryParams,
+  setQueryParsingDefaults,
+  getQueryParsingDefaults,
   FILTER_OPERATORS,
   type FilterOperator,
   type FilterItem,
@@ -82,6 +84,9 @@ export {
   type QueryFieldConfig,
   type QueryBuilderAdapter,
   type PaginatedResponse,
+  type ParseQueryOptions,
+  type QueryRejection,
+  type QueryRejectReason,
 } from './http/query'
 
 // View & SPA Adapters

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -73,6 +73,7 @@ export {
   buildQueryParams,
   setQueryParsingDefaults,
   getQueryParsingDefaults,
+  resetQueryParsingDefaults,
   FILTER_OPERATORS,
   type FilterOperator,
   type FilterItem,


### PR DESCRIPTION
Closes the four `parse-query` audit items in one self-contained PR (all in `packages/kickjs/src/http/query/`).

## What

- **`onReject` hook** — `parseQuery(query, fieldConfig, options?)` gains a `ParseQueryOptions` bag. An unknown filter/sort field, a bad operator, or a truncated search string fired a *silent drop* before; now it calls `onReject({ kind, field, reason })` so the caller decides: warn, count, or throw a 400. The 2-arg form is byte-for-byte unchanged (backward compatible).
- **Configurable limits** — `setQueryParsingDefaults({ maxLimit, defaultLimit, maxSearchLength })` replaces the hardcoded `MAX_LIMIT = 100` / `MAX_SEARCH_LENGTH = 200` constants (one-time global at bootstrap); per-call options still win.
- **`ctx.qs()` memoization** — repeat calls with the same `(fieldConfig, options)` references return the cached parse instead of re-walking the strings (`req.query` is immutable per request, so it's always sound). The common "call `ctx.qs()` once per handler, read it a few times" pattern stops re-parsing.
- **Default warn** — `ctx.qs` wires `onReject` to a `console.warn` carrying the request id, so over-broad/typo'd queries are visible out of the box; pass an explicit `onReject` to override (throw → 400) or `() => {}` to silence.

## Testing

- 17 new unit tests: parser-level `onReject` + limits + truncation reporting + backward-compat (12), and `ctx.qs` memoization / default-warn / override / per-call limits (5).
- Full kickjs suite green (50 files, 539 tests); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Query parsing now accepts configurable options to manage search length and pagination limits, with per-call overrides.
  * Added callback support to handle rejected or invalid query fields instead of silent dropping.
  * Introduced global query parsing defaults with the ability to set and retrieve them.
  * Parsed query results are now memoized per request for improved performance.
  * Rejected query fields are logged by default with request-aware context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->