### PR TITLE
feat: migrate queue + mcp adapters onto ctx.http (M2b)

### DIFF
--- a/.changeset/http-adapter-migrate-m2b.md
+++ b/.changeset/http-adapter-migrate-m2b.md
@@ -1,0 +1,12 @@
+---
+'@forinda/kickjs': minor
+'@forinda/kickjs-mcp': patch
+'@forinda/kickjs-queue': patch
+---
+
+Migrate the queue and mcp adapters onto the engine-agnostic `ctx.http` facade (M2b), and export the `AdapterHttp` type from `@forinda/kickjs` so adapter authors can type against it.
+
+- `@forinda/kickjs-queue`: the `/_kick/queue/{panel,data}` routes now register via `ctx.http.route(...)` and respond through `ctx.html` / `ctx.json` instead of reaching for the raw Express `app` / `res`.
+- `@forinda/kickjs-mcp`: the StreamableHTTP transport endpoints (`<basePath>/messages`) now mount via `ctx.http.mount(...)` — all three verbs in one route table so the engine still auto-answers the OPTIONS preflight. The transport handler reaches `ctx.req` / `ctx.res` for the raw node request/response it needs.
+
+Behavior is unchanged under the default Express runtime. Swagger and devtools migrate in M2c.

--- a/packages/kickjs/src/http/index.ts
+++ b/packages/kickjs/src/http/index.ts
@@ -17,6 +17,7 @@ export { buildRoutes, materializeRouter, expressRuntime } from './runtimes/expre
 // HTTP runtime seam (spec: docs/http/spec-http-runtimes.md)
 export type {
   HttpRuntime,
+  AdapterHttp,
   RouteEntry,
   RouteMeta,
   RouteTable,

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -24,6 +24,7 @@ export type { BuildRoutesOptions } from './http/router-builder'
 export { buildRoutes, materializeRouter, expressRuntime } from './http/runtimes/express'
 export type {
   HttpRuntime,
+  AdapterHttp,
   RouteEntry,
   RouteMeta,
   RouteTable,

--- a/packages/mcp/__tests__/mcp-transport.test.ts
+++ b/packages/mcp/__tests__/mcp-transport.test.ts
@@ -3,8 +3,29 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import express, { type Express } from 'express'
 import request from 'supertest'
 import { z } from 'zod'
-import { Container, Controller, Get, Post } from '@forinda/kickjs'
+import { Container, Controller, Get, Post, expressRuntime, type AdapterHttp } from '@forinda/kickjs'
 import { McpAdapter, McpTool } from '@forinda/kickjs-mcp'
+
+/**
+ * Build the engine-agnostic `ctx.http` facade over a bare Express app — the
+ * same wiring Application does internally. Lets these unit tests exercise the
+ * adapter's facade-based mounting without standing up a full Application.
+ */
+function adapterHttpFor(app: Express): AdapterHttp {
+  const rt = expressRuntime()
+  return {
+    route: (method, path, handler) =>
+      rt.mountRoutes(app, [
+        {
+          mountPath: '/',
+          routes: [{ method, path, middlewares: [], contributorRunner: null, handler, meta: {} }],
+        },
+      ]),
+    mount: (prefix, routes) => rt.mountRoutes(app, [{ mountPath: prefix, routes }]),
+    serveStatic: (prefix, dir) => rt.serveStatic(app, prefix, dir),
+    use: (mw, opts) => rt.useConnect(app, mw, opts),
+  }
+}
 
 // ── Fixtures ──────────────────────────────────────────────────────────────
 
@@ -43,11 +64,12 @@ async function buildAdapterOnApp(): Promise<{ adapter: McpAdapter; app: Express 
   })
 
   adapter.onRouteMount(TaskController, '/api/v1/tasks')
-  await adapter.beforeStart({ app, container: {} as never } as never)
+  const http = adapterHttpFor(app)
+  await adapter.beforeStart({ app, http, container: {} as never } as never)
 
   // afterStart captures the server base URL for dispatch — `app` was
   // already consumed in beforeStart where the HTTP routes are mounted.
-  await adapter.afterStart({ app, container: {} as never, server: undefined } as never)
+  await adapter.afterStart({ app, http, container: {} as never, server: undefined } as never)
 
   return { adapter, app }
 }

--- a/packages/mcp/src/mcp.adapter.ts
+++ b/packages/mcp/src/mcp.adapter.ts
@@ -5,10 +5,13 @@ import {
   defineAdapter,
   getClassMeta,
   type AdapterContext,
+  type AdapterHttp,
   type Constructor,
+  type RequestContext,
   type RouteDefinition,
+  type RouteEntry,
+  type RouteMethod,
 } from '@forinda/kickjs'
-import type { Express } from 'express'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
@@ -368,12 +371,19 @@ export const McpAdapter = defineAdapter<McpAdapterOptions, McpAdapterExtensions>
       return server
     }
 
-    /** Mount StreamableHTTP transport endpoints on the existing Express app. */
-    const mountHttpRoutes = (app: Express, httpTransport: StreamableHTTPServerTransport): void => {
+    /** Mount StreamableHTTP transport endpoints via the HTTP facade. */
+    const mountHttpRoutes = (
+      http: AdapterHttp,
+      httpTransport: StreamableHTTPServerTransport,
+    ): void => {
       const path = `${options.basePath!}/messages`
 
+      // The MCP transport reads/writes the raw node request/response directly,
+      // so reach through to `ctx.req` / `ctx.res` (engine-native under Express).
       /* eslint-disable @typescript-eslint/no-explicit-any */
-      const handleRequest = async (req: any, res: any): Promise<void> => {
+      const handleRequest = async (ctx: RequestContext): Promise<void> => {
+        const req = ctx.req as any
+        const res = ctx.res as any
         try {
           await httpTransport.handleRequest(req, res, req.body)
         } catch (err) {
@@ -385,9 +395,19 @@ export const McpAdapter = defineAdapter<McpAdapterOptions, McpAdapterExtensions>
       }
       /* eslint-enable @typescript-eslint/no-explicit-any */
 
-      app.post(path, handleRequest)
-      app.get(path, handleRequest)
-      app.delete(path, handleRequest)
+      // Mount all three verbs in a single table so they share one router —
+      // this is what lets the engine auto-answer the OPTIONS preflight with the
+      // correct Allow header (separate `route()` calls would each get their own
+      // router and the preflight wouldn't aggregate).
+      const makeEntry = (method: RouteMethod): RouteEntry => ({
+        method,
+        path,
+        middlewares: [],
+        contributorRunner: null,
+        handler: handleRequest,
+        meta: {},
+      })
+      http.mount('/', [makeEntry('POST'), makeEntry('GET'), makeEntry('DELETE')])
     }
 
     /**
@@ -459,9 +479,8 @@ export const McpAdapter = defineAdapter<McpAdapterOptions, McpAdapterExtensions>
           )
         }
 
-        const expressApp = ctx.app as Express | undefined
-        if (!expressApp) {
-          log.warn('McpAdapter: AdapterContext.app is unavailable, cannot mount HTTP transport')
+        if (!ctx.http) {
+          log.warn('McpAdapter: AdapterContext.http is unavailable, cannot mount HTTP transport')
           return
         }
 
@@ -472,7 +491,7 @@ export const McpAdapter = defineAdapter<McpAdapterOptions, McpAdapterExtensions>
         transport = httpTransport
 
         await mcpServer.connect(httpTransport)
-        mountHttpRoutes(expressApp, httpTransport)
+        mountHttpRoutes(ctx.http, httpTransport)
       },
 
       /**

--- a/packages/queue/src/queue.adapter.ts
+++ b/packages/queue/src/queue.adapter.ts
@@ -126,16 +126,15 @@ export const QueueAdapter = defineAdapter<QueueAdapterOptions, QueueAdapterExten
         ]
       },
 
-      // Mount the iframe panel route. Done in beforeMount (not
-      // beforeStart) because we need the Express app, not the DI
-      // container. Standalone HTML page — no framework, no build
-      // step; bundled inline so adopters don't have to ship our
-      // panel as a separate static asset.
-      beforeMount({ app }) {
-        app.get('/_kick/queue/panel', (_req, res) => {
-          res.type('html').send(QUEUE_PANEL_HTML)
+      // Mount the iframe panel route via the engine-agnostic HTTP facade.
+      // Done in beforeMount so the panel is registered before module routes.
+      // Standalone HTML page — no framework, no build step; bundled inline so
+      // adopters don't have to ship our panel as a separate static asset.
+      beforeMount({ http }) {
+        http.route('GET', '/_kick/queue/panel', (ctx) => {
+          ctx.html(QUEUE_PANEL_HTML)
         })
-        app.get('/_kick/queue/data', async (_req, res) => {
+        http.route('GET', '/_kick/queue/data', async (ctx) => {
           const queues: Array<{
             name: string
             counts: Record<string, number> | { error: string }
@@ -150,7 +149,7 @@ export const QueueAdapter = defineAdapter<QueueAdapterOptions, QueueAdapterExten
               })
             }
           }
-          res.json({ queues })
+          ctx.json({ queues })
         })
       },
 


### PR DESCRIPTION
## What

Milestone **M2b** — migrate the **queue** and **mcp** adapters off the raw Express `app` onto the engine-agnostic `ctx.http` facade (spec §4.4). Also exports the `AdapterHttp` type from `@forinda/kickjs` (added in M2a, not re-exported).

## Changes

- **queue**: `/_kick/queue/{panel,data}` → `ctx.http.route(...)`, responding via `ctx.html` / `ctx.json`.
- **mcp**: StreamableHTTP transport endpoints (`<basePath>/messages`) → `ctx.http.mount(...)`. All three verbs go in **one** route table so the engine still auto-answers the OPTIONS preflight — separate `route()` calls each get their own router and the preflight wouldn't aggregate (caught by the transport test). The handler reaches `ctx.req` / `ctx.res` for the raw node req/res the transport needs. Drops the unused Express import and swaps the `ctx.app` guard for a `ctx.http` one.
- **mcp transport test**: builds a real `ctx.http` facade over its bare Express app (mirrors Application) so facade-based mounting is exercised without a full Application.

## Behavior

Unchanged under the default Express runtime.

## Tests

kickjs (552), mcp (17), queue (27) — all green. Typecheck clean.

## Note / follow-up

The facade's `route()` creates a fresh router per call, so multiple verbs on one path don't share a router (matters for OPTIONS aggregation) — `mount()` is the right tool there, as mcp now uses. Swagger (its `docsRouter` + effectively-global CSP middleware needs care) and devtools (26 routes + SSE + static) migrate in **M2c**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
