### PR TITLE
feat: validation + native body parsing under Fastify (M3c-6)

### DIFF
--- a/.changeset/http-fastify-validation-m3c6.md
+++ b/.changeset/http-fastify-validation-m3c6.md
@@ -1,0 +1,11 @@
+---
+'@forinda/kickjs': patch
+---
+
+Validation and request-body parsing now work under the Fastify runtime.
+
+- **Validation**: the Fastify route handler now runs the route's `@Get(path, schema)` / `route.validation` schema (it previously skipped it, so validated routes weren't actually validated on Fastify). `validate` is a connect-style middleware that parses `req.body` / `query` / `params` and rejects via `next(err)` → a 422 through the error handler — same as Express.
+- **Body parsing**: a new `nativeBodyParsing` runtime capability. Fastify parses bodies itself, so the Application now skips its default `express.json()` on Fastify — previously both ran, the body stream was read twice, and the request hung. Express keeps `express.json()` (capability is `false`).
+- **Root paths**: a controller `@Post('/')` now mounts at the module prefix itself on Fastify (not `${prefix}/`), so requests without a trailing slash match.
+
+Conformance suite now covers body validation (valid → parsed, invalid → rejected) under both Express and Fastify. kickjs 572 green.

--- a/packages/kickjs/__tests__/fastify-conformance.test.ts
+++ b/packages/kickjs/__tests__/fastify-conformance.test.ts
@@ -1,11 +1,13 @@
 import 'reflect-metadata'
 import { describe, it, expect, beforeEach } from 'vitest'
 import request from 'supertest'
+import { z } from 'zod'
 import {
   Application,
   Container,
   Controller,
   Get,
+  Post,
   RequestContext,
   defineContextDecorator,
   expressRuntime,
@@ -171,6 +173,32 @@ for (const rt of RUNTIMES) {
       expect(res.headers['content-type']).toMatch(/text\/event-stream/)
       expect(res.text).toContain('event: tick')
       expect(res.text).toContain('"tick":1')
+    })
+
+    it('validates the request body and rejects invalid input', async () => {
+      const schema = z.object({ title: z.string().min(1) })
+
+      @Controller()
+      class C {
+        @Post('/', { body: schema })
+        create(ctx: RequestContext) {
+          ctx.created({ title: (ctx.body as { title: string }).title })
+        }
+      }
+      const app = new Application({
+        runtime: rt.make(),
+        modules: [{ routes: () => ({ path: '/v', controller: C }) } as never],
+      })
+      await app.setup()
+      const handler = app.handle.bind(app)
+
+      // Valid body → 201 with parsed data.
+      const ok = await request(handler).post('/api/v1/v').send({ title: 'hi' }).expect(201)
+      expect(ok.body).toEqual({ title: 'hi' })
+
+      // Invalid body → rejected by validation (not 2xx).
+      const bad = await request(handler).post('/api/v1/v').send({ title: '' })
+      expect(bad.status).toBeGreaterThanOrEqual(400)
     })
   })
 }

--- a/packages/kickjs/__tests__/http-runtime-seam.test.ts
+++ b/packages/kickjs/__tests__/http-runtime-seam.test.ts
@@ -83,7 +83,12 @@ describe('expressRuntime', () => {
   it('reports Express capabilities', () => {
     const rt = expressRuntime()
     expect(rt.name).toBe('express')
-    expect(rt.capabilities).toEqual({ render: true, uploads: true, connectMiddleware: true })
+    expect(rt.capabilities).toEqual({
+      render: true,
+      uploads: true,
+      connectMiddleware: true,
+      nativeBodyParsing: false,
+    })
   })
 
   it('mountRoutes serves a RouteTable end-to-end', async () => {

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -564,7 +564,11 @@ export class Application {
     } else {
       // Sensible defaults when no middleware declared
       this.runtime.useConnect(this.app, requestId())
-      this.runtime.useConnect(this.app, express.json({ limit: this.options.jsonLimit ?? '1mb' }))
+      // Skip express.json on engines that parse bodies natively (Fastify, h3) —
+      // otherwise the body stream is read twice and the engine's parser hangs.
+      if (!this.runtime.capabilities.nativeBodyParsing) {
+        this.runtime.useConnect(this.app, express.json({ limit: this.options.jsonLimit ?? '1mb' }))
+      }
     }
 
     // ── 5. Adapter middleware: afterGlobal ────────────────────────────

--- a/packages/kickjs/src/http/runtime.ts
+++ b/packages/kickjs/src/http/runtime.ts
@@ -194,6 +194,13 @@ export interface RuntimeCapabilities {
   uploads: boolean
   /** Connect-style middleware. Express/Fastify(middie): true; h3: best-effort. */
   connectMiddleware: boolean
+  /**
+   * The engine parses request bodies itself (Fastify, h3). When true, the
+   * Application skips its default `express.json()` so the body stream isn't
+   * consumed twice (which would deadlock the engine's own parser). Express:
+   * false — it relies on the `express.json()` connect middleware.
+   */
+  nativeBodyParsing: boolean
 }
 
 /**

--- a/packages/kickjs/src/http/runtimes/express.ts
+++ b/packages/kickjs/src/http/runtimes/express.ts
@@ -158,6 +158,7 @@ export function expressRuntime(): HttpRuntime<Express> {
       render: true,
       uploads: true,
       connectMiddleware: true,
+      nativeBodyParsing: false,
     },
   }
 }

--- a/packages/kickjs/src/http/runtimes/fastify.ts
+++ b/packages/kickjs/src/http/runtimes/fastify.ts
@@ -20,6 +20,7 @@ import { createRequire } from 'node:module'
 import { RequestContext } from '../context'
 import { requestStore } from '../request-store'
 import { createRequestStore } from '../middleware/request-scope'
+import { validate } from '../middleware/validate'
 import type {
   ConnectMiddleware,
   HttpRuntime,
@@ -162,6 +163,17 @@ function routeHandler(entry: RouteEntry): FastifyHandler {
     await requestStore.run(store, async () => {
       const ctx = new RequestContext(raw as never, reply as never, NOOP_NEXT, replyDriver(reply))
 
+      // Validation (from @Get(path, schema) / route.validation). `validate` is a
+      // connect-style middleware that mutates req.body/query/params to the parsed
+      // value and calls next(err) on failure — it never touches `res`, so it runs
+      // cleanly here. A rejection propagates to the error handler (422).
+      if (entry.meta.validation) {
+        const v = validate(entry.meta.validation)
+        await new Promise<void>((resolve, reject) => {
+          v(raw as never, undefined as never, (err?: unknown) => (err ? reject(err) : resolve()))
+        })
+      }
+
       // Class + method middleware — `(ctx, next)`; await each, stop if it ended
       // the response or called next(err).
       for (const mw of entry.middlewares) {
@@ -296,6 +308,7 @@ export function fastifyRuntime(): HttpRuntime<FastifyAppLike> {
       render: false,
       uploads: false,
       connectMiddleware: true,
+      nativeBodyParsing: true,
     },
   }
 }
@@ -303,7 +316,10 @@ export function fastifyRuntime(): HttpRuntime<FastifyAppLike> {
 /** Join a mount prefix and a route path into one URL, collapsing slashes. */
 function joinPath(mountPath: string, path: string): string {
   const a = mountPath.endsWith('/') ? mountPath.slice(0, -1) : mountPath
+  // A root route path ('/' or '') maps to the mount prefix itself — otherwise a
+  // controller `@Post('/')` would register at `${prefix}/`, and a request to
+  // `${prefix}` (no trailing slash) wouldn't match under Fastify's strict router.
+  if (path === '/' || path === '') return a === '' ? '/' : a
   const b = path.startsWith('/') ? path : `/${path}`
-  const joined = `${a}${b}`
-  return joined === '' ? '/' : joined
+  return `${a}${b}`
 }


### PR DESCRIPTION
Three Fastify correctness fixes surfaced by adding a POST + validation conformance case.

## Fixes
- **Validation was skipped**: the Fastify route handler ran middlewares / contributors / handler but **not** the route's validation schema — so `@Post('/', { body })` routes weren't validated on Fastify. Now runs `validate` (rejects → 422 via the error handler), same as Express.
- **Body parsed twice → deadlock**: `express.json` (default, via middie) consumed the body stream, then Fastify's native parser waited on the consumed stream and hung. New `nativeBodyParsing` capability — Application skips its default `express.json()` on engines that parse natively (Fastify). Express keeps it.
- **Root path mismatch**: `@Post('/')` mapped to `${prefix}/` on Fastify; a request without the trailing slash didn't match the strict router. Now maps to the prefix itself.

## Tests
Conformance covers body validation (valid → 201 parsed, invalid → 4xx) under **both** engines. kickjs 572, testing unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request body validation support for Fastify runtime.
  * Implemented native body parsing detection to prevent duplicate parsing.

* **Bug Fixes**
  * Fixed Fastify route mounting to correctly attach at module prefix paths.
  * Resolved body parsing conflicts between Express and Fastify runtimes.

* **Tests**
  * Expanded conformance test suite with request body validation coverage for both runtimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->