### PR TITLE
feat: migrate swagger adapter onto ctx.http (M2c)

### DIFF
--- a/.changeset/http-adapter-migrate-swagger.md
+++ b/.changeset/http-adapter-migrate-swagger.md
@@ -1,0 +1,7 @@
+---
+'@forinda/kickjs-swagger': patch
+---
+
+Migrate the swagger adapter onto the engine-agnostic `ctx.http` facade (M2c). The docs UI, ReDoc, and OpenAPI spec endpoints now register via `ctx.http.route(...)`, the swagger-ui-dist assets via `ctx.http.serveStatic(...)`, and the CSP middleware via `ctx.http.use(...)` — instead of building an Express `Router` and reaching for the raw `app`. Behavior is unchanged under the default Express runtime (the CSP header still applies app-wide, exactly as the previous root-mounted docs router did).
+
+The devtools adapter (26 routes + SSE + static SPA) migrates separately as the final M2 step.

--- a/packages/swagger/src/swagger.adapter.ts
+++ b/packages/swagger/src/swagger.adapter.ts
@@ -1,6 +1,6 @@
 import { dirname } from 'node:path'
 import { createRequire } from 'node:module'
-import express, { Router } from 'express'
+import type { Request, Response, NextFunction } from 'express'
 import { Logger, defineAdapter } from '@forinda/kickjs'
 import {
   buildOpenAPISpec,
@@ -157,7 +157,7 @@ export const SwaggerAdapter = defineAdapter<SwaggerAdapterOptions>({
         config.servers = [...userSuppliedServers, ...autoDetected]
       },
 
-      beforeMount({ app }) {
+      beforeMount({ http }) {
         if (isDisabled()) {
           log.info('Swagger disabled in production (disableInProd=true)')
           return
@@ -170,15 +170,13 @@ export const SwaggerAdapter = defineAdapter<SwaggerAdapterOptions>({
         const specPath = config.specPath!
         let uiDistAvailable = false
 
-        const docsRouter = Router()
-
         // ── Serve swagger-ui-dist static assets locally ──────────────────
         // This makes Swagger UI work offline — no CDN needed.
         // Assets served at /_swagger-assets/ (CSS, JS, fonts, etc.)
         const swaggerAssetsPath = '/_swagger-assets'
         try {
           const swaggerDistDir = getSwaggerUiDistPath()
-          docsRouter.use(swaggerAssetsPath, express.static(swaggerDistDir))
+          http.serveStatic(swaggerAssetsPath, swaggerDistDir)
           uiDistAvailable = true
         } catch {
           log.warn('swagger-ui-dist not found — Swagger UI will load from CDN (requires internet).')
@@ -204,7 +202,7 @@ export const SwaggerAdapter = defineAdapter<SwaggerAdapterOptions>({
             : ['https://unpkg.com', 'https://fonts.googleapis.com']
         const imgOrigins = uiDistAvailable || customSwaggerRenderer ? [] : ['https://unpkg.com']
 
-        docsRouter.use((_req, res, next) => {
+        http.use((_req: Request, res: Response, next: NextFunction) => {
           // Build connect-src dynamically so "Try it out" can call any configured server URL.
           // Includes dev-friendly localhost/127.0.0.1 origins so docs served from one host
           // can call an API spec'd at the other (a common cross-origin gotcha).
@@ -246,9 +244,8 @@ export const SwaggerAdapter = defineAdapter<SwaggerAdapterOptions>({
         })
 
         // Spec endpoint (JSON)
-        docsRouter.get(specPath, (_req, res) => {
-          const spec = buildOpenAPISpec(config)
-          res.json(spec)
+        http.route('GET', specPath, (ctx) => {
+          ctx.json(buildOpenAPISpec(config))
         })
 
         // Swagger UI — uses local assets if available, CDN fallback.
@@ -256,26 +253,22 @@ export const SwaggerAdapter = defineAdapter<SwaggerAdapterOptions>({
         // (Stoplight Elements, RapiDoc, Scalar) or apply branding.
         const renderSwagger = config.renderSwaggerUI ?? swaggerUIHtml
         const renderReDoc = config.renderReDoc ?? redocHtml
-        docsRouter.get(docsPath, (_req, res) => {
-          res
-            .type('html')
-            .send(
-              renderSwagger(
-                specPath,
-                config.info?.title,
-                uiDistAvailable ? swaggerAssetsPath : undefined,
-              ),
-            )
+        http.route('GET', docsPath, (ctx) => {
+          ctx.html(
+            renderSwagger(
+              specPath,
+              config.info?.title,
+              uiDistAvailable ? swaggerAssetsPath : undefined,
+            ),
+          )
         })
 
         // ReDoc — still CDN-based for the default renderer (no npm
         // package for the standalone bundle). Custom renderers can
         // self-host whatever they like.
-        docsRouter.get(redocPath, (_req, res) => {
-          res.type('html').send(renderReDoc(specPath, config.info?.title))
+        http.route('GET', redocPath, (ctx) => {
+          ctx.html(renderReDoc(specPath, config.info?.title))
         })
-
-        app.use(docsRouter)
 
         log.info(`Swagger UI:  ${docsPath}`)
         log.info(`ReDoc:       ${redocPath}`)


### PR DESCRIPTION
## What

**M2c** — migrate the **swagger** adapter onto the engine-agnostic `ctx.http` facade (spec §4.4), off the raw Express `app` / `Router`.

## Changes

- swagger-ui-dist assets → `ctx.http.serveStatic(...)`
- CSP middleware → `ctx.http.use(...)` (params annotated with Express types — `ConnectMiddleware` is a union, so they don't infer)
- docs UI / ReDoc / OpenAPI spec → `ctx.http.route('GET', ...)` responding via `ctx.html` / `ctx.json`
- drops the now-unused `express` / `Router` import

## Behavior

Unchanged under the default Express runtime. Registration order (static → CSP → routes) is preserved, so the CSP header still applies app-wide exactly as the old root-mounted docs router did.

## Tests

swagger suite green (54). Typecheck clean.

## Remaining

**devtools** (26 routes + SSE streams + static SPA + a stored `appRef`) is the last and largest adapter — it migrates in its own PR. After that, `application.ts`'s remaining Express-specific calls (`x-powered-by`, `trust proxy`, `/health/*`) move onto the runtime and `ApplicationOptions.runtime?` widens from `HttpRuntime<Express>` to generic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
