### PR TITLE
feat: accept any HttpRuntime in ApplicationOptions.runtime (M3c-5)

### DIFF
--- a/.changeset/http-runtime-widen-option.md
+++ b/.changeset/http-runtime-widen-option.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs': patch
+---
+
+`ApplicationOptions.runtime` now accepts any `HttpRuntime`, so `bootstrap({ runtime: fastifyRuntime() })` typechecks without a cast. It was previously typed `HttpRuntime<Express>`, which forced a `as never` / `as any` when passing a non-Express runtime. The engine-native escape hatches (`getRuntimeApp()`, `AdapterContext.app`) continue to follow the active runtime via the `ActiveRuntime` registry (Express by default). Behavior is unchanged.

--- a/packages/kickjs/__tests__/fastify-conformance.test.ts
+++ b/packages/kickjs/__tests__/fastify-conformance.test.ts
@@ -39,7 +39,7 @@ for (const rt of RUNTIMES) {
       const app = new Application({
         // runtime option is HttpRuntime<Express> until it widens with the driver
         // layer; the fastify runtime is sound here (cast at the call site).
-        runtime: rt.make() as never,
+        runtime: rt.make(),
         apiPrefix: '/api',
         defaultVersion: 1,
         modules: [{ routes: () => ({ path: '/p', controller: PingController }) } as never],
@@ -59,7 +59,7 @@ for (const rt of RUNTIMES) {
         }
       }
       const app = new Application({
-        runtime: rt.make() as never,
+        runtime: rt.make(),
         modules: [{ routes: () => ({ path: '/h', controller: HtmlController }) } as never],
       })
       await app.setup()
@@ -78,7 +78,7 @@ for (const rt of RUNTIMES) {
         }
       }
       const app = new Application({
-        runtime: rt.make() as never,
+        runtime: rt.make(),
         middlewares: [
           (_req: never, res: { setHeader: (n: string, v: string) => void }, next: () => void) => {
             res.setHeader('x-conformance', rt.name)
@@ -105,7 +105,7 @@ for (const rt of RUNTIMES) {
         }
       }
       const app = new Application({
-        runtime: rt.make() as never,
+        runtime: rt.make(),
         apiPrefix: '/api',
         defaultVersion: 1,
         modules: [{ routes: () => ({ path: '/c', controller: C }) } as never],
@@ -125,7 +125,7 @@ for (const rt of RUNTIMES) {
         }
       }
       const app = new Application({
-        runtime: rt.make() as never,
+        runtime: rt.make(),
         modules: [{ routes: () => ({ path: '/e', controller: C }) } as never],
       })
       await app.setup()
@@ -143,7 +143,7 @@ for (const rt of RUNTIMES) {
         }
       }
       const app = new Application({
-        runtime: rt.make() as never,
+        runtime: rt.make(),
         modules: [{ routes: () => ({ path: '/nf', controller: C }) } as never],
       })
       await app.setup()
@@ -162,7 +162,7 @@ for (const rt of RUNTIMES) {
         }
       }
       const app = new Application({
-        runtime: rt.make() as never,
+        runtime: rt.make(),
         modules: [{ routes: () => ({ path: '/s', controller: C }) } as never],
       })
       await app.setup()

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -184,15 +184,14 @@ export interface ApplicationOptions {
    * The HTTP engine driver. Defaults to {@link expressRuntime} — Express stays
    * the zero-config default, so existing apps are unaffected.
    *
-   * Typed `HttpRuntime<Express>` for now: all routing, middleware, and the
-   * hardened defaults (`x-powered-by` / `trust proxy`) and `/health/*` routes
-   * now go through the runtime, but the engine-native escape hatches
-   * (`getRuntimeApp()` / `getExpressApp()`, `AdapterContext.app`) are still
-   * typed `Express`. This widens to a generic `HttpRuntime` once `app` becomes
-   * runtime-typed (registry augmentation, spec §4.3b) — which lands with the
-   * Fastify / h3 subpaths. Until then, only an Express-typed runtime is sound.
+   * Any `HttpRuntime` is accepted — pass `fastifyRuntime()` (from
+   * `@forinda/kickjs/fastify`) or a custom engine driver. Defaults to
+   * {@link expressRuntime}. The engine-native escape hatches
+   * (`getRuntimeApp()`, `AdapterContext.app`) follow the active runtime via the
+   * registry (`ActiveRuntime`, spec §4.3b) — Express by default, or the augmented
+   * engine once the `kick/runtime` typegen output is present.
    */
-  runtime?: HttpRuntime<Express>
+  runtime?: HttpRuntime
 
   /** Express `trust proxy` setting */
   trustProxy?: boolean | number | string | ((ip: string, hopIndex: number) => boolean)
@@ -302,7 +301,7 @@ export interface ApplicationOptions {
 export class Application {
   private app: Express
   /** The HTTP engine driver. Defaults to {@link expressRuntime}. */
-  private readonly runtime: HttpRuntime<Express>
+  private readonly runtime: HttpRuntime
   private container: Container
   private httpServer: http.Server | null = null
   private readonly adapters: AppAdapter[]
@@ -337,7 +336,10 @@ export class Application {
 
   constructor(private readonly options: ApplicationOptions) {
     this.runtime = options.runtime ?? expressRuntime()
-    this.app = this.runtime.createApp({ trustProxy: options.trustProxy })
+    // `this.app` is the engine-native app; typed Express here (the default) for
+    // the legacy escape hatches. Under another runtime it holds that engine's
+    // app — `getRuntimeApp()` / `AdapterContext.app` expose it via ActiveRuntime.
+    this.app = this.runtime.createApp({ trustProxy: options.trustProxy }) as Express
     this.container = Container.getInstance()
 
     // Sort plugins by `dependsOn` declarations BEFORE reading their adapters/etc.
@@ -894,7 +896,7 @@ export class Application {
     try {
       Container.reset()
       this.container = Container.getInstance()
-      this.app = this.runtime.createApp({ trustProxy: this.options.trustProxy })
+      this.app = this.runtime.createApp({ trustProxy: this.options.trustProxy }) as Express
       await this.setup()
     } catch (err) {
       log.error(err, 'HMR rebuild failed, keeping previous app')


### PR DESCRIPTION
Removes the cast adopters needed to use the Fastify runtime.

## Before
```ts
bootstrap({ runtime: fastifyRuntime() as never })  // cast required
```

## After
```ts
bootstrap({ runtime: fastifyRuntime() })  // typechecks
```

`ApplicationOptions.runtime` was `HttpRuntime<Express>`; widened to `HttpRuntime`. The `HttpRuntime` methods are declared as methods (bivariant params), so a concrete `HttpRuntime<FastifyAppLike>` assigns cleanly. `this.app` stays Express-typed for the legacy escape hatches (one cast at `createApp`); `getRuntimeApp()` / `AdapterContext.app` follow `ActiveRuntime`.

Behavior unchanged: kickjs 570, whole monorepo typechecks. Conformance suite drops its `as never` runtime casts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)