### PR TITLE
feat(cli): typegen resolves module depth + kick typegen --fix for orphaned classes

### DIFF
--- a/.changeset/typegen-module-depth-globs.md
+++ b/.changeset/typegen-module-depth-globs.md
@@ -1,0 +1,20 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+typegen: resolve decorated classes at any module depth + `kick typegen --fix`
+
+Decorated classes (`@Controller`, `@Service`, …) only register at runtime if a
+module's `import.meta.glob([...], { eager: true })` imports their file. When you
+reorganise a module into sub-folders (e.g. moving controllers into
+`controllers/`), a shallow glob stops reaching them — routes silently vanish and
+DI tokens resolve `undefined`. Typegen already detected this; now it helps fix it:
+
+- **Actionable warning** — orphaned classes are grouped by their owning module
+  file, with the exact recursive glob to add (`./**/*.controller.ts`) and a
+  `kick typegen --fix` hint.
+- **`kick typegen --fix`** — patches each module's `import.meta.glob(...)` call in
+  place (array or bare-string form), adding the missing recursive patterns.
+  Idempotent; skips patterns already present.
+- **Scaffold templates** now emit recursive globs that include controllers, so
+  newly-generated modules don't orphan when reorganised.

--- a/packages/cli/__tests__/typegen-glob-fix.test.ts
+++ b/packages/cli/__tests__/typegen-glob-fix.test.ts
@@ -92,6 +92,30 @@ describe('patchModuleGlobSource — splice patterns into the call', () => {
     expect(patchModuleGlobSource(`export const x = 1`, ['./**/*.controller.ts'])).toBeNull()
   })
 
+  it('patches the EAGER call, not an earlier lazy one', () => {
+    // A lazy glob (no eager) appears first; the eager decorator-loader is
+    // second. The fix must land in the eager one.
+    const source = [
+      "const lazyPages = import.meta.glob(['./pages/*.ts'])",
+      "import.meta.glob(['./**/*.service.ts', '!./**/*.test.ts'], { eager: true })",
+    ].join('\n')
+    const out = patchModuleGlobSource(source, ['./**/*.controller.ts'])
+    expect(out).not.toBeNull()
+    // The lazy call is untouched.
+    expect(out!).toContain("import.meta.glob(['./pages/*.ts'])")
+    // The controller pattern landed inside the eager array.
+    expect(out!).toMatch(
+      /'!\.\/\*\*\/\*\.test\.ts', '\.\/\*\*\/\*\.controller\.ts'\], \{ eager: true \}/,
+    )
+  })
+
+  it('falls back to the first call when none is eager', () => {
+    const source = `import.meta.glob(['./**/*.service.ts'])`
+    const out = patchModuleGlobSource(source, ['./**/*.controller.ts'])
+    expect(out).not.toBeNull()
+    expect(extractGlobPatterns(out!)).toContain('./**/*.controller.ts')
+  })
+
   it('handles a multi-line array with a trailing comma', () => {
     const source = [
       'import.meta.glob(',

--- a/packages/cli/__tests__/typegen-glob-fix.test.ts
+++ b/packages/cli/__tests__/typegen-glob-fix.test.ts
@@ -116,6 +116,19 @@ describe('patchModuleGlobSource — splice patterns into the call', () => {
     expect(extractGlobPatterns(out!)).toContain('./**/*.controller.ts')
   })
 
+  it("isn't fooled by a ] inside a char-class pattern (array form)", () => {
+    const source = `import.meta.glob(['./[A-Z]*.ts'], { eager: true })`
+    const out = patchModuleGlobSource(source, ['./**/*.controller.ts'])
+    expect(out).toBe(`import.meta.glob(['./[A-Z]*.ts', './**/*.controller.ts'], { eager: true })`)
+    expect(extractGlobPatterns(out!)).toEqual(['./[A-Z]*.ts', './**/*.controller.ts'])
+  })
+
+  it('treats a bare string containing [ as bare-string, not array', () => {
+    const source = `import.meta.glob('./[A-Z]*.ts', { eager: true })`
+    const out = patchModuleGlobSource(source, ['./**/*.controller.ts'])
+    expect(out).toBe(`import.meta.glob(['./[A-Z]*.ts', './**/*.controller.ts'], { eager: true })`)
+  })
+
   it('handles a multi-line array with a trailing comma', () => {
     const source = [
       'import.meta.glob(',

--- a/packages/cli/__tests__/typegen-glob-fix.test.ts
+++ b/packages/cli/__tests__/typegen-glob-fix.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import {
+  globForOrphanFile,
+  suggestGlobsForOrphans,
+  patchModuleGlobSource,
+} from '../src/typegen/glob-fix'
+import { fileMatchesAnyGlob, extractGlobPatterns } from '../src/typegen/scanner'
+
+// forinda/kick-js#235 §4 follow-up — turn the orphaned-class DETECTION into a
+// FIX: derive the recursive globs that would cover orphans and splice them into
+// the module's import.meta.glob() call (`kick typegen --fix`).
+
+describe('globForOrphanFile — derive a recursive glob from a file path', () => {
+  it('uses the compound suffix so only sibling kinds match, at any depth', () => {
+    expect(globForOrphanFile('src/modules/expenses/controllers/expenses.controller.ts')).toBe(
+      './**/*.controller.ts',
+    )
+    expect(globForOrphanFile('src/modules/x/foo.service.ts')).toBe('./**/*.service.ts')
+  })
+
+  it('falls back to the bare extension when there is no compound suffix', () => {
+    expect(globForOrphanFile('src/modules/x/handlers/thing.ts')).toBe('./**/*.ts')
+  })
+
+  it('normalises Windows separators', () => {
+    expect(globForOrphanFile('src\\modules\\x\\controllers\\x.controller.ts')).toBe(
+      './**/*.controller.ts',
+    )
+  })
+
+  it('the derived glob actually matches the orphan (round-trip)', () => {
+    // fileMatchesAnyGlob takes a path relative to the module dir.
+    const glob = globForOrphanFile('controllers/expenses.controller.ts')
+    expect(fileMatchesAnyGlob('./controllers/expenses.controller.ts', [glob])).toBe(true)
+    expect(fileMatchesAnyGlob('./controllers/deep/nested/petty-cash.controller.ts', [glob])).toBe(
+      true,
+    )
+  })
+})
+
+describe('suggestGlobsForOrphans — distinct, sorted', () => {
+  it('collapses many controllers to one recursive pattern', () => {
+    const patterns = suggestGlobsForOrphans([
+      { relativePath: 'src/modules/expenses/controllers/expenses.controller.ts' },
+      { relativePath: 'src/modules/expenses/controllers/expenses-setup.controller.ts' },
+      { relativePath: 'src/modules/expenses/controllers/petty-cash.controller.ts' },
+    ])
+    expect(patterns).toEqual(['./**/*.controller.ts'])
+  })
+
+  it('returns one pattern per distinct kind, sorted', () => {
+    const patterns = suggestGlobsForOrphans([
+      { relativePath: 'a/x.service.ts' },
+      { relativePath: 'a/y.controller.ts' },
+    ])
+    expect(patterns).toEqual(['./**/*.controller.ts', './**/*.service.ts'])
+  })
+})
+
+describe('patchModuleGlobSource — splice patterns into the call', () => {
+  it('inserts into the array form before the closing bracket', () => {
+    const source = `import.meta.glob(['./**/*.service.ts', '!./**/*.test.ts'], { eager: true })`
+    const out = patchModuleGlobSource(source, ['./**/*.controller.ts'])
+    expect(out).not.toBeNull()
+    expect(extractGlobPatterns(out!)).toContain('./**/*.controller.ts')
+    // Existing patterns survive.
+    expect(extractGlobPatterns(out!)).toEqual(
+      expect.arrayContaining(['./**/*.service.ts', '!./**/*.test.ts', './**/*.controller.ts']),
+    )
+  })
+
+  it('is idempotent — already-present patterns add nothing', () => {
+    const source = `import.meta.glob(['./**/*.controller.ts'], { eager: true })`
+    expect(patchModuleGlobSource(source, ['./**/*.controller.ts'])).toBeNull()
+  })
+
+  it("doesn't re-add a pattern that exists only as a negation body", () => {
+    const source = `import.meta.glob(['./**/*.service.ts', '!./**/*.test.ts'], { eager: true })`
+    // ./**/*.test.ts is present (negated) — adding the positive form is skipped.
+    expect(patchModuleGlobSource(source, ['./**/*.test.ts'])).toBeNull()
+  })
+
+  it('upgrades the bare-string form into an array', () => {
+    const source = `import.meta.glob('./**/*.service.ts', { eager: true })`
+    const out = patchModuleGlobSource(source, ['./**/*.controller.ts'])
+    expect(out).not.toBeNull()
+    expect(out).toContain(`['./**/*.service.ts', './**/*.controller.ts']`)
+    expect(extractGlobPatterns(out!)).toEqual(['./**/*.service.ts', './**/*.controller.ts'])
+  })
+
+  it('returns null when there is no import.meta.glob call', () => {
+    expect(patchModuleGlobSource(`export const x = 1`, ['./**/*.controller.ts'])).toBeNull()
+  })
+
+  it('handles a multi-line array with a trailing comma', () => {
+    const source = [
+      'import.meta.glob(',
+      '  [',
+      "    './**/*.service.ts',",
+      "    '!./**/*.test.ts',",
+      '  ],',
+      '  { eager: true },',
+      ')',
+    ].join('\n')
+    const out = patchModuleGlobSource(source, ['./**/*.controller.ts'])
+    expect(out).not.toBeNull()
+    expect(extractGlobPatterns(out!)).toContain('./**/*.controller.ts')
+    // Still a single glob call, still valid patterns.
+    expect(extractGlobPatterns(out!)).toEqual(
+      expect.arrayContaining(['./**/*.service.ts', '!./**/*.test.ts', './**/*.controller.ts']),
+    )
+  })
+})

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -24,6 +24,7 @@ interface TypegenCliOptions {
   schemaValidator?: string
   envFile?: string
   check?: boolean
+  fix?: boolean
   list?: boolean
   cache?: boolean
 }
@@ -79,6 +80,10 @@ export function registerTypegenCommand(program: Command): void {
       "Path to env schema file for KickEnv typing (default 'src/env.ts'; pass 'false' to disable)",
     )
     .option('--check', 'CI gate: fail on plugin-typegen drift instead of writing')
+    .option(
+      '--fix',
+      "Patch module import.meta.glob() calls to cover decorated classes that aren't loaded by any glob (orphans)",
+    )
     .option('--list', 'List every registered typegen plugin id (use to populate `typegen.disable`)')
     .option(
       '--no-cache',
@@ -127,6 +132,7 @@ export function registerTypegenCommand(program: Command): void {
         srcDir: opts.src ?? config?.typegen?.srcDir,
         outDir: opts.out ?? config?.typegen?.outDir,
         silent: opts.silent,
+        fix: opts.fix,
         allowDuplicates: opts.allowDuplicates,
         // commander sets `cache: false` for `--no-cache`; default undefined → cache on
         noCache: opts.cache === false,

--- a/packages/cli/src/generators/templates/module-index.ts
+++ b/packages/cli/src/generators/templates/module-index.ts
@@ -67,9 +67,17 @@ export function generateModuleIndex(ctx: TemplateContext & { repo: RepoType }): 
 import { ${repoClass} } from './infrastructure/repositories/${repoFile}.repository'
 import { ${pascal}Controller } from './presentation/${kebab}.controller'
 
-// Eagerly load decorated classes so @Service()/@Repository() decorators register in the DI container
+// Eagerly load decorated classes so @Controller()/@Service()/@Repository() decorators
+// register in the DI container. Recursive globs (./**/) so the module keeps working
+// however you nest files (e.g. moving controllers into a controllers/ sub-folder).
 import.meta.glob(
-  ['./domain/services/**/*.ts', './application/use-cases/**/*.ts', '!./**/*.test.ts'],
+  [
+    './**/*.controller.ts',
+    './**/*.service.ts',
+    './**/*.repository.ts',
+    './application/use-cases/**/*.ts',
+    '!./**/*.test.ts',
+  ],
   { eager: true },
 )`
 
@@ -174,8 +182,13 @@ export function generateRestModuleIndex(ctx: TemplateContext & { repo: RepoType 
 import { ${repoClass} } from './${repoFile}.repository'
 import { ${pascal}Controller } from './${kebab}.controller'
 
-// Eagerly load decorated classes so @Service()/@Repository() decorators register in the DI container
-import.meta.glob(['./**/*.service.ts', './**/*.repository.ts', '!./**/*.test.ts'], { eager: true })`
+// Eagerly load decorated classes so @Controller()/@Service()/@Repository() decorators
+// register in the DI container. Recursive globs (./**/) so the module keeps working
+// however you nest files (e.g. moving controllers into a controllers/ sub-folder).
+import.meta.glob(
+  ['./**/*.controller.ts', './**/*.service.ts', './**/*.repository.ts', '!./**/*.test.ts'],
+  { eager: true },
+)`
 
   const routesDoc = `    /**
      * Declare HTTP routes for this module. Return value shape:

--- a/packages/cli/src/generators/templates/project-docs.ts
+++ b/packages/cli/src/generators/templates/project-docs.ts
@@ -1206,7 +1206,7 @@ export const TodosModule = defineModule({
 })
 \`\`\`
 
-The module file MUST include \`import.meta.glob([...], { eager: true })\` for every \`@Service\` / \`@Repository\` / \`@Component\` class — without it, decorators never fire and DI silently resolves to \`undefined\`.
+The module file MUST include \`import.meta.glob([...], { eager: true })\` for every \`@Controller\` / \`@Service\` / \`@Repository\` / \`@Component\` class — without it, decorators never fire and DI silently resolves to \`undefined\` (or routes vanish). Use **recursive** patterns (\`./**/*.controller.ts\`) so the glob keeps working when you nest files into sub-folders (\`controllers/\`, \`presentation/\`, …). If you reorganise and a class stops loading, \`kick typegen\` flags it as orphaned and \`kick typegen --fix\` patches the glob for you.
 
 **Multiple route sets / versioning** — \`routes()\` may return an array with per-entry \`version\` override:
 

--- a/packages/cli/src/typegen/glob-fix.ts
+++ b/packages/cli/src/typegen/glob-fix.ts
@@ -102,6 +102,62 @@ function matchingParen(source: string, openIdx: number): number {
   return -1
 }
 
+/**
+ * First index of `char` within `[from, to)` that sits OUTSIDE a string literal.
+ * Used to find the array's opening `[` without being fooled by a `[` inside a
+ * glob pattern (`'./[A-Z]*.ts'`). `-1` if none.
+ */
+function indexOfUnquoted(source: string, char: string, from: number, to: number): number {
+  let quote: string | null = null
+  for (let i = from; i < to; i++) {
+    const ch = source[i]
+    if (quote) {
+      if (ch === '\\') {
+        i++
+        continue
+      }
+      if (ch === quote) quote = null
+      continue
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch
+    } else if (ch === char) {
+      return i
+    }
+  }
+  return -1
+}
+
+/**
+ * Index of the `]` that closes the `[` at `openIdx`, balanced and quote-aware
+ * (brackets inside string literals — e.g. the char class in `'./[A-Z]*.ts'` —
+ * don't count). `-1` if unbalanced.
+ */
+function matchingBracket(source: string, openIdx: number): number {
+  let depth = 0
+  let quote: string | null = null
+  for (let i = openIdx; i < source.length; i++) {
+    const ch = source[i]
+    if (quote) {
+      if (ch === '\\') {
+        i++
+        continue
+      }
+      if (ch === quote) quote = null
+      continue
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch
+    } else if (ch === '[') {
+      depth++
+    } else if (ch === ']') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return -1
+}
+
 /** Locate every `import.meta.glob(...)` call with its balanced boundaries. */
 function findGlobCalls(source: string): GlobCall[] {
   const re = /\bimport\.meta\.glob\s*\(/g
@@ -153,9 +209,12 @@ export function patchModuleGlobSource(
   const insertion = fresh.map((p) => `'${p}'`).join(', ')
 
   // Array form: insert before the closing `]` of this call's array literal.
-  const bracket = source.indexOf('[', target.open)
-  if (bracket >= 0 && bracket < target.close) {
-    const closeBracket = source.indexOf(']', bracket)
+  // Both the opening `[` lookup and its matching `]` are quote-aware so a
+  // char-class inside a pattern (`'./[A-Z]*.ts'`) can't be mistaken for the
+  // array delimiters.
+  const bracket = indexOfUnquoted(source, '[', target.open, target.close)
+  if (bracket >= 0) {
+    const closeBracket = matchingBracket(source, bracket)
     if (closeBracket < 0 || closeBracket > target.close) return null
     // Respect a trailing comma / whitespace already before `]`.
     const before = source.slice(0, closeBracket)

--- a/packages/cli/src/typegen/glob-fix.ts
+++ b/packages/cli/src/typegen/glob-fix.ts
@@ -1,0 +1,119 @@
+/**
+ * Module-glob convenience for the orphaned-class case.
+ *
+ * A decorated class (`@Controller`, `@Service`, …) only registers at runtime
+ * if some module's `import.meta.glob([...], { eager: true })` imports its file —
+ * that eager import is what fires the decorator. When an adopter organises a
+ * module into sub-directories (`controllers/`, `presentation/`, …) the
+ * scaffolded glob often doesn't reach the new depth, so those classes never
+ * load: routes silently vanish, DI tokens resolve `undefined`.
+ *
+ * The scanner already detects this (`orphanedClasses`). These helpers turn the
+ * detection into a fix:
+ *
+ *   - {@link suggestGlobsForOrphans} derives the minimal set of RECURSIVE glob
+ *     patterns (`./**\/*.controller.ts`) that would cover the orphans — depth
+ *     independent, so it keeps working however the adopter nests files.
+ *   - {@link patchModuleGlobSource} splices those patterns into the module
+ *     file's existing `import.meta.glob(...)` call (array or bare-string form),
+ *     skipping any already present. Drives `kick typegen --fix`.
+ */
+
+import { extractGlobPatterns } from './scanner'
+
+/** One orphan, reduced to what the fixer needs. */
+export interface OrphanLike {
+  /** Project-relative path of the orphaned class file, e.g. `src/modules/x/controllers/x.controller.ts`. */
+  relativePath: string
+}
+
+/** Strip the trailing extension, returning `{ stem, ext }` (ext WITHOUT the dot). */
+function splitExt(basename: string): { stem: string; ext: string } {
+  const dot = basename.lastIndexOf('.')
+  if (dot <= 0) return { stem: basename, ext: '' }
+  return { stem: basename.slice(0, dot), ext: basename.slice(dot + 1) }
+}
+
+/**
+ * Derive the recursive glob that would cover a single orphan file.
+ *
+ * `expenses.controller.ts` → `./**\/*.controller.ts` (precise: only sibling
+ * controllers, at any depth). A file with no compound suffix (`thing.ts`) falls
+ * back to `./**\/*.ts` for that extension — broader, but still scoped to the
+ * module's own tree.
+ */
+export function globForOrphanFile(relativePath: string): string {
+  const normalised = relativePath.replaceAll('\\', '/')
+  const basename = normalised.slice(normalised.lastIndexOf('/') + 1)
+  const { stem, ext } = splitExt(basename)
+  const extPart = ext || 'ts'
+  // `expenses.controller` → kind = `controller`; `expenses` → no kind.
+  const innerDot = stem.lastIndexOf('.')
+  if (innerDot > 0) {
+    return `./**/*.${stem.slice(innerDot + 1)}.${extPart}`
+  }
+  return `./**/*.${extPart}`
+}
+
+/**
+ * The distinct, sorted set of recursive globs covering a module's orphans.
+ * Feed the orphans of ONE module file (group by `moduleFilePath` first).
+ */
+export function suggestGlobsForOrphans(orphans: readonly OrphanLike[]): string[] {
+  const set = new Set<string>()
+  for (const o of orphans) set.add(globForOrphanFile(o.relativePath))
+  return [...set].toSorted()
+}
+
+/**
+ * Splice `addPatterns` into the FIRST `import.meta.glob(...)` call in `source`,
+ * preserving the existing patterns. Handles both the array form
+ * (`import.meta.glob(['./a'], …)`) and the bare-string form
+ * (`import.meta.glob('./a', …)`, which is upgraded to an array).
+ *
+ * Patterns already present (positive or negated) are skipped, so it's
+ * idempotent. Returns the patched source, or `null` when there's no glob call
+ * to patch or nothing new to add.
+ */
+export function patchModuleGlobSource(
+  source: string,
+  addPatterns: readonly string[],
+): string | null {
+  const callIdx = source.search(/\bimport\.meta\.glob\s*\(/)
+  if (callIdx < 0) return null
+
+  const open = source.indexOf('(', callIdx)
+  if (open < 0) return null
+
+  // Skip patterns the call already declares (compare on the bare body so a
+  // negation like `!./**/*.test.ts` doesn't re-add `./**/*.test.ts`).
+  const existing = new Set(
+    extractGlobPatterns(source).map((p) => (p.startsWith('!') ? p.slice(1) : p)),
+  )
+  const fresh = addPatterns.filter((p) => !existing.has(p))
+  if (fresh.length === 0) return null
+
+  const insertion = fresh.map((p) => `'${p}'`).join(', ')
+
+  // Array form: insert before the closing `]` of the first array literal.
+  const bracket = source.indexOf('[', open)
+  const closeParen = source.indexOf(')', open)
+  if (bracket >= 0 && (closeParen < 0 || bracket < closeParen)) {
+    const closeBracket = source.indexOf(']', bracket)
+    if (closeBracket < 0) return null
+    // Respect a trailing comma / whitespace already before `]`.
+    const before = source.slice(0, closeBracket)
+    const needsComma = !/[[,]\s*$/.test(before)
+    const sep = needsComma ? ', ' : ''
+    return before + sep + insertion + source.slice(closeBracket)
+  }
+
+  // Bare-string form: wrap the first string literal into an array.
+  const strRe = /(['"`])((?:\\.|(?!\1).)*)\1/
+  const tail = source.slice(open + 1)
+  const m = strRe.exec(tail)
+  if (!m) return null
+  const absStart = open + 1 + m.index
+  const absEnd = absStart + m[0].length
+  return source.slice(0, absStart) + `[${m[0]}, ${insertion}]` + source.slice(absEnd)
+}

--- a/packages/cli/src/typegen/glob-fix.ts
+++ b/packages/cli/src/typegen/glob-fix.ts
@@ -65,42 +65,98 @@ export function suggestGlobsForOrphans(orphans: readonly OrphanLike[]): string[]
   return [...set].toSorted()
 }
 
+/** A single `import.meta.glob(...)` call: byte offsets of its name start, `(`, and matching `)`. */
+interface GlobCall {
+  start: number
+  open: number
+  close: number
+}
+
 /**
- * Splice `addPatterns` into the FIRST `import.meta.glob(...)` call in `source`,
- * preserving the existing patterns. Handles both the array form
- * (`import.meta.glob(['./a'], …)`) and the bare-string form
- * (`import.meta.glob('./a', …)`, which is upgraded to an array).
+ * Index of the `)` that closes the `(` at `openIdx`, balanced and
+ * quote-aware (parens inside string literals don't count). `-1` if
+ * unbalanced.
+ */
+function matchingParen(source: string, openIdx: number): number {
+  let depth = 0
+  let quote: string | null = null
+  for (let i = openIdx; i < source.length; i++) {
+    const ch = source[i]
+    if (quote) {
+      if (ch === '\\') {
+        i++
+        continue
+      }
+      if (ch === quote) quote = null
+      continue
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch
+    } else if (ch === '(') {
+      depth++
+    } else if (ch === ')') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return -1
+}
+
+/** Locate every `import.meta.glob(...)` call with its balanced boundaries. */
+function findGlobCalls(source: string): GlobCall[] {
+  const re = /\bimport\.meta\.glob\s*\(/g
+  const calls: GlobCall[] = []
+  let m: RegExpExecArray | null
+  while ((m = re.exec(source)) !== null) {
+    const open = source.indexOf('(', m.index)
+    if (open < 0) continue
+    const close = matchingParen(source, open)
+    if (close < 0) continue
+    calls.push({ start: m.index, open, close })
+  }
+  return calls
+}
+
+/**
+ * Splice `addPatterns` into the module's EAGER `import.meta.glob(...)` call,
+ * preserving its existing patterns. The eager call (`{ eager: true }`) is the
+ * one that actually fires decorators — a module may also hold lazy globs (e.g.
+ * route-component loaders) that must NOT be touched, so we target the eager
+ * call specifically and fall back to the first call only when none is marked
+ * eager. Handles both the array form (`import.meta.glob(['./a'], …)`) and the
+ * bare-string form (`import.meta.glob('./a', …)`, upgraded to an array).
  *
- * Patterns already present (positive or negated) are skipped, so it's
- * idempotent. Returns the patched source, or `null` when there's no glob call
- * to patch or nothing new to add.
+ * Patterns already present in the TARGET call (positive or negated) are
+ * skipped, so it's idempotent. Returns the patched source, or `null` when
+ * there's no glob call to patch or nothing new to add.
  */
 export function patchModuleGlobSource(
   source: string,
   addPatterns: readonly string[],
 ): string | null {
-  const callIdx = source.search(/\bimport\.meta\.glob\s*\(/)
-  if (callIdx < 0) return null
+  const calls = findGlobCalls(source)
+  if (calls.length === 0) return null
 
-  const open = source.indexOf('(', callIdx)
-  if (open < 0) return null
+  // Prefer the eager call (the decorator-firing loader); fall back to the first.
+  const target =
+    calls.find((c) => /\beager\s*:\s*true\b/.test(source.slice(c.open, c.close + 1))) ?? calls[0]
 
-  // Skip patterns the call already declares (compare on the bare body so a
-  // negation like `!./**/*.test.ts` doesn't re-add `./**/*.test.ts`).
+  // Idempotency scoped to the TARGET call only — a pattern present in some
+  // other (lazy) call shouldn't suppress adding it to the eager loader.
+  const callSource = source.slice(target.start, target.close + 1)
   const existing = new Set(
-    extractGlobPatterns(source).map((p) => (p.startsWith('!') ? p.slice(1) : p)),
+    extractGlobPatterns(callSource).map((p) => (p.startsWith('!') ? p.slice(1) : p)),
   )
   const fresh = addPatterns.filter((p) => !existing.has(p))
   if (fresh.length === 0) return null
 
   const insertion = fresh.map((p) => `'${p}'`).join(', ')
 
-  // Array form: insert before the closing `]` of the first array literal.
-  const bracket = source.indexOf('[', open)
-  const closeParen = source.indexOf(')', open)
-  if (bracket >= 0 && (closeParen < 0 || bracket < closeParen)) {
+  // Array form: insert before the closing `]` of this call's array literal.
+  const bracket = source.indexOf('[', target.open)
+  if (bracket >= 0 && bracket < target.close) {
     const closeBracket = source.indexOf(']', bracket)
-    if (closeBracket < 0) return null
+    if (closeBracket < 0 || closeBracket > target.close) return null
     // Respect a trailing comma / whitespace already before `]`.
     const before = source.slice(0, closeBracket)
     const needsComma = !/[[,]\s*$/.test(before)
@@ -108,12 +164,12 @@ export function patchModuleGlobSource(
     return before + sep + insertion + source.slice(closeBracket)
   }
 
-  // Bare-string form: wrap the first string literal into an array.
+  // Bare-string form: wrap this call's first string literal into an array.
   const strRe = /(['"`])((?:\\.|(?!\1).)*)\1/
-  const tail = source.slice(open + 1)
+  const tail = source.slice(target.open + 1, target.close)
   const m = strRe.exec(tail)
   if (!m) return null
-  const absStart = open + 1 + m.index
+  const absStart = target.open + 1 + m.index
   const absEnd = absStart + m[0].length
   return source.slice(0, absStart) + `[${m[0]}, ${insertion}]` + source.slice(absEnd)
 }

--- a/packages/cli/src/typegen/index.ts
+++ b/packages/cli/src/typegen/index.ts
@@ -9,7 +9,8 @@
  */
 
 import { resolve, basename, dirname, join } from 'node:path'
-import { mkdir, readdir, stat, unlink, writeFile } from 'node:fs/promises'
+import { mkdir, readdir, readFile, stat, unlink, writeFile } from 'node:fs/promises'
+import { patchModuleGlobSource, suggestGlobsForOrphans } from './glob-fix'
 import { scanProject, scanProjectIncremental, type ScanDelta, type ScanResult } from './scanner'
 import {
   buildModuleTokens,
@@ -73,6 +74,13 @@ export interface RunTypegenOptions {
   outDir?: string
   /** Suppress console output */
   silent?: boolean
+  /**
+   * Patch module `import.meta.glob(...)` calls in place to cover decorated
+   * classes the scanner flags as orphaned (their file isn't imported by any
+   * module glob, so the decorator never fires at runtime). Wired to
+   * `kick typegen --fix`. Off by default — diagnostics only.
+   */
+  fix?: boolean
   /**
    * When `true`, duplicate class names are auto-namespaced by file path
    * instead of throwing. `kick dev` enables this so the dev server is
@@ -257,22 +265,96 @@ export async function runTypegen(opts: RunTypegenOptions = {}): Promise<{
         }
       }
     }
-    if (scan.orphanedClasses.length > 0) {
-      // forinda/kick-js#235 §4 — decorated classes sitting inside a
-      // module directory whose globs don't pick them up. At runtime
-      // the decorator never fires; downstream code paths get
-      // confusing `MissingContributorError` or silent misroutes.
-      console.warn(
-        `  kick typegen: ${scan.orphanedClasses.length} decorated class(es) not matched by any module's import.meta.glob():`,
-      )
-      for (const orphan of scan.orphanedClasses) {
-        console.warn(`    @${orphan.decorator} ${orphan.className} (${orphan.relativePath})`)
-        console.warn(`      → not picked up by any glob in ${orphan.moduleFilePath}`)
-      }
-    }
+  }
+
+  // forinda/kick-js#235 §4 — decorated classes sitting inside a module
+  // directory whose globs don't pick them up. At runtime the decorator never
+  // fires; downstream code paths get confusing `MissingContributorError` or
+  // silent misroutes. `--fix` patches the module globs; otherwise we print the
+  // exact recursive patterns to add. Runs outside the `!silent` guard so
+  // `--fix` still applies under `--silent`.
+  if (scan.orphanedClasses.length > 0) {
+    await handleOrphanedClasses(scan.orphanedClasses, { fix: opts.fix ?? false, silent })
   }
 
   return { scan, result, tokenWarnings }
+}
+
+/**
+ * Report (and optionally fix) decorated classes whose files aren't imported by
+ * any module's `import.meta.glob(...)`. Groups orphans by their owning module
+ * file, derives the minimal recursive globs that would cover them, and either
+ * patches the module source in place (`fix`) or prints a copy-pasteable
+ * suggestion + the `--fix` hint.
+ */
+async function handleOrphanedClasses(
+  orphans: ScanResult['orphanedClasses'],
+  { fix, silent }: { fix: boolean; silent: boolean },
+): Promise<void> {
+  // Group by the module file whose globs missed them.
+  const byModule = new Map<string, typeof orphans>()
+  for (const o of orphans) {
+    const list = byModule.get(o.moduleFilePath) ?? []
+    list.push(o)
+    byModule.set(o.moduleFilePath, list)
+  }
+
+  if (fix) {
+    let patched = 0
+    const skipped: string[] = []
+    for (const [moduleFile, group] of byModule) {
+      const patterns = suggestGlobsForOrphans(group)
+      try {
+        const source = await readFile(moduleFile, 'utf-8')
+        const next = patchModuleGlobSource(source, patterns)
+        if (next && next !== source) {
+          await writeFile(moduleFile, next)
+          patched++
+          if (!silent) {
+            console.log(
+              `  kick typegen --fix: patched ${moduleFile}\n      + ${patterns.join(', ')}`,
+            )
+          }
+        } else {
+          skipped.push(moduleFile)
+        }
+      } catch {
+        skipped.push(moduleFile)
+      }
+    }
+    if (!silent) {
+      if (patched > 0) {
+        console.log(
+          `  kick typegen --fix: updated ${patched} module glob(s) — re-run typegen to pick up the now-loaded classes.`,
+        )
+      }
+      if (skipped.length > 0) {
+        console.warn(
+          `  kick typegen --fix: could not auto-patch ${skipped.length} module(s) (no import.meta.glob() call found) — add the patterns by hand:`,
+        )
+        for (const m of skipped) {
+          const group = byModule.get(m) ?? []
+          console.warn(`    ${m}: ${suggestGlobsForOrphans(group).join(', ')}`)
+        }
+      }
+    }
+    return
+  }
+
+  if (silent) return
+
+  console.warn(
+    `  kick typegen: ${orphans.length} decorated class(es) not matched by any module's import.meta.glob():`,
+  )
+  for (const [moduleFile, group] of byModule) {
+    for (const orphan of group) {
+      console.warn(`    @${orphan.decorator} ${orphan.className} (${orphan.relativePath})`)
+    }
+    const patterns = suggestGlobsForOrphans(group)
+    console.warn(`      → add to import.meta.glob([...]) in ${moduleFile}:`)
+    console.warn(`          ${patterns.map((p) => `'${p}'`).join(', ')}`)
+  }
+  console.warn(`      → or run \`kick typegen --fix\` to apply these automatically.`)
 }
 
 /** Derive the logging/test `GenerateResult` from a scan — no files written here. */


### PR DESCRIPTION
## Problem

A decorated class (`@Controller`, `@Service`, …) only registers at runtime if some module's `import.meta.glob([...], { eager: true })` imports its file — that eager import is what fires the decorator. When an adopter organises a module into sub-folders (e.g. moving controllers into `controllers/`), a shallow glob like `./*.controller.ts` no longer reaches them. The classes never load: **routes silently vanish, DI tokens resolve `undefined`.**

Typegen already *detected* this (orphaned-class warning), but the message was non-actionable:

```
@Controller ExpensesController (src/modules/expenses/controllers/expenses.controller.ts)
  → not picked up by any glob in …/expenses.module.ts
```

## What this adds

**1. Actionable warning** — orphans grouped by their owning module, with the exact recursive glob to add + a fix hint:

```
kick typegen: 2 decorated class(es) not matched by any module's import.meta.glob():
  @Controller ExpensesController (…/controllers/expenses.controller.ts)
  @Controller ExpensesSetupController (…/controllers/expenses-setup.controller.ts)
    → add to import.meta.glob([...]) in …/expenses.module.ts:
        './**/*.controller.ts'
    → or run `kick typegen --fix` to apply these automatically.
```

**2. `kick typegen --fix`** — patches each module's `import.meta.glob(...)` call in place (array **and** bare-string forms), adding the missing **recursive** patterns derived from the orphan filenames (`./**/*.controller.ts` — depth-independent). Idempotent; skips patterns already present (including negation bodies).

**3. Scaffold templates** now emit recursive globs that include controllers, so newly-generated modules don't orphan when reorganised.

## New helper + tests

`src/typegen/glob-fix.ts`:
- `globForOrphanFile(path)` → recursive glob from the file's compound suffix (fallback `./**/*.ts`)
- `suggestGlobsForOrphans(orphans)` → distinct, sorted patterns
- `patchModuleGlobSource(source, patterns)` → splice into the call, idempotent

12 unit tests + verified end-to-end on a temp project:

```
warn → './**/*.controller.ts' suggested
--fix → patched expenses.module.ts  (+ './**/*.controller.ts')
re-run → 0 orphans
--fix again → no-op (idempotent)
```

Full `@forinda/kickjs-cli` suite: 470 pass. Changeset: cli minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `kick typegen --fix` to automatically repair missing recursive `import.meta.glob(...)` loading for orphaned decorated classes after reorganizing modules.
  * Expanded module index templates to use recursive eager-loading patterns (including controllers, services, repositories, and use-cases), improving support for nested folders.

* **Bug Fixes**
  * Orphaned-class repair now avoids duplicate changes and provides actionable, copy-pasteable guidance when manual intervention is needed.

* **Tests**
  * Added coverage for glob suggestion and source patching behavior.

* **Documentation**
  * Updated generated module documentation to emphasize recursive glob requirements and the new `--fix` workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->