### PR TITLE
feat(cli): kick new --runtime express|fastify|h3 (M5)

### DIFF
--- a/.changeset/cli-runtime-flag.md
+++ b/.changeset/cli-runtime-flag.md
@@ -1,0 +1,11 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+`kick new` now scaffolds the HTTP runtime explicitly. A new `--runtime express|fastify|h3` flag (and interactive prompt, default `express`) controls:
+
+- the generated `src/index.ts` — `bootstrap({ runtime: expressRuntime() })` / `fastifyRuntime()` / `h3Runtime()`, imported from the core package (Express) or the `@forinda/kickjs/fastify` / `@forinda/kickjs/h3` subpath;
+- the installed engine peers — Fastify adds `fastify` + `@fastify/middie`, h3 adds `h3` (Express needs nothing extra);
+- the REST template's middleware — `express.json()` is only emitted for Express, since Fastify and h3 parse bodies natively (adding it would consume the body stream twice).
+
+Making the runtime explicit means switching engines later is a one-line edit, and the scaffold installs exactly the deps the chosen engine needs.

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -28,6 +28,7 @@ export function registerInitCommand(program: Command): void {
     .option('--no-install', 'Skip dependency installation')
     .option('-f, --force', 'Remove existing files without prompting')
     .option('-t, --template <type>', 'Project template: rest | minimal')
+    .option('--runtime <engine>', 'HTTP runtime: express | fastify | h3')
     .option('-r, --repo <type>', 'Repository name (inmemory, or any DB name e.g. postgres)')
     .option(
       '-s, --schema <lib>',
@@ -120,6 +121,23 @@ export function registerInitCommand(program: Command): void {
             options: [
               { value: 'rest', label: 'REST API', hint: 'Express + Swagger' },
               { value: 'minimal', label: 'Minimal', hint: 'bare Express' },
+            ],
+          })
+        }
+      }
+
+      // ── HTTP runtime ──────────────────────────────────────────────
+      let runtime = opts.runtime
+      if (!runtime) {
+        if (yes) {
+          runtime = 'express'
+        } else {
+          runtime = await select({
+            message: 'HTTP runtime',
+            options: [
+              { value: 'express', label: 'Express', hint: 'default, zero-config' },
+              { value: 'fastify', label: 'Fastify', hint: 'fastify + @fastify/middie' },
+              { value: 'h3', label: 'h3', hint: 'Nitro / Nuxt engine' },
             ],
           })
         }
@@ -250,6 +268,7 @@ export function registerInitCommand(program: Command): void {
         defaultRepo,
         packages: selectedPackages,
         schemaLib,
+        runtime,
       })
 
       outro(`Done! Next steps: ${colors.cyan(`cd ${name} && ${packageManager} dev`)}`)

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -99,6 +99,8 @@ interface InitProjectOptions {
   packages?: string[]
   /** Schema library to scaffold env / DTOs with. Defaults to `zod`. */
   schemaLib?: SchemaLib
+  /** HTTP engine to scaffold. Defaults to `express`. */
+  runtime?: 'express' | 'fastify' | 'h3'
 }
 
 /** Scaffold a new KickJS project */
@@ -111,6 +113,7 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
     defaultRepo = 'inmemory',
     packages = [],
     schemaLib = 'zod',
+    runtime = 'express',
   } = options
   const dir = directory
 
@@ -131,7 +134,7 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
   // ── package.json — template-aware deps ────────────────────────────
   await writeFileSafe(
     join(dir, 'package.json'),
-    generatePackageJson(name, template, versions, packages, schemaLib),
+    generatePackageJson(name, template, versions, packages, schemaLib, runtime),
   )
 
   // ── vite.config.ts — enables HMR + SWC for decorators ──────────────
@@ -166,7 +169,7 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
   // ── src/index.ts — template-aware entry point ─────────────────────
   await writeFileSafe(
     join(dir, 'src/index.ts'),
-    generateEntryFile(name, template, cliPkg.version, packages),
+    generateEntryFile(name, template, cliPkg.version, packages, runtime),
   )
 
   // ── src/modules/index.ts ────────────────────────────────────────────

--- a/packages/cli/src/generators/templates/project-app.ts
+++ b/packages/cli/src/generators/templates/project-app.ts
@@ -1,22 +1,43 @@
 type ProjectTemplate = 'rest' | 'minimal'
+export type ProjectRuntime = 'express' | 'fastify' | 'h3'
+
+/** Per-runtime import source + factory name for the scaffolded `runtime:` option. */
+const RUNTIME_FACTORY: Record<ProjectRuntime, { from: string; name: string }> = {
+  express: { from: '@forinda/kickjs', name: 'expressRuntime' },
+  fastify: { from: '@forinda/kickjs/fastify', name: 'fastifyRuntime' },
+  h3: { from: '@forinda/kickjs/h3', name: 'h3Runtime' },
+}
 
 /**
  * Generate src/index.ts entry file with template-specific bootstrap.
  *
+ * The runtime is always emitted explicitly (`runtime: expressRuntime()` etc.)
+ * so the entry file is self-documenting and switching engines is a one-line
+ * edit. Fastify / h3 parse bodies natively, so the REST template skips the
+ * `express.json()` middleware (and the `express` import) under those engines.
+ *
  * All templates export the app for the Vite plugin (dev mode).
- * In production, bootstrap() auto-starts the HTTP server when
- * `globalThis.__kickjs_httpServer` is not set.
  */
 export function generateEntryFile(
   name: string,
   template: ProjectTemplate,
   version: string,
   packages: string[] = [],
+  runtime: ProjectRuntime = 'express',
 ): string {
+  const factory = RUNTIME_FACTORY[runtime]
+  const isExpress = runtime === 'express'
+
   switch (template) {
     case 'minimal': {
       const imports: string[] = []
       const adapters: string[] = []
+
+      // The runtime factory comes from the core package for Express, or a
+      // subpath for Fastify / h3.
+      const kickImport = isExpress
+        ? `import { bootstrap, ${factory.name} } from '@forinda/kickjs'`
+        : `import { bootstrap } from '@forinda/kickjs'\nimport { ${factory.name} } from '${factory.from}'`
 
       if (packages.includes('swagger')) {
         imports.push(`import { SwaggerAdapter } from '@forinda/kickjs-swagger'`)
@@ -35,11 +56,11 @@ export function generateEntryFile(
 // this line ConfigService.get('YOUR_KEY') returns undefined because the
 // cached schema would still be the base shape. See guide/configuration.
 import './config'
-import { bootstrap } from '@forinda/kickjs'
+${kickImport}
 ${importsBlock}import { modules } from './modules'
 
 // Export the app for the Vite plugin (dev mode)
-export const app = await bootstrap({ modules${adaptersBlock} })
+export const app = await bootstrap({ modules, runtime: ${factory.name}()${adaptersBlock} })
 `
     }
 
@@ -64,31 +85,33 @@ export const app = await bootstrap({ modules${adaptersBlock} })
         ? `\n  adapters: [\n${restAdapters.join('\n')}\n  ],`
         : ''
 
+      // Express needs `express.json()` for body parsing; Fastify / h3 parse
+      // bodies natively, so adding it would consume the body stream twice.
+      const kickNamed = ['bootstrap', 'requestId', 'requestLogger', 'helmet', 'cors']
+      if (isExpress) kickNamed.push(factory.name)
+      const kickImport = isExpress
+        ? `import express from 'express'\nimport {\n  ${kickNamed.join(',\n  ')},\n} from '@forinda/kickjs'`
+        : `import {\n  ${kickNamed.join(',\n  ')},\n} from '@forinda/kickjs'\nimport { ${factory.name} } from '${factory.from}'`
+      const bodyParserLine = isExpress ? `\n    express.json(),` : ''
+
       return `import 'reflect-metadata'
 // Side-effect import — registers the extended env schema with kickjs
 // **before** any controller / service / @Value gets resolved. Without
 // this line ConfigService.get('YOUR_KEY') returns undefined because the
 // cached schema would still be the base shape. See guide/configuration.
 import './config'
-import express from 'express'
-import {
-  bootstrap,
-  requestId,
-  requestLogger,
-  helmet,
-  cors,
-} from '@forinda/kickjs'
+${kickImport}
 ${restImportsBlock}import { modules } from './modules'
 
 // Export the app for the Vite plugin (dev mode)
 export const app = await bootstrap({
-  modules,${restAdaptersBlock}
+  modules,
+  runtime: ${factory.name}(),${restAdaptersBlock}
   middleware: [
     helmet(),
     cors({ origin: '*' }),
     requestId(),
-    requestLogger(),
-    express.json(),
+    requestLogger(),${bodyParserLine}
   ],
 })
 `

--- a/packages/cli/src/generators/templates/project-config.ts
+++ b/packages/cli/src/generators/templates/project-config.ts
@@ -52,6 +52,7 @@ export function generatePackageJson(
   versions: SiblingVersions,
   packages: string[] = [],
   schemaLib: SchemaLib = 'zod',
+  runtime: 'express' | 'fastify' | 'h3' = 'express',
 ): string {
   const schemaDep = SCHEMA_LIB_DEPS[schemaLib]
   const baseDeps: Record<string, string> = {
@@ -66,9 +67,19 @@ export function generatePackageJson(
     // get it pre-installed so `.env` files Just Work. Apps that load
     // env from the shell or a secret manager can drop this safely.
     dotenv: '^17.3.1',
+    // `express` stays installed for every runtime: it's the default engine,
+    // and the Fastify / h3 runtimes use `express.static` for `serveStatic`.
     express: '^5.1.0',
     'reflect-metadata': '^0.2.2',
     [schemaDep.name]: schemaDep.range,
+  }
+
+  // Engine peers for the chosen runtime (optional peers of @forinda/kickjs).
+  if (runtime === 'fastify') {
+    baseDeps.fastify = '^5.0.0'
+    baseDeps['@fastify/middie'] = '^9.0.0'
+  } else if (runtime === 'h3') {
+    baseDeps.h3 = '^1.0.0'
   }
 
   // Add user-selected optional packages — each looked up against


### PR DESCRIPTION
`kick new` now scaffolds the HTTP runtime explicitly.

## New `--runtime express|fastify|h3` flag (+ prompt, default express)
Controls:
- **src/index.ts** — `bootstrap({ runtime: expressRuntime() })` / `fastifyRuntime()` / `h3Runtime()`, from the core package (Express) or the `@forinda/kickjs/fastify` / `/h3` subpath.
- **engine peers** — Fastify adds `fastify` + `@fastify/middie`, h3 adds `h3`; Express needs nothing extra (express stays installed for all runtimes — it's the default and Fastify/h3 use `express.static` for `serveStatic`).
- **REST middleware** — `express.json()` only for Express; Fastify/h3 parse bodies natively (emitting it would double-read the stream).

Making the runtime explicit (even for Express) means switching engines is a one-line edit, and the scaffold installs exactly what the chosen engine needs.

cli typecheck + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)