### PR TITLE
feat: move Application's Express-specific calls onto the runtime (M2e)

### DIFF
--- a/.changeset/http-runtime-finish-m2e.md
+++ b/.changeset/http-runtime-finish-m2e.md
@@ -1,0 +1,10 @@
+---
+'@forinda/kickjs': patch
+---
+
+Move the Application's last Express-specific calls onto the HTTP runtime, so `application.ts` no longer reaches for engine-specific APIs in its setup path:
+
+- `disable('x-powered-by')` + `set('trust proxy')` now live in `expressRuntime.createApp(opts)`; `Application` passes `trustProxy` through at both the constructor and HMR-rebuild create sites. `RuntimeAppOptions.trustProxy` widened to include Express's function form.
+- The `/health/live` and `/health/ready` endpoints now register through the `ctx.http` facade instead of `this.app.get(...)`.
+
+Behavior is unchanged under the default Express runtime. The engine-native escape hatches (`getExpressApp()` / `getRuntimeApp()`, `AdapterContext.app`) stay typed `Express` — `ApplicationOptions.runtime` widens from `HttpRuntime<Express>` to generic once `app` becomes runtime-typed (with the Fastify / h3 work).

--- a/packages/kickjs/__tests__/application-health-hardening.test.ts
+++ b/packages/kickjs/__tests__/application-health-hardening.test.ts
@@ -1,0 +1,48 @@
+import 'reflect-metadata'
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import { Application, Container, type AppAdapter } from '../src/index'
+
+beforeEach(() => {
+  Container.reset()
+})
+
+// x-powered-by disable + trust proxy moved into runtime.createApp(); the
+// /health/* routes moved onto the ctx.http facade (M2e). These assert the
+// behavior is unchanged after that move.
+describe('hardened defaults + health endpoints (via the runtime)', () => {
+  it('disables x-powered-by and serves /health/live through the facade', async () => {
+    const app = new Application({ modules: [] })
+    await app.setup()
+    const http = app.getExpressApp()
+
+    const res = await request(http).get('/health/live').expect(200)
+    expect(res.body).toEqual({ status: 'ok', uptime: expect.any(Number) })
+    expect(res.headers['x-powered-by']).toBeUndefined()
+  })
+
+  it('serves /health/ready and reflects adapter onHealthCheck results', async () => {
+    const upAdapter: AppAdapter = {
+      name: 'UpAdapter',
+      onHealthCheck: async () => ({ name: 'UpAdapter', status: 'up' }),
+    }
+    const app = new Application({ modules: [], adapters: [upAdapter] })
+    await app.setup()
+
+    const res = await request(app.getExpressApp()).get('/health/ready').expect(200)
+    expect(res.body.status).toBe('ready')
+    expect(res.body.checks).toContainEqual({ name: 'UpAdapter', status: 'up' })
+  })
+
+  it('returns 503 from /health/ready when an adapter reports down', async () => {
+    const downAdapter: AppAdapter = {
+      name: 'DownAdapter',
+      onHealthCheck: async () => ({ name: 'DownAdapter', status: 'down' }),
+    }
+    const app = new Application({ modules: [], adapters: [downAdapter] })
+    await app.setup()
+
+    const res = await request(app.getExpressApp()).get('/health/ready').expect(503)
+    expect(res.body.status).toBe('degraded')
+  })
+})

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -184,11 +184,13 @@ export interface ApplicationOptions {
    * The HTTP engine driver. Defaults to {@link expressRuntime} — Express stays
    * the zero-config default, so existing apps are unaffected.
    *
-   * Typed `HttpRuntime<Express>` for now: `Application` still calls a few
-   * Express-only APIs directly (`disable('x-powered-by')`, `set('trust proxy')`,
-   * the `/health/*` routes). Those move onto the runtime in M2, at which point
-   * this widens to a generic `HttpRuntime` so the Fastify / h3 subpaths can be
-   * passed here. Until then, only an Express-typed runtime is sound.
+   * Typed `HttpRuntime<Express>` for now: all routing, middleware, and the
+   * hardened defaults (`x-powered-by` / `trust proxy`) and `/health/*` routes
+   * now go through the runtime, but the engine-native escape hatches
+   * (`getRuntimeApp()` / `getExpressApp()`, `AdapterContext.app`) are still
+   * typed `Express`. This widens to a generic `HttpRuntime` once `app` becomes
+   * runtime-typed (registry augmentation, spec §4.3b) — which lands with the
+   * Fastify / h3 subpaths. Until then, only an Express-typed runtime is sound.
    */
   runtime?: HttpRuntime<Express>
 
@@ -335,7 +337,7 @@ export class Application {
 
   constructor(private readonly options: ApplicationOptions) {
     this.runtime = options.runtime ?? expressRuntime()
-    this.app = this.runtime.createApp()
+    this.app = this.runtime.createApp({ trustProxy: options.trustProxy })
     this.container = Container.getInstance()
 
     // Sort plugins by `dependsOn` declarations BEFORE reading their adapters/etc.
@@ -504,8 +506,7 @@ export class Application {
     }
 
     // ── 2. Hardened defaults ──────────────────────────────────────────
-    this.app.disable('x-powered-by')
-    this.app.set('trust proxy', this.options.trustProxy ?? false)
+    // x-powered-by disable + trust proxy now live in `runtime.createApp()`.
 
     // ── 2a. In-flight request tracking ──────────────────────────────
     this.runtime.useConnect(this.app, this.requestTrackingMiddleware())
@@ -890,7 +891,7 @@ export class Application {
     try {
       Container.reset()
       this.container = Container.getInstance()
-      this.app = this.runtime.createApp()
+      this.app = this.runtime.createApp({ trustProxy: this.options.trustProxy })
       await this.setup()
     } catch (err) {
       log.error(err, 'HMR rebuild failed, keeping previous app')
@@ -1157,17 +1158,19 @@ export class Application {
 
   /** Mount /health/live and /health/ready endpoints at the root (no API prefix) */
   private mountHealthEndpoints(): void {
-    this.app.get('/health/live', (_req, res) => {
+    const http = this.adapterHttp()
+
+    http.route('GET', '/health/live', (ctx) => {
       if (this._draining) {
-        res.status(503).json({ status: 'draining', uptime: process.uptime() })
+        ctx.res.status(503).json({ status: 'draining', uptime: process.uptime() })
       } else {
-        res.json({ status: 'ok', uptime: process.uptime() })
+        ctx.json({ status: 'ok', uptime: process.uptime() })
       }
     })
 
-    this.app.get('/health/ready', async (_req, res) => {
+    http.route('GET', '/health/ready', async (ctx) => {
       if (this._draining) {
-        res.status(503).json({ status: 'draining', checks: [] })
+        ctx.res.status(503).json({ status: 'draining', checks: [] })
         return
       }
       const adaptersWithHealth = this.adapters.filter((a) => a.onHealthCheck)
@@ -1177,7 +1180,7 @@ export class Application {
         return { name: adaptersWithHealth[i].name ?? 'unknown', status: 'down' as const }
       })
       const healthy = results.every((r) => r.status === 'up')
-      res.status(healthy ? 200 : 503).json({
+      ctx.res.status(healthy ? 200 : 503).json({
         status: healthy ? 'ready' : 'degraded',
         checks: results,
       })

--- a/packages/kickjs/src/http/runtime.ts
+++ b/packages/kickjs/src/http/runtime.ts
@@ -93,8 +93,12 @@ export type RouteTable = { mountPath: string; routes: RouteEntry[] }[]
 
 /** Options passed to {@link HttpRuntime.createApp}. */
 export interface RuntimeAppOptions {
-  /** Express `trust proxy` setting (and the equivalent on other engines). */
-  trustProxy?: boolean | string | number | string[]
+  /**
+   * Express `trust proxy` setting (and the equivalent on other engines). The
+   * function form is Express-specific; other runtimes interpret the simpler
+   * shapes (or normalize X-Forwarded-For themselves — see spec §10 Q1).
+   */
+  trustProxy?: boolean | string | number | string[] | ((ip: string, hopIndex: number) => boolean)
 }
 
 /** Where a connect middleware sits and what it scopes to. */

--- a/packages/kickjs/src/http/runtimes/express.ts
+++ b/packages/kickjs/src/http/runtimes/express.ts
@@ -112,6 +112,8 @@ export function expressRuntime(): HttpRuntime<Express> {
 
     createApp(options: RuntimeAppOptions = {}): Express {
       const app = express()
+      // Engine hardening + config the Application used to apply directly.
+      app.disable('x-powered-by')
       app.set('trust proxy', options.trustProxy ?? false)
       return app
     },


### PR DESCRIPTION
## What

Finish the M2 runtime work — `Application`'s setup path no longer calls engine-specific Express APIs directly.

## Changes

- `disable('x-powered-by')` + `set('trust proxy')` → folded into `expressRuntime.createApp(opts)`. Application passes `trustProxy` through at the constructor and HMR-rebuild create sites. `RuntimeAppOptions.trustProxy` widened to include Express's function form (other runtimes interpret the simpler shapes — spec §10 Q1).
- `/health/live` + `/health/ready` → register through the `ctx.http` facade instead of `this.app.get(...)`.
- Updated the `runtime?` JSDoc to reflect what's left Express-typed (only the `getExpressApp()` / `AdapterContext.app` escape hatches).

## Behavior

Unchanged under the default Express runtime.

## Tests

kickjs **552 + 3 new** (`application-health-hardening.test.ts`: x-powered-by absent, `/health/live`, `/health/ready` up + degraded paths). testing + devtools suites pass.

## Status

`application.ts` is now fully runtime-driven for setup; the only remaining Express coupling is the deliberate escape hatches. `ApplicationOptions.runtime` stays `HttpRuntime<Express>` until `app` becomes runtime-typed (registry augmentation, spec §4.3b) — that lands with **M3** (Fastify / h3 subpaths + `kick/runtime` typegen + the request/response driver layer), which needs the §10 open-question calls (trustProxy normalization, bodyParser placement, Fastify logger) first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
