### PR TITLE
feat: type ctx.req / ctx.res from the runtime registry (M3c prep)

### DIFF
--- a/.changeset/http-runtime-ctx-registry.md
+++ b/.changeset/http-runtime-ctx-registry.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs': patch
+---
+
+Type `ctx.req` / `ctx.res` from the runtime registry (`ActiveRuntime['request']` / `ActiveRuntime['response']`) instead of hard-coding Express's `Request` / `Response`. Under the default (unaugmented) Express runtime these resolve to `express.Request` / `express.Response`, so there is no change for existing apps — but a `kick/runtime` typegen augmentation now flips `ctx.req` / `ctx.res` to the active engine's native request/response, completing the §4.3b runtime-typed-context story for the request context. Behavior is unchanged; this is the last type-prep before the Fastify runtime subpath.

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -1,6 +1,6 @@
 /// <reference types="multer" />
-import type { Request, Response, NextFunction } from 'express'
-import type { RuntimeResponse } from './runtime'
+import type { Request, NextFunction } from 'express'
+import type { ActiveRuntime, RuntimeResponse } from './runtime'
 import { type ExecutionContext, type MetaValue } from '../core/execution-context'
 import { normalizeProblem, type ProblemDetails, type ValidationError } from '../core/errors'
 import { requestStore } from './request-store'
@@ -265,12 +265,14 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
   private readonly _response: RuntimeResponse
 
   constructor(
-    public readonly req: Request,
-    public readonly res: Response,
+    public readonly req: ActiveRuntime['request'],
+    public readonly res: ActiveRuntime['response'],
     public readonly next: NextFunction,
     responseDriver?: RuntimeResponse,
   ) {
-    this._response = responseDriver ?? res
+    // Under the Express runtime `res` IS a RuntimeResponse (structural); other
+    // runtimes pass an explicit driver wrapping their native reply.
+    this._response = responseDriver ?? (res as RuntimeResponse)
   }
 
   /**


### PR DESCRIPTION
## What

Type-prep before the Fastify runtime: `ctx.req` / `ctx.res` are now typed from the runtime registry (`ActiveRuntime['request']` / `ActiveRuntime['response']`) instead of hard-coded Express `Request` / `Response`.

## Behavior

None. Under the default (unaugmented) Express runtime the registry resolves to `express.Request` / `express.Response`, so the kickjs build typechecks against Express exactly as before and existing apps see no change.

A `kick/runtime` typegen augmentation flips `ctx.req` / `ctx.res` to the active engine's native request/response — completing the §4.3b runtime-typed-context story. The Fastify runtime will construct `RequestContext` with its native request/reply (casting at the trusted runtime boundary) plus a reply-wrapping `RuntimeResponse` via the optional 4th constructor arg added in M3b.

## Tests

kickjs **556** green, whole monorepo typechecks. Dropped the now-unused `Response` import.

## Next

The `@forinda/kickjs/fastify` subpath itself — `fastifyRuntime()` + middie + `@fastify/multipart` + the `kick/runtime` typegen plugin + a conformance suite running one fixture app under Express **and** Fastify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
