### PR TITLE
fix(kickjs): dev asset resolver prefers live src tree over stale built manifest

### DIFF
--- a/.changeset/assets-dev-stale-manifest.md
+++ b/.changeset/assets-dev-stale-manifest.md
@@ -1,0 +1,16 @@
+---
+'@forinda/kickjs': patch
+---
+
+assets: in dev, resolve from the live `src/` tree instead of a stale built manifest
+
+`assets.x.y()` / `resolveAsset()` could return stale paths (or throw
+`UnknownAssetError` for a freshly-added file) in development when an earlier
+`kick build` had left a `dist/.kickjs-assets.json` on disk. The dev resolver
+skips its in-memory cache so file additions show up live, but `discoverManifest`
+still probed on-disk built manifests (`dist`/`build`/`out`) _before_ walking the
+source tree — so the stale manifest shadowed `src/`.
+
+Dev now prefers a fresh source walk and only falls back to a built manifest when
+there's no `assetMap` config to walk. `KICK_ASSETS_ROOT` still wins as an
+explicit override; production behaviour is unchanged.

--- a/packages/kickjs/__tests__/assets.test.ts
+++ b/packages/kickjs/__tests__/assets.test.ts
@@ -183,6 +183,58 @@ describe('resolveAsset — dev fallback (no manifest)', () => {
   })
 })
 
+describe('resolveAsset — dev mode prefers the live source tree', () => {
+  // The shared beforeEach pins NODE_ENV=production; these cases need the
+  // dev codepath, so each flips it back to a non-prod value.
+  beforeEach(() => {
+    process.env.NODE_ENV = 'development'
+    clearAssetCache()
+  })
+
+  it('walks src/ instead of a stale dist/.kickjs-assets.json', () => {
+    // An earlier `kick build` left a built manifest on disk pointing at a
+    // file that no longer reflects the source tree. Dev must NOT read it.
+    writeManifest('dist', { 'mails/welcome': 'mails/stale.ejs' })
+    writeFile('dist/mails/stale.ejs', 'stale')
+    writeFile(
+      'kick.config.json',
+      JSON.stringify({ assetMap: { mails: { src: 'src/templates/mails' } } }),
+    )
+    writeFile('src/templates/mails/welcome.ejs', 'fresh')
+
+    expect(resolveAsset('mails', 'welcome')).toBe(
+      toPosix(join(cwd, 'src/templates/mails/welcome.ejs')),
+    )
+  })
+
+  it('picks up a newly-added file without a cache clear or restart', () => {
+    writeFile(
+      'kick.config.json',
+      JSON.stringify({ assetMap: { mails: { src: 'src/templates/mails' } } }),
+    )
+    writeFile('src/templates/mails/welcome.ejs', 'hi')
+    // Prime the resolver once.
+    expect(resolveAsset('mails', 'welcome')).toBe(
+      toPosix(join(cwd, 'src/templates/mails/welcome.ejs')),
+    )
+
+    // Drop a new template in — no clearAssetCache(), no restart.
+    writeFile('src/templates/mails/reminder.ejs', 'remember')
+    expect(resolveAsset('mails', 'reminder')).toBe(
+      toPosix(join(cwd, 'src/templates/mails/reminder.ejs')),
+    )
+  })
+
+  it('still falls back to a built manifest when no assetMap config exists', () => {
+    // No kick.config / assetMap to walk — the dev src-walk returns null,
+    // so a dev running purely off a dist build must still resolve.
+    writeManifest('dist', { 'mails/welcome': 'mails/welcome.ejs' })
+    writeFile('dist/mails/welcome.ejs', 'built')
+
+    expect(resolveAsset('mails', 'welcome')).toBe(toPosix(join(cwd, 'dist/mails/welcome.ejs')))
+  })
+})
+
 describe('resolveAsset — error surface', () => {
   it('throws UnknownAssetError carrying namespace + key fields', () => {
     writeManifest('dist', { 'x/y': 'x/y.txt' })

--- a/packages/kickjs/src/core/assets.ts
+++ b/packages/kickjs/src/core/assets.ts
@@ -129,6 +129,8 @@ function loadManifest(): ResolvedManifest | null {
 }
 
 function discoverManifest(): ResolvedManifest | null {
+  // `KICK_ASSETS_ROOT` is an explicit, deliberate override — it wins in
+  // both dev and prod.
   const envRoot = process.env.KICK_ASSETS_ROOT
   if (envRoot) {
     const fromEnv = readBuiltManifest(envRoot)
@@ -136,6 +138,20 @@ function discoverManifest(): ResolvedManifest | null {
   }
 
   const cwd = process.cwd()
+  const config = loadConfigSync(cwd)
+
+  // In dev, prefer a live walk of the source tree over any built
+  // manifest left on disk by an earlier `kick build`. Otherwise a stale
+  // `dist/.kickjs-assets.json` shadows the live `src/` tree: a freshly
+  // added template file would resolve to the old map (or throw
+  // UnknownAssetError) until the next rebuild — exactly the surprise the
+  // cache-skip in `loadManifest` exists to avoid. `synthesiseDevManifest`
+  // returns null only when there's no `assetMap` config at all, in which
+  // case we fall through to the built-manifest probes below.
+  if (process.env.NODE_ENV !== 'production') {
+    const fresh = synthesiseDevManifest(cwd, config)
+    if (fresh) return fresh
+  }
 
   // Honour `kick.config.build.outDir` BEFORE the standard probe list
   // so adopters with non-default Vite outputs (e.g. `output/`,
@@ -143,7 +159,6 @@ function discoverManifest(): ResolvedManifest | null {
   // every time. Cached config load — same loader the dev fallback
   // uses. Skip when outDir matches one of the standard candidates;
   // it'd be probed redundantly otherwise.
-  const config = loadConfigSync(cwd)
   const configOutDir = config?.build?.outDir
   if (configOutDir && !(STANDARD_OUT_DIRS as readonly string[]).includes(configOutDir)) {
     const found = readBuiltManifest(resolve(cwd, configOutDir))


### PR DESCRIPTION
## Symptom

In **development**, `assets.x.y()` / `useAssets()` / `resolveAsset()` sometimes returned **stale paths** — or threw `UnknownAssetError` for a file that clearly exists — when a new asset file was added to a source directory. Removing files had the mirror problem. A server restart "fixed" it.

## Cause

The dev resolver deliberately skips its in-memory cache (`loadManifest()` re-discovers on every call) so that adding/removing template files shows up live without a restart. But `discoverManifest()` probed on-disk **built** manifests first:

1. `KICK_ASSETS_ROOT`
2. `kick.config.build.outDir` → `.kickjs-assets.json`
3. `dist` / `build` / `out` → `.kickjs-assets.json`  ← **stale, wins in dev**
4. *then* `synthesiseDevManifest` (the live `src/` walk)

So whenever an earlier `kick build` had left `dist/.kickjs-assets.json` on disk, dev read **that** instead of walking `src/`. The cache-skip bought nothing — the resolver was pinned to a frozen build map.

## Fix

In dev (`NODE_ENV !== 'production'`), prefer the live source walk; only fall back to a built manifest when there's no `assetMap` config to walk.

- `KICK_ASSETS_ROOT` still wins as an explicit override (dev or prod).
- **Production is unchanged** — built-manifest-first + module-level cache.

## Tests

New `describe('dev mode prefers the live source tree')`:

- walks `src/` instead of a stale `dist/.kickjs-assets.json`
- picks up a newly-added file with **no** cache clear / restart
- still falls back to a built manifest when no `assetMap` config exists

`assets.test.ts`: 29 passed (was 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
