### PR TITLE
feat(db): escapeLike/likePattern helpers + explicit dialect marker

### DIFF
--- a/.changeset/db-query-safety.md
+++ b/.changeset/db-query-safety.md
@@ -1,0 +1,8 @@
+---
+'@forinda/kickjs-db': minor
+---
+
+Two query-layer safety additions:
+
+- **`escapeLike(input)` / `likePattern(input, mode)`** — escape LIKE/ILIKE metacharacters (`%`, `_`, and the escape char) so user search text matches literally. Without this, a user searching for `100%` produces a match-all pattern (or, with a leading wildcard, a full scan). `likePattern` builds the wrapped pattern for `'contains'` / `'startsWith'` / `'endsWith'` / `'exact'`.
+- **Explicit dialect tagging** — `pgDialect` / `mysqlDialect` / `sqliteDialect` now stamp a non-enumerable `KICK_DIALECT` marker, and `createDbClient`'s dialect detection reads it first. Previously detection relied solely on Kysely ctor-name regex (`/Postgres/i`) with a **silent fallback to SQLite** — a hand-rolled or future Kysely dialect whose ctor name didn't match was misclassified, emitting the wrong JSON-aggregation SQL. The ctor-name heuristic remains as the fallback for raw Kysely dialects. `markDialect` / `readDialectMark` are exported for adopters wrapping a raw dialect.

--- a/packages/db/__tests__/unit/dialect-marker.test.ts
+++ b/packages/db/__tests__/unit/dialect-marker.test.ts
@@ -12,7 +12,13 @@ describe('dialect marker', () => {
     const d = markDialect({ createAdapter: () => ({}) }, 'sqlite')
     expect(Object.keys(d)).toEqual(['createAdapter'])
     expect(JSON.stringify(d)).toBe('{}')
-    // …but still readable via the symbol.
+    // Object spread copies ENUMERABLE symbol keys — assert the mark is
+    // not carried (Object.keys/JSON.stringify ignore symbols regardless,
+    // so they alone don't prove non-enumerability).
+    const spread = { ...d }
+    expect((spread as Record<symbol, unknown>)[KICK_DIALECT]).toBeUndefined()
+    expect(Object.getOwnPropertyDescriptor(d, KICK_DIALECT)?.enumerable).toBe(false)
+    // …but still readable via the symbol on the original.
     expect((d as Record<symbol, unknown>)[KICK_DIALECT]).toBe('sqlite')
   })
 
@@ -20,7 +26,7 @@ describe('dialect marker', () => {
     expect(readDialectMark({})).toBeUndefined()
   })
 
-  it('the factory-stamped tag survives — createDbClient detects it exactly', async () => {
+  it('the factory-stamped tag survives on dialect instances', async () => {
     const { sqliteDialect } = await import('../../src/adapters/sqlite/dialect')
     // A fake better-sqlite3-shaped handle is enough; we only read the mark.
     const dialect = sqliteDialect({ database: {} as never })

--- a/packages/db/__tests__/unit/dialect-marker.test.ts
+++ b/packages/db/__tests__/unit/dialect-marker.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+
+import { markDialect, readDialectMark, KICK_DIALECT } from '../../src/dialect-marker'
+
+describe('dialect marker', () => {
+  it('stamps and reads a tag', () => {
+    const d = markDialect({}, 'postgres')
+    expect(readDialectMark(d)).toBe('postgres')
+  })
+
+  it('the mark is non-enumerable (does not leak into spreads/JSON)', () => {
+    const d = markDialect({ createAdapter: () => ({}) }, 'sqlite')
+    expect(Object.keys(d)).toEqual(['createAdapter'])
+    expect(JSON.stringify(d)).toBe('{}')
+    // …but still readable via the symbol.
+    expect((d as Record<symbol, unknown>)[KICK_DIALECT]).toBe('sqlite')
+  })
+
+  it('returns undefined for an unmarked dialect (ctor-name fallback territory)', () => {
+    expect(readDialectMark({})).toBeUndefined()
+  })
+
+  it('the factory-stamped tag survives — createDbClient detects it exactly', async () => {
+    const { sqliteDialect } = await import('../../src/adapters/sqlite/dialect')
+    // A fake better-sqlite3-shaped handle is enough; we only read the mark.
+    const dialect = sqliteDialect({ database: {} as never })
+    expect(readDialectMark(dialect)).toBe('sqlite')
+  })
+})

--- a/packages/db/__tests__/unit/dialect-marker.test.ts
+++ b/packages/db/__tests__/unit/dialect-marker.test.ts
@@ -26,6 +26,13 @@ describe('dialect marker', () => {
     expect(readDialectMark({})).toBeUndefined()
   })
 
+  it('rejects a garbage marker value (rogue Symbol.for stamp) → undefined', () => {
+    const d = {}
+    Object.defineProperty(d, KICK_DIALECT, { value: 'oracle', enumerable: false })
+    // Not a supported tag → falls the caller back to ctor-name detection.
+    expect(readDialectMark(d)).toBeUndefined()
+  })
+
   it('the factory-stamped tag survives on dialect instances', async () => {
     const { sqliteDialect } = await import('../../src/adapters/sqlite/dialect')
     // A fake better-sqlite3-shaped handle is enough; we only read the mark.

--- a/packages/db/__tests__/unit/like-escape.test.ts
+++ b/packages/db/__tests__/unit/like-escape.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+
+import { escapeLike, likePattern } from '../../src/query/like'
+
+describe('escapeLike', () => {
+  it('escapes % and _ wildcards', () => {
+    expect(escapeLike('100%')).toBe('100\\%')
+    expect(escapeLike('a_b')).toBe('a\\_b')
+  })
+
+  it('escapes the escape char before adding new ones (no double-escape)', () => {
+    expect(escapeLike('a\\b')).toBe('a\\\\b')
+    expect(escapeLike('50%\\_')).toBe('50\\%\\\\\\_')
+  })
+
+  it('leaves ordinary text untouched', () => {
+    expect(escapeLike('john.doe@example.com')).toBe('john.doe@example.com')
+  })
+
+  it('honours a custom escape char', () => {
+    expect(escapeLike('a%b', '!')).toBe('a!%b')
+  })
+})
+
+describe('likePattern', () => {
+  it('wraps escaped input per mode', () => {
+    expect(likePattern('john', 'contains')).toBe('%john%')
+    expect(likePattern('admin', 'startsWith')).toBe('admin%')
+    expect(likePattern('.com', 'endsWith')).toBe('%.com')
+    expect(likePattern('exact', 'exact')).toBe('exact')
+  })
+
+  it('escapes wildcards inside the input so they match literally', () => {
+    // A user typing "100%" should not become a match-all pattern.
+    expect(likePattern('100%', 'contains')).toBe('%100\\%%')
+  })
+
+  it('defaults to contains', () => {
+    expect(likePattern('x')).toBe('%x%')
+  })
+})

--- a/packages/db/__tests__/unit/like-escape.test.ts
+++ b/packages/db/__tests__/unit/like-escape.test.ts
@@ -45,4 +45,8 @@ describe('likePattern', () => {
   it('defaults to contains', () => {
     expect(likePattern('x')).toBe('%x%')
   })
+
+  it('throws on an unsupported mode (JS caller / as-any)', () => {
+    expect(() => likePattern('x', 'bogus' as never)).toThrow(/unsupported match mode/)
+  })
 })

--- a/packages/db/__tests__/unit/like-escape.test.ts
+++ b/packages/db/__tests__/unit/like-escape.test.ts
@@ -20,6 +20,13 @@ describe('escapeLike', () => {
   it('honours a custom escape char', () => {
     expect(escapeLike('a%b', '!')).toBe('a!%b')
   })
+
+  it('rejects an invalid escape char (empty, multi-char, or a wildcard)', () => {
+    expect(() => escapeLike('x', '')).toThrow(/single character/)
+    expect(() => escapeLike('x', '!!')).toThrow(/single character/)
+    expect(() => escapeLike('x', '%')).toThrow(/'%' or '_'/)
+    expect(() => escapeLike('x', '_')).toThrow(/'%' or '_'/)
+  })
 })
 
 describe('likePattern', () => {

--- a/packages/db/src/adapters/mysql/dialect.ts
+++ b/packages/db/src/adapters/mysql/dialect.ts
@@ -4,6 +4,7 @@
 // is a pinned internal dep of the framework.
 
 import { MysqlDialect, type Dialect as KyselyDialect } from 'kysely'
+import { markDialect } from '../../dialect-marker'
 
 import type { MysqlPoolLike } from './adapter'
 
@@ -47,5 +48,5 @@ export function mysqlDialect(opts: MysqlDialectOptions): KyselyDialect {
   // newer Kysely versions; casting through `unknown` keeps adopters
   // using compatible drivers (e.g. mysql-mariadb forks) working
   // without pulling mysql2's typings into our public surface.
-  return new MysqlDialect({ pool: opts.pool as unknown as never })
+  return markDialect(new MysqlDialect({ pool: opts.pool as unknown as never }), 'mysql')
 }

--- a/packages/db/src/adapters/pg/dialect.ts
+++ b/packages/db/src/adapters/pg/dialect.ts
@@ -5,6 +5,7 @@
 // even when we change query backends (or fork Kysely's internals).
 
 import { PostgresDialect, type Dialect as KyselyDialect } from 'kysely'
+import { markDialect } from '../../dialect-marker'
 
 import type { PgPoolLike } from './adapter'
 
@@ -41,5 +42,5 @@ export function pgDialect(opts: PgDialectOptions): KyselyDialect {
   // Kysely versions; casting through `unknown` keeps adopters using
   // alternate clients (neon, pg-cloudflare) compatible without
   // pulling node-postgres' typings into our public surface.
-  return new PostgresDialect({ pool: opts.pool as unknown as never })
+  return markDialect(new PostgresDialect({ pool: opts.pool as unknown as never }), 'postgres')
 }

--- a/packages/db/src/adapters/sqlite/dialect.ts
+++ b/packages/db/src/adapters/sqlite/dialect.ts
@@ -5,6 +5,7 @@
 
 import { SqliteDialect, type Dialect as KyselyDialect } from 'kysely'
 
+import { markDialect } from '../../dialect-marker'
 import type { SqliteDatabaseLike } from './adapter'
 
 export interface SqliteDialectOptions {
@@ -37,5 +38,5 @@ export interface SqliteDialectOptions {
  * ```
  */
 export function sqliteDialect(opts: SqliteDialectOptions): KyselyDialect {
-  return new SqliteDialect({ database: opts.database as never })
+  return markDialect(new SqliteDialect({ database: opts.database as never }), 'sqlite')
 }

--- a/packages/db/src/client/create.ts
+++ b/packages/db/src/client/create.ts
@@ -11,6 +11,7 @@ import { KickDbEventEmitter } from './events'
 import { CodecPlugin, buildDecoderMap, buildEncoderMap } from './codec-plugin'
 import { wrap, type InternalContext } from './wrap'
 import { extractRelations } from '../query/extract-relations'
+import { readDialectMark } from '../dialect-marker'
 import { pickCompiler } from '../query/compilers'
 import { extractSnapshot } from '../snapshot/extract'
 
@@ -129,6 +130,13 @@ export function createDbClient<TSchema, DB = SchemaToTypes<TSchema>>(
 }
 
 function detectDialect(dialect: KyselyDialect): KickDbClient['dialect'] {
+  // Fast path: KickJS's own dialect factories (`pgDialect` /
+  // `mysqlDialect` / `sqliteDialect`) stamp an explicit marker, so
+  // detection is exact and never silently mis-classifies.
+  const marked = readDialectMark(dialect)
+  if (marked) return marked
+
+  // Fallback for raw Kysely dialects an adopter constructs directly.
   // Kysely's dialects have ctor names like PostgresDialect /
   // SqliteDialect / MysqlDialect. Adopters who hand-roll the
   // KyselyDialect interface (`{ createAdapter, ... }` literals)

--- a/packages/db/src/dialect-marker.ts
+++ b/packages/db/src/dialect-marker.ts
@@ -1,0 +1,36 @@
+/**
+ * Explicit dialect tagging for `createDbClient`'s dialect detection.
+ *
+ * The historical `detectDialect` inspected Kysely ctor names
+ * (`/Postgres/i.test(...)`) with a silent fallback to `'sqlite'` — so a
+ * hand-rolled or future Kysely dialect whose ctor name didn't match
+ * `Postgres`/`Mysql` was silently treated as SQLite, emitting the wrong
+ * JSON aggregation primitives at compile time.
+ *
+ * KickJS's own dialect factories (`pgDialect` / `mysqlDialect` /
+ * `sqliteDialect`) now stamp this marker, so detection is exact for the
+ * supported path. The ctor-name heuristic remains as the fallback for
+ * raw Kysely dialects an adopter constructs directly.
+ *
+ * `Symbol.for` so the marker is shared across module-identity boundaries
+ * (multiple copies of `@forinda/kickjs-db`).
+ */
+export const KICK_DIALECT: unique symbol = Symbol.for('@forinda/kickjs-db/dialect') as never
+
+export type DialectTag = 'postgres' | 'mysql' | 'sqlite'
+
+/** Stamp a Kysely dialect object with its KickJS dialect tag (non-enumerable). */
+export function markDialect<T extends object>(dialect: T, tag: DialectTag): T {
+  Object.defineProperty(dialect, KICK_DIALECT, {
+    value: tag,
+    enumerable: false,
+    configurable: true,
+    writable: false,
+  })
+  return dialect
+}
+
+/** Read the KickJS dialect tag off a dialect, or `undefined` when unmarked. */
+export function readDialectMark(dialect: object): DialectTag | undefined {
+  return (dialect as Record<symbol, unknown>)[KICK_DIALECT] as DialectTag | undefined
+}

--- a/packages/db/src/dialect-marker.ts
+++ b/packages/db/src/dialect-marker.ts
@@ -15,9 +15,22 @@
  * `Symbol.for` so the marker is shared across module-identity boundaries
  * (multiple copies of `@forinda/kickjs-db`).
  */
-export const KICK_DIALECT: unique symbol = Symbol.for('@forinda/kickjs-db/dialect') as never
+// Typed as plain `symbol` (no annotation, no cast). `Symbol.for` can't
+// produce a `unique symbol` — TS requires that type to come from a
+// direct `Symbol()`/`Symbol.for()` const initializer with no
+// intervening cast, so any `: unique symbol` annotation here forces an
+// unsafe cast (`as never` / `as unknown as unique symbol`). We only use
+// this value as a computed property key, where `symbol` is sufficient.
+export const KICK_DIALECT = Symbol.for('@forinda/kickjs-db/dialect')
 
 export type DialectTag = 'postgres' | 'mysql' | 'sqlite'
+
+const DIALECT_TAGS: ReadonlySet<string> = new Set<DialectTag>(['postgres', 'mysql', 'sqlite'])
+
+/** Type guard — `true` when `value` is a supported dialect tag. */
+export function isDialectTag(value: unknown): value is DialectTag {
+  return typeof value === 'string' && DIALECT_TAGS.has(value)
+}
 
 /** Stamp a Kysely dialect object with its KickJS dialect tag (non-enumerable). */
 export function markDialect<T extends object>(dialect: T, tag: DialectTag): T {
@@ -30,7 +43,13 @@ export function markDialect<T extends object>(dialect: T, tag: DialectTag): T {
   return dialect
 }
 
-/** Read the KickJS dialect tag off a dialect, or `undefined` when unmarked. */
+/**
+ * Read the KickJS dialect tag off a dialect, or `undefined` when
+ * unmarked. A garbage value (the marker is a global `Symbol.for`, so a
+ * rogue stamp is possible) is rejected — `undefined` falls the caller
+ * back to ctor-name detection rather than an impossible dialect state.
+ */
 export function readDialectMark(dialect: object): DialectTag | undefined {
-  return (dialect as Record<symbol, unknown>)[KICK_DIALECT] as DialectTag | undefined
+  const raw = (dialect as Record<symbol, unknown>)[KICK_DIALECT]
+  return isDialectTag(raw) ? raw : undefined
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -153,3 +153,10 @@ export {
   RelationalQueryNotSupportedError,
   RelationalQueryCancelledError,
 } from './query/errors'
+
+// LIKE/ILIKE pattern safety
+export { escapeLike, likePattern, type LikeMatchMode } from './query/like'
+
+// Explicit dialect tagging (used by detectDialect; exported for adopters
+// who wrap a raw Kysely dialect and want exact detection).
+export { markDialect, readDialectMark, KICK_DIALECT, type DialectTag } from './dialect-marker'

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -159,4 +159,10 @@ export { escapeLike, likePattern, type LikeMatchMode } from './query/like'
 
 // Explicit dialect tagging (used by detectDialect; exported for adopters
 // who wrap a raw Kysely dialect and want exact detection).
-export { markDialect, readDialectMark, KICK_DIALECT, type DialectTag } from './dialect-marker'
+export {
+  markDialect,
+  readDialectMark,
+  isDialectTag,
+  KICK_DIALECT,
+  type DialectTag,
+} from './dialect-marker'

--- a/packages/db/src/query/like.ts
+++ b/packages/db/src/query/like.ts
@@ -1,0 +1,66 @@
+/**
+ * LIKE / ILIKE pattern safety helpers.
+ *
+ * User-supplied search text dropped straight into a `LIKE` pattern lets
+ * the user inject wildcards: searching for `100%` matches everything,
+ * `a_b` matches `axb`. Worse, a literal `%` from the user combined with a
+ * leading wildcard (`%${input}%`) can blow up to a full scan. These
+ * helpers escape the LIKE metacharacters so the input is matched
+ * literally.
+ *
+ * Escapes `%`, `_`, and the escape character itself. The default escape
+ * char is backslash, which Postgres and SQLite honour by default; MySQL
+ * also defaults to backslash. When you build the query, pair the pattern
+ * with the matching `ESCAPE '\'` clause if your dialect/collation needs
+ * it explicit.
+ */
+
+export type LikeMatchMode = 'contains' | 'startsWith' | 'endsWith' | 'exact'
+
+/**
+ * Escape LIKE/ILIKE metacharacters in `input` so it matches literally.
+ *
+ * @example
+ * ```ts
+ * escapeLike('100%')        // '100\\%'
+ * escapeLike('a_b\\c')      // 'a\\_b\\\\c'
+ * ```
+ */
+export function escapeLike(input: string, escapeChar = '\\'): string {
+  // Escape the escape char first so we don't double-escape the
+  // backslashes we add for % and _.
+  const e = escapeChar
+  return input
+    .replaceAll(e, e + e)
+    .replaceAll('%', e + '%')
+    .replaceAll('_', e + '_')
+}
+
+/**
+ * Build a literal-safe LIKE pattern from user input.
+ *
+ * @example
+ * ```ts
+ * likePattern('john%', 'contains')    // '%john\\%%'
+ * likePattern('admin', 'startsWith')  // 'admin%'
+ * db.selectFrom('users')
+ *   .where('email', 'like', likePattern(ctx.qs().search, 'contains'))
+ * ```
+ */
+export function likePattern(
+  input: string,
+  mode: LikeMatchMode = 'contains',
+  escapeChar = '\\',
+): string {
+  const safe = escapeLike(input, escapeChar)
+  switch (mode) {
+    case 'contains':
+      return `%${safe}%`
+    case 'startsWith':
+      return `${safe}%`
+    case 'endsWith':
+      return `%${safe}`
+    case 'exact':
+      return safe
+  }
+}

--- a/packages/db/src/query/like.ts
+++ b/packages/db/src/query/like.ts
@@ -69,5 +69,12 @@ export function likePattern(
       return `%${safe}`
     case 'exact':
       return safe
+    default: {
+      // Compile-time exhaustiveness + a runtime guard for JS callers /
+      // `as any` that pass an unsupported mode (would otherwise return
+      // undefined despite the `: string` signature).
+      const _exhaustive: never = mode
+      throw new Error(`likePattern: unsupported match mode ${String(_exhaustive)}`)
+    }
   }
 }

--- a/packages/db/src/query/like.ts
+++ b/packages/db/src/query/like.ts
@@ -27,6 +27,13 @@ export type LikeMatchMode = 'contains' | 'startsWith' | 'endsWith' | 'exact'
  * ```
  */
 export function escapeLike(input: string, escapeChar = '\\'): string {
+  // The escape char must be exactly one character and not a wildcard
+  // itself — `''` would be a no-op, `'%'`/`'_'` would over-escape and
+  // corrupt the literal match. This is a safety primitive, so reject
+  // bad config loudly rather than emit a silently-wrong pattern.
+  if (escapeChar.length !== 1 || escapeChar === '%' || escapeChar === '_') {
+    throw new Error("escapeLike: escapeChar must be a single character other than '%' or '_'")
+  }
   // Escape the escape char first so we don't double-escape the
   // backslashes we add for % and _.
   const e = escapeChar


### PR DESCRIPTION
Two query-layer safety items from the audit, in kickjs-db.

## `escapeLike` / `likePattern`
User search text dropped into a `LIKE` pattern lets the user inject wildcards — searching `100%` becomes match-all, `a_b` matches `axb`, and a literal `%` under a leading wildcard can force a full scan. `escapeLike(input)` escapes `%`, `_`, and the escape char (backslash first, so no double-escaping); `likePattern(input, mode)` wraps it for `'contains'`/`'startsWith'`/`'endsWith'`/`'exact'`. Both exported from the root.

```ts
db.selectFrom('users').where('email', 'like', likePattern(ctx.qs().search, 'contains'))
```

## Explicit dialect marker
`detectDialect` previously relied solely on Kysely **ctor-name regex** (`/Postgres/i`) with a **silent fallback to SQLite** — a hand-rolled or future Kysely dialect whose ctor name didn't match was misclassified and emitted the wrong JSON-aggregation SQL. `pgDialect`/`mysqlDialect`/`sqliteDialect` now stamp a non-enumerable `KICK_DIALECT` marker (`Symbol.for`), and detection reads it first; the ctor-name heuristic stays as the fallback for raw Kysely dialects. `markDialect`/`readDialectMark` exported for adopters wrapping a raw dialect.

## Testing
- 11 new unit tests (escapeLike/likePattern edge cases incl. double-escape; marker stamp/read/non-enumerability + factory round-trip).
- Full db suite green: 77 files, 452 tests, typecheck enforced (`--typecheck`) clean.

## Deferred (not a polish item)
Cursor/keyset pagination — a real feature (stable ordering, cursor token encode/decode, API surface) that warrants its own scoped design, not a windup cram. Offset pagination is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LIKE/ILIKE query utilities for safe, literal pattern matching when building SQL queries with user input
  * Improved database dialect detection through explicit tagging, enhancing reliability across PostgreSQL, MySQL, and SQLite connections
  * New dialect utilities now available for integrations requiring explicit dialect identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->