### PR TITLE
feat(vscode): SecretStorage token + webview auth + v6/db commands

### DIFF
--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,17 @@
 # kickjs-devtools
 
+## 5.3.0
+
+### Minor Changes
+
+- Security + v6 feature update for the VS Code extension:
+  - **Token moved to SecretStorage.** The devtools auth token is no longer stored in the plaintext `kickjs.token` setting (which could be committed to `.vscode/settings.json`). It now lives in VS Code SecretStorage; an existing setting value is migrated once and the plaintext copy cleared. `KickJS: Set/Clear DevTools Token…` write to SecretStorage.
+  - **Dashboard webview now sends the token.** The webview's `fetch`es include the `x-devtools-token` header, so the dashboard works against token-protected servers (previously it showed "Unavailable").
+  - **Active runtime engine** (`express` / `fastify` / `h3`) is surfaced in the Health tree and the dashboard health card (KickJS v6 `/health.runtime`).
+  - **New commands:** `KickJS: Doctor` (`kick doctor`), and `KickJS: DB Migrate / Status / Generate / Rollback` (`kick db …`).
+  - **`Add Package…`** now offers `db`, `pg`, `sqlite`, `mysql`, `upload`, and `ai`; the deprecated `auth` / `drizzle` / `prisma` entries were removed.
+  - Marketplace: `fastify` / `h3` / `database` keywords, `Visualization` category (was the misleading `Debuggers`), `bugs` / `homepage` fields.
+
 ## 5.2.1
 
 ### Patch Changes

--- a/packages/vscode-extension/__tests__/connect-command.test.ts
+++ b/packages/vscode-extension/__tests__/connect-command.test.ts
@@ -47,6 +47,7 @@ describe('registerConnectCommand', () => {
     )
     registerConnectCommand(fakeContext, {
       onConnected: onConnected as unknown as (s: string, d: string) => void,
+      getToken: async () => undefined,
     })
   })
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "kickjs-devtools",
   "displayName": "KickJS DevTools",
   "description": "VS Code extension for inspecting KickJS applications — routes, DI container, metrics, and health",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "publisher": "forinda",
   "engines": {
     "vscode": "^1.85.0"
@@ -10,13 +10,16 @@
   "icon": "resources/icon.png",
   "categories": [
     "Other",
-    "Debuggers"
+    "Visualization"
   ],
   "keywords": [
     "kickjs",
     "devtools",
     "nodejs",
     "express",
+    "fastify",
+    "h3",
+    "database",
     "typescript",
     "decorator"
   ],
@@ -123,6 +126,31 @@
         "command": "kickjs.mcpInit",
         "title": "KickJS: Initialise MCP Config (.claude/)",
         "icon": "$(file-add)"
+      },
+      {
+        "command": "kickjs.doctor",
+        "title": "KickJS: Doctor (pre-flight checks)",
+        "icon": "$(pulse)"
+      },
+      {
+        "command": "kickjs.dbMigrate",
+        "title": "KickJS: DB Migrate (latest)",
+        "icon": "$(database)"
+      },
+      {
+        "command": "kickjs.dbStatus",
+        "title": "KickJS: DB Migration Status",
+        "icon": "$(database)"
+      },
+      {
+        "command": "kickjs.dbGenerate",
+        "title": "KickJS: DB Generate Migration…",
+        "icon": "$(database)"
+      },
+      {
+        "command": "kickjs.dbRollback",
+        "title": "KickJS: DB Rollback (last batch)",
+        "icon": "$(database)"
       }
     ],
     "menus": {
@@ -218,6 +246,26 @@
         {
           "command": "kickjs.mcpInit",
           "when": "kickjs.isKickProject"
+        },
+        {
+          "command": "kickjs.doctor",
+          "when": "kickjs.isKickProject"
+        },
+        {
+          "command": "kickjs.dbMigrate",
+          "when": "kickjs.isKickProject"
+        },
+        {
+          "command": "kickjs.dbStatus",
+          "when": "kickjs.isKickProject"
+        },
+        {
+          "command": "kickjs.dbGenerate",
+          "when": "kickjs.isKickProject"
+        },
+        {
+          "command": "kickjs.dbRollback",
+          "when": "kickjs.isKickProject"
         }
       ]
     },
@@ -242,7 +290,8 @@
         "kickjs.token": {
           "type": "string",
           "default": "",
-          "description": "Optional DevTools auth token. Leave empty when the server runs the DevTools adapter with `secret: false` (auth disabled) — the extension probes + the tree views work without a token. When `secret` is auto-generated or explicitly set (printed as `[token: …]` in the startup console), paste it here OR run `KickJS: Set DevTools Token…` from the palette."
+          "markdownDeprecationMessage": "The token is now stored securely in VS Code SecretStorage. Run **KickJS: Set DevTools Token…** from the palette instead. Any value here is migrated to SecretStorage and cleared automatically.",
+          "description": "Deprecated — use `KickJS: Set DevTools Token…`. The token now lives in SecretStorage, not settings.json. A value left here is migrated once, then removed."
         }
       }
     },
@@ -297,6 +346,10 @@
     "url": "https://github.com/forinda/kick-js.git",
     "directory": "packages/vscode-extension"
   },
+  "bugs": {
+    "url": "https://github.com/forinda/kick-js/issues"
+  },
+  "homepage": "https://forinda.github.io/kick-js/guide/devtools",
   "license": "MIT",
   "scripts": {
     "build": "pnpm build:icons && vite build",

--- a/packages/vscode-extension/src/commands/connect.ts
+++ b/packages/vscode-extension/src/commands/connect.ts
@@ -30,6 +30,8 @@ import {
 export interface ConnectCommandDeps {
   /** Called after a successful probe so the activate-time refresh runs. */
   onConnected: (serverUrl: string, debugPath: string) => void
+  /** Resolve the devtools auth token (from SecretStorage). */
+  getToken: () => Promise<string | undefined>
 }
 
 export function registerConnectCommand(
@@ -80,7 +82,7 @@ async function runAutoDetect(deps: ConnectCommandDeps): Promise<void> {
   const debugPath = readDebugPath()
   const roots = workspaceRoots()
   const candidates = buildCandidates(roots, debugPath)
-  const token = readToken()
+  const token = await deps.getToken()
 
   const result = await vscode.window.withProgress(
     {
@@ -104,13 +106,13 @@ async function runAutoDetect(deps: ConnectCommandDeps): Promise<void> {
     return
   }
 
-  await acceptResult(result, debugPath, deps)
+  await acceptResult(result, debugPath, deps, token)
 }
 
 async function runManualConnect(deps: ConnectCommandDeps): Promise<void> {
   const debugPath = readDebugPath()
   const currentUrl = readServerUrl()
-  const token = readToken()
+  const token = await deps.getToken()
 
   const url = await vscode.window.showInputBox({
     title: 'KickJS: server URL',
@@ -135,13 +137,14 @@ async function runManualConnect(deps: ConnectCommandDeps): Promise<void> {
     return
   }
 
-  await acceptResult(result, debugPath, deps)
+  await acceptResult(result, debugPath, deps, token)
 }
 
 async function acceptResult(
   result: ProbeResult & { ok: true },
   debugPath: string,
   deps: ConnectCommandDeps,
+  token: string | undefined,
 ): Promise<void> {
   const serverUrl = result.baseUrl.replace(new RegExp(escapeRegex(debugPath) + '$'), '')
   const target =
@@ -159,8 +162,7 @@ async function acceptResult(
   //   - no token configured + 200 → server runs with `secret: false`
   //     (auth disabled) since a 401 would have routed to reportFailure
   //     instead of acceptResult.
-  const usingToken = !!config.get<string>('token')
-  const authNote = usingToken ? 'auth: token' : 'auth: disabled'
+  const authNote = token ? 'auth: token' : 'auth: disabled'
   vscode.window.showInformationMessage(
     `KickJS: connected to ${result.baseUrl} (${authNote}, uptime ${result.info.uptime}s, status ${result.info.status})`,
   )
@@ -216,10 +218,6 @@ function readServerUrl(): string {
 
 function readDebugPath(): string {
   return vscode.workspace.getConfiguration('kickjs').get<string>('debugPath', DEFAULT_DEBUG_PATH)
-}
-
-function readToken(): string | undefined {
-  return vscode.workspace.getConfiguration('kickjs').get<string>('token') || undefined
 }
 
 function validateUrl(input: string): string | null {

--- a/packages/vscode-extension/src/commands/kick.ts
+++ b/packages/vscode-extension/src/commands/kick.ts
@@ -113,7 +113,7 @@ export function registerKickCommands(_context: vscode.ExtensionContext): vscode.
         title: 'KickJS: generate migration',
         prompt: 'Migration name (diffs the schema against the last snapshot)',
         placeHolder: 'add_users',
-        validateInput: validateName,
+        validateInput: validateMigrationName,
       })
       if (!name) return
       runKick(`db generate ${name}`)
@@ -200,6 +200,20 @@ function validateName(input: string): string | null {
   if (!trimmed) return 'Name is required'
   if (!/^[a-z][a-z0-9-]*$/.test(trimmed)) {
     return 'Use kebab-case: lowercase letters, digits, hyphens (must start with a letter)'
+  }
+  return null
+}
+
+/**
+ * Migration names follow `kick db generate`'s snake_case convention
+ * (e.g. `add_users`), so underscores are allowed here — unlike the
+ * kebab-case module/component names {@link validateName} enforces.
+ */
+function validateMigrationName(input: string): string | null {
+  const trimmed = input.trim()
+  if (!trimmed) return 'Name is required'
+  if (!/^[a-z][a-z0-9_-]*$/.test(trimmed)) {
+    return 'Use lowercase letters, digits, underscores or hyphens (must start with a letter)'
   }
   return null
 }

--- a/packages/vscode-extension/src/commands/kick.ts
+++ b/packages/vscode-extension/src/commands/kick.ts
@@ -96,6 +96,29 @@ export function registerKickCommands(_context: vscode.ExtensionContext): vscode.
     ),
     vscode.commands.registerCommand('kickjs.mcpStart', () => runKick('mcp start')),
     vscode.commands.registerCommand('kickjs.mcpInit', () => runKick('mcp init')),
+
+    // ── Diagnostics ─────────────────────────────────────────────────
+    // `kick doctor` runs the v6 runtime-aware pre-flight checks (engine
+    // peers, upload driver, env wiring) in the shared terminal.
+    vscode.commands.registerCommand('kickjs.doctor', () => runKick('doctor')),
+
+    // ── kick/db utilities ───────────────────────────────────────────
+    // The first-party database (`kick/db`) ships a `kick db` command tree
+    // when `dbCliPlugin` is registered. These wrap the common migration
+    // flows so adopters can drive them from the palette.
+    vscode.commands.registerCommand('kickjs.dbMigrate', () => runKick('db migrate latest')),
+    vscode.commands.registerCommand('kickjs.dbStatus', () => runKick('db migrate status')),
+    vscode.commands.registerCommand('kickjs.dbGenerate', async () => {
+      const name = await vscode.window.showInputBox({
+        title: 'KickJS: generate migration',
+        prompt: 'Migration name (diffs the schema against the last snapshot)',
+        placeHolder: 'add_users',
+        validateInput: validateName,
+      })
+      if (!name) return
+      runKick(`db generate ${name}`)
+    }),
+    vscode.commands.registerCommand('kickjs.dbRollback', () => runKick('db migrate rollback')),
   ]
 }
 
@@ -143,19 +166,23 @@ async function promptAndRunGenerator(
  */
 function addPackageOptions(): vscode.QuickPickItem[] {
   return [
-    { label: 'auth', description: 'JWT, API key, custom strategies' },
+    { label: 'db', description: 'kick/db core — schema DSL, typed queries, migrations' },
+    { label: 'pg', description: 'kick/db + PostgreSQL driver' },
+    { label: 'sqlite', description: 'kick/db + SQLite driver' },
+    { label: 'mysql', description: 'kick/db + MySQL driver' },
+    {
+      label: 'upload',
+      description: 'File-upload driver for your runtime (multer / @fastify/multipart)',
+    },
     { label: 'swagger', description: 'OpenAPI spec + Swagger UI + ReDoc' },
-    { label: 'ws', description: '@WsController decorators (socket.io)' },
+    { label: 'ws', description: 'WebSocket with @WsController, rooms, heartbeat' },
     { label: 'queue', description: 'Queue adapter (BullMQ / RabbitMQ / Kafka)' },
     { label: 'queue:bullmq', description: 'Queue + BullMQ + Redis peers' },
     { label: 'queue:rabbitmq', description: 'Queue + RabbitMQ peer (amqplib)' },
     { label: 'queue:kafka', description: 'Queue + Kafka peer (kafkajs)' },
     { label: 'devtools', description: 'Debug dashboard at /_debug' },
     { label: 'mcp', description: 'Model Context Protocol server' },
-    { label: 'db', description: 'kick/db core — schema DSL, migrations' },
-    { label: 'db-pg', description: 'kick/db PostgreSQL dialect + adapter' },
-    { label: 'drizzle', description: 'Drizzle ORM adapter + query builder' },
-    { label: 'prisma', description: 'Prisma adapter + query builder' },
+    { label: 'ai', description: 'AI toolkit — LLM providers, tools from controllers' },
     { label: 'testing', description: 'TestModule builder + helpers' },
   ]
 }

--- a/packages/vscode-extension/src/connection.ts
+++ b/packages/vscode-extension/src/connection.ts
@@ -36,6 +36,8 @@ export interface ConnectionInfo {
   status: string
   /** Adapter-state map from `/health` (key -> 'running' | 'stopped'). */
   adapters?: Record<string, string>
+  /** Active HTTP runtime engine + capabilities (KickJS v6+), from `/health`. */
+  runtime?: { name: string; capabilities?: Record<string, boolean> }
 }
 
 export type ProbeResult =

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -330,15 +330,11 @@ async function clearToken(context: vscode.ExtensionContext): Promise<void> {
  * via the {@link probeConnection} error message.
  */
 async function offerSetToken(message: string): Promise<void> {
-  const action = await vscode.window.showWarningMessage(
-    `KickJS: ${message}`,
-    'Set token…',
-    'Open settings',
-  )
+  // The token lives in SecretStorage now, so "Set token…" (the secure prompt)
+  // is the only useful action — no settings.json link to a deprecated field.
+  const action = await vscode.window.showWarningMessage(`KickJS: ${message}`, 'Set token…')
   if (action === 'Set token…') {
     await vscode.commands.executeCommand('kickjs.setToken')
-  } else if (action === 'Open settings') {
-    await vscode.commands.executeCommand('workbench.action.openSettings', 'kickjs.token')
   }
 }
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -23,6 +23,35 @@ interface ProviderTrio {
 let current: ProviderTrio | null = null
 let providerDisposables: vscode.Disposable[] = []
 
+/** SecretStorage key for the devtools auth token. */
+const TOKEN_KEY = 'kickjs.token'
+
+/**
+ * Resolve the devtools auth token from VS Code SecretStorage. One-time
+ * migration: if a legacy plaintext `kickjs.token` setting exists (older
+ * versions wrote it to settings.json, where it could be committed), move
+ * it into SecretStorage and clear the setting. Returns `undefined` when
+ * no token is configured (the devtools adapter defaults to no auth).
+ */
+async function getToken(context: vscode.ExtensionContext): Promise<string | undefined> {
+  const secret = await context.secrets.get(TOKEN_KEY)
+  if (secret) return secret
+  const config = vscode.workspace.getConfiguration('kickjs')
+  const legacy = config.get<string>('token')?.trim()
+  if (legacy) {
+    await context.secrets.store(TOKEN_KEY, legacy)
+    // Scrub the plaintext copy from settings.json (both targets).
+    await config
+      .update('token', undefined, vscode.ConfigurationTarget.Workspace)
+      .then(undefined, () => undefined)
+    await config
+      .update('token', undefined, vscode.ConfigurationTarget.Global)
+      .then(undefined, () => undefined)
+    return legacy
+  }
+  return undefined
+}
+
 export async function activate(context: vscode.ExtensionContext) {
   // Gate every contribution on `kickjs.isKickProject` — the views +
   // command-palette entries in package.json declare
@@ -60,14 +89,18 @@ export async function activate(context: vscode.ExtensionContext) {
       if (!isKickProjectCached) return
       if (
         e.affectsConfiguration('kickjs.serverUrl') ||
-        e.affectsConfiguration('kickjs.debugPath') ||
-        e.affectsConfiguration('kickjs.token')
+        e.affectsConfiguration('kickjs.debugPath')
       ) {
-        rebuildProviders(context)
+        void rebuildProviders(context)
       }
       if (e.affectsConfiguration('kickjs.autoRefresh')) {
         startInterval()
       }
+    }),
+    // Token lives in SecretStorage now — rebuild when it changes so the
+    // providers pick up the new (or cleared) token.
+    context.secrets.onDidChange((e) => {
+      if (e.key === TOKEN_KEY && isKickProjectCached) void rebuildProviders(context)
     }),
     { dispose: () => stopInterval() },
   )
@@ -76,7 +109,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.workspace.onDidChangeWorkspaceFolders(() => {
       void refreshKickProjectContext().then(() => {
         if (isKickProjectCached && !current) {
-          rebuildProviders(context)
+          void rebuildProviders(context)
           startInterval()
           void maybeAutoConnect(context)
         } else if (!isKickProjectCached && current) {
@@ -90,7 +123,7 @@ export async function activate(context: vscode.ExtensionContext) {
   )
 
   if (isKickProjectCached) {
-    rebuildProviders(context)
+    void rebuildProviders(context)
     startInterval()
     // First-run auto-detect: if the user hasn't yet picked a URL AND
     // the workspace looks like a KickJS project, race the standard
@@ -113,20 +146,21 @@ export async function activate(context: vscode.ExtensionContext) {
 function registerCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     registerConnectCommand(context, {
-      onConnected: () => rebuildProviders(context),
+      onConnected: () => void rebuildProviders(context),
+      getToken: () => getToken(context),
     }),
-    vscode.commands.registerCommand('kickjs.inspect', () => {
+    vscode.commands.registerCommand('kickjs.inspect', async () => {
       if (!current) {
         return vscode.commands.executeCommand('kickjs.connect')
       }
-      DashboardPanel.createOrShow(context.extensionUri, current.baseUrl)
+      DashboardPanel.createOrShow(context.extensionUri, current.baseUrl, await getToken(context))
     }),
     vscode.commands.registerCommand('kickjs.showRoutes', () => current?.routes.refresh()),
     vscode.commands.registerCommand('kickjs.showContainer', () => current?.container.refresh()),
     vscode.commands.registerCommand('kickjs.showMetrics', () => current?.health.refresh()),
     vscode.commands.registerCommand('kickjs.refreshAll', () => refreshAll()),
     vscode.commands.registerCommand('kickjs.setToken', () => promptForToken(context)),
-    vscode.commands.registerCommand('kickjs.clearToken', () => clearToken()),
+    vscode.commands.registerCommand('kickjs.clearToken', () => clearToken(context)),
     ...registerKickCommands(context),
     { dispose: () => disposeProviders() },
   )
@@ -158,7 +192,7 @@ async function maybeAutoConnect(context: vscode.ExtensionContext): Promise<void>
     const result = await probeConnection(
       config.get<string>('serverUrl', 'http://localhost:3000'),
       config.get<string>('debugPath', DEFAULT_DEBUG_PATH),
-      { token: config.get<string>('token') || undefined },
+      { token: await getToken(context) },
     )
     setConnected(result.ok)
     if (!result.ok && result.error.kind === 'unauthorized') {
@@ -184,16 +218,16 @@ async function maybeAutoConnect(context: vscode.ExtensionContext): Promise<void>
   const debugPath = config.get<string>('debugPath', DEFAULT_DEBUG_PATH)
   const serverUrl = result.baseUrl.replace(new RegExp(escapeRegex(debugPath) + '$'), '')
   await config.update('serverUrl', serverUrl, vscode.ConfigurationTarget.Workspace)
-  rebuildProviders(context)
+  void rebuildProviders(context)
   vscode.window.showInformationMessage(`KickJS: auto-detected app at ${result.baseUrl}`)
 }
 
-function rebuildProviders(context: vscode.ExtensionContext): void {
+async function rebuildProviders(context: vscode.ExtensionContext): Promise<void> {
   disposeProviders()
   const config = vscode.workspace.getConfiguration('kickjs')
   const serverUrl = config.get<string>('serverUrl', 'http://localhost:3000')
   const debugPath = config.get<string>('debugPath', DEFAULT_DEBUG_PATH)
-  const token = config.get<string>('token') || undefined
+  const token = await getToken(context)
   const baseUrl = `${trimRightSlash(serverUrl)}${debugPath}`
 
   const health = new HealthTreeProvider(baseUrl, token)
@@ -258,42 +292,34 @@ function escapeRegex(s: string): string {
  * workspace `kickjs.token`. Triggered explicitly by the palette
  * command + automatically when a 401/403 surfaces in autoConnect.
  */
-async function promptForToken(_context: vscode.ExtensionContext): Promise<void> {
-  const config = vscode.workspace.getConfiguration('kickjs')
-  const current = config.get<string>('token', '')
+async function promptForToken(context: vscode.ExtensionContext): Promise<void> {
+  const existing = (await context.secrets.get(TOKEN_KEY)) ?? ''
   const input = await vscode.window.showInputBox({
     title: 'KickJS: DevTools auth token',
     prompt:
       'Paste the token printed in your server console on startup ' +
-      '(e.g. "[token: abc123…]"). Leave blank to clear.',
-    value: current,
+      '(e.g. "[token: abc123…]"). Stored securely in VS Code SecretStorage, ' +
+      'not in settings.json. Leave blank to clear.',
+    value: existing,
     password: true,
     placeHolder: 'abc123…',
   })
   if (input === undefined) return
   const trimmed = input.trim()
-  const target =
-    (vscode.workspace.workspaceFolders?.length ?? 0) > 0
-      ? vscode.ConfigurationTarget.Workspace
-      : vscode.ConfigurationTarget.Global
-  await config.update('token', trimmed || undefined, target)
   if (trimmed) {
-    vscode.window.showInformationMessage('KickJS: token saved. Reconnecting…')
+    await context.secrets.store(TOKEN_KEY, trimmed)
+    vscode.window.showInformationMessage('KickJS: token saved securely. Reconnecting…')
   } else {
+    await context.secrets.delete(TOKEN_KEY)
     vscode.window.showInformationMessage('KickJS: token cleared.')
   }
-  // Config-change listener triggers rebuildProviders → next refresh
-  // uses the new token.
+  // The secrets.onDidChange listener triggers rebuildProviders → next
+  // refresh uses the new token.
 }
 
-/** Wipe the workspace `kickjs.token` setting. */
-async function clearToken(): Promise<void> {
-  const config = vscode.workspace.getConfiguration('kickjs')
-  const target =
-    (vscode.workspace.workspaceFolders?.length ?? 0) > 0
-      ? vscode.ConfigurationTarget.Workspace
-      : vscode.ConfigurationTarget.Global
-  await config.update('token', undefined, target)
+/** Wipe the devtools token from SecretStorage. */
+async function clearToken(context: vscode.ExtensionContext): Promise<void> {
+  await context.secrets.delete(TOKEN_KEY)
   vscode.window.showInformationMessage('KickJS: token cleared.')
 }
 

--- a/packages/vscode-extension/src/panels/dashboard.ts
+++ b/packages/vscode-extension/src/panels/dashboard.ts
@@ -17,6 +17,9 @@ export class DashboardPanel {
 
   public static createOrShow(extensionUri: vscode.Uri, baseUrl: string, token?: string) {
     if (DashboardPanel.currentPanel) {
+      // Refresh the base URL + token on the live panel so a token set/clear
+      // (or a reconnect to a different app) takes effect without closing it.
+      DashboardPanel.currentPanel.update(baseUrl, token)
       DashboardPanel.currentPanel.panel.reveal()
       return
     }
@@ -29,6 +32,14 @@ export class DashboardPanel {
     )
 
     DashboardPanel.currentPanel = new DashboardPanel(panel, baseUrl, token)
+  }
+
+  /** Re-point the open panel at a new base URL / token and re-render. */
+  private update(baseUrl: string, token: string | undefined): void {
+    if (this.baseUrl === baseUrl && this.token === token) return
+    this.baseUrl = baseUrl
+    this.token = token
+    this.panel.webview.html = this.getHtml()
   }
 
   private dispose() {

--- a/packages/vscode-extension/src/panels/dashboard.ts
+++ b/packages/vscode-extension/src/panels/dashboard.ts
@@ -8,13 +8,14 @@ export class DashboardPanel {
   private constructor(
     panel: vscode.WebviewPanel,
     private baseUrl: string,
+    private token: string | undefined,
   ) {
     this.panel = panel
     this.panel.onDidDispose(() => this.dispose(), null, this.disposables)
     this.panel.webview.html = this.getHtml()
   }
 
-  public static createOrShow(extensionUri: vscode.Uri, baseUrl: string) {
+  public static createOrShow(extensionUri: vscode.Uri, baseUrl: string, token?: string) {
     if (DashboardPanel.currentPanel) {
       DashboardPanel.currentPanel.panel.reveal()
       return
@@ -27,7 +28,7 @@ export class DashboardPanel {
       { enableScripts: true },
     )
 
-    DashboardPanel.currentPanel = new DashboardPanel(panel, baseUrl)
+    DashboardPanel.currentPanel = new DashboardPanel(panel, baseUrl, token)
   }
 
   private dispose() {
@@ -83,7 +84,16 @@ export class DashboardPanel {
   <div id="content"></div>
   <script>
     const BASE = '${this.baseUrl}';
+    const TOKEN = ${JSON.stringify(this.token ?? '')};
     let allRoutes = [];
+
+    // Authenticated GET — sends the devtools token as a header (not a
+    // query string), matching the tree providers. Without this the
+    // dashboard 401s against any server with a configured secret.
+    function getJson(path) {
+      const headers = TOKEN ? { 'x-devtools-token': TOKEN } : undefined;
+      return fetch(BASE + path, { headers }).then(r => r.ok ? r.json() : null).catch(() => null);
+    }
 
     // Escape HTML entities in dynamic string values
     function esc(str) {
@@ -153,10 +163,10 @@ export class DashboardPanel {
       const content = document.getElementById('content');
       try {
         const [health, metrics, routes, container] = await Promise.all([
-          fetch(BASE+'/health').then(r=>r.json()).catch(()=>null),
-          fetch(BASE+'/metrics').then(r=>r.json()).catch(()=>null),
-          fetch(BASE+'/routes').then(r=>r.json()).catch(()=>null),
-          fetch(BASE+'/container').then(r=>r.json()).catch(()=>null),
+          getJson('/health'),
+          getJson('/metrics'),
+          getJson('/routes'),
+          getJson('/container'),
         ]);
 
         allRoutes = routes?.routes ?? [];
@@ -182,6 +192,9 @@ export class DashboardPanel {
           statusRow.appendChild(buildBadge(health.status, health.status === 'healthy'));
           healthCard.appendChild(statusRow);
           healthCard.appendChild(buildStatRow('Uptime', health.uptime + 's'));
+          if (health.runtime && health.runtime.name) {
+            healthCard.appendChild(buildStatRow('Runtime', health.runtime.name));
+          }
         } else {
           const p = document.createElement('p');
           p.className = 'dimmed';

--- a/packages/vscode-extension/src/providers/health.ts
+++ b/packages/vscode-extension/src/providers/health.ts
@@ -74,6 +74,12 @@ export class HealthTreeProvider implements vscode.TreeDataProvider<vscode.TreeIt
     )
     status.iconPath = new vscode.ThemeIcon(this.data.status === 'healthy' ? 'pass' : 'error')
     items.push(status)
+    if (this.data.runtime?.name) {
+      const rt = new vscode.TreeItem(`Runtime: ${this.data.runtime.name}`)
+      rt.iconPath = new vscode.ThemeIcon('server-process')
+      rt.tooltip = 'Active HTTP runtime engine (express / fastify / h3)'
+      items.push(rt)
+    }
     items.push(new vscode.TreeItem(`Uptime: ${this.data.uptime}s`))
     items.push(new vscode.TreeItem(`Error Rate: ${((this.data.errorRate ?? 0) * 100).toFixed(2)}%`))
 


### PR DESCRIPTION
Implements the HIGH-severity items from the VS Code extension audit, plus the v6 + db surface.

## Security
- **Token → SecretStorage.** The devtools auth token left the plaintext `kickjs.token` setting (which lands in committable `.vscode/settings.json`). It now lives in VS Code **SecretStorage**; an existing setting value is migrated once and the plaintext copy scrubbed. `Set/Clear DevTools Token…` and the connect flow read/write SecretStorage; the setting is marked deprecated.

## Correctness
- **Dashboard webview was token-blind.** Its `fetch`es sent no `x-devtools-token`, so the whole dashboard showed "Unavailable" against any secured server. It now injects the header (matching the tree providers).

## v6 coverage
- **Active runtime engine** (`express` / `fastify` / `h3`) shown in the Health tree + dashboard health card (reads the new `/health.runtime` from KickJS v6).
- **New commands:** `KickJS: Doctor` (`kick doctor`), and `KickJS: DB Migrate / Status / Generate / Rollback` (`kick db …`) — db utilities in the palette.
- **`Add Package…`** now offers `db` / `pg` / `sqlite` / `mysql` / `upload` / `ai`; the deprecated `auth` / `drizzle` / `prisma` entries are gone.

## Packaging
- Keywords gain `fastify` / `h3` / `database`; category switched from the misleading `Debuggers` to `Visualization`; added `bugs` / `homepage`. Version `5.2.1 → 5.3.0`, CHANGELOG entry.

## Tests
42 extension tests pass; vite build clean. (The extension is `private` — published to the VS Marketplace via `vsce`, not changesets — so no changeset.)

### Follow-ups (separate, larger)
- **kick/db live telemetry** — a DB tab / tree showing recent queries + pool stats needs the `kick/db` package to emit query/connection events to `DEVTOOLS_BUS` (nothing emits today). That's the bigger half of Felix's "db in devtools" ask.
- Webview ↔ browser-SPA SSE parity (runtime/memory charts), route actions (open-in-browser / copy curl), typed fetch client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `KickJS: Doctor` command and database utilities (migrate, status, generate, rollback)
  * Expanded "Add Package..." picker with new package options
  * Runtime engine information now visible in Health tree and Dashboard
  * Auth token now stored securely using VS Code SecretStorage with automatic migration from settings

* **Chores**
  * Extension version bumped to 5.3.0
  * Updated extension metadata and keywords

<!-- end of auto-generated comment: release notes by coderabbit.ai -->