### PR TITLE
feat: error/404 + SSE under the Fastify runtime (M3c-4)

### DIFF
--- a/.changeset/http-fastify-errors-sse-m3c4.md
+++ b/.changeset/http-fastify-errors-sse-m3c4.md
@@ -1,0 +1,10 @@
+---
+'@forinda/kickjs': patch
+---
+
+Error handling, 404s, and Server-Sent Events now work under the Fastify runtime.
+
+- **Errors / 404**: the Fastify runtime passed the raw node response to the connect-style `errorHandler` / `notFoundHandler`, whose `res.status().json()` calls failed on it. They now receive the `RuntimeResponse` reply driver, so thrown errors map to the proper 500 / problem response and unmatched routes return the standard 404 — same shape as Express.
+- **SSE / `ctx.signal`**: `ctx.sse()` and `ctx.signal` register `req.on('close')` / `req.once('close')`, which Fastify's request object doesn't expose. The runtime now hands `ctx` the raw node request (which has the stream events) with Fastify's parsed `body` / `params` / `query` copied onto it, so streaming and request accessors both work.
+
+The conformance suite now runs error, 404, and SSE cases under **both** Express and Fastify (14 cases total).

--- a/packages/kickjs/__tests__/fastify-conformance.test.ts
+++ b/packages/kickjs/__tests__/fastify-conformance.test.ts
@@ -115,5 +115,62 @@ for (const rt of RUNTIMES) {
       const res = await request(app.handle.bind(app)).get('/api/v1/c/who').expect(200)
       expect(res.body).toEqual({ who: 'ada' })
     })
+
+    it('maps a thrown error to a 500 through the error handler', async () => {
+      @Controller()
+      class C {
+        @Get('/boom')
+        boom() {
+          throw new Error('kaboom')
+        }
+      }
+      const app = new Application({
+        runtime: rt.make() as never,
+        modules: [{ routes: () => ({ path: '/e', controller: C }) } as never],
+      })
+      await app.setup()
+
+      const res = await request(app.handle.bind(app)).get('/api/v1/e/boom').expect(500)
+      expect(res.body).toEqual({ message: 'Internal Server Error' })
+    })
+
+    it('returns 404 for an unmatched route', async () => {
+      @Controller()
+      class C {
+        @Get('/here')
+        here(ctx: RequestContext) {
+          ctx.json({ ok: true })
+        }
+      }
+      const app = new Application({
+        runtime: rt.make() as never,
+        modules: [{ routes: () => ({ path: '/nf', controller: C }) } as never],
+      })
+      await app.setup()
+
+      await request(app.handle.bind(app)).get('/api/v1/nf/nope').expect(404)
+    })
+
+    it('streams Server-Sent Events through the response driver', async () => {
+      @Controller()
+      class C {
+        @Get('/events')
+        events(ctx: RequestContext) {
+          const sse = ctx.sse()
+          sse.send({ tick: 1 }, 'tick')
+          sse.close()
+        }
+      }
+      const app = new Application({
+        runtime: rt.make() as never,
+        modules: [{ routes: () => ({ path: '/s', controller: C }) } as never],
+      })
+      await app.setup()
+
+      const res = await request(app.handle.bind(app)).get('/api/v1/s/events').expect(200)
+      expect(res.headers['content-type']).toMatch(/text\/event-stream/)
+      expect(res.text).toContain('event: tick')
+      expect(res.text).toContain('"tick":1')
+    })
   })
 }

--- a/packages/kickjs/src/http/runtimes/fastify.ts
+++ b/packages/kickjs/src/http/runtimes/fastify.ts
@@ -51,6 +51,9 @@ interface FastifyReplyLike {
 }
 interface FastifyRequestLike {
   raw: IncomingMessage
+  body?: unknown
+  params?: unknown
+  query?: unknown
 }
 type FastifyHandler = (request: FastifyRequestLike, reply: FastifyReplyLike) => void | Promise<void>
 interface FastifyAppLike {
@@ -134,7 +137,20 @@ function routeHandler(entry: RouteEntry): FastifyHandler {
     // ctx.set/get work. Reuse the inbound x-request-id, or the id a connect
     // middleware (requestId / requestScope, run earlier via middie) already
     // stamped on the raw request, before generating a fresh one.
-    const raw = request.raw as IncomingMessage & { requestId?: string }
+    // Use the raw node request as `ctx.req`: it natively provides the stream
+    // events (`on('close')` / `once`) that SSE and `ctx.signal` need — Fastify's
+    // request object doesn't. Copy Fastify's parsed body/params/query onto it so
+    // `ctx.body` / `ctx.params` / `ctx.query` keep working.
+    const raw = request.raw as IncomingMessage & {
+      requestId?: string
+      body?: unknown
+      params?: unknown
+      query?: unknown
+    }
+    raw.body = request.body
+    raw.params = request.params
+    raw.query = request.query
+
     const headerId = raw.headers['x-request-id']
     const requestId = (Array.isArray(headerId) ? headerId[0] : headerId) || raw.requestId
     const store = createRequestStore(requestId)
@@ -144,12 +160,7 @@ function routeHandler(entry: RouteEntry): FastifyHandler {
     raw.requestId = store.requestId
 
     await requestStore.run(store, async () => {
-      const ctx = new RequestContext(
-        request as never,
-        reply as never,
-        NOOP_NEXT,
-        replyDriver(reply),
-      )
+      const ctx = new RequestContext(raw as never, reply as never, NOOP_NEXT, replyDriver(reply))
 
       // Class + method middleware — `(ctx, next)`; await each, stop if it ended
       // the response or called next(err).
@@ -258,9 +269,11 @@ export function fastifyRuntime(): HttpRuntime<FastifyAppLike> {
           next()
           return
         }
+        // Pass the reply DRIVER (not raw res) so the connect-style
+        // notFoundHandler's `res.status().json()` lands on the Fastify reply.
         ;(mw as (req: unknown, res: unknown, next: () => void) => void)(
           request.raw,
-          reply.raw,
+          replyDriver(reply),
           NOOP_NEXT,
         )
       })
@@ -268,10 +281,12 @@ export function fastifyRuntime(): HttpRuntime<FastifyAppLike> {
 
     setErrorHandler(app, mw: ConnectMiddleware) {
       app.setErrorHandler((err, request, reply) => {
+        // Reply driver (not raw res) so the connect-style errorHandler's
+        // `res.status().json()` / `setHeader` land on the Fastify reply.
         ;(mw as (e: unknown, req: unknown, res: unknown, next: () => void) => void)(
           err,
           request.raw,
-          reply.raw,
+          replyDriver(reply),
           NOOP_NEXT,
         )
       })


### PR DESCRIPTION
Hardens the Fastify runtime (#384/#385) — error handling, 404s, and SSE now work.

## Fixes
- **Errors / 404**: `setErrorHandler` / `setNotFound` passed the **raw node response** to the connect-style `errorHandler` / `notFoundHandler`, whose `res.status().json()` failed on it. They now get the `RuntimeResponse` reply driver → proper 500 / 404, same shape as Express.
- **SSE / `ctx.signal`**: `ctx.sse()` registers `req.on('close')`, which Fastify's request object doesn't expose. The route handler now hands `ctx` the **raw node request** (has the stream events) with Fastify's parsed `body`/`params`/`query` copied onto it.

## Tests
Conformance suite now runs error → 500, 404, and SSE under **both** Express and Fastify — 14 cases. kickjs 570 green.

## Remaining Fastify follow-ups
`@fastify/multipart` uploads, validation path, the `kick/runtime` typegen plugin (for cast-free `runtime: fastifyRuntime()`), widening `ApplicationOptions.runtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)