### PR TITLE
feat: route bootstrap through the HTTP runtime seam (M1b)

### DIFF
--- a/.changeset/http-runtime-application-seam.md
+++ b/.changeset/http-runtime-application-seam.md
@@ -1,0 +1,9 @@
+---
+'@forinda/kickjs': minor
+---
+
+Route the bootstrap path through the HTTP-runtime seam (M1b). `Application` now holds an `HttpRuntime` (default `expressRuntime()`) and drives it for app creation, every middleware registration, route mounting, the terminal not-found / error handlers, the production server, and HMR rebuilds — instead of calling Express directly. The new `ApplicationOptions.runtime` lets you supply a different engine driver.
+
+No behavior change: Express stays the zero-config default, so existing apps are byte-for-byte unaffected (full suite passes untouched). Engine-native escape hatches (`getExpressApp()`, `AdapterContext.app`, the health-check routes) still resolve to the Express app under the default runtime; moving those onto the runtime's adapter facade is the next milestone (M2).
+
+This makes the runtime load-bearing — the foundation the Fastify / h3 subpaths plug into later.

--- a/packages/kickjs/__tests__/application-runtime-seam.test.ts
+++ b/packages/kickjs/__tests__/application-runtime-seam.test.ts
@@ -1,0 +1,101 @@
+import 'reflect-metadata'
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import {
+  Application,
+  Container,
+  Controller,
+  Get,
+  RequestContext,
+  expressRuntime,
+  type HttpRuntime,
+} from '../src/index'
+
+beforeEach(() => {
+  Container.reset()
+})
+
+/**
+ * Wrap the real Express runtime and record which seam methods fire. Proves the
+ * `runtime` option is load-bearing in `Application` — i.e. M1b actually routed
+ * the bootstrap path through the runtime rather than calling Express directly.
+ */
+function recordingRuntime() {
+  const base = expressRuntime()
+  const calls: Record<string, number> = {
+    createApp: 0,
+    useConnect: 0,
+    mountRoutes: 0,
+    serveStatic: 0,
+    setNotFound: 0,
+    setErrorHandler: 0,
+    nodeHandler: 0,
+  }
+  const rt: HttpRuntime<ReturnType<typeof base.createApp>> = {
+    name: 'express-recording',
+    capabilities: base.capabilities,
+    createApp: (o) => (calls.createApp++, base.createApp(o)),
+    useConnect: (app, mw, opts) => (calls.useConnect++, base.useConnect(app, mw, opts)),
+    mountRoutes: (app, table) => (calls.mountRoutes++, base.mountRoutes(app, table)),
+    serveStatic: (app, p, d) => (calls.serveStatic++, base.serveStatic(app, p, d)),
+    setNotFound: (app, mw) => (calls.setNotFound++, base.setNotFound(app, mw)),
+    setErrorHandler: (app, mw) => (calls.setErrorHandler++, base.setErrorHandler(app, mw)),
+    nodeHandler: (app) => (calls.nodeHandler++, base.nodeHandler(app)),
+  }
+  return { rt, calls }
+}
+
+describe('Application runtime seam (M1b)', () => {
+  it('drives the configured runtime through bootstrap and serves requests', async () => {
+    @Controller()
+    class PingController {
+      @Get('/ping')
+      ping(ctx: RequestContext) {
+        ctx.json({ pong: true })
+      }
+    }
+
+    const { rt, calls } = recordingRuntime()
+    const app = new Application({
+      runtime: rt,
+      apiPrefix: '/api',
+      defaultVersion: 1,
+      modules: [
+        {
+          routes: () => ({ path: '/probe', controller: PingController }),
+        } as any,
+      ],
+    })
+    await app.setup()
+
+    // The runtime built the app, registered middleware + the route, and the
+    // terminal not-found / error handlers.
+    expect(calls.createApp).toBe(1)
+    expect(calls.useConnect).toBeGreaterThan(0)
+    expect(calls.setNotFound).toBe(1)
+    expect(calls.setErrorHandler).toBe(1)
+
+    // And it actually serves — through the same runtime app.
+    const res = await request(app.getExpressApp()).get('/api/v1/probe/ping').expect(200)
+    expect(res.body).toEqual({ pong: true })
+  })
+
+  it('defaults to expressRuntime when no runtime is supplied', async () => {
+    @Controller()
+    class HelloController {
+      @Get('/')
+      hi(ctx: RequestContext) {
+        ctx.json({ hi: true })
+      }
+    }
+
+    const app = new Application({
+      apiPrefix: '/api',
+      defaultVersion: 1,
+      modules: [{ routes: () => ({ path: '/hello', controller: HelloController }) } as any],
+    })
+    await app.setup()
+
+    await request(app.getExpressApp()).get('/api/v1/hello').expect(200, { hi: true })
+  })
+})

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -182,11 +182,15 @@ export interface ApplicationOptions {
 
   /**
    * The HTTP engine driver. Defaults to {@link expressRuntime} — Express stays
-   * the zero-config default, so existing apps are unaffected. Pass a different
-   * runtime (e.g. the Fastify / h3 subpaths, in a later milestone) to swap the
-   * engine without touching controllers, modules, or context decorators.
+   * the zero-config default, so existing apps are unaffected.
+   *
+   * Typed `HttpRuntime<Express>` for now: `Application` still calls a few
+   * Express-only APIs directly (`disable('x-powered-by')`, `set('trust proxy')`,
+   * the `/health/*` routes). Those move onto the runtime in M2, at which point
+   * this widens to a generic `HttpRuntime` so the Fastify / h3 subpaths can be
+   * passed here. Until then, only an Express-typed runtime is sound.
    */
-  runtime?: HttpRuntime
+  runtime?: HttpRuntime<Express>
 
   /** Express `trust proxy` setting */
   trustProxy?: boolean | number | string | ((ip: string, hopIndex: number) => boolean)
@@ -330,7 +334,7 @@ export class Application {
   private _drainResolvers: Array<() => void> = []
 
   constructor(private readonly options: ApplicationOptions) {
-    this.runtime = (options.runtime as HttpRuntime<Express> | undefined) ?? expressRuntime()
+    this.runtime = options.runtime ?? expressRuntime()
     this.app = this.runtime.createApp()
     this.container = Container.getInstance()
 

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -27,7 +27,8 @@ import { requestId } from './middleware/request-id'
 import { notFoundHandler, errorHandler } from './middleware/error-handler'
 import { requestScopeMiddleware, isRequestScopeMiddleware } from './middleware/request-scope'
 import { _setExternalContributorSources } from './router-builder'
-import { buildRoutes } from './runtimes/express'
+import { buildRoutes, expressRuntime } from './runtimes/express'
+import type { HttpRuntime } from './runtime'
 import { requestStore } from './request-store'
 
 const log = createLogger('Application')
@@ -179,6 +180,14 @@ export interface ApplicationOptions {
    */
   processHooks?: 'auto' | 'errors-only' | 'manual'
 
+  /**
+   * The HTTP engine driver. Defaults to {@link expressRuntime} — Express stays
+   * the zero-config default, so existing apps are unaffected. Pass a different
+   * runtime (e.g. the Fastify / h3 subpaths, in a later milestone) to swap the
+   * engine without touching controllers, modules, or context decorators.
+   */
+  runtime?: HttpRuntime
+
   /** Express `trust proxy` setting */
   trustProxy?: boolean | number | string | ((ip: string, hopIndex: number) => boolean)
   /** Maximum JSON body size (only used when middleware is not provided) */
@@ -286,6 +295,8 @@ export interface ApplicationOptions {
  */
 export class Application {
   private app: Express
+  /** The HTTP engine driver. Defaults to {@link expressRuntime}. */
+  private readonly runtime: HttpRuntime<Express>
   private container: Container
   private httpServer: http.Server | null = null
   private readonly adapters: AppAdapter[]
@@ -319,7 +330,8 @@ export class Application {
   private _drainResolvers: Array<() => void> = []
 
   constructor(private readonly options: ApplicationOptions) {
-    this.app = express()
+    this.runtime = (options.runtime as HttpRuntime<Express> | undefined) ?? expressRuntime()
+    this.app = this.runtime.createApp()
     this.container = Container.getInstance()
 
     // Sort plugins by `dependsOn` declarations BEFORE reading their adapters/etc.
@@ -384,10 +396,11 @@ export class Application {
    * ```
    */
   handle(req: http.IncomingMessage, res: http.ServerResponse, next?: (err?: any) => void): void {
+    const handler = this.runtime.nodeHandler(this.app)
     if (next) {
-      this.app(req as any, res as any, next)
+      handler(req, res, next)
     } else {
-      this.app(req as any, res as any)
+      handler(req, res)
     }
   }
 
@@ -460,7 +473,7 @@ export class Application {
     this.app.set('trust proxy', this.options.trustProxy ?? false)
 
     // ── 2a. In-flight request tracking ──────────────────────────────
-    this.app.use(this.requestTrackingMiddleware())
+    this.runtime.useConnect(this.app, this.requestTrackingMiddleware())
 
     // ── 2b. Health check endpoints (before middleware, at root) ──────
     this.mountHealthEndpoints()
@@ -469,7 +482,7 @@ export class Application {
     // Auto-mounted unless the user opted out (`contextStore: 'manual'`)
     // or already included one in their middleware list.
     if (this.shouldAutoMountRequestScope()) {
-      this.app.use(requestScopeMiddleware())
+      this.runtime.useConnect(this.app, requestScopeMiddleware())
     }
 
     // ── 3. Adapter middleware: beforeGlobal ───────────────────────────
@@ -485,7 +498,7 @@ export class Application {
       try {
         const mw = plugin.middleware?.() ?? []
         for (const handler of mw) {
-          this.app.use(handler)
+          this.runtime.useConnect(this.app, handler)
         }
       } catch (err) {
         log.error(err, `Plugin middleware failed: ${(plugin as any).name ?? 'unknown'}`)
@@ -498,7 +511,7 @@ export class Application {
     if (autoHelmet) {
       try {
         const { helmet: helmetFn } = await import('./middleware/helmet')
-        this.app.use(helmetFn())
+        this.runtime.useConnect(this.app, helmetFn())
       } catch {
         // helmet middleware not available — skip silently
       }
@@ -512,8 +525,8 @@ export class Application {
       }
     } else {
       // Sensible defaults when no middleware declared
-      this.app.use(requestId())
-      this.app.use(express.json({ limit: this.options.jsonLimit ?? '1mb' }))
+      this.runtime.useConnect(this.app, requestId())
+      this.runtime.useConnect(this.app, express.json({ limit: this.options.jsonLimit ?? '1mb' }))
     }
 
     // ── 5. Adapter middleware: afterGlobal ────────────────────────────
@@ -667,7 +680,7 @@ export class Application {
           if (!router) {
             throw moduleRouteMissingControllerError(mountPath)
           }
-          this.app.use(mountPath, router)
+          this.runtime.useConnect(this.app, router, { path: mountPath })
 
           // Notify adapters (e.g. SwaggerAdapter for OpenAPI spec generation)
           if (route.controller) {
@@ -741,8 +754,8 @@ export class Application {
     // ── 11. Error handlers ───────────────────────────────────────────
     // Last in the chain so any adapter-mounted route (step 10) gets
     // a chance to match before the catch-all 404 fires.
-    this.app.use(this.options.onNotFound ?? notFoundHandler())
-    this.app.use(this.options.onError ?? errorHandler())
+    this.runtime.setNotFound(this.app, this.options.onNotFound ?? notFoundHandler())
+    this.runtime.setErrorHandler(this.app, this.options.onError ?? errorHandler())
   }
 
   /** Register modules and DI without starting the HTTP server (used by kick tinker) */
@@ -793,7 +806,7 @@ export class Application {
 
     // ── PRODUCTION: Create and own the http.Server ─────────────────
     const port = this.options.port ?? parseInt(process.env.PORT || '3000', 10)
-    this.httpServer = http.createServer(this.app)
+    this.httpServer = http.createServer(this.runtime.nodeHandler(this.app))
 
     this.httpServer.on('error', (err: NodeJS.ErrnoException) => {
       if (err.code === 'EADDRINUSE') {
@@ -842,7 +855,7 @@ export class Application {
     try {
       Container.reset()
       this.container = Container.getInstance()
-      this.app = express()
+      this.app = this.runtime.createApp()
       await this.setup()
     } catch (err) {
       log.error(err, 'HMR rebuild failed, keeping previous app')
@@ -854,8 +867,8 @@ export class Application {
 
     if (this.httpServer) {
       this.httpServer.removeAllListeners('request')
-      this.httpServer.on('request', this.app)
-      log.debug('HMR: Express app rebuilt and swapped')
+      this.httpServer.on('request', this.runtime.nodeHandler(this.app))
+      log.debug('HMR: app rebuilt and swapped')
     }
   }
 
@@ -1070,24 +1083,18 @@ export class Application {
   private mountMiddlewareList(entries: AdapterMiddleware[]): void {
     for (const entry of entries) {
       if (entry.path === undefined) {
-        this.app.use(entry.handler)
+        this.runtime.useConnect(this.app, entry.handler)
         continue
       }
-      // Copy ReadonlyArray paths to a mutable array — Express's
-      // `PathParams` doesn't accept readonly arrays, even though the
-      // function never mutates them. Pass-through for non-array shapes.
-      const path: string | RegExp | (string | RegExp)[] = Array.isArray(entry.path)
-        ? [...entry.path]
-        : (entry.path as string | RegExp)
-      this.app.use(path, entry.handler)
+      this.runtime.useConnect(this.app, entry.handler, { path: entry.path })
     }
   }
 
   private mountMiddlewareEntry(entry: MiddlewareEntry): void {
     if (typeof entry === 'function') {
-      this.app.use(entry)
+      this.runtime.useConnect(this.app, entry)
     } else {
-      this.app.use(entry.path, entry.handler)
+      this.runtime.useConnect(this.app, entry.handler, { path: entry.path })
     }
   }
 


### PR DESCRIPTION
## What

Milestone **M1b** of the pluggable-HTTP-runtimes spec (`docs/http/spec-http-runtimes.md`). Makes the `HttpRuntime` seam from #370 **load-bearing**: `Application` now drives the runtime for every transport concern instead of calling Express directly.

## Changes (`application.ts`)

- New field `private readonly runtime: HttpRuntime<Express>`, default `expressRuntime()`; new `ApplicationOptions.runtime` to override.
- Routed through the runtime:
  - app creation → `createApp()` (constructor + HMR rebuild)
  - ~10 middleware sites (request-tracking, request-scope, plugin, adapter `beforeGlobal`/`afterRoutes`, auto-helmet, user middleware, defaults) → `useConnect`
  - route mounting → `useConnect(app, router, { path: mountPath })`
  - terminal 404 / error → `setNotFound` / `setErrorHandler`
  - production server → `http.createServer(runtime.nodeHandler(app))`
  - `handle()` node listener + HMR `on('request', …)` → `runtime.nodeHandler(app)`

## Behavior change

**None.** Express is the zero-config default; existing apps are byte-for-byte unaffected.

## Still Express-specific (moves to the runtime in M2)

`getExpressApp()`, `AdapterContext.app`, the `disable('x-powered-by')` / `trust proxy` setup, and the `/health/*` routes still touch `this.app` directly — these resolve to the Express app under the default runtime. The adapter-facade (`AdapterContext.http`) migration is M2.

## Tests

- kickjs: **549 passed** (+2 new). All other package suites green — the only monorepo-run failures are `@forinda/kickjs-db` **integration** tests that require a live Postgres (DB-gated, unrelated).
- New `application-runtime-seam.test.ts`: a recording runtime wrapper proves the configured runtime is actually driven through `bootstrap` (createApp / useConnect / setNotFound / setErrorHandler fire, and requests serve), plus the default-runtime path.

Stress-ran the kickjs suite 4× after the change — stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pluggable HTTP runtimes via the new `runtime` option in application configuration, enabling developers to use alternative HTTP engines beyond the default Express setup.
  * Default behavior remains unchanged—Express continues as the zero-config default with no impact on existing applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->