### PR TITLE
fix(runtime): drop express from fastify/h3 (serve-static), scaffold ranges

### DIFF
--- a/.changeset/runtime-drop-express-static.md
+++ b/.changeset/runtime-drop-express-static.md
@@ -1,0 +1,8 @@
+---
+'@forinda/kickjs': minor
+'@forinda/kickjs-cli': patch
+---
+
+The Fastify and h3 runtimes no longer depend on `express`. Their `serveStatic` used `express.static`, which forced `express` to be installed even on a pure Fastify/h3 app — defeating the point of swapping the engine. They now use `serve-static` (the standalone connect middleware that `express.static` wraps), bridged through middie / `fromNodeMiddleware` exactly as before. `serve-static` is a new optional peer of `@forinda/kickjs`.
+
+CLI scaffolding follows suit: `kick new --runtime fastify|h3` now installs `serve-static` instead of `express` (and drops the `@types/express` devDependency) — an Express scaffold still gets `express`. The alpha-channel pins for the runtime toolchain (`@forinda/kickjs`, `-cli`, `-vite`) are now `^`-ranges rather than exact versions, so a generated project floats to newer alphas and auto-graduates to the stable release once it ships.

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -86,17 +86,19 @@ async function resolveSiblingVersions(): Promise<Record<string, string>> {
 }
 
 /**
- * Resolve the exact published version of a package at a given dist-tag
+ * Resolve the published version of a package at a given dist-tag
  * (`npm view <name>@<tag> version`). Returns `null` on any failure. Used
  * to pin `@forinda/kickjs` to the `alpha` channel when scaffolding a
  * Fastify / h3 app — the engine subpaths (`@forinda/kickjs/fastify`,
  * `/h3`) ship only on the alpha until the runtimes land in a stable
  * release, so the default `latest` resolution would install a kickjs
  * that doesn't export them (→ Vite "./h3 is not exported" at boot).
- * Prerelease versions are pinned exactly (no `^`) — a caret range over a
- * prerelease has surprising semver semantics.
+ * Returns the bare version; the caller applies a `^` range so the project
+ * floats to newer alphas and auto-graduates to stable (a caret over a
+ * prerelease matches same-tuple prereleases ≥ it, plus later stables `< next
+ * major`).
  */
-function resolveExactVersionAtTag(name: string, tag: string): string | null {
+function resolveVersionAtTag(name: string, tag: string): string | null {
   try {
     const out = execFileSync('npm', ['view', `${name}@${tag}`, 'version'], {
       encoding: 'utf-8',
@@ -232,12 +234,14 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
       const pinned: string[] = []
       let kickjsPinned = false
       for (const pkg of RUNTIME_PKGS) {
-        const alpha = resolveExactVersionAtTag(pkg, 'alpha')
-        // Only pin when the alpha is newer-or-equal to the stable we'd otherwise
-        // install — never downgrade a package onto a stale prerelease.
+        const alpha = resolveVersionAtTag(pkg, 'alpha')
+        // Only switch when the alpha is newer-or-equal to the stable we'd
+        // otherwise install — never downgrade onto a stale prerelease. Use a
+        // `^` range (not an exact pin) so the project picks up newer alphas and
+        // auto-graduates to the stable release once it ships.
         if (alpha && baseVersionGte(alpha, stripRange(versions[pkg]))) {
-          versions[pkg] = alpha
-          pinned.push(`${pkg}@${alpha}`)
+          versions[pkg] = `^${alpha}`
+          pinned.push(`${pkg}@^${alpha}`)
           if (pkg === '@forinda/kickjs') kickjsPinned = true
         }
       }

--- a/packages/cli/src/generators/templates/project-config.ts
+++ b/packages/cli/src/generators/templates/project-config.ts
@@ -67,19 +67,22 @@ export function generatePackageJson(
     // get it pre-installed so `.env` files Just Work. Apps that load
     // env from the shell or a secret manager can drop this safely.
     dotenv: '^17.3.1',
-    // `express` stays installed for every runtime: it's the default engine,
-    // and the Fastify / h3 runtimes use `express.static` for `serveStatic`.
-    express: '^5.1.0',
     'reflect-metadata': '^0.2.2',
     [schemaDep.name]: schemaDep.range,
   }
 
   // Engine peers for the chosen runtime (optional peers of @forinda/kickjs).
-  if (runtime === 'fastify') {
+  if (runtime === 'express') {
+    // Express is the engine itself.
+    baseDeps.express = '^5.1.0'
+  } else if (runtime === 'fastify') {
     baseDeps.fastify = '^5.0.0'
     baseDeps['@fastify/middie'] = '^9.0.0'
+    // Static serving uses `serve-static` (no express dependency).
+    baseDeps['serve-static'] = '^2.2.0'
   } else if (runtime === 'h3') {
     baseDeps.h3 = '^1.0.0'
+    baseDeps['serve-static'] = '^2.2.0'
   }
 
   // Add user-selected optional packages — each looked up against
@@ -122,7 +125,9 @@ export function generatePackageJson(
         '@forinda/kickjs-cli': take(versions, '@forinda/kickjs-cli'),
         '@forinda/kickjs-vite': take(versions, '@forinda/kickjs-vite'),
         '@swc/core': '^1.15.21',
-        '@types/express': '^5.0.6',
+        // Express types only when Express is the engine (it's the only runtime
+        // that imports `express` in src/index.ts).
+        ...(runtime === 'express' ? { '@types/express': '^5.0.6' } : {}),
         '@types/node': '^25.0.0',
         'unplugin-swc': '^1.5.9',
         vite: '^8.0.3',

--- a/packages/kickjs/package.json
+++ b/packages/kickjs/package.json
@@ -123,6 +123,7 @@
     "fastify": "^5.0.0",
     "h3": "^1.0.0",
     "multer": "^2.0.0",
+    "serve-static": "^1.15.0 || ^2.0.0",
     "zod": "^4.0.0"
   },
   "peerDependenciesMeta": {
@@ -144,6 +145,9 @@
     "multer": {
       "optional": true
     },
+    "serve-static": {
+      "optional": true
+    },
     "zod": {
       "optional": true
     }
@@ -155,9 +159,11 @@
     "@types/express": "^5.0.6",
     "@types/multer": "^2.1.0",
     "@types/node": "^25.9.2",
+    "@types/serve-static": "^1.15.7",
     "fastify": "^5.8.5",
     "h3": "1.15.11",
     "multer": "^2.1.1",
+    "serve-static": "^2.2.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.8",

--- a/packages/kickjs/src/http/runtimes/fastify.ts
+++ b/packages/kickjs/src/http/runtimes/fastify.ts
@@ -32,8 +32,8 @@ import type {
   UseConnectOptions,
 } from '../runtime'
 
-// ESM-safe require for the optional peers (fastify / @fastify/middie / express),
-// resolved from wherever this module is installed.
+// ESM-safe require for the optional peers (fastify / @fastify/middie /
+// serve-static), resolved from wherever this module is installed.
 const peerRequire = createRequire(import.meta.url)
 const loadPeer = (name: string): any => {
   const mod = peerRequire(name)
@@ -328,9 +328,11 @@ export function fastifyRuntime(): HttpRuntime<FastifyAppLike> {
     },
 
     serveStatic(app, prefix, dir) {
-      // Serve via express.static as a connect middleware, queued like any other.
-      const expressStatic = loadPeer('express').static
-      this.useConnect(app, expressStatic(dir) as ConnectMiddleware, { path: prefix })
+      // Serve via `serve-static` (the standalone connect middleware behind
+      // express.static) so the Fastify runtime carries no `express` dependency —
+      // queued like any other connect middleware, bridged through middie.
+      const serveStatic = loadPeer('serve-static')
+      this.useConnect(app, serveStatic(dir) as ConnectMiddleware, { path: prefix })
     },
 
     setNotFound(app, mw: ConnectMiddleware) {

--- a/packages/kickjs/src/http/runtimes/h3.ts
+++ b/packages/kickjs/src/http/runtimes/h3.ts
@@ -245,8 +245,11 @@ export function h3Runtime(): HttpRuntime<H3AppLike> {
     },
 
     serveStatic(app, prefix, dir) {
-      const expressStatic = peerRequire('express').static
-      this.useConnect(app, expressStatic(dir) as ConnectMiddleware, { path: prefix })
+      // `serve-static` (the standalone connect middleware behind express.static)
+      // so the h3 runtime carries no `express` dependency — bridged via
+      // fromNodeMiddleware like any other connect middleware.
+      const serveStatic = peerRequire('serve-static')
+      this.useConnect(app, serveStatic(dir) as ConnectMiddleware, { path: prefix })
     },
 
     setNotFound(app, mw: ConnectMiddleware) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,6 +481,9 @@ importers:
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.2
+      '@types/serve-static':
+        specifier: ^1.15.7
+        version: 1.15.10
       fastify:
         specifier: ^5.8.5
         version: 5.8.5
@@ -490,6 +493,9 @@ importers:
       multer:
         specifier: ^2.1.1
         version: 2.1.1
+      serve-static:
+        specifier: ^2.2.0
+        version: 2.2.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -2938,6 +2944,9 @@ packages:
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
 
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
@@ -2968,8 +2977,14 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/send@0.17.6':
+    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
+
   '@types/send@1.2.1':
     resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
@@ -8039,6 +8054,8 @@ snapshots:
 
   '@types/methods@1.1.4': {}
 
+  '@types/mime@1.3.5': {}
+
   '@types/ms@2.1.0': {}
 
   '@types/multer@2.1.0':
@@ -8072,9 +8089,20 @@ snapshots:
       csstype: 3.2.3
     optional: true
 
+  '@types/send@0.17.6':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 25.9.2
+
   '@types/send@1.2.1':
     dependencies:
       '@types/node': 25.9.2
+
+  '@types/serve-static@1.15.10':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 25.9.2
+      '@types/send': 0.17.6
 
   '@types/serve-static@2.2.0':
     dependencies:


### PR DESCRIPTION
## Why

A scaffolded **h3** (or Fastify) app still installed `express`:

```jsonc
"dependencies": { "@forinda/kickjs": "...", "h3": "...", "express": "^5.1.0" }
```

Both runtimes' `serveStatic` called `express.static`, so `express` was a hard dependency even on a pure non-Express app — defeating "swap the engine, drop Express."

## Fix

- **Runtime:** Fastify + h3 `serveStatic` now use **`serve-static`** (the standalone connect middleware `express.static` wraps), bridged via middie / `fromNodeMiddleware` exactly as before. No behavior change. `serve-static` is a new **optional peer** of `@forinda/kickjs`; `express` is no longer referenced by either runtime.
- **Scaffold:** `kick new --runtime fastify|h3` installs `serve-static` instead of `express`, and drops the `@types/express` devDependency. **Express scaffolds are unchanged** (still get `express`).
- **Ranges, not pins:** the alpha-channel resolution for the runtime toolchain (`@forinda/kickjs`, `-cli`, `-vite`) now emits `^`-ranges instead of exact versions — projects float to newer alphas and auto-graduate to the stable release once it ships.

## Verified

`kick new --runtime h3 --yes` →

```jsonc
"@forinda/kickjs": "^5.18.0-alpha.0",
"@forinda/kickjs-cli": "^6.2.0-alpha.1",
"@forinda/kickjs-vite": "^7.0.0-alpha.0",
"serve-static": "^2.2.0",
"h3": "^1.0.0"
// no express, no @types/express
```

`kick new --runtime express --yes` still pins `express: ^5.1.0`, no serve-static.

Tests: kickjs conformance 33/33 (express+fastify+h3) green; CLI scaffold 6/6. Changeset: `@forinda/kickjs` minor, `@forinda/kickjs-cli` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Express as a dependency for Fastify and h3 runtimes; now using the standalone serve-static package for static file serving
  * Updated project scaffolding to install serve-static instead of express when creating new Fastify or h3 projects
  * Updated alpha version pinning to use caret ranges, allowing generated projects to automatically upgrade to newer alphas and stable releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->