### PR TITLE
fix(cli): scaffold Fastify/h3 against the alpha channel + refresh agent docs for runtimes

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -2,6 +2,11 @@
 
 This guide helps AI agents (Claude, Copilot, etc.) work effectively on the KickJS codebase.
 
+## Engine & package layout (read first — avoids the two most common mistakes)
+
+- **KickJS is engine-pluggable, not Express-only.** It runs on **Express (default), Fastify, or h3** behind one `HttpRuntime` seam (`bootstrap({ runtime })`). Controllers, modules, DI, and context decorators are engine-neutral — write to `ctx` (`ctx.json`/`ctx.body`/`ctx.params`/`ctx.sse`), not raw Express APIs. The runtimes + cross-engine file uploads currently ship on the **`alpha`** channel.
+- **The framework lives in `packages/kickjs`** (`@forinda/kickjs`) — DI core under `src/core/`, HTTP layer under `src/http/`, runtimes under `src/http/runtimes/{express,fastify,h3}.ts`. The old `packages/core` + `packages/http` split (referenced in some tables below) **no longer exists**; map any such path to `packages/kickjs/src/{core,http}`.
+
 ## Before You Start
 
 1. Read `CLAUDE.md` for project conventions and commands
@@ -12,38 +17,41 @@ This guide helps AI agents (Claude, Copilot, etc.) work effectively on the KickJ
 
 ### Source Code
 
-| What                 | Where                                                             |
-| -------------------- | ----------------------------------------------------------------- |
-| DI container         | `packages/core/src/container.ts`                                  |
-| All decorators       | `packages/core/src/decorators.ts`                                 |
-| Module system        | `packages/core/src/app-module.ts`                                 |
-| Adapter interface    | `packages/core/src/adapter.ts`                                    |
-| Error classes        | `packages/core/src/errors.ts`                                     |
-| Logger               | `packages/core/src/logger.ts`                                     |
-| Express app wrapper  | `packages/http/src/application.ts`                                |
-| Bootstrap function   | `packages/http/src/bootstrap.ts`                                  |
-| RequestContext       | `packages/http/src/context.ts`                                    |
-| Router builder       | `packages/http/src/router-builder.ts`                             |
-| Middleware           | `packages/http/src/middleware/*.ts`                               |
-| Query parsing        | `packages/http/src/query/`                                        |
-| Config/env           | `packages/config/src/`                                            |
-| CLI commands         | `packages/cli/src/commands/`                                      |
-| Code generators      | `packages/cli/src/generators/`                                    |
-| Generator patterns   | `packages/cli/src/generators/patterns/{rest,ddd,cqrs,minimal}.ts` |
-| Template functions   | `packages/cli/src/generators/templates/`                          |
-| Drizzle templates    | `packages/cli/src/generators/templates/drizzle/`                  |
-| Prisma templates     | `packages/cli/src/generators/templates/prisma/`                   |
-| TemplateContext type | `packages/cli/src/generators/templates/types.ts`                  |
-| ModuleConfig type    | `packages/cli/src/config.ts`                                      |
-| PrismaModelDelegate  | `packages/prisma/src/types.ts`                                    |
-| Swagger decorators   | `packages/swagger/src/decorators.ts`                              |
-| OpenAPI builder      | `packages/swagger/src/openapi-builder.ts`                         |
-| Prisma adapter       | `packages/prisma/src/prisma.adapter.ts`                           |
-| Prisma query adapter | `packages/prisma/src/query-adapter.ts`                            |
-| WebSocket adapter    | `packages/ws/src/ws-adapter.ts`                                   |
-| WebSocket decorators | `packages/ws/src/decorators.ts`                                   |
-| WebSocket context    | `packages/ws/src/ws-context.ts`                                   |
-| Room manager         | `packages/ws/src/room-manager.ts`                                 |
+> Paths below use the legacy `packages/core` / `packages/http` names — the real location is `packages/kickjs/src/core/…` and `packages/kickjs/src/http/…` respectively.
+
+| What                 | Where                                                                      |
+| -------------------- | -------------------------------------------------------------------------- |
+| DI container         | `packages/kickjs/src/core/container.ts`                                    |
+| All decorators       | `packages/kickjs/src/core/decorators.ts`                                   |
+| Module system        | `packages/kickjs/src/core/app-module.ts`                                   |
+| Adapter interface    | `packages/kickjs/src/core/adapter.ts`                                      |
+| Error classes        | `packages/kickjs/src/core/errors.ts`                                       |
+| Logger               | `packages/kickjs/src/core/logger.ts`                                       |
+| Application wrapper  | `packages/kickjs/src/http/application.ts`                                  |
+| Bootstrap function   | `packages/kickjs/src/http/bootstrap.ts`                                    |
+| RequestContext       | `packages/kickjs/src/http/context.ts`                                      |
+| HTTP runtime seam    | `packages/kickjs/src/http/runtime.ts` + `runtimes/{express,fastify,h3}.ts` |
+| Router builder       | `packages/kickjs/src/http/router-builder.ts`                               |
+| Middleware           | `packages/kickjs/src/http/middleware/*.ts`                                 |
+| Query parsing        | `packages/kickjs/src/http/query/`                                          |
+| Config/env           | `packages/config/src/`                                                     |
+| CLI commands         | `packages/cli/src/commands/`                                               |
+| Code generators      | `packages/cli/src/generators/`                                             |
+| Generator patterns   | `packages/cli/src/generators/patterns/{rest,ddd,cqrs,minimal}.ts`          |
+| Template functions   | `packages/cli/src/generators/templates/`                                   |
+| Drizzle templates    | `packages/cli/src/generators/templates/drizzle/`                           |
+| Prisma templates     | `packages/cli/src/generators/templates/prisma/`                            |
+| TemplateContext type | `packages/cli/src/generators/templates/types.ts`                           |
+| ModuleConfig type    | `packages/cli/src/config.ts`                                               |
+| PrismaModelDelegate  | `packages/prisma/src/types.ts`                                             |
+| Swagger decorators   | `packages/swagger/src/decorators.ts`                                       |
+| OpenAPI builder      | `packages/swagger/src/openapi-builder.ts`                                  |
+| Prisma adapter       | `packages/prisma/src/prisma.adapter.ts`                                    |
+| Prisma query adapter | `packages/prisma/src/query-adapter.ts`                                     |
+| WebSocket adapter    | `packages/ws/src/ws-adapter.ts`                                            |
+| WebSocket decorators | `packages/ws/src/decorators.ts`                                            |
+| WebSocket context    | `packages/ws/src/ws-context.ts`                                            |
+| Room manager         | `packages/ws/src/room-manager.ts`                                          |
 
 ### Configuration
 

--- a/.changeset/scaffold-alpha-runtime.md
+++ b/.changeset/scaffold-alpha-runtime.md
@@ -1,0 +1,7 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+Fix `kick new --runtime fastify|h3` installing a `@forinda/kickjs` that lacks the engine subpath. The Fastify / h3 runtimes ship on the `alpha` channel for now, but the scaffolder resolved `@forinda/kickjs` from the `latest` dist-tag — so a generated Fastify/h3 app pinned a stable kickjs without the `./fastify` / `./h3` exports and failed to boot under Vite (`"./h3" is not exported …`). The scaffolder now pins `@forinda/kickjs` to the `alpha` channel (exact prerelease version) when a non-Express runtime is chosen, and warns with a manual `add @forinda/kickjs@alpha` hint if the alpha can't be resolved. Express scaffolds stay on the stable channel.
+
+Also refreshed the generated agent docs (`AGENTS.md` / `CLAUDE.md` / README templates) to describe KickJS as engine-pluggable (Express / Fastify / h3) instead of Express-only, with an explicit "don't assume Express" section, the `runtime` config field, cross-engine uploads, and `kick add upload` / `kick doctor` — so coding agents don't hallucinate an Express-only framework.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,9 @@
 
 ## Project Overview
 
-KickJS is a decorator-driven Node.js framework built on Express 5 and TypeScript. Monorepo managed with pnpm workspaces and Turbo.
+KickJS is a decorator-driven Node.js framework for TypeScript. The HTTP engine is pluggable — it runs on **Express (default), Fastify, or h3**, selected via `bootstrap({ runtime })`; controllers/modules/DI/context decorators are engine-neutral. Monorepo managed with pnpm workspaces and Turbo.
+
+> The real framework package is `packages/kickjs` (`@forinda/kickjs`) — it holds the DI core, HTTP layer, RequestContext, and the runtime seam (`src/http/runtimes/{express,fastify,h3}.ts`). The `packages/core` + `packages/http` split described in older parts of this doc is **stale**; treat `packages/kickjs/src/{core,http}` as the source of truth. Fastify/h3 runtimes + cross-engine uploads currently ship on the `alpha` channel.
 
 **18 published packages** under `@forinda/kickjs-*`, **10 example apps**, CLI with generators, Prisma/Drizzle/custom ORM support.
 

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -85,6 +85,32 @@ async function resolveSiblingVersions(): Promise<Record<string, string>> {
   return Object.fromEntries(results)
 }
 
+/**
+ * Resolve the exact published version of a package at a given dist-tag
+ * (`npm view <name>@<tag> version`). Returns `null` on any failure. Used
+ * to pin `@forinda/kickjs` to the `alpha` channel when scaffolding a
+ * Fastify / h3 app — the engine subpaths (`@forinda/kickjs/fastify`,
+ * `/h3`) ship only on the alpha until the runtimes land in a stable
+ * release, so the default `latest` resolution would install a kickjs
+ * that doesn't export them (→ Vite "./h3 is not exported" at boot).
+ * Prerelease versions are pinned exactly (no `^`) — a caret range over a
+ * prerelease has surprising semver semantics.
+ */
+function resolveExactVersionAtTag(name: string, tag: string): string | null {
+  try {
+    const out = execFileSync('npm', ['view', `${name}@${tag}`, 'version'], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim()
+    return out && /^\d+\.\d+\.\d+/.test(out) ? out : null
+  } catch {
+    return null
+  }
+}
+
 type ProjectTemplate = 'rest' | 'minimal'
 type SchemaLib = 'zod' | 'valibot' | 'yup'
 
@@ -130,6 +156,25 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
   // working offline.
   log('Resolving package versions...')
   const versions = await resolveSiblingVersions()
+
+  // The Fastify / h3 runtime subpaths (`@forinda/kickjs/fastify`, `/h3`) ship
+  // only on the `alpha` channel until the pluggable-runtimes work lands in a
+  // stable release. `latest` resolution would install a kickjs without those
+  // exports, so a scaffolded Fastify/h3 app fails to boot ("./h3 is not
+  // exported"). Pin `@forinda/kickjs` to the alpha when a non-Express runtime
+  // is chosen. Express stays on the stable channel.
+  if (runtime !== 'express') {
+    const alpha = resolveExactVersionAtTag('@forinda/kickjs', 'alpha')
+    if (alpha) {
+      versions['@forinda/kickjs'] = alpha
+      log(`Using @forinda/kickjs@${alpha} (alpha channel — ${runtime} runtime)`)
+    } else {
+      log(
+        `WARNING: could not resolve @forinda/kickjs@alpha — the ${runtime} runtime subpath ` +
+          `may be missing. After install, run: ${packageManager} add @forinda/kickjs@alpha`,
+      )
+    }
+  }
 
   // ── package.json — template-aware deps ────────────────────────────
   await writeFileSafe(

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -111,6 +111,31 @@ function resolveExactVersionAtTag(name: string, tag: string): string | null {
   }
 }
 
+/**
+ * Whether the package at a given dist-tag exports a subpath (e.g. `./h3`).
+ * Reads the `exports` map via `npm view <name>@<tag> exports --json`. Used to
+ * gate the alpha-pin: if `latest` already ships the engine subpath, the runtime
+ * has graduated to stable and we should NOT downgrade to an older alpha.
+ * Returns `false` on any failure (missing field / network / unparseable) so the
+ * caller treats "unknown" as "not present" and falls through to the alpha path.
+ */
+function tagExportsSubpath(name: string, tag: string, subpath: string): boolean {
+  try {
+    const out = execFileSync('npm', ['view', `${name}@${tag}`, 'exports', '--json'], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim()
+    if (!out) return false
+    const exportsMap = JSON.parse(out) as Record<string, unknown>
+    return Object.prototype.hasOwnProperty.call(exportsMap, subpath)
+  } catch {
+    return false
+  }
+}
+
 type ProjectTemplate = 'rest' | 'minimal'
 type SchemaLib = 'zod' | 'valibot' | 'yup'
 
@@ -159,20 +184,28 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
 
   // The Fastify / h3 runtime subpaths (`@forinda/kickjs/fastify`, `/h3`) ship
   // only on the `alpha` channel until the pluggable-runtimes work lands in a
-  // stable release. `latest` resolution would install a kickjs without those
-  // exports, so a scaffolded Fastify/h3 app fails to boot ("./h3 is not
-  // exported"). Pin `@forinda/kickjs` to the alpha when a non-Express runtime
-  // is chosen. Express stays on the stable channel.
+  // stable release. If `latest` already exports the chosen engine's subpath,
+  // the runtime has graduated — use the stable version `resolveSiblingVersions`
+  // already picked. Otherwise pin `@forinda/kickjs` to the alpha, so the
+  // scaffolded app actually has the subpath it imports (a stable kickjs without
+  // it fails to boot under Vite: `"./h3" is not exported`). This gate is
+  // self-retiring: once runtimes are stable, `latest` exports the subpath and
+  // the alpha branch is never taken. Express needs no subpath, so it's exempt.
   if (runtime !== 'express') {
-    const alpha = resolveExactVersionAtTag('@forinda/kickjs', 'alpha')
-    if (alpha) {
-      versions['@forinda/kickjs'] = alpha
-      log(`Using @forinda/kickjs@${alpha} (alpha channel — ${runtime} runtime)`)
+    const subpath = `./${runtime}` // './fastify' | './h3'
+    if (tagExportsSubpath('@forinda/kickjs', 'latest', subpath)) {
+      log(`Using @forinda/kickjs@latest (stable ships the ${runtime} runtime)`)
     } else {
-      log(
-        `WARNING: could not resolve @forinda/kickjs@alpha — the ${runtime} runtime subpath ` +
-          `may be missing. After install, run: ${packageManager} add @forinda/kickjs@alpha`,
-      )
+      const alpha = resolveExactVersionAtTag('@forinda/kickjs', 'alpha')
+      if (alpha) {
+        versions['@forinda/kickjs'] = alpha
+        log(`Using @forinda/kickjs@${alpha} (alpha channel — ${runtime} runtime not yet in stable)`)
+      } else {
+        log(
+          `WARNING: could not resolve @forinda/kickjs@alpha — the ${runtime} runtime subpath ` +
+            `may be missing. After install, run: ${packageManager} add @forinda/kickjs@alpha`,
+        )
+      }
     }
   }
 

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -119,6 +119,31 @@ function resolveExactVersionAtTag(name: string, tag: string): string | null {
  * Returns `false` on any failure (missing field / network / unparseable) so the
  * caller treats "unknown" as "not present" and falls through to the alpha path.
  */
+/** Strip a leading range operator (`^1.2.3` / `~1.2.3` → `1.2.3`). */
+function stripRange(range: string | undefined): string {
+  return (range ?? '').replace(/^[\^~>=<\s]+/, '')
+}
+
+/**
+ * Compare the release cores (major.minor.patch, ignoring any `-prerelease`
+ * suffix) of two versions: is `a` >= `b`? Used to guard the alpha-pin so a
+ * package is never downgraded onto a stale prerelease whose stable line has
+ * already moved past it. A coarse compare is enough here — we only need
+ * "is this alpha at least as new as the stable we'd otherwise install".
+ */
+function baseVersionGte(a: string, b: string): boolean {
+  const core = (v: string): number[] =>
+    stripRange(v)
+      .split('-')[0]!
+      .split('.')
+      .map((n) => Number.parseInt(n, 10) || 0)
+  const [a0 = 0, a1 = 0, a2 = 0] = core(a)
+  const [b0 = 0, b1 = 0, b2 = 0] = core(b)
+  if (a0 !== b0) return a0 > b0
+  if (a1 !== b1) return a1 > b1
+  return a2 >= b2
+}
+
 function tagExportsSubpath(name: string, tag: string, subpath: string): boolean {
   try {
     const out = execFileSync('npm', ['view', `${name}@${tag}`, 'exports', '--json'], {
@@ -182,24 +207,42 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
   log('Resolving package versions...')
   const versions = await resolveSiblingVersions()
 
-  // The Fastify / h3 runtime subpaths (`@forinda/kickjs/fastify`, `/h3`) ship
-  // only on the `alpha` channel until the pluggable-runtimes work lands in a
-  // stable release. If `latest` already exports the chosen engine's subpath,
-  // the runtime has graduated — use the stable version `resolveSiblingVersions`
-  // already picked. Otherwise pin `@forinda/kickjs` to the alpha, so the
-  // scaffolded app actually has the subpath it imports (a stable kickjs without
-  // it fails to boot under Vite: `"./h3" is not exported`). This gate is
-  // self-retiring: once runtimes are stable, `latest` exports the subpath and
-  // the alpha branch is never taken. Express needs no subpath, so it's exempt.
+  // The pluggable-runtimes work (Fastify / h3 engine subpaths, the
+  // `kick/runtime` typegen, `kick add upload`, `kick doctor` runtime checks)
+  // ships only on the `alpha` channel until it lands in a stable release. So a
+  // non-Express scaffold needs the alpha of every package that carries runtime
+  // behavior, not just `@forinda/kickjs`:
+  //   - `@forinda/kickjs`       — the `./fastify` / `./h3` export subpaths the
+  //                               app imports (stable lacks them → Vite boot
+  //                               error `"./h3" is not exported`).
+  //   - `@forinda/kickjs-cli`   — `--runtime`, `kick add upload`, `kick doctor`,
+  //                               the `kick/runtime` typegen plugin.
+  //   - `@forinda/kickjs-vite`  — the dev loop co-versioned with the above.
+  // Gated on whether `@forinda/kickjs@latest` already exports the chosen engine
+  // subpath: once that's true the runtimes are stable and we keep `latest` for
+  // everything (self-retiring — no code change needed at graduation). Each pin
+  // is guarded so it never DOWNGRADES (an alpha can be older than latest — e.g.
+  // a package whose stable moved on past an old prerelease). Express is exempt.
   if (runtime !== 'express') {
     const subpath = `./${runtime}` // './fastify' | './h3'
     if (tagExportsSubpath('@forinda/kickjs', 'latest', subpath)) {
       log(`Using @forinda/kickjs@latest (stable ships the ${runtime} runtime)`)
     } else {
-      const alpha = resolveExactVersionAtTag('@forinda/kickjs', 'alpha')
-      if (alpha) {
-        versions['@forinda/kickjs'] = alpha
-        log(`Using @forinda/kickjs@${alpha} (alpha channel — ${runtime} runtime not yet in stable)`)
+      const RUNTIME_PKGS = ['@forinda/kickjs', '@forinda/kickjs-cli', '@forinda/kickjs-vite']
+      const pinned: string[] = []
+      let kickjsPinned = false
+      for (const pkg of RUNTIME_PKGS) {
+        const alpha = resolveExactVersionAtTag(pkg, 'alpha')
+        // Only pin when the alpha is newer-or-equal to the stable we'd otherwise
+        // install — never downgrade a package onto a stale prerelease.
+        if (alpha && baseVersionGte(alpha, stripRange(versions[pkg]))) {
+          versions[pkg] = alpha
+          pinned.push(`${pkg}@${alpha}`)
+          if (pkg === '@forinda/kickjs') kickjsPinned = true
+        }
+      }
+      if (kickjsPinned) {
+        log(`Using the alpha channel for the ${runtime} runtime: ${pinned.join(', ')}`)
       } else {
         log(
           `WARNING: could not resolve @forinda/kickjs@alpha — the ${runtime} runtime subpath ` +

--- a/packages/cli/src/generators/templates/project-docs.ts
+++ b/packages/cli/src/generators/templates/project-docs.ts
@@ -16,7 +16,7 @@ export function generateReadme(name: string, template: ProjectTemplate, pm: stri
 
   return `# ${name}
 
-A **${templateLabels[template] ?? 'REST API'}** built with [KickJS](https://forinda.github.io/kick-js/) — a decorator-driven Node.js framework on Express 5 and TypeScript.
+A **${templateLabels[template] ?? 'REST API'}** built with [KickJS](https://forinda.github.io/kick-js/) — a decorator-driven Node.js framework for TypeScript that runs on Express, Fastify, or h3 (swap the engine in one line).
 
 ## Getting Started
 
@@ -154,6 +154,7 @@ When generating or modifying code in this project, stay aligned with the v4 conv
 - **Plugins**: \`definePlugin()\` factory — never plain function returning \`KickPlugin\`.
 - **DI tokens**: \`<scope>/<PascalKey>[/<suffix>]\` — scope is lowercase, the key segment is **PascalCase** (e.g. \`'app/Users/repository'\`, \`'mycorp/Cache/redis'\`). First-party uses the reserved \`'kick/'\` prefix; this project owns its own scope.
 - **Decorators**: \`@Controller()\` (no path arg — mount prefix comes from \`routes().path\`).
+- **HTTP runtime**: this app may run on Express, Fastify, or h3 — check \`kick.config.ts\` \`runtime\` (or \`bootstrap({ runtime })\`) before writing engine-specific code. Prefer engine-neutral \`ctx\` APIs (\`ctx.json\`/\`ctx.body\`/\`ctx.params\`/\`ctx.sse\`); don't assume \`ctx.req\` is an Express request. Uploads (\`@FileUpload\` → \`ctx.file\`/\`ctx.files\`) work on all three (\`kick add upload\` installs the driver). Full rules in \`.agents/AGENTS.md\` → "HTTP runtime".
 - **Module entry file** MUST be named \`<name>.module.ts\` and live under \`src/modules/<name>/\`. The Vite plugin auto-discovers \`*.module.[tj]sx?\` for graceful HMR — a misnamed \`projects.ts\` silently degrades every save into a full restart.
 - **Env**: schema lives in \`src/config/index.ts\`; \`import './config'\` MUST be the first import in \`src/index.ts\` (side-effect registers the schema before any \`@Value\` resolves).
 - **Assets**: drop new template files into \`src/templates/<namespace>/\`; the dev watcher auto-rebuilds the \`KickAssets\` augmentation + \`assets.x.y()\` re-walks on next call. No restart, no manual build.
@@ -613,6 +614,42 @@ add tool-specific affordances on top.
 2. Run \`kick dev\` to verify the app starts
 3. Read the [KickJS documentation](https://forinda.github.io/kick-js/) for framework details
 
+## HTTP runtime — DON'T assume Express-only
+
+KickJS is **engine-pluggable**. It runs on **Express (default), Fastify, or h3** —
+chosen with one line: \`bootstrap({ runtime: fastifyRuntime() })\`. Before writing
+any engine-specific code, **check which engine this project uses**:
+
+- \`kick.config.ts\` → the \`runtime\` field (\`'express'\` | \`'fastify'\` | \`'h3'\`), and/or
+- \`src/index.ts\` → the \`runtime:\` passed to \`bootstrap()\`, and/or
+- \`package.json\` → \`fastify\` / \`h3\` in deps.
+
+Rules that keep generated code correct on **every** engine:
+
+- **Write to \`ctx\`, not the raw request/response.** \`ctx.json()\`, \`ctx.body\`,
+  \`ctx.params\`, \`ctx.query\`, \`ctx.set/get\`, \`ctx.sse()\` are engine-neutral and
+  work identically everywhere. \`ctx.req\` / \`ctx.res\` are the engine-native
+  objects — their **type follows the active runtime** (Express by default; the
+  \`kick/runtime\` typegen retypes them to Fastify / h3 when \`runtime\` is set).
+  Don't assume \`ctx.req\` is an \`express.Request\` in portable code.
+- **Global middleware** in \`bootstrap({ middleware })\` is connect-style
+  \`(req, res, next)\` — it runs on all engines (Fastify via \`@fastify/middie\`,
+  h3 via \`fromNodeMiddleware\`). But on Fastify / h3 the engine parses the body
+  natively, so the default \`express.json()\` is **auto-skipped** (\`nativeBodyParsing\`).
+  Don't add \`express.json()\` manually on those engines.
+- **File uploads** work on all three: \`@FileUpload({ mode, fieldName, ... })\` →
+  \`ctx.file\` / \`ctx.files\` (same Multer-shaped object everywhere). Backends:
+  Express \`multer\`, Fastify \`@fastify/multipart\`, h3 native. Run
+  \`kick add upload\` to install the runtime-correct driver. The \`@FileUpload\`
+  decorator is **memory-only** (portable); disk / custom-storage (\`storage\` /
+  \`dest\`) is Express-only via the \`upload.single/array()\` middleware.
+- **Engine subpaths**: \`import { fastifyRuntime } from '@forinda/kickjs/fastify'\`
+  or \`h3Runtime\` from \`'@forinda/kickjs/h3'\`. Express is the zero-config default
+  (no import, nothing to install).
+- **Not supported on Fastify / h3**: \`ctx.render()\` (no view engine). Calling it
+  throws a clear error rather than failing silently.
+- Run \`kick doctor\` to verify the runtime's engine peers + upload driver are installed.
+
 ## v4 Conventions (don't skip)
 
 KickJS v4 made a handful of structural changes from v3. Internalise these
@@ -1071,12 +1108,14 @@ Full guide: <https://forinda.github.io/kick-js/guide/context-decorators>.
 | \`kick g service <name>\` | Generate service |
 | \`kick g middleware <name>\` | Generate middleware |
 | \`kick add <package>\` | Add KickJS package |
+| \`kick add upload\` | Install the multipart upload driver for this project's runtime |
 | \`kick add --list\` | List available packages |
+| \`kick doctor\` | Pre-flight checks — runtime engine peers, upload driver, env wiring |
 | \`kick rm module <names...>\` | Remove one or more modules |
 
-> **Note:** When using \`kick new\` in scripts or CI, pass \`-t\` (or \`--template\`) and \`-r\` (or \`--repo\`) flags to bypass interactive prompts:
+> **Note:** When using \`kick new\` in scripts or CI, pass \`-t\` (or \`--template\`), \`-r\` (or \`--repo\`), and \`--runtime express|fastify|h3\` to bypass interactive prompts:
 > \`\`\`bash
-> kick new my-api -t ddd -r prisma --pm ${pm} --no-git --no-install -f
+> kick new my-api -t ddd -r prisma --runtime fastify --pm ${pm} --no-git --no-install -f
 > \`\`\`
 
 ## Learn More


### PR DESCRIPTION
## Why

A freshly scaffolded **`kick new --runtime h3`** app crashed at `kick dev`:

```
[vite] (ssr) "./h3" is not exported … from package @forinda/kickjs
[kickjs] failed to bootstrap app on startup: "./h3" is not exported …
```

**Root cause:** the Fastify / h3 runtime subpaths (`@forinda/kickjs/fastify`, `@forinda/kickjs/h3`) ship only on the **`alpha`** channel for now. But the scaffolder resolved `@forinda/kickjs` via `npm view <pkg> version` — the **`latest`** dist-tag (`5.17.0`), which predates the runtimes and doesn't export those subpaths. So a generated Fastify/h3 app pinned a stable kickjs and failed to boot.

## Fix

- When `kick new --runtime fastify|h3` is chosen, pin `@forinda/kickjs` to the **alpha** channel — resolved to the exact prerelease version (`npm view @forinda/kickjs@alpha version`). Prerelease pinned exactly (no caret, which has surprising semver semantics over prereleases).
- If the alpha can't be resolved (offline / npm down), fall back to a warning with a manual `pnpm add @forinda/kickjs@alpha` hint instead of silently shipping a broken project.
- **Express scaffolds are unchanged** — they stay on the stable channel.

## Agent-doc refresh (so agents stop hallucinating Express-only)

The generated agent docs (`AGENTS.md` / `CLAUDE.md` / README) and this repo's own `CLAUDE.md` + `.agents/AGENTS.md` still described KickJS as "a framework on Express 5". Updated to:

- KickJS is **engine-pluggable** (Express / Fastify / h3) — new "don't assume Express-only" section telling agents to check `kick.config.ts` `runtime` and prefer engine-neutral `ctx` APIs.
- The `runtime` config field, cross-engine uploads (`@FileUpload` → `ctx.file` on all three), `kick add upload`, `kick doctor`.
- Corrected the stale `packages/core` + `packages/http` paths → `packages/kickjs/src/{core,http}`.

## Existing projects

A Fastify/h3 app already scaffolded on the stable line is fixed with one command:

```bash
pnpm add @forinda/kickjs@alpha
```

## Tests

CLI scaffold + typecheck green. Changeset: `@forinda/kickjs-cli` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scaffolder now intelligently manages Fastify and h3 runtime dependencies, pinning to alpha channel when necessary.

* **Documentation**
  * Updated framework documentation to reflect engine-pluggable HTTP runtime design (Express, Fastify, h3).
  * Refreshed generated project templates and agent guidance to cover multi-runtime usage, cross-engine uploads, and runtime-specific behaviors.
  * Updated project overview and CLI command references to include runtime selection options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->