### PR TITLE
docs: HTTP Runtimes guide (Express / Fastify)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -23,6 +23,7 @@ const guideSidebar = [
       { text: 'Controllers & Routes', link: '/guide/controllers' },
       { text: 'Type Generation', link: '/guide/typegen' },
       { text: 'Middleware', link: '/guide/middleware' },
+      { text: 'HTTP Runtimes (Express / Fastify)', link: '/guide/http-runtimes' },
       { text: 'Context Decorators', link: '/guide/context-decorators' },
       { text: 'Validation', link: '/guide/validation' },
       { text: 'Schema (Zod / Valibot / Yup)', link: '/guide/schema' },

--- a/docs/guide/http-runtimes.md
+++ b/docs/guide/http-runtimes.md
@@ -1,0 +1,100 @@
+# HTTP Runtimes
+
+KickJS runs on **Express by default**, but the HTTP engine is a bootstrap-time
+choice. Controllers, modules, context decorators, DI, and the dev loop don't
+change when you swap engines — the runtime is an infrastructure decision, not an
+application rewrite.
+
+```ts
+import { bootstrap } from '@forinda/kickjs'
+
+// Express — the zero-config default. Nothing to install or configure.
+export const app = await bootstrap({ modules })
+```
+
+```ts
+import { bootstrap } from '@forinda/kickjs'
+import { fastifyRuntime } from '@forinda/kickjs/fastify'
+
+// Opt in to Fastify — same modules, same controllers.
+export const app = await bootstrap({ modules, runtime: fastifyRuntime() })
+```
+
+## Why it works
+
+Your controllers already speak `RequestContext`, not Express:
+
+```ts
+@Controller()
+class UsersController {
+  @Get('/:id')
+  get(ctx: RequestContext) {
+    ctx.json({ id: ctx.params.id }) // engine-agnostic — works on any runtime
+  }
+}
+```
+
+KickJS turns decorators into an engine-neutral **route table**, and each runtime
+materializes that table onto its own router (real Express routes, real Fastify
+routes). `ctx.json` / `ctx.html` / `ctx.sse` / `ctx.problem` write through a
+small response driver, so the same handler code runs unchanged on every engine.
+
+## Fastify
+
+Fastify ships as a **subpath** of the core package — there's no separate npm
+package. Install the engine peers alongside `@forinda/kickjs`:
+
+```bash
+pnpm add fastify @fastify/middie
+```
+
+```ts
+import { fastifyRuntime } from '@forinda/kickjs/fastify'
+
+export const app = await bootstrap({ modules, runtime: fastifyRuntime() })
+```
+
+What works on Fastify today: routing, JSON / HTML / `ctx.problem` responses,
+connect-style middleware (the built-ins — `helmet`, `cors`, `requestId`,
+`requestLogger`, … — plus your own, bridged via `@fastify/middie`),
+request-scoped DI and context decorators (`ctx.set` / `ctx.get`), `X-Request-Id`
+propagation, error / 404 handling, and Server-Sent Events (`ctx.sse`).
+
+Fastify's built-in pino logger is disabled (`logger: false`) so the kickjs
+`requestLogger` stays the single log format across engines.
+
+## Capability matrix
+
+Some `ctx` features depend on the engine. Calling an unsupported one raises a
+clear error rather than failing silently.
+
+| Capability                | Express | Fastify             |
+| ------------------------- | ------- | ------------------- |
+| Routing + `ctx.json`      | ✅      | ✅                  |
+| Connect middleware        | ✅      | ✅ (via middie)     |
+| Context decorators        | ✅      | ✅                  |
+| Errors / 404              | ✅      | ✅                  |
+| Server-Sent Events        | ✅      | ✅                  |
+| `ctx.render` (views)      | ✅      | ❌ (no view engine) |
+| File uploads (`ctx.file`) | ✅      | ⏳ (planned)        |
+
+## The engine-native escape hatch
+
+For genuinely engine-specific needs, the raw app and request/response are still
+reachable:
+
+- `AdapterContext.app` / `app.getRuntimeApp()` — the engine-native app instance.
+- `ctx.req` / `ctx.res` — the engine-native request / response.
+
+Under the default Express runtime these are typed as Express's `Application`,
+`Request`, and `Response`. The types follow the active runtime via the
+`ActiveRuntime` registry, so a future `kick/runtime` typegen step can retype them
+to Fastify's `FastifyInstance` / `FastifyRequest` / `FastifyReply`.
+
+## Writing a custom runtime
+
+A runtime implements the `HttpRuntime` contract (`createApp`, `nodeHandler`,
+`mountRoutes`, `useConnect`, `serveStatic`, `setNotFound`, `setErrorHandler`,
+`capabilities`). `expressRuntime()` is the reference implementation; the Fastify
+runtime is ~250 lines over the same contract. See the
+[design spec](../http/spec-http-runtimes.md) for the full contract and rationale.

--- a/docs/http/spec-http-runtimes.md
+++ b/docs/http/spec-http-runtimes.md
@@ -1,6 +1,11 @@
 # Spec: Pluggable HTTP Runtimes (Express / Fastify / h3)
 
-> Status: **DRAFT — design spec, no implementation yet.**
+> Status: **IMPLEMENTED (M1–M3).** The `HttpRuntime` seam, the engine-neutral
+> `RouteTable` + `RequestContext` response driver, the runtime-typed registry,
+> and the `@forinda/kickjs/fastify` runtime have shipped. Adopter usage lives in
+> the [HTTP Runtimes guide](../guide/http-runtimes.md); this file is kept as the
+> design record. Remaining niceties: `@fastify/multipart` uploads, the
+> `kick/runtime` typegen plugin, and the h3 runtime (M4).
 > Mirrors the `docs/db/` spec convention. Companion inventory: the
 > coupling audit summarized in §2 (31 core coupling points + per-package
 > downstream matrix, file:line refs in §2.3/§2.4).


### PR DESCRIPTION
Documents the now-shipped multi-engine support (M1–M3, PRs #370–387).

## Adds
- `docs/guide/http-runtimes.md` — pick the engine at bootstrap, the `@forinda/kickjs/fastify` subpath + peers, the capability matrix (routing / middleware / contributors / errors / SSE work on Fastify; `ctx.render` and uploads don't yet), engine-native escape hatches, and a pointer to the design spec.
- Sidebar entry under Core Concepts.

## Updates
- Flips `docs/http/spec-http-runtimes.md` status from "DRAFT — no implementation yet" to "IMPLEMENTED (M1–M3)".

Docs only — no changeset. Internal links relative per convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)