### PR TITLE
chore: freeze deprecated packages (private + changeset ignore)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,7 +12,14 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [],
+  "ignore": [
+    "@forinda/kickjs-auth",
+    "@forinda/kickjs-prisma",
+    "@forinda/kickjs-drizzle",
+    "@forinda/kickjs-db-pg",
+    "@forinda/kickjs-db-mysql",
+    "@forinda/kickjs-db-sqlite"
+  ],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@forinda/kickjs-auth",
   "version": "6.0.1",
+  "private": true,
   "description": "Pluggable authentication for KickJS — JWT, API key, and custom strategies",
   "keywords": [
     "kickjs",

--- a/packages/cli/__tests__/add-registry.test.ts
+++ b/packages/cli/__tests__/add-registry.test.ts
@@ -36,7 +36,7 @@ describe('PACKAGE_REGISTRY catalog health', () => {
     expect(PACKAGE_REGISTRY.auth?.deprecated).toContain('BYO')
   })
 
-  it('every first-party entry points at an existing, non-private workspace package', () => {
+  it('every first-party entry points at an existing workspace package; non-deprecated ones are public', () => {
     for (const [name, entry] of Object.entries(PACKAGE_REGISTRY)) {
       if (!entry.pkg.startsWith('@forinda/')) continue
       const manifest = manifests.get(entry.pkg)
@@ -44,6 +44,11 @@ describe('PACKAGE_REGISTRY catalog health', () => {
         manifest,
         `registry entry '${name}' → ${entry.pkg} not found in workspace`,
       ).toBeDefined()
+      // Deprecated entries (auth/prisma/drizzle) are frozen `private: true`:
+      // they no longer cut new versions but remain installable from their last
+      // npm release, so `kick add <name>` still works (with a deprecation
+      // warning). Only non-deprecated entries must be published (non-private).
+      if (entry.deprecated) continue
       expect(manifest?.private ?? false, `registry entry '${name}' → ${entry.pkg} is private`).toBe(
         false,
       )

--- a/packages/db-mysql/package.json
+++ b/packages/db-mysql/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@forinda/kickjs-db-mysql",
   "version": "3.1.0",
+  "private": true,
   "description": "mysql2 adapter for @forinda/kickjs-db — MigrationAdapter + Kysely MysqlDialect (MySQL 8.0+)",
   "keywords": [
     "kickjs",

--- a/packages/db-pg/package.json
+++ b/packages/db-pg/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@forinda/kickjs-db-pg",
   "version": "10.1.0",
+  "private": true,
   "description": "node-postgres adapter for @forinda/kickjs-db — MigrationAdapter + Kysely PostgresDialect",
   "keywords": [
     "kickjs",

--- a/packages/db-sqlite/package.json
+++ b/packages/db-sqlite/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@forinda/kickjs-db-sqlite",
   "version": "3.1.0",
+  "private": true,
   "description": "better-sqlite3 adapter for @forinda/kickjs-db — MigrationAdapter + Kysely SqliteDialect",
   "keywords": [
     "kickjs",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@forinda/kickjs-drizzle",
   "version": "6.0.1",
+  "private": true,
   "description": "Drizzle ORM adapter with DI integration, transaction support, and query building for KickJS",
   "keywords": [
     "kickjs",

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@forinda/kickjs-prisma",
   "version": "6.0.1",
+  "private": true,
   "description": "Prisma ORM adapter with DI integration, transaction support, and query building for KickJS",
   "keywords": [
     "kickjs",


### PR DESCRIPTION
## Why

The deprecated packages get patch-bumped and republished on every `@forinda/kickjs` release — they're internal dependents, so changeset cascades a bump to them. They're end-of-life; no reason to keep cutting versions.

## What

Mark all six `private: true` (stops publish) **and** add them to the changeset `ignore` list (stops the version bump itself):

| Package | Replacement |
| --- | --- |
| `@forinda/kickjs-auth` | BYO via context decorators |
| `@forinda/kickjs-prisma` | BYO or `@forinda/kickjs-db` |
| `@forinda/kickjs-drizzle` | BYO or `@forinda/kickjs-db` |
| `@forinda/kickjs-db-pg` | `@forinda/kickjs-db/pg` subpath |
| `@forinda/kickjs-db-mysql` | `@forinda/kickjs-db/mysql` subpath |
| `@forinda/kickjs-db-sqlite` | `@forinda/kickjs-db/sqlite` subpath |

## Safety

- Verified **nothing** in the workspace depends on any of the six → ignoring is safe (changeset requires ignored packages to be leaves).
- `changeset status` confirms the six no longer appear in the bump list.
- Already-published versions stay on npm for back-compat; we just stop cutting new ones. Workspace linking is unaffected (`private` only blocks publish).

## Heads-up (separate, pre-existing)

`changeset status` currently shows **10 other packages** (ai, db, devtools, devtools-kit, mcp, queue, swagger, testing, vite, ws) queued for a **major** bump, even though no changeset declares `major`. This reproduces on clean `main` — it predates this PR. Likely the stale `alpha` dist-tag (still at `5.10.0-alpha.0`) making pre-mode compute a major jump from the current `6.x`. Worth a look before the next publish so these don't unintentionally go to `7.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Changesets configuration for package management.
  * Marked internal database and authentication packages as private.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->