### PR TITLE
perf(container): skip change-event emit when no listeners attached

### DIFF
--- a/.changeset/container-emit-zero-listener.md
+++ b/.changeset/container-emit-zero-listener.md
@@ -1,0 +1,14 @@
+---
+'@forinda/kickjs': patch
+---
+
+perf(container): skip change-event bookkeeping when no listener is attached
+
+`Container.resolve()` emitted a debounced change event on every call — including
+the hot cached-singleton path. With no `onChange` subscriber (the production
+default; only DevTools or tests subscribe), each resolve still scanned the
+pending batch, pushed an entry, and rescheduled a `setTimeout`, only for the
+flush to iterate an empty listener set and discard the work. `emit()` now
+short-circuits when there are zero listeners, keeping `resolve()` allocation- and
+timer-free on the common path. Behaviour is unchanged when a listener is present;
+registration counters (`resolveCount`, `lastResolvedAt`) are updated regardless.

--- a/packages/kickjs/__tests__/container-introspection.test.ts
+++ b/packages/kickjs/__tests__/container-introspection.test.ts
@@ -92,3 +92,56 @@ describe('Container introspection — dependency capture', () => {
     expect(reg!.dependencies).toEqual([])
   })
 })
+
+describe('Container change emit — zero-listener fast path', () => {
+  let c: Container
+
+  beforeEach(() => {
+    c = Container.create()
+  })
+
+  it('buffers nothing while no listener is attached (no timer churn per resolve)', () => {
+    @Service()
+    class Hot {}
+    c.register(Hot, Hot)
+
+    // Resolve repeatedly with NO subscriber. The emit fast-path should
+    // short-circuit, so nothing accumulates in the pending batch.
+    for (let i = 0; i < 50; i++) c.resolve(Hot)
+
+    // Attach AFTER the resolves and flush: a listener that subscribes late
+    // must not receive a backlog of events it never asked for.
+    const seen: string[] = []
+    c.onChange((batch) => {
+      for (const e of batch) seen.push(e.token)
+    })
+    c.flushChanges()
+    expect(seen).toHaveLength(0)
+  })
+
+  it('still tracks resolveCount with no listener (registration state unaffected)', () => {
+    @Service()
+    class Counted {}
+    c.register(Counted, Counted)
+
+    for (let i = 0; i < 5; i++) c.resolve(Counted)
+
+    const reg = c.getRegistrations().find((r) => r.token === 'Counted')
+    expect(reg!.resolveCount).toBe(5)
+  })
+
+  it('emits normally once a listener is attached', () => {
+    const seen: string[] = []
+    @Service()
+    class Live {}
+    c.register(Live, Live)
+
+    c.onChange((batch) => {
+      for (const e of batch) seen.push(e.token)
+    })
+    c.resolve(Live)
+    c.flushChanges()
+
+    expect(seen).toContain('Live')
+  })
+})

--- a/packages/kickjs/__tests__/container-introspection.test.ts
+++ b/packages/kickjs/__tests__/container-introspection.test.ts
@@ -97,6 +97,9 @@ describe('Container change emit — zero-listener fast path', () => {
   let c: Container
 
   beforeEach(() => {
+    // Decorators (@Service) register on the global container at definition
+    // time; reset it per test so DI/decorator state can't leak between cases.
+    Container.reset()
     c = Container.create()
   })
 

--- a/packages/kickjs/src/core/container.ts
+++ b/packages/kickjs/src/core/container.ts
@@ -557,6 +557,17 @@ export class Container {
 
   /** Batch-emit a change event (debounced, flushed after 50ms of quiet) */
   private emit(token: string, event: ContainerChangeEvent['event'], kind?: ClassKind): void {
+    // Zero-listener fast path. Nobody subscribes to container changes unless
+    // DevTools (or a test) calls `onChange` — the production default. Without
+    // this guard, every `resolve()` (including the hot cached-singleton path)
+    // would scan `pendingChanges`, push an entry, and reschedule a `setTimeout`
+    // only for the eventual flush to iterate an empty listener set and discard
+    // the batch. Short-circuiting here keeps `resolve()` allocation- and
+    // timer-free when no one is watching. When a listener attaches later,
+    // subsequent emits work exactly as before — past resolves had no observer
+    // to notify anyway.
+    if (this.changeListeners.size === 0) return
+
     // Dedupe within the pending batch: a high-throughput TRANSIENT
     // token that resolves 1000× per request would otherwise queue
     // 1000 identical 'resolved' events. The downstream listener only


### PR DESCRIPTION
## What

`Container.resolve()` emitted a debounced change event on **every** call — including the hot cached-singleton path (`container.ts:390`). `emit()` did this regardless of whether anyone was listening:

```ts
const existing = this.pendingChanges.find((p) => p.token === token && p.event === event) // O(N) scan
…push…
if (this.notifyTimer) clearTimeout(this.notifyTimer)
this.notifyTimer = setTimeout(…, 50)  // rescheduled every resolve
```

`changeListeners` is empty in production — only DevTools (or a test) ever calls `onChange()`. So for a request resolving 5–10 singletons, that's 5–10 array scans + timer reschedules per request, and the eventual flush just iterates an empty `Set` and discards the batch.

## Fix

Early-return from `emit()` when there are no listeners:

```ts
if (this.changeListeners.size === 0) return
```

`resolve()` is now allocation- and timer-free on the common path.

## Safety

- **Behaviour unchanged when a listener is attached** — DevTools subscribes at startup, before requests, so it sees every event as before.
- Registration counters (`resolveCount`, `lastResolvedAt`) are updated at the **call site**, not inside `emit()`, so introspection / `getRegistrations()` is unaffected with or without listeners.
- A listener that subscribes *late* doesn't get a backlog — but it never could have observed pre-subscription resolves anyway; `onChange` is live observation, not replay.

## Tests

New `describe('zero-listener fast path')`:

- buffers nothing while no listener is attached (late subscriber + flush → 0 events)
- `resolveCount` still tracks with no listener (state unaffected)
- emits normally once a listener is attached

Full `@forinda/kickjs` suite: 600 pass (the one unrelated fastify cold-start flake is fixed separately in #422).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved container resolution performance by skipping unnecessary event processing when no change listeners are registered.

* **Tests**
  * Added test coverage for container change event behavior with and without listeners attached.

* **Documentation**
  * Added changelog documenting the performance optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->