### PR TITLE
feat: request-scoped contributors + ctx.set/get under Fastify (M3c-3)

### DIFF
--- a/.changeset/http-fastify-als-m3c3.md
+++ b/.changeset/http-fastify-als-m3c3.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs': patch
+---
+
+Make request-scoped contributors and `ctx.set` / `ctx.get` work under the Fastify runtime. Fastify runs the route handler outside the connect-middleware chain, so the `requestScopeMiddleware` AsyncLocalStorage frame (which Express relies on) wasn't active inside the handler. The Fastify route handler now establishes the ALS frame itself around the pipeline (reusing the inbound `x-request-id` when present), so REQUEST-scoped DI, context decorators (`defineContextDecorator`), and `ctx.set` / `ctx.get` behave the same on Fastify as on Express. Adds a shared `createRequestStore` helper (used by both the Express middleware and the Fastify runtime) and a conformance test covering contributors under both engines.

--- a/packages/kickjs/__tests__/fastify-conformance.test.ts
+++ b/packages/kickjs/__tests__/fastify-conformance.test.ts
@@ -7,6 +7,7 @@ import {
   Controller,
   Get,
   RequestContext,
+  defineContextDecorator,
   expressRuntime,
   type HttpRuntime,
 } from '../src/index'
@@ -90,6 +91,29 @@ for (const rt of RUNTIMES) {
 
       const res = await request(app.handle.bind(app)).get('/api/v1/mw/m').expect(200)
       expect(res.headers['x-conformance']).toBe(rt.name)
+    })
+
+    it('runs a context contributor and exposes it via ctx.get (ALS frame)', async () => {
+      const LoadWho = defineContextDecorator({ key: 'who', resolve: () => 'ada' })
+
+      @Controller()
+      class C {
+        @LoadWho
+        @Get('/who')
+        who(ctx: RequestContext) {
+          ctx.json({ who: ctx.get('who') })
+        }
+      }
+      const app = new Application({
+        runtime: rt.make() as never,
+        apiPrefix: '/api',
+        defaultVersion: 1,
+        modules: [{ routes: () => ({ path: '/c', controller: C }) } as never],
+      })
+      await app.setup()
+
+      const res = await request(app.handle.bind(app)).get('/api/v1/c/who').expect(200)
+      expect(res.body).toEqual({ who: 'ada' })
     })
   })
 }

--- a/packages/kickjs/src/http/middleware/request-scope.ts
+++ b/packages/kickjs/src/http/middleware/request-scope.ts
@@ -17,6 +17,20 @@ import { requestStore, type RequestStore } from '../request-store'
 const REQUEST_SCOPE_MIDDLEWARE_MARKER = Symbol.for('@kickjs/requestScopeMiddleware')
 
 /**
+ * Build a fresh per-request store. Shared by {@link requestScopeMiddleware}
+ * (Express) and by runtimes whose handler runs outside the connect-middleware
+ * chain (e.g. Fastify), so both establish an identical ALS frame.
+ */
+export function createRequestStore(requestId?: string): RequestStore {
+  return {
+    requestId: requestId || crypto.randomUUID(),
+    instances: new Map(),
+    // Explicit generic locks the "string keys only" decision.
+    values: new Map<string, unknown>(),
+  }
+}
+
+/**
  * Wraps each request in an AsyncLocalStorage context.
  * Enables REQUEST-scoped DI and automatic requestId propagation to logs.
  *
@@ -29,14 +43,7 @@ export function requestScopeMiddleware() {
     const requestIdHeader = req.headers['x-request-id']
     const requestId =
       (Array.isArray(requestIdHeader) ? requestIdHeader[0] : requestIdHeader) || crypto.randomUUID()
-    const store: RequestStore = {
-      requestId,
-      instances: new Map(),
-      // Explicit generic locks the "string keys only" decision
-      // (architecture.md §20.12 #4) at construction time, so accidental
-      // non-string keys can't slip in via the inferred Map<any, any>.
-      values: new Map<string, unknown>(),
-    }
+    const store = createRequestStore(requestId)
     // Surface the requestId on req so the standalone requestId() middleware
     // (when also mounted) reuses this value instead of generating a divergent
     // second one. Without this, log lines that read from the ALS store would

--- a/packages/kickjs/src/http/runtimes/fastify.ts
+++ b/packages/kickjs/src/http/runtimes/fastify.ts
@@ -131,10 +131,17 @@ function routeHandler(entry: RouteEntry): FastifyHandler {
     // Fastify runs the route handler OUTSIDE the connect-middleware chain, so
     // (unlike Express) the requestScopeMiddleware ALS frame isn't active here.
     // Establish it around the pipeline so REQUEST-scoped DI, contributors, and
-    // ctx.set/get work. Reuse the inbound x-request-id when present.
-    const headerId = request.raw.headers['x-request-id']
-    const requestId = Array.isArray(headerId) ? headerId[0] : headerId
+    // ctx.set/get work. Reuse the inbound x-request-id, or the id a connect
+    // middleware (requestId / requestScope, run earlier via middie) already
+    // stamped on the raw request, before generating a fresh one.
+    const raw = request.raw as IncomingMessage & { requestId?: string }
+    const headerId = raw.headers['x-request-id']
+    const requestId = (Array.isArray(headerId) ? headerId[0] : headerId) || raw.requestId
     const store = createRequestStore(requestId)
+    // Propagate the resolved id back onto the raw request so anything reading
+    // `req.requestId` inside the frame (e.g. request-logger) matches the store
+    // and the X-Request-Id response header — parity with Express.
+    raw.requestId = store.requestId
 
     await requestStore.run(store, async () => {
       const ctx = new RequestContext(

--- a/packages/kickjs/src/http/runtimes/fastify.ts
+++ b/packages/kickjs/src/http/runtimes/fastify.ts
@@ -18,6 +18,8 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import { createRequire } from 'node:module'
 
 import { RequestContext } from '../context'
+import { requestStore } from '../request-store'
+import { createRequestStore } from '../middleware/request-scope'
 import type {
   ConnectMiddleware,
   HttpRuntime,
@@ -126,26 +128,41 @@ function replyDriver(reply: FastifyReplyLike): RuntimeResponse {
 /** Build the Fastify per-route handler that runs the kickjs pipeline. */
 function routeHandler(entry: RouteEntry): FastifyHandler {
   return async (request, reply) => {
-    const ctx = new RequestContext(request as never, reply as never, NOOP_NEXT, replyDriver(reply))
+    // Fastify runs the route handler OUTSIDE the connect-middleware chain, so
+    // (unlike Express) the requestScopeMiddleware ALS frame isn't active here.
+    // Establish it around the pipeline so REQUEST-scoped DI, contributors, and
+    // ctx.set/get work. Reuse the inbound x-request-id when present.
+    const headerId = request.raw.headers['x-request-id']
+    const requestId = Array.isArray(headerId) ? headerId[0] : headerId
+    const store = createRequestStore(requestId)
 
-    // Class + method middleware — `(ctx, next)`; await each, stop if it ended
-    // the response or called next(err).
-    for (const mw of entry.middlewares) {
-      let advanced = false
-      await new Promise<void>((resolve, reject) => {
-        const next = (err?: unknown): void => {
-          advanced = true
-          if (err) reject(err)
-          else resolve()
-        }
-        Promise.resolve(mw(ctx, next)).catch(reject)
-      })
-      if (!advanced || reply.sent) return
-    }
+    await requestStore.run(store, async () => {
+      const ctx = new RequestContext(
+        request as never,
+        reply as never,
+        NOOP_NEXT,
+        replyDriver(reply),
+      )
 
-    if (entry.contributorRunner) await entry.contributorRunner(ctx)
-    if (reply.sent) return
-    await entry.handler(ctx)
+      // Class + method middleware — `(ctx, next)`; await each, stop if it ended
+      // the response or called next(err).
+      for (const mw of entry.middlewares) {
+        let advanced = false
+        await new Promise<void>((resolve, reject) => {
+          const next = (err?: unknown): void => {
+            advanced = true
+            if (err) reject(err)
+            else resolve()
+          }
+          Promise.resolve(mw(ctx, next)).catch(reject)
+        })
+        if (!advanced || reply.sent) return
+      }
+
+      if (entry.contributorRunner) await entry.contributorRunner(ctx)
+      if (reply.sent) return
+      await entry.handler(ctx)
+    })
   }
 }
 


### PR DESCRIPTION
Closes the highest-value Fastify gap from #384: request-scoped contributors and `ctx.set`/`ctx.get`.

## Problem
Fastify runs the route handler outside the connect-middleware chain, so the `requestScopeMiddleware` ALS frame — which Express keeps active into the handler via its synchronous chain — wasn't established when the Fastify handler ran. Context decorators and `ctx.set`/`get` silently failed under Fastify.

## Fix
The Fastify route handler opens the ALS frame itself (`requestStore.run`) around the pipeline, reusing the inbound `x-request-id` when present. Extracts a shared `createRequestStore` helper used by both the Express middleware and the Fastify runtime.

## Tests
Conformance suite now runs a context contributor (`ctx.get`) under **both** Express and Fastify — green. kickjs 564, testing unaffected.

## Remaining Fastify follow-ups
`@fastify/multipart` uploads, SSE conformance, validation path, the `kick/runtime` typegen plugin, widening `ApplicationOptions.runtime` to generic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Request-scoped context and contributors now work correctly under Fastify runtime
  * Incoming request IDs are properly preserved across requests

* **Tests**
  * Added conformance tests validating context behavior across Express and Fastify runtimes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->