### PR TITLE
docs: correct stale package README claims

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -31,7 +31,7 @@ kick mcp start            # Run app as an MCP stdio server
 kick typegen              # Refresh KickRoutes / KickEnv type maps
 ```
 
-`kick new` is interactive (template, package manager, ORM, package multi-select, git init, install) — every prompt has a flag for CI: `--template rest|ddd|cqrs|minimal`, `--pm pnpm|npm|yarn|bun`, `--repo prisma|drizzle|inmemory|custom`, `--no-git`, `--no-install`, `--force`.
+`kick new` is interactive (template, package manager, repository, package multi-select, git init, install) — every prompt has a flag for CI: `--template rest|minimal`, `--pm pnpm|npm|yarn|bun`, `--repo inmemory|<db-name>` (e.g. `postgres`), `--packages auth,swagger,…`, `--no-git`, `--no-install`, `--force`, `-y/--yes`.
 
 ## Documentation
 

--- a/packages/db-mysql/README.md
+++ b/packages/db-mysql/README.md
@@ -1,5 +1,12 @@
 # @forinda/kickjs-db-mysql
 
+> ⚠️ **Deprecated — merged into [`@forinda/kickjs-db`](https://www.npmjs.com/package/@forinda/kickjs-db).**
+> This package is now a thin re-export shim kept for one release. Install only
+> `@forinda/kickjs-db` (plus the `mysql2` driver) and import from the `/mysql`
+> subpath: `import { mysqlAdapter, mysqlDialect } from '@forinda/kickjs-db/mysql'`.
+> Importing from this package logs a runtime deprecation warning. It will stop
+> being published in a future release.
+
 > MySQL adapter for [`@forinda/kickjs-db`](https://www.npmjs.com/package/@forinda/kickjs-db). **MySQL 8.0+ / MariaDB 10.5+ required.**
 
 Two factories:

--- a/packages/db-pg/README.md
+++ b/packages/db-pg/README.md
@@ -1,5 +1,12 @@
 # @forinda/kickjs-db-pg
 
+> ⚠️ **Deprecated — merged into [`@forinda/kickjs-db`](https://www.npmjs.com/package/@forinda/kickjs-db).**
+> This package is now a thin re-export shim kept for one release. Install only
+> `@forinda/kickjs-db` (plus the `pg` driver) and import from the `/pg` subpath:
+> `import { pgAdapter, pgDialect } from '@forinda/kickjs-db/pg'`. Importing from
+> this package logs a runtime deprecation warning. It will stop being published
+> in a future release.
+
 > PostgreSQL adapter for [`@forinda/kickjs-db`](https://www.npmjs.com/package/@forinda/kickjs-db).
 
 Two factories:

--- a/packages/db-sqlite/README.md
+++ b/packages/db-sqlite/README.md
@@ -1,5 +1,13 @@
 # @forinda/kickjs-db-sqlite
 
+> ⚠️ **Deprecated — merged into [`@forinda/kickjs-db`](https://www.npmjs.com/package/@forinda/kickjs-db).**
+> This package is now a thin re-export shim kept for one release. Install only
+> `@forinda/kickjs-db` (plus the `better-sqlite3` driver) and import from the
+> `/sqlite` subpath:
+> `import { sqliteAdapter, sqliteDialect } from '@forinda/kickjs-db/sqlite'`.
+> Importing from this package logs a runtime deprecation warning. It will stop
+> being published in a future release.
+
 > SQLite adapter for [`@forinda/kickjs-db`](https://www.npmjs.com/package/@forinda/kickjs-db).
 
 Two factories:

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -7,15 +7,14 @@ Phantom-typed column builders, `SchemaToTypes<S>` for end-to-end row inference, 
 ## Install
 
 ```bash
-pnpm add @forinda/kickjs-db
-pnpm add @forinda/kickjs-db-pg pg          # PostgreSQL adapter
+pnpm add @forinda/kickjs-db pg          # PostgreSQL — dialect ships as the /pg subpath
 ```
 
 ## Quick start
 
 ```ts
 import { table, uuid, varchar, timestamp, createDbClient } from '@forinda/kickjs-db'
-import { pgAdapter, pgDialect } from '@forinda/kickjs-db-pg'
+import { pgAdapter, pgDialect } from '@forinda/kickjs-db/pg'
 import { Pool } from 'pg'
 
 // 1. Schema — phantom T flows through every column automatically.
@@ -55,9 +54,18 @@ const row = await db
 - [DB Extensions](https://forinda.github.io/kick-js/guide/db-extensions) — `customType<T>()`, `$extends({ model })`
 - [Type Generation](https://forinda.github.io/kick-js/guide/typegen) — `kick typegen` plugin contract + `kick/db` auto-emit
 
+## Dialect subpaths
+
+Each dialect ships inside this package — no extra install beyond the driver:
+
+- `@forinda/kickjs-db/pg` — PostgreSQL (`pgDialect`, `pgAdapter`); peer driver `pg`
+- `@forinda/kickjs-db/mysql` — MySQL (`mysqlDialect`, `mysqlAdapter`); peer driver `mysql2`
+- `@forinda/kickjs-db/sqlite` — SQLite (`sqliteDialect`, `sqliteAdapter`); peer driver `better-sqlite3`
+
+> The standalone `@forinda/kickjs-db-pg` / `-db-mysql` / `-db-sqlite` packages are deprecated re-export shims kept for one release; import from the subpaths above instead.
+
 ## Companion packages
 
-- [`@forinda/kickjs-db-pg`](https://www.npmjs.com/package/@forinda/kickjs-db-pg) — node-postgres adapter
 - [`@forinda/kickjs`](https://www.npmjs.com/package/@forinda/kickjs) — framework runtime + DI container
 - [`@forinda/kickjs-cli`](https://www.npmjs.com/package/@forinda/kickjs-cli) — `kick db generate`, `kick db migrate`, `kick typegen`
 

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -1,5 +1,12 @@
 # @forinda/kickjs-drizzle
 
+> ⚠️ **Deprecated — no longer maintained.**
+> This was an early-adoption adapter. Wire Drizzle directly in your app (BYO),
+> or use [`@forinda/kickjs-db`](https://www.npmjs.com/package/@forinda/kickjs-db)
+> — the built-in Kick ORM — if you prefer to skip external ORMs. Importing this
+> package logs a one-time runtime warning (silence with
+> `KICKJS_SUPPRESS_DEPRECATION=1`). It will be removed in a future major.
+
 Drizzle ORM adapter for KickJS — DI integration, lifecycle management, and a `DrizzleQueryAdapter` that translates `ParsedQuery` into Drizzle `where` / `orderBy` / `limit` / `offset`.
 
 ## Install

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -1,5 +1,12 @@
 # @forinda/kickjs-prisma
 
+> ⚠️ **Deprecated — no longer maintained.**
+> This was an early-adoption adapter. Wire Prisma directly in your app (BYO),
+> or use [`@forinda/kickjs-db`](https://www.npmjs.com/package/@forinda/kickjs-db)
+> — the built-in Kick ORM — if you prefer to skip external ORMs. Importing this
+> package logs a one-time runtime warning (silence with
+> `KICKJS_SUPPRESS_DEPRECATION=1`). It will be removed in a future major.
+
 Prisma adapter for KickJS. Registers `PrismaClient` in the DI container, manages lifecycle (connect/disconnect), and ships a typed `PrismaModelDelegate` for cast-free repositories. Supports Prisma 5, 6, and 7+ (auto-detects logging method).
 
 ## Install

--- a/packages/queue/v5-design.md
+++ b/packages/queue/v5-design.md
@@ -1,5 +1,11 @@
 # `@forinda/kickjs-queue` v5 — slim shape
 
+> 📐 **Archived design proposal — not shipped.** This documents a proposed
+> "slim" rework that was never adopted. The published package still ships the
+> multi-provider shape described under _Current shape_ below (`QueueService`,
+> `QUEUE_MANAGER`, and the BullMQ / RabbitMQ / Kafka providers). Kept for design
+> history; do not read it as the package's current API.
+
 ## Why slim instead of drop
 
 Queue earns its keep where the other 6 deprecated wrappers didn't:


### PR DESCRIPTION
## Why

Audit pass over package markdown surfaced several docs that no longer match the shipped code. All fixes verified against source before editing.

## Changes

| File | Was wrong | Now |
| --- | --- | --- |
| `cli/README.md` | `--template rest\|ddd\|cqrs\|minimal`, `--repo prisma\|drizzle\|inmemory\|custom` (ddd/cqrs templates and prisma/drizzle/custom repo presets were removed) | `--template rest\|minimal`, `--repo inmemory\|<db-name>`, plus `--packages` and `-y/--yes` — matches `init.ts` |
| `db/README.md` | install + import used the standalone `@forinda/kickjs-db-pg` package | `pnpm add @forinda/kickjs-db pg`; `import … from '@forinda/kickjs-db/pg'`; new "Dialect subpaths" section documenting `/pg`, `/mysql`, `/sqlite` + peer drivers |
| `db-pg`, `db-mysql`, `db-sqlite` READMEs | no deprecation notice — read as live packages | deprecation banner: thin re-export shims, import from the subpath |
| `prisma`, `drizzle` READMEs | no deprecation notice | banner mirroring the runtime `warnDeprecated()` text (early-adoption adapters, unmaintained → BYO or `@forinda/kickjs-db`) |
| `queue/v5-design.md` | read as a current spec | "archived design proposal — not shipped"; published package still ships the multi-provider shape it proposes dropping |

## Verification

- `db` package `exports` confirmed to expose `./pg`, `./mysql`, `./sqlite` subpaths; each re-exports `{pg,mysql,sqlite}Dialect` + `{…}Adapter`.
- Peer drivers (`pg`, `mysql2`, `better-sqlite3`) confirmed as optional peers in `db/package.json`.
- `init.ts` template/repo option strings confirmed (`rest | minimal`, `inmemory, or any DB name`).
- prisma/drizzle `warnDeprecated()` runtime warnings confirmed present.

Docs only — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
