### PR TITLE
fix(runtime): h3 shared router + fastify trailing-slash — all route sources reachable

### DIFF
--- a/.changeset/h3-shared-router.md
+++ b/.changeset/h3-shared-router.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs': patch
+---
+
+Fix the h3 runtime 404-ing routes from any source past the first (`/health`, devtools `/_debug/*`, ad-hoc adapter routes), with errors like `Cannot find any path matching /_debug/health`. h3's `createRouter` is terminal — on no match it throws a 404 rather than falling through to the next `app.use` layer like an Express Router — so mounting each route source as its own router let the first one shadow the rest. The runtime now keeps **one shared router** per app (all `mountRoutes` calls add to it), registers it once after the connect middleware, and dispatches the router's no-match 404 through `onError` to the framework's notFound handler (or the Vite dev fall-through) instead of surfacing it as a logged error.

--- a/.changeset/h3-shared-router.md
+++ b/.changeset/h3-shared-router.md
@@ -2,4 +2,9 @@
 '@forinda/kickjs': patch
 ---
 
-Fix the h3 runtime 404-ing routes from any source past the first (`/health`, devtools `/_debug/*`, ad-hoc adapter routes), with errors like `Cannot find any path matching /_debug/health`. h3's `createRouter` is terminal — on no match it throws a 404 rather than falling through to the next `app.use` layer like an Express Router — so mounting each route source as its own router let the first one shadow the rest. The runtime now keeps **one shared router** per app (all `mountRoutes` calls add to it), registers it once after the connect middleware, and dispatches the router's no-match 404 through `onError` to the framework's notFound handler (or the Vite dev fall-through) instead of surfacing it as a logged error.
+Two HTTP-runtime route-reachability fixes surfaced by linked-build testing:
+
+- **h3:** routes from any source past the first 404'd (`/health`, devtools `/_debug/*`, ad-hoc adapter routes) with `Cannot find any path matching …`. h3's `createRouter` is terminal — on no match it throws rather than falling through like an Express Router — so mounting each source as its own router let the first shadow the rest. The runtime now uses one shared router per app (registered after the connect middleware), and dispatches the router's no-match 404 through `onError` to the framework's notFound handler (or the Vite dev fall-through) instead of surfacing it as a logged error.
+- **fastify:** a controller's root `@Get('/')` (mounted at the prefix) 404'd a trailing-slash request (`/api/v1/hello/`) because Fastify's router is strict by default, while Express and h3 are lenient. The runtime now sets `routerOptions.ignoreTrailingSlash`, so `${prefix}` and `${prefix}/` both resolve.
+
+Conformance gains multi-mount-source and root-trailing-slash cases across express + fastify + h3.

--- a/packages/kickjs/__tests__/fastify-conformance.test.ts
+++ b/packages/kickjs/__tests__/fastify-conformance.test.ts
@@ -271,6 +271,30 @@ for (const rt of RUNTIMES) {
       expect(res.body).toEqual({ names: ['a.txt', 'b.txt'] })
     })
 
+    it('serves a controller root route with and without a trailing slash', async () => {
+      // Regression: a controller `@Get('/')` mounts at the prefix itself. Fastify's
+      // strict router 404s `${prefix}/` (trailing slash) unless ignoreTrailingSlash
+      // is on — Express and h3 are lenient. Both forms must resolve.
+      @Controller()
+      class Root {
+        @Get('/')
+        root(ctx: RequestContext) {
+          ctx.json({ ok: true })
+        }
+      }
+      const app = new Application({
+        runtime: rt.make(),
+        modules: [{ routes: () => ({ path: '/root', controller: Root }) } as never],
+      })
+      await app.setup()
+      const handler = app.handle.bind(app)
+
+      const noSlash = await request(handler).get('/api/v1/root').expect(200)
+      expect(noSlash.body).toEqual({ ok: true })
+      const withSlash = await request(handler).get('/api/v1/root/').expect(200)
+      expect(withSlash.body).toEqual({ ok: true })
+    })
+
     it('reaches routes from multiple mount sources, and still 404s the rest', async () => {
       // Regression: h3's router is terminal (throws on no match), so two route
       // sources mounted as separate routers would let the first shadow the

--- a/packages/kickjs/__tests__/fastify-conformance.test.ts
+++ b/packages/kickjs/__tests__/fastify-conformance.test.ts
@@ -271,6 +271,42 @@ for (const rt of RUNTIMES) {
       expect(res.body).toEqual({ names: ['a.txt', 'b.txt'] })
     })
 
+    it('reaches routes from multiple mount sources, and still 404s the rest', async () => {
+      // Regression: h3's router is terminal (throws on no match), so two route
+      // sources mounted as separate routers would let the first shadow the
+      // second. Both controllers must be reachable; an unmatched path is a clean
+      // 404, not a surfaced error.
+      @Controller()
+      class A {
+        @Get('/a')
+        a(ctx: RequestContext) {
+          ctx.json({ from: 'a' })
+        }
+      }
+      @Controller()
+      class B {
+        @Get('/b')
+        b(ctx: RequestContext) {
+          ctx.json({ from: 'b' })
+        }
+      }
+      const app = new Application({
+        runtime: rt.make(),
+        modules: [
+          { routes: () => ({ path: '/one', controller: A }) } as never,
+          { routes: () => ({ path: '/two', controller: B }) } as never,
+        ],
+      })
+      await app.setup()
+      const handler = app.handle.bind(app)
+
+      const ra = await request(handler).get('/api/v1/one/a').expect(200)
+      expect(ra.body).toEqual({ from: 'a' })
+      const rb = await request(handler).get('/api/v1/two/b').expect(200)
+      expect(rb.body).toEqual({ from: 'b' })
+      await request(handler).get('/api/v1/one/nope').expect(404)
+    })
+
     it('rejects a file whose type is not allowed', async () => {
       @Controller()
       class C {

--- a/packages/kickjs/src/http/runtimes/fastify.ts
+++ b/packages/kickjs/src/http/runtimes/fastify.ts
@@ -260,6 +260,13 @@ export function fastifyRuntime(): HttpRuntime<FastifyAppLike> {
       const Fastify = loadPeer('fastify')
       const app = Fastify({
         logger: false,
+        // Match Express / h3 routing leniency: `/api/v1/hello` and
+        // `/api/v1/hello/` resolve to the same route. Without this, Fastify's
+        // strict router 404s a trailing-slash request — e.g. a controller's
+        // root `@Get('/')` (mounted at the prefix) misses `${prefix}/`. Set under
+        // `routerOptions` (Fastify 5+; top-level `ignoreTrailingSlash` is
+        // deprecated, removed in Fastify 6).
+        routerOptions: { ignoreTrailingSlash: true },
         // trustProxy passed through for now; core X-Forwarded-For
         // normalization (spec §10 Q1) is a follow-up.
         trustProxy: typeof options.trustProxy === 'function' ? false : options.trustProxy,

--- a/packages/kickjs/src/http/runtimes/h3.ts
+++ b/packages/kickjs/src/http/runtimes/h3.ts
@@ -48,6 +48,13 @@ interface H3AppLike {
 
 const NEXT = Symbol('kickjs.h3.next')
 const ERROR_MW = Symbol('kickjs.h3.errorMw')
+// h3's `createRouter` is terminal — on no match it THROWS a 404, it does not
+// fall through to the next `app.use` layer like an Express Router. So every
+// route source (controllers, /health, devtools /_debug, ad-hoc adapter routes)
+// must live on ONE shared router, registered AFTER all connect middleware.
+const ROUTER = Symbol('kickjs.h3.router')
+const NOTFOUND_MW = Symbol('kickjs.h3.notFoundMw')
+const ASSEMBLED = Symbol('kickjs.h3.assembled')
 const NOOP_NEXT = (): void => {}
 const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 
@@ -199,12 +206,40 @@ export function h3Runtime(): HttpRuntime<H3AppLike> {
       const { createApp } = h3()
       const app = createApp({
         onError: (error: unknown, event: H3EventLike) => {
-          const mw = (app as { [ERROR_MW]?: ConnectMiddleware })[ERROR_MW]
-          if (mw && !event.node.res.writableEnded) {
+          const res = event.node.res
+          if (res.writableEnded) return
+          const state = app as {
+            [ERROR_MW]?: ConnectMiddleware
+            [NOTFOUND_MW]?: ConnectMiddleware
+          }
+          // The shared router throws a 404 on no match (it's terminal). Treat
+          // that as "not found", not a server error: hand back to the outer
+          // chain (Vite dev fall-through) when present, else run the framework's
+          // notFound handler so it returns a proper 404 — only genuine handler
+          // errors reach the error middleware (and the ErrorHandler log).
+          const status = (error as { statusCode?: number } | undefined)?.statusCode
+          if (status === 404) {
+            const next = (event.node.req as IncomingMessage & { [NEXT]?: () => void })[NEXT]
+            if (next) {
+              next()
+              return
+            }
+            const nf = state[NOTFOUND_MW]
+            if (nf) {
+              ;(nf as (req: unknown, res: unknown, next: () => void) => void)(
+                event.node.req,
+                resDriver(res),
+                NOOP_NEXT,
+              )
+              return
+            }
+          }
+          const mw = state[ERROR_MW]
+          if (mw) {
             ;(mw as (e: unknown, req: unknown, res: unknown, next: () => void) => void)(
               error,
               event.node.req,
-              resDriver(event.node.res),
+              resDriver(res),
               NOOP_NEXT,
             )
           }
@@ -215,6 +250,15 @@ export function h3Runtime(): HttpRuntime<H3AppLike> {
 
     nodeHandler(app) {
       const { toNodeListener } = h3()
+      // Register the shared router exactly once, AFTER all connect middleware
+      // (serveStatic / useConnect) the setup phase added via `app.use` — the
+      // router is terminal, so anything that must run for non-route paths has to
+      // sit before it in the stack.
+      const state = app as { [ROUTER]?: unknown; [ASSEMBLED]?: boolean }
+      if (!state[ASSEMBLED]) {
+        state[ASSEMBLED] = true
+        if (state[ROUTER]) app.use(state[ROUTER])
+      }
       const listener = toNodeListener(app)
       return (req: IncomingMessage, res: ServerResponse, next?: (err?: unknown) => void) => {
         if (next) (req as IncomingMessage & { [NEXT]?: (err?: unknown) => void })[NEXT] = next
@@ -226,7 +270,12 @@ export function h3Runtime(): HttpRuntime<H3AppLike> {
 
     mountRoutes(app, table: RouteTable) {
       const { createRouter, eventHandler } = h3()
-      const router = createRouter()
+      // One shared router per app — every mountRoutes call (controllers, health,
+      // devtools, ad-hoc adapter routes) adds to it. `app.use(router)` is
+      // deferred to nodeHandler so the router lands after connect middleware.
+      const state = app as { [ROUTER]?: ReturnType<typeof createRouter> }
+      if (!state[ROUTER]) state[ROUTER] = createRouter()
+      const router = state[ROUTER]
       for (const { mountPath, routes } of table) {
         for (const entry of routes) {
           const url = joinPath(mountPath, entry.path)
@@ -234,7 +283,6 @@ export function h3Runtime(): HttpRuntime<H3AppLike> {
           router[method](url, eventHandler(makeEventHandler(entry)))
         }
       }
-      app.use(router)
     },
 
     useConnect(app, mw: ConnectMiddleware, opts?: UseConnectOptions) {
@@ -253,22 +301,11 @@ export function h3Runtime(): HttpRuntime<H3AppLike> {
     },
 
     setNotFound(app, mw: ConnectMiddleware) {
-      const { eventHandler } = h3()
-      // Registered after the router, so it only runs when nothing matched.
-      app.use(
-        eventHandler((event: H3EventLike) => {
-          const next = (event.node.req as IncomingMessage & { [NEXT]?: () => void })[NEXT]
-          if (next) {
-            next()
-            return
-          }
-          ;(mw as (req: unknown, res: unknown, next: () => void) => void)(
-            event.node.req,
-            resDriver(event.node.res),
-            NOOP_NEXT,
-          )
-        }),
-      )
+      // Stash it — the shared router throws a 404 on no match, which `onError`
+      // (createApp) dispatches to this handler (or to the Vite fall-through when
+      // a `next` is present). A post-router `app.use` could never run, since the
+      // terminal router throws before the stack advances.
+      ;(app as { [NOTFOUND_MW]?: ConnectMiddleware })[NOTFOUND_MW] = mw
     },
 
     setErrorHandler(app, mw: ConnectMiddleware) {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'packages/*'
   - 'packages/*/spa'
+  - '!examples'


### PR DESCRIPTION
## Two route-reachability fixes (found via linked-build testing of real h3/fastify apps)

### h3 — routes past the first 404'd
```
ERROR [ErrorHandler] GET /_debug/health — Cannot find any path matching /_debug/health.
```
h3's `createRouter` is **terminal** — on no match it *throws* a 404 rather than falling through like an Express Router. The runtime mounted each route source (controllers, `/health`, devtools `/_debug/*`, ad-hoc routes) as its **own** router via `app.use`, so the first one threw before the rest ran.

**Fix:** one shared router per app (every `mountRoutes` adds to it), `app.use`'d once after the connect middleware; the router's no-match 404 is dispatched through `onError` → notFound handler (clean 404) or Vite dev fall-through, not surfaced as a logged error.

### fastify — root `@Get('/')` 404'd a trailing slash
A controller root route mounts at the prefix. Fastify's router is **strict** by default, so `GET /api/v1/hello/` (trailing slash) 404'd while `/api/v1/hello` worked — Express and h3 are lenient.

**Fix:** `routerOptions.ignoreTrailingSlash: true` (the Fastify 5+ form; top-level `ignoreTrailingSlash` is deprecated, removed in Fastify 6). Both `${prefix}` and `${prefix}/` resolve.

## Verified end-to-end

Scaffolded `--runtime h3` and `--runtime fastify` example apps, **hard-linked** to the local build (`link:../../packages/kickjs`), built, booted, curled:

| | h3 | fastify |
| --- | --- | --- |
| `GET /hello/` (root, trailing slash) | 200 | 200 |
| `GET /hello/health` (2nd source) | 200 | 200 |
| `GET /hello/boom` (throws) → `onError` | 500 custom-error | 500 custom-error |
| `GET /nope` → `onNotFound` | 404 custom-not-found | 404 custom-not-found |
| `Cannot find any path` errors in log | 0 | 0 |

Custom `onError` + `onNotFound` both fire on both engines.

## Tests

Conformance gains **multi-mount-source** and **root-trailing-slash** cases across express + fastify + h3 (39 tests, no Fastify deprecation warnings). Changeset: `@forinda/kickjs` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
