### PR TITLE
feat: migrate devtools adapter onto ctx.http (M2d)

### DIFF
--- a/.changeset/http-adapter-migrate-devtools.md
+++ b/.changeset/http-adapter-migrate-devtools.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-devtools': patch
+---
+
+Migrate the devtools adapter off the raw Express `app` / `Router` onto the engine-agnostic `ctx.http` facade (final M2 adapter). A thin local `router` shim forwards `.get` / `.post` / `.use` to `ctx.http.route` / `ctx.http.use`, so every dashboard handler — the ~20 JSON routes, the SSE streams, the heap-snapshot download, the static dashboard, and the token guard — is kept verbatim. Registration order is preserved and the guard still sees router-relative `req.path` (the facade scopes it to `basePath`, and Express strips the prefix), so behavior is unchanged under the default Express runtime. `ctx.app` is still used only as the documented escape hatch for `__kickApp` (topology needs the live Application instance).

--- a/packages/devtools/__tests__/devtools.test.ts
+++ b/packages/devtools/__tests__/devtools.test.ts
@@ -666,10 +666,11 @@ describe('DevToolsAdapter', () => {
 
     it('starts the sampler in beforeMount', async () => {
       const adapter = createAdapter()
-      // Stub the express app + container so beforeMount can run
+      // Stub the express app, http facade, and container so beforeMount can run
       const fakeApp = { use: vi.fn() } as any
+      const fakeHttp = { route: vi.fn(), mount: vi.fn(), serveStatic: vi.fn(), use: vi.fn() } as any
       const container = new Container()
-      await adapter.beforeMount?.({ app: fakeApp, container } as any)
+      await adapter.beforeMount?.({ app: fakeApp, http: fakeHttp, container } as any)
       expect(adapter.runtimeSampler?.isRunning()).toBe(true)
       // Initial sample should already be in the buffer
       expect(adapter.runtimeSampler?.latest()).not.toBeNull()
@@ -679,8 +680,9 @@ describe('DevToolsAdapter', () => {
     it('stops the sampler in shutdown', async () => {
       const adapter = createAdapter()
       const fakeApp = { use: vi.fn() } as any
+      const fakeHttp = { route: vi.fn(), mount: vi.fn(), serveStatic: vi.fn(), use: vi.fn() } as any
       const container = new Container()
-      await adapter.beforeMount?.({ app: fakeApp, container } as any)
+      await adapter.beforeMount?.({ app: fakeApp, http: fakeHttp, container } as any)
       expect(adapter.runtimeSampler?.isRunning()).toBe(true)
       adapter.shutdown()
       expect(adapter.runtimeSampler?.isRunning()).toBe(false)

--- a/packages/devtools/src/adapter.ts
+++ b/packages/devtools/src/adapter.ts
@@ -1,5 +1,5 @@
-import type { Request, Response, NextFunction } from 'express'
-import { Router, static as serveStatic } from 'express'
+import type { Request, Response, NextFunction, RequestHandler } from 'express'
+import { static as serveStatic } from 'express'
 import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
@@ -433,7 +433,7 @@ export const DevToolsAdapter = defineAdapter<DevToolsOptions, DevToolsAdapterExt
 
       // ── Lifecycle ─────────────────────────────────────────────────
 
-      beforeMount({ app, container: containerArg }) {
+      beforeMount({ app, http, container: containerArg }) {
         if (!enabled) return
 
         appRef = app
@@ -453,7 +453,24 @@ export const DevToolsAdapter = defineAdapter<DevToolsOptions, DevToolsAdapterExt
         runtimeSampler?.start()
         memoryAnalyzer?.start()
 
-        const router = Router()
+        // Register dashboard routes through the engine-agnostic HTTP facade
+        // (`ctx.http`) instead of an Express Router, so devtools no longer
+        // depends on the raw Express app for mounting. The `router` shim keeps
+        // every existing `(req, res)` handler verbatim — `req` / `res` are the
+        // engine-native request/response under the default runtime.
+        //
+        // `use()` scopes the middleware to `basePath` (Express strips the
+        // prefix, so the guard still sees router-relative `req.path`). `get` /
+        // `post` register the prefixed path; the dashboard root (`'/'`) maps to
+        // `basePath` itself, matching the old `router.get('/')` at the mount.
+        const joinBase = (p: string): string => (p === '/' ? basePath : `${basePath}${p}`)
+        const router = {
+          use: (mw: RequestHandler): void => http.use(mw, { path: basePath }),
+          get: (path: string, handler: (req: Request, res: Response) => unknown): void =>
+            http.route('GET', joinBase(path), (ctx) => handler(ctx.req, ctx.res)),
+          post: (path: string, handler: (req: Request, res: Response) => unknown): void =>
+            http.route('POST', joinBase(path), (ctx) => handler(ctx.req, ctx.res)),
+        }
 
         // ── Access guard — require secret token ──────────────────
         if (secret !== false) {
@@ -916,7 +933,8 @@ export const DevToolsAdapter = defineAdapter<DevToolsOptions, DevToolsAdapterExt
           })
         }
 
-        app.use(basePath, router)
+        // Routes self-register through the facade as they're declared above —
+        // no Router to mount here.
 
         if (secret) {
           log.info(`DevTools mounted at ${basePath} [token: ${secret}]`)


### PR DESCRIPTION
## What

**M2d** — migrate the **devtools** adapter onto `ctx.http`, the last and largest of the M2 adapter migrations.

## Approach

devtools builds its dashboard as one Express `Router` (token guard + ~20 JSON routes + SSE streams + heap-snapshot download + static SPA) mounted at `basePath`. Instead of rewriting ~20 handlers, a thin local `router` shim forwards `.get` / `.post` / `.use` to `ctx.http.route` / `ctx.http.use` — every handler body is kept **verbatim** (`req` / `res` are the engine-native objects under the default runtime).

Why this is behavior-neutral:
- Shim calls register in the same order → same middleware-stack order.
- Token guard still sees router-relative `req.path`: `http.use(mw, { path: basePath })` mounts at `basePath` and Express strips the prefix — exactly what `router.use(...)` inside a `basePath`-mounted Router did.
- Dashboard root (`'/'`) maps to `basePath`; static + SSE unchanged.
- `ctx.app` remains only as the escape hatch for `appRef.__kickApp` (topology needs the live Application instance) — no routing depends on it.

## Tests

devtools suite green (**94**), typecheck clean. Two sampler tests updated to pass a stub `http` in their mock context.

Note: the dashboard routes/guard were already only unit-tested via replicated logic (an end-to-end harness "requires Express"), so this PR keeps that coverage and relies on the shim being faithful by construction + standard Express sub-mount path-stripping.

## M2 status

Adapter migrations complete: **queue ✓ mcp ✓ swagger ✓ devtools ✓**. Remaining runtime work: move `application.ts`'s last Express-specific calls (`disable('x-powered-by')`, `set('trust proxy')`, `/health/*`) onto the runtime, then widen `ApplicationOptions.runtime?` from `HttpRuntime<Express>` to generic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated devtools adapter to use a framework-agnostic HTTP facade, improving platform compatibility while preserving all existing debugging functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->