### PR TITLE
fix(vscode): align @types/vscode with engines.vscode so vsce can package

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "KickJS DevTools",
   "description": "VS Code extension for inspecting KickJS applications — routes, DI container, metrics, and health",
   "version": "5.3.0",
-  "publisher": "forinda",
+  "publisher": "forinda82",
   "engines": {
     "vscode": "^1.85.0"
   },
@@ -359,7 +359,7 @@
     "package": "pnpm build && vsce package"
   },
   "devDependencies": {
-    "@types/vscode": "^1.120.0",
+    "@types/vscode": "^1.85.0",
     "@types/node": "^25.9.2",
     "sharp": "^0.34.0",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -754,7 +754,7 @@ importers:
         specifier: ^25.9.2
         version: 25.9.2
       '@types/vscode':
-        specifier: ^1.120.0
+        specifier: ^1.85.0
         version: 1.120.0
       sharp:
         specifier: ^0.34.0


### PR DESCRIPTION
## Problem

`pnpm --filter kickjs-devtools package` (→ `vsce package`) failed:

```
ERROR  @types/vscode ^1.120.0 greater than engines.vscode ^1.85.0.
Either upgrade engines.vscode or use an older @types/vscode version
```

`vsce` enforces that the declared `@types/vscode` range minimum is ≤ `engines.vscode`. The devDependency had drifted to `^1.120.0` while the engine floor stayed at `^1.85.0`.

## Fix

Lower `@types/vscode` to `^1.85.0` (match the engine floor) rather than bumping `engines.vscode`:

- The extension uses no API newer than 1.85 — `SecretStorage`, webviews, and the command APIs all predate it.
- Bumping `engines` instead would drop support for users on VS Code 1.85–1.119 for no benefit.
- Build is unaffected: tsc still resolves whatever 1.x typings pnpm installs.

Also sets the marketplace `publisher` to `forinda82`.

## Verify

```
pnpm build && vsce package
→ DONE  Packaged: kickjs-devtools-5.3.0.vsix (20 files, 26.13 KB)
```

`kickjs-devtools` is a private package (no changeset — manual version, currently 5.3.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VS Code extension publisher identity
  * Updated TypeScript type definitions for improved compatibility with VS Code engine requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->