### PR TITLE
fix: kick add ws peer (socket.io→ws) + missing AI_ADAPTER/AiAdapterInstance exports

### DIFF
--- a/.changeset/ai-adapter-export.md
+++ b/.changeset/ai-adapter-export.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-ai': patch
+---
+
+Export `AI_ADAPTER` and the `AiAdapterInstance` type from the package root. Both are documented in the README and the adapter's own JSDoc as the way to inject the adapter (`@Inject(AI_ADAPTER) private ai: AiAdapterInstance`), but were missing from `src/index.ts` so the documented import didn't resolve.

--- a/.changeset/ws-peer-fix.md
+++ b/.changeset/ws-peer-fix.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+`kick add ws` now installs the correct peer dependency. The catalog listed `socket.io`, but `@forinda/kickjs-ws` is built on the `ws` package (`WebSocketServer`) — adopters running `kick add ws` got the wrong library. Fixed the registry entry to `ws`.

--- a/packages/ai/__tests__/exports.test.ts
+++ b/packages/ai/__tests__/exports.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+
+import * as ai from '../src/index'
+
+describe('@forinda/kickjs-ai public exports', () => {
+  it('exports AI_ADAPTER (the documented @Inject token for the adapter instance)', () => {
+    // The README and the adapter's own JSDoc document
+    // `import { AI_ADAPTER, type AiAdapterInstance } from '@forinda/kickjs-ai'`
+    // — both must be reachable from the package root.
+    expect(ai.AI_ADAPTER).toBeDefined()
+    expect((ai.AI_ADAPTER as { name?: string }).name).toBe('kick/ai/adapter')
+  })
+
+  it('still exports the provider/store tokens', () => {
+    expect(ai.AI_PROVIDER).toBeDefined()
+    expect(ai.VECTOR_STORE).toBeDefined()
+    expect(ai.AI_TOOL_METADATA).toBeDefined()
+  })
+})

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,6 +1,6 @@
 export { AiAdapter } from './ai.adapter'
 export { AiTool, getAiToolMeta, isAiTool } from './decorators'
-export { AI_PROVIDER, AI_TOOL_METADATA, VECTOR_STORE } from './constants'
+export { AI_ADAPTER, AI_PROVIDER, AI_TOOL_METADATA, VECTOR_STORE } from './constants'
 export { OpenAIProvider, type OpenAIProviderOptions } from './providers/openai'
 export { AnthropicProvider, type AnthropicProviderOptions } from './providers/anthropic'
 export { ProviderError } from './providers/base'
@@ -39,6 +39,7 @@ export type {
 } from './rag'
 export type {
   AiProvider,
+  AiAdapterInstance,
   AiAdapterOptions,
   AiToolOptions,
   AiToolDefinition,

--- a/packages/cli/__tests__/add-registry.test.ts
+++ b/packages/cli/__tests__/add-registry.test.ts
@@ -68,7 +68,10 @@ describe('planAddPackages', () => {
   it('resolves a known package with its peers', () => {
     const plan = planAddPackages(['ws'], false)
     expect(plan.prodDeps).toContain('@forinda/kickjs-ws')
-    expect(plan.prodDeps).toContain('socket.io')
+    // @forinda/kickjs-ws is built on the `ws` package (WebSocketServer),
+    // not socket.io — the catalog peer must match the actual dependency.
+    expect(plan.prodDeps).toContain('ws')
+    expect(plan.prodDeps).not.toContain('socket.io')
     expect(plan.unknown).toEqual([])
     expect(plan.warnings).toEqual([])
   })

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -135,7 +135,7 @@ export const PACKAGE_REGISTRY: Record<string, PackageEntry> = {
   // Real-time
   ws: {
     pkg: '@forinda/kickjs-ws',
-    peers: ['socket.io'],
+    peers: ['ws'],
     description: 'WebSocket with @WsController decorators',
   },
 


### PR DESCRIPTION
Two code bugs surfaced by the package-README audit.

## kick add ws installed the wrong dependency
The `kick add` catalog (`add.ts:138`) listed `socket.io` as the ws peer, but `@forinda/kickjs-ws` is built on the **`ws`** package (`WebSocketServer`, peer `"ws": "^8.0.0"`). Adopters running `kick add ws` got socket.io and a non-working setup. Fixed to `ws`. The drift-guard test had locked the bug in (asserted `socket.io`) — updated to assert `ws` and explicitly `not` socket.io.

## ai: AI_ADAPTER / AiAdapterInstance not exported
The ai README and the adapter's own JSDoc document `import { AI_ADAPTER, type AiAdapterInstance } from '@forinda/kickjs-ai'` (`@Inject(AI_ADAPTER) private ai: AiAdapterInstance`), but neither was re-exported from `src/index.ts` — the documented import didn't resolve. Added both. New export test asserts AI_ADAPTER is reachable and is the `kick/ai/adapter` token.

Both with changesets (cli + ai patch). Builds + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)