### PR TITLE
docs(readme): add downloads, CI, TypeScript, and stars badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@forinda/kickjs"><img src="https://img.shields.io/npm/v/@forinda/kickjs?color=FACC15&label=npm" alt="npm version" /></a>
+  <a href="https://www.npmjs.com/package/@forinda/kickjs"><img src="https://img.shields.io/npm/dw/@forinda/kickjs?color=3B82F6&label=downloads" alt="npm weekly downloads" /></a>
+  <a href="https://github.com/forinda/kick-js/actions/workflows/ci.yml"><img src="https://github.com/forinda/kick-js/actions/workflows/ci.yml/badge.svg" alt="CI status" /></a>
+  <a href="https://www.npmjs.com/package/@forinda/kickjs"><img src="https://img.shields.io/npm/types/@forinda/kickjs?color=3178C6" alt="TypeScript types" /></a>
   <a href="https://github.com/forinda/kick-js/blob/main/LICENSE"><img src="https://img.shields.io/github/license/forinda/kick-js?color=312E81" alt="license" /></a>
   <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D20-brightgreen" alt="node version" /></a>
+  <a href="https://github.com/forinda/kick-js"><img src="https://img.shields.io/github/stars/forinda/kick-js?style=flat&color=FACC15" alt="GitHub stars" /></a>
 </p>
 
 NestJS ergonomics without the complexity — decorators, DI, module system, code generators, and end-to-end type safety, powered by Zod and Vite.


### PR DESCRIPTION
## Badges

Adds high-signal badges to the README header, alongside the existing npm-version / license / node ones:

| Badge | Why |
| --- | --- |
| **npm weekly downloads** (`npm/dw`) | adoption / momentum |
| **CI status** (`ci.yml/badge.svg`) | build health at a glance |
| **TypeScript types** (`npm/types`) | signals first-class TS (ships `.d.mts`) |
| **GitHub stars** (`github/stars`) | social proof |

Kept it tasteful — no badge soup. Brand-colored where it made sense (downloads blue, stars/version amber).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
