### PR TITLE
fix(db): warn on customType codec collision (same column name, different codecs)

### DIFF
--- a/.changeset/db-codec-collision-warning.md
+++ b/.changeset/db-codec-collision-warning.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-db': patch
+---
+
+`customType` codecs are keyed by column name, so two tables declaring a same-named column with _different_ codecs previously had one silently overwrite the other — corrupting encode/decode for one table with no signal. `createDbClient` now warns at startup when a column name maps to two different codec functions, names both tables, and keeps the first deterministically (first-write-wins instead of the old last-write-wins). Sharing one `customType` instance across tables is the common, safe case and stays silent.

--- a/packages/db/__tests__/unit/codec-plugin.test.ts
+++ b/packages/db/__tests__/unit/codec-plugin.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import {
   ColumnNode,
   ColumnUpdateNode,
@@ -295,6 +295,47 @@ describe('buildDecoderMap()', () => {
     expect(buildDecoderMap(null).size).toBe(0)
     expect(buildDecoderMap('schema').size).toBe(0)
   })
+})
+
+describe('codec column-name collision detection', () => {
+  it('warns and keeps the first when two tables map the same column to different codecs', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const codecA = customType<string>({
+      dataType: () => 'text',
+      fromDriver: (r) => `a:${String(r)}`,
+    })
+    const codecB = customType<string>({
+      dataType: () => 'text',
+      fromDriver: (r) => `b:${String(r)}`,
+    })
+    const users = table('users', { id: serial().primaryKey(), token: codecA().notNull() })
+    const orders = table('orders', { id: serial().primaryKey(), token: codecB().notNull() })
+
+    const map = buildDecoderMap({ users, orders })
+
+    expect(map.size).toBe(1)
+    // First table wins — deterministic regardless of how the row arrives.
+    expect(map.get('token')!('x')).toBe('a:x')
+    expect(warn).toHaveBeenCalledTimes(1)
+    const msg = warn.mock.calls[0][0] as string
+    expect(msg).toContain("column 'token'")
+    expect(msg).toContain('users')
+    expect(msg).toContain('orders')
+  })
+
+  it('does NOT warn when the SAME customType is shared across tables', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const shared = customType<string>({ dataType: () => 'text', fromDriver: (r) => String(r) })
+    const a = table('a', { id: serial().primaryKey(), meta: shared().notNull() })
+    const b = table('b', { id: serial().primaryKey(), meta: shared().notNull() })
+
+    const map = buildDecoderMap({ a, b })
+
+    expect(map.size).toBe(1) // one codec, shared — fine
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  afterEach(() => vi.restoreAllMocks())
 })
 
 describe('buildEncoderMap()', () => {

--- a/packages/db/src/client/codec-plugin.ts
+++ b/packages/db/src/client/codec-plugin.ts
@@ -212,12 +212,36 @@ function collectCodecs(schema: unknown, key: 'toDriver' | 'fromDriver'): CodecMa
   const out: CodecMap = new Map()
   if (!schema || typeof schema !== 'object') return out
 
+  // Track which table first claimed each column name so a collision can
+  // name both sides. Codecs are keyed by column name (see the file
+  // header for why a table-aware scheme can't work on the decode path);
+  // a same-named column with a DIFFERENT codec in another table would
+  // otherwise silently corrupt one of them. First-write-wins +
+  // a loud warning makes the clash debuggable instead of invisible.
+  const owner = new Map<string, string>()
+
   for (const value of Object.values(schema as Record<string, unknown>)) {
     if (!isTableDecl(value)) continue
+    const tableName = value.__name
     for (const [colName, col] of Object.entries(value.__columns)) {
-      if (col instanceof CustomColumnBuilder) {
-        const fn = col[key]
-        if (fn) out.set(colName, fn as (v: unknown) => unknown)
+      if (!(col instanceof CustomColumnBuilder)) continue
+      const fn = col[key] as ((v: unknown) => unknown) | undefined
+      if (!fn) continue
+
+      const existing = out.get(colName)
+      if (existing === undefined) {
+        out.set(colName, fn)
+        owner.set(colName, tableName)
+      } else if (existing !== fn) {
+        // Same codec instance shared across tables (existing === fn) is
+        // the common, safe case and stays quiet. Only a genuinely
+        // different codec function triggers the warning.
+        console.warn(
+          `[kickjs-db] customType codec conflict: column '${colName}' maps to different ` +
+            `${key} codecs in tables '${owner.get(colName)}' and '${tableName}'. Codecs are ` +
+            `keyed by column name, so the first ('${owner.get(colName)}') wins and the other ` +
+            `is ignored — rename the column or share a single customType instance.`,
+        )
       }
     }
   }


### PR DESCRIPTION
Addresses the one real concern from the db audit: silent `customType` codec collision.

## Problem
Encoder/decoder maps (`codec-plugin.ts`) are keyed by **column name only** — the decode path can't always recover table provenance from join result rows, so a table-aware scheme isn't possible. The consequence: two tables declaring a same-named column with **different** codecs had one silently overwrite the other (last-write-wins by map iteration order), corrupting encode/decode for one table with **no signal**.

## Fix
`collectCodecs` now tracks the first table to claim each column name and **warns** when a second table maps it to a *different* codec function — naming both tables and the column, keeping the first deterministically (first-write-wins). Converts silent data corruption into a loud, debuggable startup signal.

Sharing a single `customType` instance across tables (the common, safe case — same function reference) stays completely silent; only genuinely different codecs trigger the warning.

## Testing
- 2 new tests: collision warns + first-wins; shared instance stays quiet.
- Full db suite: 77 files, 457 tests, typecheck enforced — clean. Lint clean.

## Audit note
The rest of the db audit came back sound — identifier quoting, migration lock (try/finally), hash verify, enum-drop gate, pool ownership, diff/invert. The investigator's "savepoint counter HIGH / unbounded memory" was a false positive (monotonic int producing unique names; decrementing would be unsafe since ROLLBACK TO SAVEPOINT doesn't destroy the savepoint). Cursor pagination + count/findMany drift remain deliberate, documented design choices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added codec collision detection that emits a startup warning when multiple tables define the same column name with different codec functions.

* **Bug Fixes**
  * Codec conflicts now resolve deterministically using first-write-wins behavior instead of the previous silent overwrite behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->