### PR TITLE
perf(kickjs): object-lifecycle audit fixes — hot path, leaks, @PreDestroy

### DIFF
--- a/.changeset/lifecycle-optimizations.md
+++ b/.changeset/lifecycle-optimizations.md
@@ -1,0 +1,40 @@
+---
+'@forinda/kickjs': minor
+---
+
+perf + lifecycle: object-lifecycle audit fixes across the framework layer
+
+**Hot-path allocations removed**
+
+- Fastify/h3 runtimes: validation middleware is now built once per route
+  (previously re-constructed on every request) and the response driver is a
+  shared-prototype class (previously ~12 method closures allocated per request)
+- DI container: instantiation plans are precomputed per registration — REQUEST-
+  and TRANSIENT-scoped resolves no longer re-read Reflect metadata (5 reads +
+  2 throwaway Maps per instantiation)
+- `tokenName()` is no longer computed on the cached-singleton resolve path when
+  no container change listener is attached
+- `ctx.problem` is memoized per context (was ~10 closures per access)
+- `@Autowired` singleton dependencies memoize into a data property on first
+  read; REQUEST/TRANSIENT deps keep the live getter
+
+**Leaks fixed**
+
+- Reactivity: `watch().stop()` now detaches the effect from all dependency
+  Sets (previously dead watchers accumulated and kept firing); effects re-track
+  per run so conditional getters drop stale branches; `computed()` gains
+  `dispose()`; `reactive()` memoizes nested proxies (stable identity)
+- `MemoryCacheProvider` is bounded (LRU, default 10 000 entries)
+- In-memory session/rate-limit store cleanup intervals are now disposed by
+  `Application.shutdown()` via a new disposables registry
+  (`registerDisposable`/`disposeAll`)
+- Container change-batch debounce timer is `unref()`'d and flushed on shutdown
+
+**New: `@PreDestroy`**
+
+Counterpart to `@PostConstruct`. On REQUEST-scoped services the hook runs when
+the response closes (finished or aborted) on all three runtimes — release
+per-request transactions/handles/subscriptions there.
+
+`@Cacheable` now caches legitimate `null` results (previously indistinguishable
+from a cache miss, so null-returning methods re-executed on every call).

--- a/packages/kickjs/__tests__/lifecycle-optimizations.test.ts
+++ b/packages/kickjs/__tests__/lifecycle-optimizations.test.ts
@@ -8,6 +8,7 @@ import { Service, PreDestroy, Autowired } from '../src/core/decorators'
 import { Scope } from '../src/core/interfaces'
 import { requestStore, type RequestStore } from '../src/http/request-store'
 import { createRequestStore, disposeRequestStore } from '../src/http/middleware/request-scope'
+import { registerDisposable, disposeAll } from '../src/core/disposables'
 
 /**
  * Locks in the object-lifecycle fixes from the framework audit:
@@ -53,6 +54,22 @@ describe('reactivity — effect cleanup', () => {
     expect(doubled.value).toBe(10) // recomputes on demand, untracked
   })
 
+  it('reading a disposed computed inside a watcher does not attach the watcher to its sources', () => {
+    const count = ref(1)
+    const other = ref(0)
+    const doubled = computed(() => count.value * 2)
+    doubled.dispose()
+    let calls = 0
+    watch(
+      () => other.value + doubled.value, // reads disposed computed under an active effect
+      () => calls++,
+    )
+    count.value = 10 // must NOT fire — tracking is suspended through disposal
+    expect(calls).toBe(0)
+    other.value = 1 // direct dep — must fire
+    expect(calls).toBe(1)
+  })
+
   it('reactive() returns a stable proxy for nested objects', () => {
     const state = reactive({ nested: { x: 1 } })
     expect(state.nested).toBe(state.nested)
@@ -85,6 +102,20 @@ describe('MemoryCacheProvider — bounds and null caching', () => {
     expect(await repo.find('x')).toBeNull()
     expect(await repo.find('x')).toBeNull()
     expect(executions).toBe(1)
+  })
+})
+
+describe('disposables — sync-throw isolation', () => {
+  it('a synchronously throwing disposable does not prevent the others from running', async () => {
+    let ran = 0
+    registerDisposable(() => {
+      throw new Error('bad disposable')
+    })
+    registerDisposable(() => {
+      ran++
+    })
+    await expect(disposeAll()).resolves.toBeUndefined()
+    expect(ran).toBe(1)
   })
 })
 

--- a/packages/kickjs/__tests__/lifecycle-optimizations.test.ts
+++ b/packages/kickjs/__tests__/lifecycle-optimizations.test.ts
@@ -1,0 +1,145 @@
+import 'reflect-metadata'
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { ref, computed, watch, reactive } from '../src/core/reactivity'
+import { MemoryCacheProvider, Cacheable, setCacheProvider } from '../src/core/cache'
+import { Container } from '../src/core/container'
+import { Service, PreDestroy, Autowired } from '../src/core/decorators'
+import { Scope } from '../src/core/interfaces'
+import { requestStore, type RequestStore } from '../src/http/request-store'
+import { createRequestStore, disposeRequestStore } from '../src/http/middleware/request-scope'
+
+/**
+ * Locks in the object-lifecycle fixes from the framework audit:
+ * reactivity effect cleanup, bounded LRU cache + cached-null sentinel,
+ * and @PreDestroy teardown for REQUEST-scoped instances.
+ */
+
+describe('reactivity — effect cleanup', () => {
+  it('watch stop() detaches the effect so the callback never fires again', () => {
+    const count = ref(0)
+    let calls = 0
+    const stop = watch(count, () => calls++)
+    count.value = 1
+    expect(calls).toBe(1)
+    stop()
+    count.value = 2
+    expect(calls).toBe(1)
+  })
+
+  it('conditional getter drops the branch it no longer reads', () => {
+    const cond = ref(true)
+    const a = ref('a')
+    const b = ref('b')
+    let calls = 0
+    watch(
+      () => (cond.value ? a.value : b.value),
+      () => calls++,
+    )
+    cond.value = false // now reads b, must drop a's subscription
+    expect(calls).toBe(1)
+    a.value = 'a2' // stale dep — must NOT fire
+    expect(calls).toBe(1)
+    b.value = 'b2' // live dep — must fire
+    expect(calls).toBe(2)
+  })
+
+  it('computed dispose() detaches from sources; reads still work untracked', () => {
+    const count = ref(1)
+    const doubled = computed(() => count.value * 2)
+    expect(doubled.value).toBe(2)
+    doubled.dispose()
+    count.value = 5
+    expect(doubled.value).toBe(10) // recomputes on demand, untracked
+  })
+
+  it('reactive() returns a stable proxy for nested objects', () => {
+    const state = reactive({ nested: { x: 1 } })
+    expect(state.nested).toBe(state.nested)
+  })
+})
+
+describe('MemoryCacheProvider — bounds and null caching', () => {
+  it('evicts least-recently-used entries at maxEntries', async () => {
+    const cache = new MemoryCacheProvider(2)
+    await cache.set('a', 1, 60_000)
+    await cache.set('b', 2, 60_000)
+    await cache.get('a') // touch a → b is now LRU
+    await cache.set('c', 3, 60_000) // evicts b
+    expect(await cache.get('a')).toBe(1)
+    expect(await cache.get('b')).toBeNull()
+    expect(await cache.get('c')).toBe(3)
+  })
+
+  it('@Cacheable serves cached null instead of re-executing', async () => {
+    setCacheProvider(new MemoryCacheProvider())
+    let executions = 0
+    class Repo {
+      @Cacheable(60)
+      async find(_id: string): Promise<string | null> {
+        executions++
+        return null
+      }
+    }
+    const repo = new Repo()
+    expect(await repo.find('x')).toBeNull()
+    expect(await repo.find('x')).toBeNull()
+    expect(executions).toBe(1)
+  })
+})
+
+describe('@PreDestroy — REQUEST-scope teardown', () => {
+  beforeEach(() => {
+    Container.reset()
+  })
+
+  it('runs the hook when the request store is disposed, once', () => {
+    let destroyed = 0
+
+    @Service({ scope: Scope.REQUEST })
+    class TxService {
+      @PreDestroy()
+      close(): void {
+        destroyed++
+      }
+    }
+
+    Container._requestStoreProvider = () => requestStore.getStore()
+    const container = Container.getInstance()
+    const store: RequestStore = createRequestStore()
+    requestStore.run(store, () => {
+      const svc = container.resolve(TxService)
+      expect(svc).toBeInstanceOf(TxService)
+    })
+    expect(destroyed).toBe(0)
+    disposeRequestStore(store)
+    disposeRequestStore(store) // idempotent
+    expect(destroyed).toBe(1)
+    expect(store.instances.size).toBe(0)
+  })
+})
+
+describe('@Autowired — singleton memoization', () => {
+  beforeEach(() => {
+    Container.reset()
+  })
+
+  it('memoizes singleton deps as a data property after first read', () => {
+    @Service()
+    class Dep {}
+
+    @Service()
+    class Owner {
+      @Autowired()
+      dep!: Dep
+    }
+
+    const owner = Container.getInstance().resolve(Owner)
+    const first = owner.dep // triggers memoization
+    expect(owner.dep).toBe(first)
+    // After first read the property must be a plain value, not a getter.
+    const desc = Object.getOwnPropertyDescriptor(owner, 'dep')
+    expect(desc?.get).toBeUndefined()
+    expect(desc?.value).toBe(first)
+  })
+})

--- a/packages/kickjs/src/core/cache.ts
+++ b/packages/kickjs/src/core/cache.ts
@@ -46,12 +46,19 @@ export interface CacheProvider {
 // ── Built-in Memory Provider ────────────────────────────────────────────
 
 /**
- * Default in-memory cache provider using a Map.
+ * Default in-memory cache provider using a Map with LRU eviction.
  * Suitable for development and single-instance deployments.
  * For multi-instance or production, use a Redis-backed provider.
+ *
+ * Bounded: at most `maxEntries` (default 10 000) live entries. Expiry is
+ * lazy (checked on read); the size cap is what bounds memory — without it,
+ * a `@Cacheable` method over high-cardinality args grew the Map without
+ * limit, since write-once-never-read keys were never revisited.
  */
 export class MemoryCacheProvider implements CacheProvider {
   private store = new Map<string, { data: any; expiresAt: number }>()
+
+  constructor(private readonly maxEntries = 10_000) {}
 
   async get(key: string): Promise<any | null> {
     const entry = this.store.get(key)
@@ -60,10 +67,20 @@ export class MemoryCacheProvider implements CacheProvider {
       this.store.delete(key)
       return null
     }
+    // LRU touch: re-insert so Map iteration order tracks recency and
+    // eviction removes the least-recently-used key, not the oldest write.
+    this.store.delete(key)
+    this.store.set(key, entry)
     return entry.data
   }
 
   async set(key: string, value: any, ttlMs: number): Promise<void> {
+    if (!this.store.has(key) && this.store.size >= this.maxEntries) {
+      // Evict the least-recently-used entry (first in iteration order).
+      const oldest = this.store.keys().next().value
+      if (oldest !== undefined) this.store.delete(oldest)
+    }
+    this.store.delete(key)
     this.store.set(key, { data: value, expiresAt: Date.now() + ttlMs })
   }
 
@@ -129,6 +146,13 @@ export interface CacheOptions {
  * @param ttl - Time-to-live in seconds (default: 60)
  * @param options.key - Custom cache key prefix
  */
+// Sentinel stored in place of a legitimate `null` result. Providers signal
+// "miss" with null, so caching null directly was indistinguishable from a
+// miss — the method re-executed on every call (cache stampede on the exact
+// path caching should protect). A string survives any JSON round-trip
+// (Redis, etc.) without needing changes to the CacheProvider contract.
+const CACHED_NULL = '__kickjs_cached_null__'
+
 export function Cacheable(ttl?: number, options?: { key?: string }): MethodDecorator {
   return (_target, propertyKey, descriptor: PropertyDescriptor) => {
     const original = descriptor.value
@@ -141,11 +165,14 @@ export function Cacheable(ttl?: number, options?: { key?: string }): MethodDecor
 
       const cached = await provider.get(cacheKey)
       if (cached !== null) {
-        return cached
+        return cached === CACHED_NULL ? null : cached
       }
 
       const result = await original.apply(this, args)
-      await provider.set(cacheKey, result, cacheTtl)
+      // Cache legit-null results via the sentinel; `undefined` stays
+      // uncached (callers returning undefined get pre-existing behavior).
+      if (result === null) await provider.set(cacheKey, CACHED_NULL, cacheTtl)
+      else if (result !== undefined) await provider.set(cacheKey, result, cacheTtl)
       return result
     }
 

--- a/packages/kickjs/src/core/cache.ts
+++ b/packages/kickjs/src/core/cache.ts
@@ -149,9 +149,22 @@ export interface CacheOptions {
 // Sentinel stored in place of a legitimate `null` result. Providers signal
 // "miss" with null, so caching null directly was indistinguishable from a
 // miss — the method re-executed on every call (cache stampede on the exact
-// path caching should protect). A string survives any JSON round-trip
-// (Redis, etc.) without needing changes to the CacheProvider contract.
-const CACHED_NULL = '__kickjs_cached_null__'
+// path caching should protect). An object envelope (structurally checked,
+// so it survives any JSON round-trip through Redis etc.) rather than a bare
+// string: a method legitimately RETURNING that string (echoing user input,
+// etc.) must not be replayed as null. A user value could still forge this
+// exact single-key shape, but that requires deliberately constructing it —
+// not a value class that occurs by accident.
+const CACHED_NULL = { __kickjs_cached_null__: true }
+
+function isCachedNull(value: unknown): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Record<string, unknown>).__kickjs_cached_null__ === true &&
+    Object.keys(value).length === 1
+  )
+}
 
 export function Cacheable(ttl?: number, options?: { key?: string }): MethodDecorator {
   return (_target, propertyKey, descriptor: PropertyDescriptor) => {
@@ -165,7 +178,7 @@ export function Cacheable(ttl?: number, options?: { key?: string }): MethodDecor
 
       const cached = await provider.get(cacheKey)
       if (cached !== null) {
-        return cached === CACHED_NULL ? null : cached
+        return isCachedNull(cached) ? null : cached
       }
 
       const result = await original.apply(this, args)

--- a/packages/kickjs/src/core/container.ts
+++ b/packages/kickjs/src/core/container.ts
@@ -39,6 +39,27 @@ interface Registration {
   resolveDurationMs?: number
   postConstructStatus: PostConstructStatus
   dependencies: string[]
+  /** Lazily built instantiation plan — see {@link Container.buildPlan}. */
+  plan?: InstantiationPlan
+}
+
+/**
+ * Precomputed instantiation recipe for a class. Class metadata is immutable
+ * after definition, so the Reflect reads (5 per create) and the derived
+ * structures only need computing ONCE — previously they re-ran on every
+ * REQUEST-scoped resolve (i.e. every request) and every TRANSIENT resolve.
+ */
+interface InstantiationPlan {
+  /** Ordered, validated constructor parameter tokens. */
+  ctorTokens: any[]
+  /** `@Autowired` properties: [property, resolved token]. */
+  autowired: Array<[string, any]>
+  /** `@Value` properties: [property, env config]. */
+  values: Array<[string, { envKey: string; defaultValue?: any }]>
+  /** `@Asset` properties: [property, pre-split namespace/key]. */
+  assets: Array<[string, { namespace: string; key: string }]>
+  /** `@PostConstruct` method name, if any. */
+  postConstruct?: string | symbol
 }
 
 /** Create a Registration with observability defaults */
@@ -250,7 +271,7 @@ export class Container {
     if (typeof token === 'function' && token.name) {
       this.registrations.set(`__hmr__${token.name}`, reg)
     }
-    this.emit(tokenName(token), 'registered', kind)
+    this.emit(token, 'registered', kind)
   }
 
   /** Register a factory function under the given token */
@@ -390,7 +411,7 @@ export class Container {
     if (reg.scope === Scope.SINGLETON && reg.instance !== undefined) {
       reg.resolveCount++
       reg.lastResolvedAt = Date.now()
-      this.emit(tokenName(token), 'resolved', reg.kind)
+      this.emit(token, 'resolved', reg.kind)
       return reg.instance
     }
 
@@ -407,14 +428,14 @@ export class Container {
       if (store.values.has(token)) {
         reg.resolveCount++
         reg.lastResolvedAt = Date.now()
-        this.emit(tokenName(token), 'resolved', reg.kind)
+        this.emit(token, 'resolved', reg.kind)
         return store.values.get(token) as T
       }
       // Check per-request instance cache
       if (store.instances.has(token)) {
         reg.resolveCount++
         reg.lastResolvedAt = Date.now()
-        this.emit(tokenName(token), 'resolved', reg.kind)
+        this.emit(token, 'resolved', reg.kind)
         return store.instances.get(token) as T
       }
       // Factory-registered binding: invoke the factory once per request
@@ -431,7 +452,7 @@ export class Container {
         reg.lastResolvedAt = Date.now()
         if (!reg.firstResolvedAt) reg.firstResolvedAt = Date.now()
         store.instances.set(token, instance)
-        this.emit(tokenName(token), 'resolved', reg.kind)
+        this.emit(token, 'resolved', reg.kind)
         return instance as T
       }
       // Create instance and cache for this request only
@@ -442,7 +463,7 @@ export class Container {
       reg.lastResolvedAt = Date.now()
       if (!reg.firstResolvedAt) reg.firstResolvedAt = Date.now()
       store.instances.set(token, instance)
-      this.emit(tokenName(token), 'resolved', reg.kind)
+      this.emit(token, 'resolved', reg.kind)
       return instance as T
     }
 
@@ -458,7 +479,7 @@ export class Container {
         // Persist resolved factory instances so they survive module re-evaluation
         getPersistentStore().resolvedInstances.set(tokenName(token), instance)
       }
-      this.emit(tokenName(token), 'resolved', reg.kind)
+      this.emit(token, 'resolved', reg.kind)
       return instance
     }
 
@@ -479,7 +500,7 @@ export class Container {
       if (reg.scope === Scope.SINGLETON) {
         reg.instance = instance
       }
-      this.emit(tokenName(token), 'resolved', reg.kind)
+      this.emit(token, 'resolved', reg.kind)
       return instance
     } finally {
       this.resolving.delete(token)
@@ -555,8 +576,13 @@ export class Container {
     }
   }
 
-  /** Batch-emit a change event (debounced, flushed after 50ms of quiet) */
-  private emit(token: string, event: ContainerChangeEvent['event'], kind?: ClassKind): void {
+  /**
+   * Batch-emit a change event (debounced, flushed after 50ms of quiet).
+   * Takes the RAW token — `tokenName()` is only computed after the
+   * zero-listener guard, so the hot cached-singleton resolve path never pays
+   * the name derivation when nobody is watching (the production default).
+   */
+  private emit(rawToken: any, event: ContainerChangeEvent['event'], kind?: ClassKind): void {
     // Zero-listener fast path. Nobody subscribes to container changes unless
     // DevTools (or a test) calls `onChange` — the production default. Without
     // this guard, every `resolve()` (including the hot cached-singleton path)
@@ -567,6 +593,7 @@ export class Container {
     // subsequent emits work exactly as before — past resolves had no observer
     // to notify anyway.
     if (this.changeListeners.size === 0) return
+    const token = tokenName(rawToken)
 
     // Dedupe within the pending batch: a high-throughput TRANSIENT
     // token that resolves 1000× per request would otherwise queue
@@ -594,6 +621,9 @@ export class Container {
         }
       }
     }, Container.DEBOUNCE_MS)
+    // Don't let a pending debounce window hold the event loop open — flush is
+    // best-effort telemetry, not critical work.
+    this.notifyTimer.unref?.()
   }
 
   /** Flush pending change events immediately (useful in tests) */
@@ -613,7 +643,17 @@ export class Container {
     }
   }
 
-  private createInstance(reg: Registration): any {
+  /**
+   * Build the one-time instantiation plan for a registration. Runs on the
+   * FIRST createInstance for the class — the metadata it reads is immutable
+   * after class definition, so every later create (REQUEST scope: every
+   * request) skips all Reflect reads and re-derivation.
+   *
+   * Scope validation (SINGLETON must not ctor-inject REQUEST) lives here
+   * too: it's a static property of the (parent, dep) registration pair, so
+   * checking it once at plan build is equivalent to the old per-create loop.
+   */
+  private buildPlan(reg: Registration): InstantiationPlan {
     const paramTypes = getClassMeta<Constructor[]>(METADATA.PARAM_TYPES, reg.target, [])
     const injectTokens = getMetaRecord<any>(METADATA.INJECT, reg.target)
 
@@ -627,7 +667,7 @@ export class Container {
         : 0
     const paramCount = Math.max(paramTypes.length, maxInjectIndex)
 
-    const args: any[] = []
+    const ctorTokens: any[] = []
     for (let index = 0; index < paramCount; index++) {
       const token = injectTokens[index] || paramTypes[index]
       if (!token) {
@@ -647,19 +687,67 @@ export class Container {
           )
         }
       }
+      ctorTokens.push(token)
+    }
+
+    // @Autowired properties — resolve each property's token once.
+    const autowiredProps = getMetaMap<string, any>(METADATA.AUTOWIRED, reg.target.prototype)
+    const autowired: InstantiationPlan['autowired'] = []
+    for (const [prop, token] of autowiredProps) {
+      const resolvedToken =
+        token || getMethodMetaOrUndefined(METADATA.PROPERTY_TYPE, reg.target.prototype, prop)
+      if (resolvedToken) autowired.push([prop, resolvedToken])
+    }
+
+    // @Value properties.
+    const valueProps = getMetaMap<string, { envKey: string; defaultValue?: any }>(
+      METADATA.VALUE,
+      reg.target.prototype,
+    )
+    const values: InstantiationPlan['values'] = [...valueProps.entries()]
+
+    // @Asset properties — pre-split namespace/key (and fail fast on bad keys).
+    const assetProps = getMetaMap<string, { assetKey: string }>(
+      METADATA.ASSET,
+      reg.target.prototype,
+    )
+    const assets: InstantiationPlan['assets'] = []
+    for (const [prop, config] of assetProps) {
+      const slashIdx = config.assetKey.indexOf('/')
+      if (slashIdx === -1) {
+        throw new Error(
+          `@Asset('${config.assetKey}'): asset key must include a '/' separator (e.g. 'mails/welcome').`,
+        )
+      }
+      assets.push([
+        prop,
+        { namespace: config.assetKey.slice(0, slashIdx), key: config.assetKey.slice(slashIdx + 1) },
+      ])
+    }
+
+    const postConstruct = getClassMetaOrUndefined<string | symbol>(
+      METADATA.POST_CONSTRUCT,
+      reg.target.prototype,
+    )
+
+    return { ctorTokens, autowired, values, assets, postConstruct }
+  }
+
+  private createInstance(reg: Registration): any {
+    const plan = (reg.plan ??= this.buildPlan(reg))
+
+    const args: any[] = []
+    for (const token of plan.ctorTokens) {
       args.push(this.resolve(token))
     }
 
     const instance = new reg.target(...args)
 
-    // Property injection via @Autowired
-    this.injectProperties(instance, reg.target)
+    // Property injection via @Autowired / @Value / @Asset
+    this.injectProperties(instance, plan)
 
     // @PostConstruct lifecycle hook
-    const postConstruct = getClassMetaOrUndefined<string | symbol>(
-      METADATA.POST_CONSTRUCT,
-      reg.target.prototype,
-    )
+    const postConstruct = plan.postConstruct
     if (postConstruct && typeof instance[postConstruct] === 'function') {
       try {
         const result = instance[postConstruct]()
@@ -724,29 +812,36 @@ export class Container {
     return [...new Set([...ctorDeps, ...propDeps])]
   }
 
-  private injectProperties(instance: any, target: Constructor): void {
-    // @Autowired — lazy DI property injection
-    const autowiredProps = getMetaMap<string, any>(METADATA.AUTOWIRED, target.prototype)
-
-    for (const [prop, token] of autowiredProps) {
-      const resolvedToken =
-        token || getMethodMetaOrUndefined(METADATA.PROPERTY_TYPE, target.prototype, prop)
-      if (resolvedToken) {
-        Object.defineProperty(instance, prop, {
-          get: () => this.resolve(resolvedToken),
-          enumerable: true,
-          configurable: true,
-        })
-      }
+  private injectProperties(instance: any, plan: InstantiationPlan): void {
+    // @Autowired — lazy DI property injection. The getter re-resolves per
+    // access by design (a SINGLETON may lazily read a REQUEST-scoped dep at
+    // call time). For SINGLETON deps that laziness buys nothing after the
+    // first read — the container returns the same cached instance forever —
+    // so the getter memoizes itself into a plain data property then. REQUEST
+    // and TRANSIENT deps keep the live getter (memoizing would pin the first
+    // request's instance across requests).
+    for (const [prop, resolvedToken] of plan.autowired) {
+      Object.defineProperty(instance, prop, {
+        get: () => {
+          const value = this.resolve(resolvedToken)
+          const depReg = this.registrations.get(resolvedToken)
+          if (depReg?.scope === Scope.SINGLETON) {
+            Object.defineProperty(instance, prop, {
+              value,
+              enumerable: true,
+              configurable: true,
+              writable: false,
+            })
+          }
+          return value
+        },
+        enumerable: true,
+        configurable: true,
+      })
     }
 
     // @Value — lazy environment variable injection
-    const valueProps = getMetaMap<string, { envKey: string; defaultValue?: any }>(
-      METADATA.VALUE,
-      target.prototype,
-    )
-
-    for (const [prop, config] of valueProps) {
+    for (const [prop, config] of plan.values) {
       Object.defineProperty(instance, prop, {
         get() {
           // Use the registered env resolver if available (wired by the
@@ -771,28 +866,15 @@ export class Container {
     // @Asset — lazy asset path injection (assets-plan.md). Same lazy-
     // getter pattern as @Value: resolve on every property access via
     // the asset manager's cached resolver, not at class instantiation.
-    // Splits the key on the FIRST '/' so `mails/orders/confirmation`
-    // becomes namespace=`mails` + key=`orders/confirmation`.
-    const assetProps = getMetaMap<string, { assetKey: string }>(METADATA.ASSET, target.prototype)
-
-    if (assetProps.size > 0) {
-      for (const [prop, config] of assetProps) {
-        const slashIdx = config.assetKey.indexOf('/')
-        if (slashIdx === -1) {
-          throw new Error(
-            `@Asset('${config.assetKey}'): asset key must include a '/' separator (e.g. 'mails/welcome').`,
-          )
-        }
-        const namespace = config.assetKey.slice(0, slashIdx)
-        const key = config.assetKey.slice(slashIdx + 1)
-        Object.defineProperty(instance, prop, {
-          get() {
-            return resolveAsset(namespace, key)
-          },
-          enumerable: true,
-          configurable: true,
-        })
-      }
+    // namespace/key were pre-split at plan build.
+    for (const [prop, { namespace, key }] of plan.assets) {
+      Object.defineProperty(instance, prop, {
+        get() {
+          return resolveAsset(namespace, key)
+        },
+        enumerable: true,
+        configurable: true,
+      })
     }
   }
 }

--- a/packages/kickjs/src/core/decorators.ts
+++ b/packages/kickjs/src/core/decorators.ts
@@ -131,6 +131,20 @@ export function PostConstruct(): MethodDecorator {
   }
 }
 
+/**
+ * Mark a method as a teardown hook — the counterpart to {@link PostConstruct}.
+ *
+ * For REQUEST-scoped services it runs when the request's scope closes
+ * (response finished or aborted): release per-request resources there
+ * (transactions, handles, subscriptions). May be async; errors are logged
+ * and swallowed so one failing hook can't break request completion.
+ */
+export function PreDestroy(): MethodDecorator {
+  return (target, propertyKey) => {
+    setClassMeta(METADATA.PRE_DESTROY, propertyKey, target)
+  }
+}
+
 // ── Injection Decorators (property + constructor parameter) ─────────────
 
 /**

--- a/packages/kickjs/src/core/disposables.ts
+++ b/packages/kickjs/src/core/disposables.ts
@@ -1,0 +1,29 @@
+/**
+ * Registry for framework-owned resources that hold timers or other handles
+ * outside the adapter/plugin lifecycle — e.g. the in-memory session and
+ * rate-limit stores' cleanup intervals. `Application.shutdown()` drains it so
+ * startup and shutdown stay symmetric even for resources created lazily by
+ * middleware factories.
+ *
+ * Intervals are `.unref()`'d so they never wedge process exit — this registry
+ * exists for IN-PROCESS teardown (test suites, HMR, multi-app hosts) where
+ * each un-disposed store would otherwise leak a live interval + backing Map
+ * per app instance.
+ */
+
+export type Disposable = () => void | Promise<void>
+
+const disposables = new Set<Disposable>()
+
+/** Register a cleanup callback. Returns an unregister function. */
+export function registerDisposable(fn: Disposable): () => void {
+  disposables.add(fn)
+  return () => disposables.delete(fn)
+}
+
+/** Run and clear all registered disposables. Errors are swallowed per-entry. */
+export async function disposeAll(): Promise<void> {
+  const pending = [...disposables]
+  disposables.clear()
+  await Promise.allSettled(pending.map((fn) => Promise.resolve(fn())))
+}

--- a/packages/kickjs/src/core/disposables.ts
+++ b/packages/kickjs/src/core/disposables.ts
@@ -21,9 +21,30 @@ export function registerDisposable(fn: Disposable): () => void {
   return () => disposables.delete(fn)
 }
 
-/** Run and clear all registered disposables. Errors are swallowed per-entry. */
-export async function disposeAll(): Promise<void> {
+/**
+ * Remove and return all currently registered disposables WITHOUT running
+ * them. Used by HMR rebuild to snapshot the outgoing app's resources before
+ * `setup()` registers the incoming app's — so the stale set can be disposed
+ * on success, or restored on failure, without touching the new one.
+ */
+export function drainDisposables(): Disposable[] {
   const pending = [...disposables]
   disposables.clear()
-  await Promise.allSettled(pending.map((fn) => Promise.resolve(fn())))
+  return pending
+}
+
+/**
+ * Run a list of disposables. Errors — including SYNCHRONOUS throws — are
+ * swallowed per-entry: the `async` callback converts a sync throw into a
+ * rejection that `allSettled` absorbs, so one bad disposable can't abort
+ * the rest (a bare `Promise.resolve(fn())` would let the throw escape the
+ * `.map()` before `allSettled` ever ran).
+ */
+export async function runDisposables(list: Disposable[]): Promise<void> {
+  await Promise.allSettled(list.map(async (fn) => fn()))
+}
+
+/** Run and clear all registered disposables. Errors are swallowed per-entry. */
+export async function disposeAll(): Promise<void> {
+  await runDisposables(drainDisposables())
 }

--- a/packages/kickjs/src/core/index.ts
+++ b/packages/kickjs/src/core/index.ts
@@ -33,6 +33,7 @@ export {
   Repository,
   Controller,
   PostConstruct,
+  PreDestroy,
   Autowired,
   Inject,
   Value,
@@ -109,6 +110,9 @@ export {
 
 // Logger
 export { Logger, createLogger, ConsoleLoggerProvider, type LoggerProvider } from './logger'
+
+// Disposables — framework-owned resource teardown drained by Application.shutdown()
+export { registerDisposable, disposeAll, type Disposable } from './disposables'
 
 // Errors
 export {

--- a/packages/kickjs/src/core/interfaces.ts
+++ b/packages/kickjs/src/core/interfaces.ts
@@ -68,6 +68,7 @@ export const METADATA = {
   AUTOWIRED: 'kick:autowired',
   INJECT: 'kick:inject',
   POST_CONSTRUCT: 'kick:post_construct',
+  PRE_DESTROY: 'kick:pre_destroy',
   BUILDER: 'kick:builder',
   QUERY_PARAMS: 'kick:query:params',
   ROUTES: 'kick:routes',

--- a/packages/kickjs/src/core/reactivity.ts
+++ b/packages/kickjs/src/core/reactivity.ts
@@ -5,10 +5,48 @@
  */
 
 // ── Dependency Tracking ─────────────────────────────────────────────────
+//
+// Effects carry back-references to every dep Set they were added to, so
+// stopping a watcher / disposing a computed — or simply re-running an
+// effect whose getter reads different keys this time — removes it from the
+// old Sets instead of leaving dead subscriptions to accumulate (and be
+// invoked!) forever. Same cleanup discipline as Vue 3's ReactiveEffect.
 
-type Effect = () => void
+interface Effect {
+  (): void
+  /** Dep Sets this effect is currently registered in (for cleanup). */
+  deps: Set<Set<Effect>>
+}
+
 let activeEffect: Effect | null = null
 const targetMap = new WeakMap<object, Map<string | symbol, Set<Effect>>>()
+
+function createEffect(fn: () => void): Effect {
+  const effect = fn as Effect
+  effect.deps = new Set()
+  return effect
+}
+
+/** Remove the effect from every dep Set it was tracked into. */
+function cleanupEffect(effect: Effect): void {
+  for (const depSet of effect.deps) depSet.delete(effect)
+  effect.deps.clear()
+}
+
+/**
+ * Run `fn` with `effect` as the active tracking target, first clearing the
+ * effect's previous subscriptions so conditional reads don't leave stale deps.
+ */
+function runTracked<T>(effect: Effect, fn: () => T): T {
+  cleanupEffect(effect)
+  const prev = activeEffect
+  activeEffect = effect
+  try {
+    return fn()
+  } finally {
+    activeEffect = prev
+  }
+}
 
 function track(target: object, key: string | symbol): void {
   if (!activeEffect) return
@@ -23,14 +61,19 @@ function track(target: object, key: string | symbol): void {
     depsMap.set(key, deps)
   }
   deps.add(activeEffect)
+  activeEffect.deps.add(deps)
 }
 
 function trigger(target: object, key: string | symbol): void {
   const depsMap = targetMap.get(target)
   if (!depsMap) return
   const deps = depsMap.get(key)
-  if (!deps) return
-  for (const effect of deps) {
+  if (!deps || deps.size === 0) return
+  // Iterate a snapshot — a triggered effect re-tracks (mutating `deps`)
+  // during its run, which would otherwise corrupt this iteration. The
+  // array copy is deliberate, not a useless spread.
+  // eslint-disable-next-line unicorn/no-useless-spread
+  for (const effect of [...deps]) {
     effect()
   }
 }
@@ -107,6 +150,15 @@ export interface ComputedRef<T = any> {
    * same as reading `.value`.
    */
   toJSON(): T
+  /**
+   * Unsubscribe this computed from its reactive sources. Call when the
+   * computed's lifetime is shorter than its sources' (e.g. created
+   * per-request/per-tenant against app-lifetime refs) — without it the
+   * internal effect stays pinned in the sources' dep Sets forever.
+   * After disposal, reading `.value` still works but recomputes on every
+   * access and no longer tracks.
+   */
+  dispose(): void
 }
 
 /**
@@ -124,22 +176,20 @@ export interface ComputedRef<T = any> {
 export function computed<T>(getter: () => T): ComputedRef<T> {
   let cached: T
   let dirty = true
+  let disposed = false
   const wrapper = { _value: undefined as T }
 
-  const effect: Effect = () => {
+  const effect = createEffect(() => {
     dirty = true
     trigger(wrapper, '_value')
-  }
+  })
 
   const recompute = (): T => {
+    // Disposed: plain evaluation, no tracking — the computed must not
+    // re-subscribe itself to sources it was explicitly detached from.
+    if (disposed) return getter()
     if (dirty) {
-      const prev = activeEffect
-      activeEffect = effect
-      try {
-        cached = getter()
-      } finally {
-        activeEffect = prev
-      }
+      cached = runTracked(effect, getter)
       wrapper._value = cached
       dirty = false
     }
@@ -150,6 +200,10 @@ export function computed<T>(getter: () => T): ComputedRef<T> {
     get value(): T {
       track(wrapper, '_value')
       return recompute()
+    },
+    dispose(): void {
+      disposed = true
+      cleanupEffect(effect)
     },
     /**
      * Auto-unwrap on `JSON.stringify`, matching {@link ref}'s behavior
@@ -200,30 +254,30 @@ export function watch<T>(
 
   const getter = typeof source === 'function' ? source : () => source.value
 
-  const job: Effect = () => {
+  const job = createEffect(() => {
     if (stopped) return
-    const newValue = getter()
+    // Re-run the getter UNDER tracking so deps are refreshed each run —
+    // a conditional getter (`cond ? a.value : b.value`) drops the branch
+    // it no longer reads instead of staying subscribed to it forever.
+    const newValue = runTracked(job, getter)
     if (!Object.is(newValue, oldValue)) {
       callback(newValue, oldValue)
       oldValue = newValue
     }
-  }
+  })
 
   // Initial run to establish tracking
-  const prev = activeEffect
-  activeEffect = job
-  try {
-    oldValue = getter()
-  } finally {
-    activeEffect = prev
-  }
+  oldValue = runTracked(job, getter)
 
   if (options?.immediate) {
     callback(oldValue, undefined as T)
   }
 
   return () => {
+    // Detach from every dep Set — a flag alone would leave the dead effect
+    // referenced (and invoked) by its sources for their entire lifetime.
     stopped = true
+    cleanupEffect(job)
   }
 }
 
@@ -244,8 +298,15 @@ export function watch<T>(
  * console.log(errorRate.value) // 0.05
  * ```
  */
+// Memoize proxies per target: repeated reads of the same nested object must
+// return the SAME proxy — otherwise every access allocates a fresh Proxy and
+// referential identity breaks (`state.nested !== state.nested`).
+const proxyCache = new WeakMap<object, any>()
+
 export function reactive<T extends Record<string, any>>(target: T): T {
-  return new Proxy(target, {
+  const existing = proxyCache.get(target)
+  if (existing) return existing as T
+  const proxy = new Proxy(target, {
     get(obj, key, receiver) {
       const value = Reflect.get(obj, key, receiver)
       if (typeof key === 'symbol') return value
@@ -265,6 +326,8 @@ export function reactive<T extends Record<string, any>>(target: T): T {
       return result
     },
   })
+  proxyCache.set(target, proxy)
+  return proxy
 }
 
 // ── Utility ──────────────────────────────────────────────────────────────

--- a/packages/kickjs/src/core/reactivity.ts
+++ b/packages/kickjs/src/core/reactivity.ts
@@ -70,10 +70,8 @@ function trigger(target: object, key: string | symbol): void {
   const deps = depsMap.get(key)
   if (!deps || deps.size === 0) return
   // Iterate a snapshot — a triggered effect re-tracks (mutating `deps`)
-  // during its run, which would otherwise corrupt this iteration. The
-  // array copy is deliberate, not a useless spread.
-  // eslint-disable-next-line unicorn/no-useless-spread
-  for (const effect of [...deps]) {
+  // during its run, which would otherwise corrupt this iteration.
+  for (const effect of Array.from(deps)) {
     effect()
   }
 }
@@ -185,9 +183,19 @@ export function computed<T>(getter: () => T): ComputedRef<T> {
   })
 
   const recompute = (): T => {
-    // Disposed: plain evaluation, no tracking — the computed must not
-    // re-subscribe itself to sources it was explicitly detached from.
-    if (disposed) return getter()
+    // Disposed: plain evaluation with tracking SUSPENDED — neither this
+    // computed's effect nor any OUTER active effect (a watcher reading
+    // `.value`) may attach to the sources through a disposed computed;
+    // otherwise disposal wouldn't actually sever the subscription chain.
+    if (disposed) {
+      const prev = activeEffect
+      activeEffect = null
+      try {
+        return getter()
+      } finally {
+        activeEffect = prev
+      }
+    }
     if (dirty) {
       cached = runTracked(effect, getter)
       wrapper._value = cached

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -22,7 +22,12 @@ import {
   MutableModuleRegistry,
 } from '../core'
 import { moduleRouteMissingControllerError } from '../core/kick-errors'
-import { disposeAll } from '../core/disposables'
+import {
+  disposeAll,
+  drainDisposables,
+  registerDisposable,
+  runDisposables,
+} from '../core/disposables'
 import { getClassMeta } from '../core/metadata'
 import { requestId } from './middleware/request-id'
 import { notFoundHandler, errorHandler } from './middleware/error-handler'
@@ -903,6 +908,12 @@ export class Application {
     // the old app keeps running so the server stays responsive.
     const prevApp = this.app
     const prevContainer = this.container
+    // Snapshot the outgoing app's disposables (session/rate-limit store
+    // intervals) BEFORE setup() registers the incoming app's. On success the
+    // stale set is disposed — without this, every HMR swap leaked one live
+    // interval + Map per store. On failure it's restored, and whatever the
+    // failed setup() half-registered is disposed instead.
+    const staleDisposables = drainDisposables()
 
     try {
       Container.reset()
@@ -912,10 +923,14 @@ export class Application {
     } catch (err) {
       log.error(err, 'HMR rebuild failed, keeping previous app')
       // Restore previous state so the server stays responsive
+      await runDisposables(drainDisposables())
+      for (const d of staleDisposables) registerDisposable(d)
       this.app = prevApp
       this.container = prevContainer
       return
     }
+
+    await runDisposables(staleDisposables)
 
     if (this.httpServer) {
       this.httpServer.removeAllListeners('request')

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -22,6 +22,7 @@ import {
   MutableModuleRegistry,
 } from '../core'
 import { moduleRouteMissingControllerError } from '../core/kick-errors'
+import { disposeAll } from '../core/disposables'
 import { getClassMeta } from '../core/metadata'
 import { requestId } from './middleware/request-id'
 import { notFoundHandler, errorHandler } from './middleware/error-handler'
@@ -992,6 +993,13 @@ export class Application {
           log.error({ err: result.reason }, 'Adapter shutdown failed')
         }
       }
+
+      // Step 4: Release framework-owned resources started outside the
+      // adapter lifecycle — in-memory session/rate-limit store intervals —
+      // and flush any pending container change batch so its debounce timer
+      // doesn't outlive the app.
+      await disposeAll()
+      this.container.flushChanges()
     } finally {
       if (timer) clearTimeout(timer)
     }

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -283,6 +283,9 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
    */
   private _qsMemo?: { config: unknown; options: unknown; result: unknown }
 
+  /** Memoized {@link problem} sender — built lazily on first access. */
+  private _problem?: ProblemSender
+
   /**
    * Read-side accessor for the per-request metadata map.
    *
@@ -634,6 +637,9 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
    * (use it from services where `ctx` isn't in scope).
    */
   get problem(): ProblemSender {
+    // Memoized — building the sender allocates ~10 closures, so pay that only
+    // on the first access per context instead of per `ctx.problem.*` call.
+    if (this._problem) return this._problem
     const send = (input: ProblemDetails): RuntimeResponse => this.sendProblem(input)
     send.badRequest = (input: ProblemInput = {}): RuntimeResponse =>
       this.sendProblem({ status: 400, ...input })
@@ -664,7 +670,8 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
         errors,
       })
     }
-    return send as ProblemSender
+    this._problem = send as ProblemSender
+    return this._problem
   }
 
   private sendProblem(input: ProblemDetails): RuntimeResponse {

--- a/packages/kickjs/src/http/middleware/rate-limit.ts
+++ b/packages/kickjs/src/http/middleware/rate-limit.ts
@@ -1,5 +1,7 @@
 import type { Request, Response, NextFunction } from 'express'
 
+import { registerDisposable } from '../../core/disposables'
+
 export interface RateLimitStore {
   increment(key: string): Promise<{ totalHits: number; resetTime: Date }>
   decrement(key: string): Promise<void>
@@ -42,6 +44,16 @@ class MemoryStore implements RateLimitStore {
     if (this.cleanupTimer.unref) {
       this.cleanupTimer.unref()
     }
+    // Symmetric teardown: Application.shutdown() drains the disposables
+    // registry — without this, every in-process app re-create (tests, HMR)
+    // leaked one live interval + its hits Map.
+    registerDisposable(() => this.dispose())
+  }
+
+  /** Clear the cleanup interval and drop all hit counters. */
+  dispose(): void {
+    clearInterval(this.cleanupTimer)
+    this.hits.clear()
   }
 
   async increment(key: string): Promise<{ totalHits: number; resetTime: Date }> {

--- a/packages/kickjs/src/http/middleware/request-scope.ts
+++ b/packages/kickjs/src/http/middleware/request-scope.ts
@@ -1,6 +1,60 @@
 import crypto from 'node:crypto'
 import type { Request, Response, NextFunction } from 'express'
 import { requestStore, type RequestStore } from '../request-store'
+import { METADATA } from '../../core/interfaces'
+import { getClassMetaOrUndefined } from '../../core/metadata'
+import { createLogger } from '../../core/logger'
+
+const log = createLogger('RequestScope')
+
+// Per-class @PreDestroy method-name cache: the metadata is immutable after
+// class definition, so pay the Reflect read once per class, not once per
+// instance per request. `null` = "checked, none declared".
+const preDestroyCache = new Map<Function, string | symbol | null>()
+
+function preDestroyMethod(ctor: Function): string | symbol | null {
+  let method = preDestroyCache.get(ctor)
+  if (method === undefined) {
+    method =
+      getClassMetaOrUndefined<string | symbol>(METADATA.PRE_DESTROY, (ctor as any).prototype) ??
+      null
+    preDestroyCache.set(ctor, method)
+  }
+  return method
+}
+
+/**
+ * Run `@PreDestroy` hooks on every REQUEST-scoped instance the request
+ * created, then drop them. Called when the response closes (finished or
+ * aborted) — the counterpart to `@PostConstruct`, closing the lifecycle gap
+ * where per-request services holding transactions/handles/subscriptions were
+ * silently dropped with no cleanup callback.
+ *
+ * Idempotent (guarded by `store.disposed`); hook errors are logged and
+ * swallowed so one failing teardown can't break request completion. Async
+ * hooks are fired without being awaited — the response is already gone.
+ */
+export function disposeRequestStore(store: RequestStore): void {
+  if (store.disposed) return
+  store.disposed = true
+  if (store.instances.size === 0) return
+  for (const instance of store.instances.values()) {
+    if (instance === null || typeof instance !== 'object') continue
+    const method = preDestroyMethod(instance.constructor)
+    if (!method || typeof instance[method] !== 'function') continue
+    try {
+      const result = instance[method]()
+      if (result && typeof result.then === 'function') {
+        ;(result as Promise<void>).catch((err) =>
+          log.error(err, `@PreDestroy on ${instance.constructor.name} rejected`),
+        )
+      }
+    } catch (err) {
+      log.error(err, `@PreDestroy on ${instance.constructor.name} threw`)
+    }
+  }
+  store.instances.clear()
+}
 
 /**
  * Marker symbol stamped on the function returned by {@link requestScopeMiddleware}.
@@ -39,7 +93,7 @@ export function createRequestStore(requestId?: string): RequestStore {
  * or the user already includes one in their middleware list.
  */
 export function requestScopeMiddleware() {
-  const mw = (req: Request, _res: Response, next: NextFunction) => {
+  const mw = (req: Request, res: Response, next: NextFunction) => {
     const requestIdHeader = req.headers['x-request-id']
     const requestId =
       (Array.isArray(requestIdHeader) ? requestIdHeader[0] : requestIdHeader) || crypto.randomUUID()
@@ -50,7 +104,12 @@ export function requestScopeMiddleware() {
     // disagree with the X-Request-Id response header for any request that
     // didn't carry an inbound x-request-id header.
     ;(req as Request & { requestId?: string }).requestId = requestId
-    requestStore.run(store, () => next())
+    // 'close' fires once the response finished OR the client aborted — run
+    // @PreDestroy teardown for the request's scoped instances either way.
+    res.once('close', () => disposeRequestStore(store))
+    // Pass `next` directly — `run` invokes it with no args, so the arrow
+    // wrapper previously allocated per request added nothing.
+    requestStore.run(store, next)
   }
   ;(mw as unknown as Record<symbol, unknown>)[REQUEST_SCOPE_MIDDLEWARE_MARKER] = true
   return mw

--- a/packages/kickjs/src/http/middleware/session.ts
+++ b/packages/kickjs/src/http/middleware/session.ts
@@ -1,6 +1,8 @@
 import { randomUUID, createHmac, timingSafeEqual } from 'node:crypto'
 import type { Request, Response, NextFunction } from 'express'
 
+import { registerDisposable } from '../../core/disposables'
+
 export interface SessionData {
   [key: string]: unknown
 }
@@ -53,6 +55,16 @@ class MemoryStore implements SessionStore {
     // Purge expired sessions every 60 seconds
     this.cleanupInterval = setInterval(() => this.purge(), 60_000)
     this.cleanupInterval.unref()
+    // Symmetric teardown: Application.shutdown() drains the disposables
+    // registry — without this, every in-process app re-create (tests, HMR)
+    // leaked one live interval + its session Map.
+    registerDisposable(() => this.dispose())
+  }
+
+  /** Clear the cleanup interval and drop all sessions. */
+  dispose(): void {
+    clearInterval(this.cleanupInterval)
+    this.sessions.clear()
   }
 
   async get(sid: string): Promise<SessionData | null> {

--- a/packages/kickjs/src/http/request-store.ts
+++ b/packages/kickjs/src/http/request-store.ts
@@ -32,6 +32,8 @@ export interface RequestStore {
    * write helper.
    */
   values: Map<string, unknown>
+  /** Set once {@link disposeRequestStore} has run — guards double-dispose. */
+  disposed?: boolean
 }
 
 /** AsyncLocalStorage instance shared across the framework */

--- a/packages/kickjs/src/http/runtimes/fastify.ts
+++ b/packages/kickjs/src/http/runtimes/fastify.ts
@@ -19,7 +19,7 @@ import { createRequire } from 'node:module'
 
 import { RequestContext } from '../context'
 import { requestStore } from '../request-store'
-import { createRequestStore } from '../middleware/request-scope'
+import { createRequestStore, disposeRequestStore } from '../middleware/request-scope'
 import { validate } from '../middleware/validate'
 import { applyUploadConfig, type RawUploadPart } from '../middleware/upload'
 import type {
@@ -91,63 +91,73 @@ interface MultipartPart {
   toBuffer?: () => Promise<Buffer>
 }
 
-/** Wrap a Fastify reply so the RequestContext response helpers drive it. */
-function replyDriver(reply: FastifyReplyLike): RuntimeResponse {
-  const driver: RuntimeResponse = {
-    status(code) {
-      reply.code(code)
-      return driver
-    },
-    json(data) {
-      reply.send(data)
-      return driver
-    },
-    send(data) {
-      reply.send(data)
-      return driver
-    },
-    type(contentType) {
-      reply.type(contentType)
-      return driver
-    },
-    setHeader(name, value) {
-      reply.header(name, value)
-      return driver
-    },
-    render() {
-      throw new Error('ctx.render() is not supported on the Fastify runtime (no view engine).')
-    },
-    writeHead(statusCode, headers) {
-      // Streaming / SSE: take over the raw socket so Fastify doesn't try to
-      // serialize a reply we're writing by hand.
-      reply.hijack()
-      reply.raw.writeHead(statusCode, headers)
-      return driver
-    },
-    flushHeaders() {
-      ;(reply.raw as ServerResponse & { flushHeaders?: () => void }).flushHeaders?.()
-      return driver
-    },
-    write(chunk) {
-      return reply.raw.write(chunk)
-    },
-    end(data) {
-      reply.raw.end(data)
-      return driver
-    },
-    once(event, listener) {
-      reply.raw.once(event, listener)
-      return driver
-    },
-    get headersSent() {
-      return reply.sent || reply.raw.headersSent
-    },
+/**
+ * Wrap a Fastify reply so the RequestContext response helpers drive it.
+ * A class so the ~12 driver methods live on a shared prototype — the previous
+ * object-literal version re-allocated every method closure on each request.
+ */
+class FastifyReplyDriver implements RuntimeResponse {
+  constructor(private readonly reply: FastifyReplyLike) {}
+  status(code: number): this {
+    this.reply.code(code)
+    return this
   }
-  return driver
+  json(data: unknown): this {
+    this.reply.send(data)
+    return this
+  }
+  send(data: unknown): this {
+    this.reply.send(data)
+    return this
+  }
+  type(contentType: string): this {
+    this.reply.type(contentType)
+    return this
+  }
+  setHeader(name: string, value: unknown): this {
+    this.reply.header(name, value)
+    return this
+  }
+  render(): never {
+    throw new Error('ctx.render() is not supported on the Fastify runtime (no view engine).')
+  }
+  writeHead(statusCode: number, headers?: Record<string, string | number | string[]>): this {
+    // Streaming / SSE: take over the raw socket so Fastify doesn't try to
+    // serialize a reply we're writing by hand.
+    this.reply.hijack()
+    this.reply.raw.writeHead(statusCode, headers)
+    return this
+  }
+  flushHeaders(): this {
+    ;(this.reply.raw as ServerResponse & { flushHeaders?: () => void }).flushHeaders?.()
+    return this
+  }
+  write(chunk: unknown): boolean {
+    return this.reply.raw.write(chunk as never)
+  }
+  end(data?: unknown): this {
+    this.reply.raw.end(data as never)
+    return this
+  }
+  once(event: string, listener: (...args: unknown[]) => void): this {
+    this.reply.raw.once(event, listener)
+    return this
+  }
+  get headersSent(): boolean {
+    return this.reply.sent || this.reply.raw.headersSent
+  }
+}
+
+function replyDriver(reply: FastifyReplyLike): RuntimeResponse {
+  return new FastifyReplyDriver(reply) as unknown as RuntimeResponse
 }
 
 /** Build the Fastify per-route handler that runs the kickjs pipeline. */
 function routeHandler(entry: RouteEntry): FastifyHandler {
+  // Validation middleware is built ONCE per route (parity with the Express
+  // materializer) — `validate()` constructs a fresh closure, so calling it
+  // per request was pure allocation waste.
+  const validator = entry.meta.validation ? validate(entry.meta.validation) : undefined
   return async (request, reply) => {
     // Fastify runs the route handler OUTSIDE the connect-middleware chain, so
     // (unlike Express) the requestScopeMiddleware ALS frame isn't active here.
@@ -211,17 +221,23 @@ function routeHandler(entry: RouteEntry): FastifyHandler {
     // and the X-Request-Id response header — parity with Express.
     raw.requestId = store.requestId
 
+    // @PreDestroy teardown for REQUEST-scoped instances once the response
+    // closes (finished or aborted) — parity with requestScopeMiddleware.
+    reply.raw.once('close', () => disposeRequestStore(store))
+
     await requestStore.run(store, async () => {
       const ctx = new RequestContext(raw as never, reply as never, NOOP_NEXT, replyDriver(reply))
 
-      // Validation (from @Get(path, schema) / route.validation). `validate` is a
-      // connect-style middleware that mutates req.body/query/params to the parsed
-      // value and calls next(err) on failure — it never touches `res`, so it runs
-      // cleanly here. A rejection propagates to the error handler (422).
-      if (entry.meta.validation) {
-        const v = validate(entry.meta.validation)
+      // Validation (from @Get(path, schema) / route.validation). `validator` is a
+      // connect-style middleware built once at route registration; it mutates
+      // req.body/query/params to the parsed value and calls next(err) on failure
+      // — it never touches `res`, so it runs cleanly here. A rejection
+      // propagates to the error handler (422).
+      if (validator) {
         await new Promise<void>((resolve, reject) => {
-          v(raw as never, undefined as never, (err?: unknown) => (err ? reject(err) : resolve()))
+          validator(raw as never, undefined as never, (err?: unknown) =>
+            err ? reject(err) : resolve(),
+          )
         })
       }
 

--- a/packages/kickjs/src/http/runtimes/h3.ts
+++ b/packages/kickjs/src/http/runtimes/h3.ts
@@ -21,7 +21,7 @@ import { createRequire } from 'node:module'
 
 import { RequestContext } from '../context'
 import { requestStore } from '../request-store'
-import { createRequestStore } from '../middleware/request-scope'
+import { createRequestStore, disposeRequestStore } from '../middleware/request-scope'
 import { validate } from '../middleware/validate'
 import { applyUploadConfig, type RawUploadPart } from '../middleware/upload'
 import type {
@@ -58,63 +58,72 @@ const ASSEMBLED = Symbol('kickjs.h3.assembled')
 const NOOP_NEXT = (): void => {}
 const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 
-/** Wrap a node ServerResponse (from `event.node.res`) as a RuntimeResponse. */
-function resDriver(res: ServerResponse): RuntimeResponse {
-  const driver: RuntimeResponse = {
-    status(code) {
-      res.statusCode = code
-      return driver
-    },
-    json(data) {
-      if (!res.headersSent) res.setHeader('content-type', 'application/json; charset=utf-8')
-      res.end(JSON.stringify(data))
-      return driver
-    },
-    send(data) {
-      res.end(data as never)
-      return driver
-    },
-    type(contentType) {
-      res.setHeader('content-type', contentType)
-      return driver
-    },
-    setHeader(name, value) {
-      res.setHeader(name, value as never)
-      return driver
-    },
-    render() {
-      throw new Error('ctx.render() is not supported on the h3 runtime (no view engine).')
-    },
-    writeHead(statusCode, headers) {
-      res.writeHead(statusCode, headers)
-      return driver
-    },
-    flushHeaders() {
-      res.flushHeaders()
-      return driver
-    },
-    write(chunk) {
-      return res.write(chunk)
-    },
-    end(data) {
-      res.end(data as never)
-      return driver
-    },
-    once(event, listener) {
-      res.once(event, listener)
-      return driver
-    },
-    get headersSent() {
-      return res.headersSent
-    },
+/**
+ * Wrap a node ServerResponse (from `event.node.res`) as a RuntimeResponse.
+ * A class so the ~12 driver methods live on a shared prototype — the previous
+ * object-literal version re-allocated every method closure on each request.
+ */
+class NodeResDriver implements RuntimeResponse {
+  constructor(private readonly res: ServerResponse) {}
+  status(code: number): this {
+    this.res.statusCode = code
+    return this
   }
-  return driver
+  json(data: unknown): this {
+    if (!this.res.headersSent) this.res.setHeader('content-type', 'application/json; charset=utf-8')
+    this.res.end(JSON.stringify(data))
+    return this
+  }
+  send(data: unknown): this {
+    this.res.end(data as never)
+    return this
+  }
+  type(contentType: string): this {
+    this.res.setHeader('content-type', contentType)
+    return this
+  }
+  setHeader(name: string, value: unknown): this {
+    this.res.setHeader(name, value as never)
+    return this
+  }
+  render(): never {
+    throw new Error('ctx.render() is not supported on the h3 runtime (no view engine).')
+  }
+  writeHead(statusCode: number, headers?: Record<string, string | number | string[]>): this {
+    this.res.writeHead(statusCode, headers)
+    return this
+  }
+  flushHeaders(): this {
+    this.res.flushHeaders()
+    return this
+  }
+  write(chunk: unknown): boolean {
+    return this.res.write(chunk as never)
+  }
+  end(data?: unknown): this {
+    this.res.end(data as never)
+    return this
+  }
+  once(event: string, listener: (...args: unknown[]) => void): this {
+    this.res.once(event, listener)
+    return this
+  }
+  get headersSent(): boolean {
+    return this.res.headersSent
+  }
+}
+
+function resDriver(res: ServerResponse): RuntimeResponse {
+  return new NodeResDriver(res) as unknown as RuntimeResponse
 }
 
 /** Build the h3 event handler that runs the kickjs pipeline for one route. */
 function makeEventHandler(entry: RouteEntry): (event: H3EventLike) => Promise<void> {
   const { getRouterParams, getQuery, readBody, readMultipartFormData } = h3()
   const upload = entry.meta.upload
+  // Validation middleware built ONCE per route (parity with Express) — calling
+  // validate() per request re-allocated the closure every time.
+  const validator = entry.meta.validation ? validate(entry.meta.validation) : undefined
   return async (event: H3EventLike) => {
     const req = event.node.req as IncomingMessage & {
       requestId?: string
@@ -163,13 +172,18 @@ function makeEventHandler(entry: RouteEntry): (event: H3EventLike) => Promise<vo
     const store = createRequestStore(requestId)
     req.requestId = store.requestId
 
+    // @PreDestroy teardown for REQUEST-scoped instances once the response
+    // closes (finished or aborted) — parity with requestScopeMiddleware.
+    res.once('close', () => disposeRequestStore(store))
+
     await requestStore.run(store, async () => {
       const ctx = new RequestContext(req as never, res as never, NOOP_NEXT, resDriver(res))
 
-      if (entry.meta.validation) {
-        const v = validate(entry.meta.validation)
+      if (validator) {
         await new Promise<void>((resolve, reject) => {
-          v(req as never, undefined as never, (err?: unknown) => (err ? reject(err) : resolve()))
+          validator(req as never, undefined as never, (err?: unknown) =>
+            err ? reject(err) : resolve(),
+          )
         })
       }
 


### PR DESCRIPTION
## Summary

Fixes from a 4-subsystem object-lifecycle audit of `packages/kickjs` (DI container, RequestContext, request pipeline/runtimes, long-lived resources). Three tiers: hot-path allocations, leaks, and lifecycle gaps.

## Hot path (per-request waste removed)

- **Fastify/h3: `validate()` hoisted to route-build time** — was re-constructing the validation middleware closure on *every request*; Express already did this right at mount time.
- **Fastify/h3: response drivers are shared-prototype classes** — the object-literal drivers allocated ~12 method closures per request; now one object + one field.
- **DI instantiation plan** — per-`Registration` recipe (ctor tokens, autowired/value/asset descriptors, `@PostConstruct` key) built once on first create. REQUEST/TRANSIENT resolves previously re-ran 5 `Reflect.getMetadata` reads + allocated 2 throwaway Maps per instantiation. Scope validation moved to plan build (equivalent semantics — it's a static property of the registration pair).
- **`tokenName()` lazy on the cached-singleton path** — `emit()` now takes the raw token and derives the name only after the zero-listener guard.
- **`ctx.problem` memoized** (was ~10 closures per access); **`@Autowired` singleton deps** self-memoize into a data property on first read (REQUEST/TRANSIENT deps keep the live getter — memoizing those would pin the first request's instance).

## Leaks

- **Reactivity teardown** (the big one): effects now carry dep-Set back-references (Vue-style). `watch().stop()` actually detaches (previously a boolean flag — dead watchers stayed subscribed *and kept firing* forever); effects re-track per run so conditional getters drop stale branches; `computed()` gains `dispose()`; `reactive()` memoizes nested proxies (fixes `state.nested !== state.nested`).
- **`MemoryCacheProvider` bounded** — LRU, default 10 000 entries. Was unbounded: write-once-never-read keys lived until shutdown.
- **Session/rate-limit store intervals disposed** — new `registerDisposable`/`disposeAll` registry drained by `Application.shutdown()`. Previously each in-process app re-create (tests, HMR) leaked one live interval + Map.
- **Container debounce timer** `unref()`'d + flushed on shutdown.

## Lifecycle gaps

- **New `@PreDestroy` decorator** — counterpart to `@PostConstruct`. For REQUEST-scoped services the hook runs on response close (finished or aborted) on all three runtimes. Previously per-request instances holding transactions/handles were silently dropped.
- **`@Cacheable` caches legit `null`** via a sentinel — was indistinguishable from a miss, so null-returning methods re-executed on every call (stampede on the exact path caching protects).

## Confirmed already-optimal (untouched)

Route table, handler binding, contributor topo-sort — all boot-time. No per-request child container (ALS store as scope cache). Lazy `RequestContext` getters. Balanced ALS frames.

## Verification

- `packages/kickjs`: **609 tests pass** (601 existing + 8 new in `lifecycle-optimizations.test.ts` covering watch-stop detach, conditional-dep re-tracking, computed dispose, proxy identity, LRU eviction, cached-null, `@PreDestroy` fire-once, autowired memoization).
- Turbo suite: **46/46 tasks green** across the monorepo.
- Root `test:integration`: 62 failures are **pre-existing env issues** (missing `vscode` module, machine-dependent pm-detection/dotenv tests) — verified identical on unmodified `main` via stash.

Changeset: minor bump for `@forinda/kickjs` (new `@PreDestroy` + `dispose()` APIs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request-level teardown support for cleanup when a response closes.
  * Introduced a new lifecycle hook for running cleanup logic before scoped services are discarded.

* **Performance**
  * Reduced allocation and repeated work during requests and dependency resolution.
  * Improved reactivity stability and reduced unnecessary proxy creation.

* **Bug Fixes**
  * Fixed cached `null` values being treated like cache misses.
  * Prevented stopped watchers and computed values from continuing to retain stale dependencies.
  * Added safer shutdown cleanup for sessions, rate limits, and in-memory caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->