### PR TITLE
docs: multi-engine reframe + release channels + runtimes migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  A production-grade, decorator-driven Node.js framework built on Express 5 and TypeScript.
+  A production-grade, decorator-driven Node.js framework for TypeScript — runs on Express, Fastify, or h3, swap the engine in one line.
 </p>
 
 <p align="center">
@@ -179,11 +179,11 @@ KickJS deliberately ships a small, stable core. The extension surface — `defin
 
 Three packages ship with every project — `kick new` always installs them, and `kick add` won't list them as optional. Together they're the framework runtime + the dev/build/scaffold loop:
 
-| Package                                  | Description                                                                                                         |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| [`@forinda/kickjs`](packages/kickjs/)    | Core framework — DI, decorators, Express 5, routing, middleware, contributors, request store, `processHooks`        |
-| [`@forinda/kickjs-vite`](packages/vite/) | Vite plugin — single-port HMR, typegen watcher, customizable HMR log                                                |
-| [`@forinda/kickjs-cli`](packages/cli/)   | Scaffolding, DDD generators, custom commands, `kick g agents`, jiti-powered TS config loading, walk-up project root |
+| Package                                  | Description                                                                                                                                         |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`@forinda/kickjs`](packages/kickjs/)    | Core framework — DI, decorators, pluggable HTTP runtimes (Express / Fastify / h3), routing, middleware, contributors, request store, `processHooks` |
+| [`@forinda/kickjs-vite`](packages/vite/) | Vite plugin — single-port HMR, typegen watcher, customizable HMR log                                                                                |
+| [`@forinda/kickjs-cli`](packages/cli/)   | Scaffolding, DDD generators, custom commands, `kick g agents`, jiti-powered TS config loading, walk-up project root                                 |
 
 ### Optional packages
 
@@ -242,15 +242,15 @@ kick tinker                          # Interactive REPL with full DI graph
 
 ## Technical Decisions
 
-| Area       | Choice           | Why                                               |
-| ---------- | ---------------- | ------------------------------------------------- |
-| Runtime    | Node.js 20+      | LTS with native ESM                               |
-| HTTP       | Express 5        | Mature, async middleware, wide ecosystem          |
-| Validation | Zod              | Runtime + static types, doubles as OpenAPI schema |
-| Build      | Vite 8           | Unified toolchain — library builds, HMR, SSR      |
-| Test       | Vitest 4         | ESM-native, fast, Vite-compatible                 |
-| Logging    | Pino             | Fastest Node.js logger, structured JSON           |
-| Monorepo   | pnpm + Turborepo | Efficient deps, build caching                     |
+| Area       | Choice                 | Why                                               |
+| ---------- | ---------------------- | ------------------------------------------------- |
+| Runtime    | Node.js 20+            | LTS with native ESM                               |
+| HTTP       | Express / Fastify / h3 | Pluggable runtime — pick the engine at bootstrap  |
+| Validation | Zod                    | Runtime + static types, doubles as OpenAPI schema |
+| Build      | Vite 8                 | Unified toolchain — library builds, HMR, SSR      |
+| Test       | Vitest 4               | ESM-native, fast, Vite-compatible                 |
+| Logging    | Pino                   | Fastest Node.js logger, structured JSON           |
+| Monorepo   | pnpm + Turborepo       | Efficient deps, build caching                     |
 
 ## Runtime Compatibility
 

--- a/README.md
+++ b/README.md
@@ -242,15 +242,15 @@ kick tinker                          # Interactive REPL with full DI graph
 
 ## Technical Decisions
 
-| Area       | Choice                 | Why                                               |
-| ---------- | ---------------------- | ------------------------------------------------- |
-| Runtime    | Node.js 20+            | LTS with native ESM                               |
-| HTTP       | Express / Fastify / h3 | Pluggable runtime — pick the engine at bootstrap  |
-| Validation | Zod                    | Runtime + static types, doubles as OpenAPI schema |
-| Build      | Vite 8                 | Unified toolchain — library builds, HMR, SSR      |
-| Test       | Vitest 4               | ESM-native, fast, Vite-compatible                 |
-| Logging    | Pino                   | Fastest Node.js logger, structured JSON           |
-| Monorepo   | pnpm + Turborepo       | Efficient deps, build caching                     |
+| Area       | Choice                 | Why                                                                  |
+| ---------- | ---------------------- | -------------------------------------------------------------------- |
+| Runtime    | Node.js 20+            | LTS with native ESM                                                  |
+| HTTP       | Express / Fastify / h3 | Pluggable runtime — pick the engine at bootstrap                     |
+| Validation | Zod                    | Runtime + static types, doubles as OpenAPI schema                    |
+| Build      | Vite 8                 | Unified toolchain — library builds, HMR, SSR                         |
+| Test       | Vitest 4               | ESM-native, fast, Vite-compatible                                    |
+| Logging    | console (pluggable)    | Zero-dep default; swap for Pino / Winston via `Logger.setProvider()` |
+| Monorepo   | pnpm + Turborepo       | Efficient deps, build caching                                        |
 
 ## Runtime Compatibility
 
@@ -266,7 +266,7 @@ kick tinker                          # Interactive REPL with full DI graph
 >
 > **Bun**: core DI and decorators work; full HTTP pipeline is experimental.
 >
-> **Deno**: blocked by `reflect-metadata` and `pino` dependencies. Use `Logger.setProvider()` for core-only usage.
+> **Deno**: blocked by `reflect-metadata`. The default logger is `console`-based (zero deps), so logging is not a blocker.
 
 ## Documentation
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -10,6 +10,7 @@ const guideSidebar = [
       { text: 'Getting Started', link: '/guide/getting-started' },
       { text: 'Samples', link: '/guide/samples' },
       { text: 'Migration from Express', link: '/guide/migration-from-express' },
+      { text: 'Pluggable Runtimes (major upgrade)', link: '/guide/migration-runtimes' },
       { text: 'Migrating v3 → v4', link: '/guide/migration-v3-to-v4' },
       { text: 'Project Structure', link: '/guide/project-structure' },
     ],

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -196,7 +196,7 @@ const sharedSidebar = {
 export default defineConfig({
   title: 'KickJS',
   description:
-    'A production-grade, decorator-driven Node.js framework built on Express 5 and TypeScript',
+    'A production-grade, decorator-driven Node.js framework for TypeScript — runs on Express, Fastify, or h3, swap the engine in one line.',
   base: '/kick-js/',
   ignoreDeadLinks: true,
   head: [
@@ -209,7 +209,7 @@ export default defineConfig({
       {
         property: 'og:description',
         content:
-          'Decorator-driven APIs on Express 5. REST, WebSocket, queues, scheduled jobs — pick what you need.',
+          'Decorator-driven APIs that run on Express, Fastify, or h3. REST, WebSocket, queues, scheduled jobs — pick what you need.',
       },
     ],
     ['meta', { property: 'og:url', content: 'https://forinda.github.io/kick-js/' }],
@@ -241,7 +241,7 @@ export default defineConfig({
 
     footer: {
       message:
-        'Released under the <a href="https://github.com/forinda/kick-js/blob/main/LICENSE">MIT License</a>. Built with TypeScript + Express 5.',
+        'Released under the <a href="https://github.com/forinda/kick-js/blob/main/LICENSE">MIT License</a>. Built with TypeScript — runs on Express, Fastify, or h3.',
       copyright: `Copyright &copy; ${new Date().getFullYear()} <a href="https://github.com/forinda">Felix Orinda</a>`,
     },
 

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -450,7 +450,7 @@ type MetaValue<K extends string, Fallback = unknown> = K extends keyof ContextMe
 
 ## Logger
 
-Named logger built on pino with component context.
+Named logger with component context. Console-based by default (zero deps) and pluggable via `Logger.setProvider()`.
 
 ```typescript
 class Logger {
@@ -491,14 +491,15 @@ Logger.resetProvider(): void
 
 - **setProvider** -- Replaces the active logging backend for all loggers. Clears the internal logger cache so subsequent `Logger.for()` calls use the new provider.
 - **getProvider** -- Returns the currently active provider (useful for testing).
-- **resetProvider** -- Reverts to the default pino-based provider. Intended for test teardown.
+- **resetProvider** -- Reverts to the default console-based provider. Intended for test teardown.
 
-**Built-in providers:**
+**Built-in provider:**
 
-| Provider                       | Description                                                           |
-| ------------------------------ | --------------------------------------------------------------------- |
-| `PinoLoggerProvider` (default) | Delegates to the root pino instance with `pino-pretty` in development |
-| `ConsoleLoggerProvider`        | Uses `console.*` methods. Accepts an optional prefix string           |
+| Provider                          | Description                                                            |
+| --------------------------------- | ---------------------------------------------------------------------- |
+| `ConsoleLoggerProvider` (default) | Uses `console.*` methods. Zero deps; accepts an optional prefix string |
+
+Bring your own backend (Pino, Winston, …) by implementing `LoggerProvider` and passing it to `Logger.setProvider()` — see the [Logging guide](../guide/logging.md).
 
 ```typescript
 import { Logger, ConsoleLoggerProvider } from '@forinda/kickjs'
@@ -509,7 +510,7 @@ Logger.setProvider(new ConsoleLoggerProvider())
 const log = Logger.for('MyService')
 log.info('Hello') // Output: [MyService] Hello
 
-// Restore default pino backend (e.g. in afterEach)
+// Restore default console backend (e.g. in afterEach)
 Logger.resetProvider()
 ```
 

--- a/docs/db/architecture.md
+++ b/docs/db/architecture.md
@@ -576,7 +576,7 @@ Internally reads via `getRequestValue('db')`. Never exposes raw store APIs to us
 
 ### Logger integration
 
-`KickDbClient` accepts `log: Logger | { level, logger }`. When omitted, pulls the framework Logger from DI. All query/error events route through the same Pino instance, module name `kickjs-db`.
+`KickDbClient` accepts `log: Logger | { level, logger }`. When omitted, pulls the framework Logger from DI. All query/error events route through the same framework `Logger`, module name `kickjs-db`.
 
 ### CLI generator
 
@@ -639,7 +639,7 @@ Constraint errors expose structured detail (`constraint`, `table`, `columns`, `d
 
 ### Logging
 
-Three topics through Pino, module `kickjs-db`:
+Three topics through the framework `Logger`, module `kickjs-db`:
 
 - `query` — `{ sql, parameters, ms, rowCount }`, `debug`, off in prod by default.
 - `migration` — `{ id, direction, ms }`, `info`.

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -1,6 +1,6 @@
 # Error Handling
 
-KickJS provides a structured error-handling pipeline built on the `HttpException` class and a global error handler middleware. Errors are logged through Pino and serialized into consistent JSON responses.
+KickJS provides a structured error-handling pipeline built on the `HttpException` class and a global error handler middleware. Errors are logged through the framework `Logger` and serialized into consistent JSON responses.
 
 ## HttpException
 
@@ -67,7 +67,7 @@ Any error with `name === 'ZodError'` is caught and returned as a **422** respons
 
 ### 2. HttpException Instances
 
-The handler reads `err.status` and returns the appropriate status code. If validation `details` are present, they are included as `errors`. Server errors (status >= 500) are logged at the `error` level via Pino.
+The handler reads `err.status` and returns the appropriate status code. If validation `details` are present, they are included as `errors`. Server errors (status >= 500) are logged at the `error` level via the framework `Logger`.
 
 ### 3. Unexpected Errors
 
@@ -79,7 +79,7 @@ If Express has already started streaming the response (`res.headersSent === true
 
 ## Logging
 
-Errors are logged using the `@forinda/kickjs` Pino logger tagged with `ErrorHandler`:
+Errors are logged using the `@forinda/kickjs` `Logger` tagged with `ErrorHandler`:
 
 - **500+ HttpException** and **unexpected errors** are logged at `error` level with full stack traces.
 - **Headers-already-sent** conditions are logged at `warn` level.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -7,6 +7,23 @@
 - Node.js 20+
 - pnpm (recommended) or npm
 
+## Release channels
+
+KickJS publishes to two npm dist-tags:
+
+- **`@latest`** — the stable channel. This is the default; `npm install @forinda/kickjs` and `npx @forinda/kickjs-cli new` install from here. Use it for production.
+- **`@alpha`** — the preview channel for upcoming features and experiments (new HTTP runtimes, in-progress subsystems). Opt in to try things before they stabilize:
+
+  ```bash
+  # scaffold with the preview CLI
+  npx @forinda/kickjs-cli@alpha new my-api
+
+  # or pin a package to the alpha channel in an existing project
+  pnpm add @forinda/kickjs@alpha
+  ```
+
+  Alpha builds can change without notice — pin an exact version if you depend on one.
+
 ## Create a New Project
 
 ```bash

--- a/docs/guide/hmr.md
+++ b/docs/guide/hmr.md
@@ -90,9 +90,13 @@ Adapter shutdown failures are logged but do not prevent other adapters from clea
 
 ## Troubleshooting
 
-### Raw JSON logs instead of colored output
+### Raw JSON logs instead of colored output (Pino provider)
 
-Pino uses a worker thread to load `pino-pretty`. Vite's SSR bundler can't resolve it from the bundled output. Fix: add `pino` and `pino-pretty` to `ssr.external` in your `vite.config.ts`:
+The default logger is `console`-based and needs no setup. This only applies if
+you've opted into the **Pino** logger via `Logger.setProvider()`: Pino loads
+`pino-pretty` in a worker thread, which Vite's SSR bundler can't resolve from the
+bundled output. Fix: add `pino` and `pino-pretty` to `ssr.external` in your
+`vite.config.ts`:
 
 ```ts
 export default defineConfig({

--- a/docs/guide/migration-runtimes.md
+++ b/docs/guide/migration-runtimes.md
@@ -1,0 +1,96 @@
+# Migrating to the Pluggable-Runtimes Release
+
+This release makes the HTTP engine **pluggable** — KickJS now runs on Express,
+Fastify, or h3. It's a major version because the public surface around the HTTP
+layer changed, but for the common case the upgrade is a no-op.
+
+## TL;DR
+
+- **Express apps need no code changes.** Express stays the zero-config default;
+  existing apps behave exactly as before.
+- **New:** opt into another engine with one line —
+  `bootstrap({ modules, runtime: fastifyRuntime() })`. See
+  [HTTP Runtimes](./http-runtimes.md).
+- A few **type** and **adapter-author** details changed; they're listed below.
+
+## For app authors
+
+### Nothing required
+
+Your controllers speak `RequestContext`, not Express, so they already run on any
+engine. `bootstrap({ modules })` keeps using Express. Done.
+
+### Optional: make the runtime explicit
+
+New projects scaffolded with `kick new` now emit the runtime explicitly:
+
+```ts
+import { bootstrap, expressRuntime } from '@forinda/kickjs'
+
+export const app = await bootstrap({ modules, runtime: expressRuntime() })
+```
+
+You don't have to add this to existing apps — it's purely for clarity and to
+make switching engines a one-line edit. To switch:
+
+```ts
+import { fastifyRuntime } from '@forinda/kickjs/fastify' // pnpm add fastify @fastify/middie
+// or
+import { h3Runtime } from '@forinda/kickjs/h3' // pnpm add h3
+```
+
+### Response-helper return types
+
+`ctx.json()` / `ctx.html()` / `ctx.problem.*` and friends now return
+`RuntimeResponse` instead of Express's `Response`. The value is almost never
+consumed (handlers just call the helper and return), so this rarely matters. If
+you stored it — `const r: Response = ctx.json(...)` — drop the annotation or use
+`ctx.res` for the raw engine response.
+
+### `getExpressApp()` → `getRuntimeApp()`
+
+`app.getExpressApp()` still works but is **deprecated**. Prefer
+`app.getRuntimeApp()`, which returns the engine-native app typed from the active
+runtime.
+
+## For adapter authors
+
+### Use `ctx.http` instead of `ctx.app`
+
+`AdapterContext` gained an engine-agnostic **`http`** surface — the supported way
+to add routes, mounts, static dirs, and middleware:
+
+```ts
+beforeMount({ http }) {
+  http.route('GET', '/_my/panel', (ctx) => ctx.html(PANEL))
+  http.serveStatic('/_my/assets', assetsDir)
+  http.use(myConnectMiddleware)
+}
+```
+
+`ctx.app` is still available as the engine-native escape hatch (Express by
+default), but an adapter written against `ctx.http` works on every runtime.
+
+### `AdapterContext.app` is now runtime-typed
+
+`AdapterContext.app` and `getRuntimeApp()` are typed `ActiveRuntime['app']` —
+`Express` by default. If you build a **mock** `AdapterContext` in tests, it now
+needs an `http` entry alongside `app`.
+
+## Deprecated packages
+
+`@forinda/kickjs-auth`, `@forinda/kickjs-prisma`, `@forinda/kickjs-drizzle`, and
+the `@forinda/kickjs-db-{pg,mysql,sqlite}` shims are frozen — they stay installed
+and working at their last published version, but no longer receive updates. See
+their READMEs for the recommended replacements (BYO auth via context decorators,
+`@forinda/kickjs-db` with its `/pg` · `/mysql` · `/sqlite` subpaths).
+
+## Trying it early
+
+Preview builds publish under the `@alpha` npm channel:
+
+```bash
+pnpm add @forinda/kickjs@alpha
+```
+
+See [Release channels](./getting-started.md#release-channels).

--- a/docs/guide/what-is-kickjs.md
+++ b/docs/guide/what-is-kickjs.md
@@ -32,7 +32,7 @@ KickJS is a production-grade, decorator-driven Node.js framework for TypeScript.
 @forinda/kickjs (unified: core + http + config)
        ↓ (peer dependency)
 ┌──────┼──────────┬───────────┬──────────┐
-auth  swagger  ws  devtools  ...
+db  swagger  ws  devtools  ...
                                     (adapter packages)
 
 @forinda/kickjs-cli (standalone)
@@ -41,7 +41,7 @@ auth  swagger  ws  devtools  ...
 
 - **@forinda/kickjs** — Unified framework: DI container, 20+ decorators, pluggable HTTP runtimes (Express / Fastify / h3), middleware, routing, logger, Zod env config
 - **@forinda/kickjs-swagger** — OpenAPI spec generation, Swagger UI, ReDoc
-- **@forinda/kickjs-auth** — JWT, API key, OAuth strategies, JWKS URI support
+- **@forinda/kickjs-db** — Code-first ORM (Kysely-based): schema, reversible migrations, typed queries — Postgres / MySQL / SQLite
 - **@forinda/kickjs-ws** — WebSocket with @WsController, rooms, heartbeat
 - **@forinda/kickjs-devtools** — Debug dashboard at /\_debug
 - **@forinda/kickjs-ai** — AI/LLM integration adapter

--- a/docs/guide/what-is-kickjs.md
+++ b/docs/guide/what-is-kickjs.md
@@ -39,7 +39,7 @@ auth  swagger  ws  devtools  ...
 @forinda/kickjs-vite (dev tooling)
 ```
 
-- **@forinda/kickjs** — Unified framework: DI container, 20+ decorators, Express 5, middleware, routing, logger, Zod env config
+- **@forinda/kickjs** — Unified framework: DI container, 20+ decorators, pluggable HTTP runtimes (Express / Fastify / h3), middleware, routing, logger, Zod env config
 - **@forinda/kickjs-swagger** — OpenAPI spec generation, Swagger UI, ReDoc
 - **@forinda/kickjs-auth** — JWT, API key, OAuth strategies, JWKS URI support
 - **@forinda/kickjs-ws** — WebSocket with @WsController, rooms, heartbeat

--- a/docs/guide/what-is-kickjs.md
+++ b/docs/guide/what-is-kickjs.md
@@ -1,6 +1,6 @@
 # What is KickJS?
 
-KickJS is a production-grade, decorator-driven Node.js framework built on Express 5 and TypeScript. It provides the developer experience of NestJS without the heavy dependencies.
+KickJS is a production-grade, decorator-driven Node.js framework for TypeScript. It provides the developer experience of NestJS without the heavy dependencies — and the HTTP engine is **pluggable**: the same controllers, modules, and context decorators run on **Express** (the zero-config default), **Fastify**, or **h3**. Swap the engine in one line at bootstrap; see [HTTP Runtimes](./http-runtimes.md).
 
 ## Why KickJS?
 


### PR DESCRIPTION
Follow-up to the SEO PR (#392) — the prose reframe + the major-release migration guide.

## Changes
- **what-is-kickjs**: reframed from "built on Express 5" to the pluggable-engine story (Express default, or Fastify / h3), linking the runtimes guide.
- **getting-started**: new **Release channels** section — `@latest` (stable) vs `@alpha` (preview / upcoming features), with install examples.
- **New migration guide** (`guide/migration-runtimes.md`) for the pluggable-runtimes major:
  - TL;DR — Express apps need **no** changes.
  - How to switch engines (one line + peer install).
  - Type notes: response-helper return types (`RuntimeResponse`), `getExpressApp()` → `getRuntimeApp()`.
  - Adapter authors: prefer `ctx.http`; `AdapterContext.app` is runtime-typed; mocks need an `http` entry.
  - Frozen deprecated packages.
  - Sidebar entry under Introduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Pluggable Runtimes" guide documenting Express (default), Fastify, and h3 HTTP engine support.
  * Introduced "Release channels" documentation for stable (`@latest`) and preview (`@alpha`) versions.
  * Added migration guide addressing API changes for the runtime upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->