### PR TITLE
test(kickjs): head-room for fastify conformance cold-start (fix flaky timeout)

### DIFF
--- a/packages/kickjs/__tests__/fastify-conformance.test.ts
+++ b/packages/kickjs/__tests__/fastify-conformance.test.ts
@@ -1,5 +1,16 @@
 import 'reflect-metadata'
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// This is a heavy integration suite: 13 cases run against three real HTTP
+// engines (express + fastify + h3) over supertest. Fastify in particular pays a
+// one-time cold cost on the first case — `require('fastify')` + `@fastify/middie`
+// + avvio's async `ready()` plugin-graph boot — which, when the full package
+// suite (50+ files) imports in parallel and saturates the CPU, can blow past
+// vitest's default 5s budget and flake the first test. The work is the same in
+// production (boots once at startup); only the test-time contention makes it
+// slow. Give the whole file generous head-room so cold-start jitter never trips
+// a timeout. File-scoped — other suites keep the 5s default.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 })
 import request from 'supertest'
 import { z } from 'zod'
 import {


### PR DESCRIPTION
## Symptom

The `runtime conformance — fastify` suite intermittently failed its first case in CI:

```
FAIL  __tests__/fastify-conformance.test.ts > runtime conformance — fastify > routes a GET …
Error: Test timed out in 5000ms.
```

Green on an isolated re-run (39 tests in ~3s). Express and h3 never trip it.

## Cause — cold-start, not a hang

The conformance file runs 13 cases against **three** real HTTP engines over supertest. Fastify pays a one-time cold cost on the **first** case:

- `require('fastify')` ESM resolution + module eval
- `@fastify/middie` registration
- avvio's async `app.ready()` plugin-graph boot

When the full package suite (50+ files) imports in parallel and saturates the CPU, that first-case cost can exceed vitest's default **5000ms** budget. Express/h3 have no async avvio boot, so they're unaffected. The work is identical in production — Fastify boots **once** at startup; only test-time contention makes it slow. The runtime logic is correct (verified: `READY` is computed once, `routing` runs after `ready()` — no hang path).

## Fix

Raise the timeout for this file via `vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 })`. File-scoped — every other suite keeps the 5s default. No production code touched.

## Verify

`__tests__/fastify-conformance.test.ts` → 39 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
