### PR TITLE
chore: enter alpha pre-release mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,30 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@forinda/kickjs-ai": "6.0.0",
+    "@forinda/kickjs-auth": "6.0.1",
+    "@forinda/kickjs-cli": "6.1.0",
+    "@forinda/kickjs-cli-kit": "0.1.1",
+    "@forinda/kickjs-db": "6.2.0",
+    "@forinda/kickjs-db-mysql": "3.1.0",
+    "@forinda/kickjs-db-pg": "10.1.0",
+    "@forinda/kickjs-db-sqlite": "3.1.0",
+    "@forinda/kickjs-devtools": "6.0.0",
+    "@forinda/kickjs-devtools-kit": "6.0.0",
+    "@forinda/kickjs-devtools-spa": "3.2.0",
+    "@forinda/kickjs-drizzle": "6.0.1",
+    "@forinda/kickjs": "5.16.0",
+    "@forinda/kickjs-lint": "5.2.3",
+    "@forinda/kickjs-mcp": "6.0.2",
+    "@forinda/kickjs-prisma": "6.0.1",
+    "@forinda/kickjs-queue": "6.0.0",
+    "@forinda/kickjs-schema": "0.1.2",
+    "@forinda/kickjs-swagger": "6.0.2",
+    "@forinda/kickjs-testing": "6.0.0",
+    "@forinda/kickjs-vite": "6.1.0",
+    "kickjs-devtools": "5.2.1",
+    "@forinda/kickjs-ws": "6.0.0"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
## What

Enter **alpha** pre-release mode (`changeset pre enter alpha`).

## Effect

- All currently pending changesets and any added afterward version as `-alpha.N` prereleases and publish under the `alpha` npm dist-tag (via `release.yml` OIDC) — not under `latest`.
- Once this merges to `main`, the **Version Packages** PR (#366) regenerates with prerelease versions.
- Per-package independence is unchanged — each package still bumps on its own changesets.

## Exit

When ready to cut stable releases again: `pnpm release:exit:pre` (`changeset pre exit`), then merge the resulting Version Packages PR.

Only change in this PR: `.changeset/pre.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
