### PR TITLE
fix(cli): derive Available list (drop deprecated); bump @forinda/kickjs to 6.0.0

### DIFF
--- a/.changeset/kickjs-major-stable-runtimes.md
+++ b/.changeset/kickjs-major-stable-runtimes.md
@@ -1,0 +1,13 @@
+---
+'@forinda/kickjs': major
+---
+
+**Major release — the pluggable HTTP runtimes line.** `@forinda/kickjs` now runs on Express (default), Fastify, or h3 behind one `HttpRuntime` seam, selected with `bootstrap({ runtime })`. Express apps need no code changes (see the migration guide), but this is a major because the runtime/adapter refactor changed a few surfaces that adapter and tooling authors depend on:
+
+- `RequestContext` response helpers (`json`/`html`/`sse`/`download`/`render`/`problem`) now return `RuntimeResponse` instead of the Express `Response` — they write through an engine-neutral response driver.
+- `AdapterContext` gained a required `http` facade (`route`/`mount`/`serveStatic`/`use`) and `AdapterContext.app` / `getRuntimeApp()` are typed to the active runtime via the `KickRuntimeRegister` registry (Express by default).
+- `getExpressApp()` is deprecated in favour of `getRuntimeApp()`.
+- The default logger is `ConsoleLoggerProvider` (pino dropped — zero default deps).
+- The Fastify and h3 runtimes carry no `express` dependency (static serving uses `serve-static`).
+
+New: `@FileUpload` works on all three engines, `bootstrap({ runtime })`, the `@forinda/kickjs/fastify` and `@forinda/kickjs/h3` subpaths, cross-engine uploads, and the `KickRuntimeRegister` type registry.

--- a/.changeset/scaffold-available-list.md
+++ b/.changeset/scaffold-available-list.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+The post-scaffold "Available:" hint no longer advertises deprecated packages. It was a hardcoded list that included `auth`, `drizzle`, and `prisma` (all deprecated); it's now derived from `PACKAGE_REGISTRY`, filtering out deprecated, core, `:` sub-variants, and db-dialect/schema-lib duplicates — so it can't drift. A test locks it (no deprecated/core names in the list).

--- a/packages/cli/__tests__/add-registry.test.ts
+++ b/packages/cli/__tests__/add-registry.test.ts
@@ -3,7 +3,12 @@ import { join, resolve } from 'node:path'
 
 import { describe, it, expect } from 'vitest'
 
-import { PACKAGE_REGISTRY, planAddPackages, UPLOAD_DRIVERS } from '../src/commands/add'
+import {
+  PACKAGE_REGISTRY,
+  planAddPackages,
+  UPLOAD_DRIVERS,
+  AVAILABLE_ADD_PACKAGES,
+} from '../src/commands/add'
 
 const WORKSPACE_PACKAGES_DIR = resolve(__dirname, '../..')
 
@@ -53,6 +58,20 @@ describe('PACKAGE_REGISTRY catalog health', () => {
         false,
       )
     }
+  })
+
+  it('the post-scaffold "Available:" list excludes deprecated and core packages', () => {
+    const names = AVAILABLE_ADD_PACKAGES.split(',').map((s) => s.trim())
+    expect(names.length).toBeGreaterThan(0)
+    for (const name of names) {
+      const entry = PACKAGE_REGISTRY[name]
+      expect(entry, `'${name}' is not a known registry package`).toBeDefined()
+      expect(entry?.deprecated, `'${name}' is deprecated — must not be advertised`).toBeUndefined()
+      expect(entry?.core, `'${name}' is core — already installed, don't advertise`).toBeFalsy()
+    }
+    expect(names).not.toContain('auth')
+    expect(names).not.toContain('drizzle')
+    expect(names).not.toContain('prisma')
   })
 
   it('never offers the merged db-* dialect shims or internal support packages', () => {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -191,6 +191,25 @@ export const PACKAGE_REGISTRY: Record<string, PackageEntry> = {
 }
 
 /**
+ * Headline `kick add` packages shown after scaffolding — derived from
+ * {@link PACKAGE_REGISTRY} so it can never advertise a deprecated package (the
+ * old hardcoded list included auth / drizzle / prisma). Excludes core packages
+ * (already installed), deprecated ones, `:` sub-variants (e.g. `queue:bullmq`),
+ * and the db-dialect / schema-lib duplicates that clutter a one-line summary.
+ * `kick add --list` shows the full catalog.
+ */
+export const AVAILABLE_ADD_PACKAGES = Object.entries(PACKAGE_REGISTRY)
+  .filter(
+    ([name, entry]) =>
+      !entry.core &&
+      !entry.deprecated &&
+      !name.includes(':') &&
+      !['pg', 'sqlite', 'mysql', 'zod', 'valibot', 'yup'].includes(name),
+  )
+  .map(([name]) => name)
+  .join(', ')
+
+/**
  * The `upload` catalog name is special — file uploads ship inside
  * `@forinda/kickjs` itself, so there's no package to install. What an app
  * needs is the multipart DRIVER for its HTTP runtime, and that differs per

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -25,6 +25,7 @@ import {
   generateHelloModule,
 } from './templates/project-app'
 import { generateReadme } from './templates/project-docs'
+import { AVAILABLE_ADD_PACKAGES } from '../commands/add'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const cliPkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
@@ -413,6 +414,6 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
   log('  kick add <pkg>            Install a KickJS package + peers')
   log('  kick add --list           Show all available packages')
   log('')
-  log('Available: auth, swagger, drizzle, prisma, ws, queue, devtools, mcp, testing')
+  log(`Available: ${AVAILABLE_ADD_PACKAGES}`)
   log('')
 }

--- a/packages/kickjs/README.md
+++ b/packages/kickjs/README.md
@@ -1,6 +1,6 @@
 # @forinda/kickjs
 
-Decorator-driven Node.js framework on Express 5 + TypeScript. Custom DI container, factory-first module system, code generators, Zod-native validation, end-to-end type safety via typegen, and Vite HMR for sub-200ms dev reloads.
+Decorator-driven Node.js framework for TypeScript — runs on **Express, Fastify, or h3** (swap the engine in one line). Custom DI container, factory-first module system, code generators, Zod-native validation, end-to-end type safety via typegen, and Vite HMR for sub-200ms dev reloads.
 
 ## Install
 

--- a/packages/kickjs/package.json
+++ b/packages/kickjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forinda/kickjs",
   "version": "5.18.0",
-  "description": "A production-grade, decorator-driven Node.js framework built on Express 5 and TypeScript.",
+  "description": "A production-grade, decorator-driven Node.js framework for TypeScript — runs on Express, Fastify, or h3 (swap the engine in one line).",
   "keywords": [
     "kickjs",
     "nodejs",
@@ -9,7 +9,9 @@
     "decorator-driven",
     "framework",
     "express",
-    "express-5",
+    "fastify",
+    "h3",
+    "pluggable-runtime",
     "dependency-injection",
     "decorators",
     "di-container",


### PR DESCRIPTION
## Two changes

### 1. Post-scaffold "Available:" list dropped deprecated packages
After `kick new`, the printed hint was hardcoded:

```
Available: auth, swagger, drizzle, prisma, ws, queue, devtools, mcp, testing
```

`auth`, `drizzle`, and `prisma` are **deprecated** — shouldn't be advertised to new projects. The list is now **derived from `PACKAGE_REGISTRY`** (filtering deprecated, core, `:` sub-variants, and db-dialect/schema-lib duplicates), so it can't drift:

```
Available: ai, swagger, db, ws, devtools, queue, mcp, testing
```

A test locks it (no deprecated/core names in the list).

### 2. Changeset: bump `@forinda/kickjs` to 6.0.0 (major)

The pluggable-runtimes/adapter-facade work shipped as `5.18.0` (minor), but it changed surfaces adapter/tooling authors depend on. This changeset cuts a proper **major** to signal them:

- `RequestContext` response helpers now return `RuntimeResponse` (not Express `Response`)
- `AdapterContext.http` required; `AdapterContext.app` / `getRuntimeApp()` runtime-typed
- `getExpressApp()` deprecated → `getRuntimeApp()`
- default logger is `ConsoleLoggerProvider` (pino dropped)
- Fastify/h3 runtimes carry no `express` dep (serve-static)

`changeset status`: `@forinda/kickjs` → **6.0.0**, `@forinda/kickjs-cli` → patch. **No dependent cascade** — sibling peer ranges (`>=5.18.0`) already satisfy 6.0.0, so vite/db/etc. are not bumped.

> The version bump + publish happen on the next release cycle (merge → Version PR → gated publish). Express apps need no code changes — see the migration guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pluggable HTTP runtimes (Express, Fastify, h3) selectable via `bootstrap({ runtime })`
  * Added cross-engine file upload support
  * New runtime options for Fastify and h3 subpaths

* **Deprecated**
  * `getExpressApp()` deprecated in favor of `getRuntimeApp()`

* **Improvements**
  * Updated logger default to ConsoleLoggerProvider
  * CLI "Available" packages list now dynamically generated from registry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->