### PR TITLE
feat(kickjs): @forinda/kickjs/web — web-standard fetch entry for edge/Bun/Deno (P2)

### DIFF
--- a/.changeset/web-fetch-entry.md
+++ b/.changeset/web-fetch-entry.md
@@ -1,0 +1,26 @@
+---
+'@forinda/kickjs': minor
+---
+
+feat: `@forinda/kickjs/web` — web-standard fetch entry for edge runtimes, Bun and Deno
+
+`createWebApp({ h3, modules })` builds a KickJS app as a pure
+`fetch(Request) → Promise<Response>` handler — no node http server, no
+Application/bootstrap in the bundle graph. Same modules, DI, decorators and
+contributor pipeline as `bootstrap()`.
+
+```ts
+// Cloudflare Workers (compatibility_flags = ["nodejs_compat"])
+import { createWebApp } from '@forinda/kickjs/web'
+import * as h3 from 'h3' // v2
+const app = createWebApp({ h3, modules })
+export default { fetch: (req) => app.fetch(req) }
+```
+
+- `createFetchHandler((env) => options)` — Workers convenience that seeds
+  ConfigService/@Value from the `env` binding on first request
+- Bundle purity enforced by test: the built `dist/web.mjs` graph contains no
+  `express` and no `node:*` imports besides `node:async_hooks` (ALS)
+- Internal: container's `@Asset` resolution now goes through a resolver slot
+  so the asset manager's `node:fs` never enters the edge graph; the pure
+  upload core moved to `upload-config.ts` (public API unchanged)

--- a/packages/kickjs/__tests__/web-entry.test.ts
+++ b/packages/kickjs/__tests__/web-entry.test.ts
@@ -1,0 +1,155 @@
+import 'reflect-metadata'
+import { readFileSync, existsSync } from 'node:fs'
+import { resolve, dirname, join } from 'node:path'
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as h3v2 from 'h3-v2'
+
+import { createWebApp, createFetchHandler } from '../src/web'
+import { Container } from '../src/core/container'
+import { Controller, Get, Post, Service, Value } from '../src/core/decorators'
+import { defineModule } from '../src/core/define-module'
+import type { RequestContext } from '../src/http/context'
+
+/**
+ * `@forinda/kickjs/web` — the edge/Bun/Deno fetch entry. Round-trips real
+ * decorated modules through `createWebApp().fetch(new Request(...))` and
+ * enforces the bundle purity contract (design §3.4).
+ */
+
+beforeEach(() => {
+  Container.reset()
+})
+
+function makeModule() {
+  @Service()
+  class GreetService {
+    greet(name: string): string {
+      return `hello ${name}`
+    }
+  }
+
+  @Controller()
+  class GreetController {
+    private svc = Container.getInstance().resolve(GreetService)
+
+    @Get('/hello/:name')
+    async hello(ctx: RequestContext): Promise<void> {
+      ctx.json({ msg: this.svc.greet(ctx.params.name) })
+    }
+
+    @Post('/echo')
+    async echo(ctx: RequestContext): Promise<void> {
+      ctx.created({ body: ctx.body })
+    }
+  }
+
+  return defineModule({
+    name: 'GreetModule',
+    build: () => ({
+      routes: () => ({ path: '/greet', controller: GreetController }),
+    }),
+  })()
+}
+
+describe('createWebApp — fetch entry', () => {
+  it('serves decorated module routes end to end', async () => {
+    const app = createWebApp({ h3: h3v2, modules: [makeModule()] })
+    const res = await app.fetch(new Request('http://edge/api/v1/greet/hello/bun'))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ msg: 'hello bun' })
+
+    const posted = await app.fetch(
+      new Request('http://edge/api/v1/greet/echo', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ x: 1 }),
+      }),
+    )
+    expect(posted.status).toBe(201)
+    expect(await posted.json()).toEqual({ body: { x: 1 } })
+  })
+
+  it('respects apiPrefix + defaultVersion options', async () => {
+    const app = createWebApp({
+      h3: h3v2,
+      modules: [makeModule()],
+      apiPrefix: '/edge',
+      defaultVersion: 3,
+    })
+    const res = await app.fetch(new Request('http://x/edge/v3/greet/hello/deno'))
+    expect(res.status).toBe(200)
+  })
+
+  it('fails fast when handed h3 v1 (no H3 class)', () => {
+    expect(() => createWebApp({ h3: { createApp: () => ({}) }, modules: [] })).toThrow(/h3 v2/)
+  })
+
+  it('seeds env for @Value resolution (Workers-style env binding)', async () => {
+    @Service()
+    class Cfg {
+      @Value('EDGE_REGION')
+      region!: string
+    }
+
+    @Controller()
+    class CfgController {
+      @Get('/region')
+      async region(ctx: RequestContext): Promise<void> {
+        ctx.json({ region: Container.getInstance().resolve(Cfg).region })
+      }
+    }
+
+    const mod = defineModule({
+      name: 'CfgModule',
+      build: () => ({
+        routes: () => ({ path: '/cfg', controller: CfgController }),
+      }),
+    })()
+
+    const handler = createFetchHandler((env) => ({ h3: h3v2, modules: [mod], env }))
+    const res = await handler.fetch(new Request('http://x/api/v1/cfg/region'), {
+      EDGE_REGION: 'weur',
+    })
+    expect(await res.json()).toEqual({ region: 'weur' })
+  })
+})
+
+describe('web entry — bundle purity (design §3.4)', () => {
+  it('the built dist/web graph contains no node-only or express imports', () => {
+    const distDir = resolve(__dirname, '../dist')
+    const entry = join(distDir, 'web.mjs')
+    expect(existsSync(entry), 'dist/web.mjs missing — run pnpm build first').toBe(true)
+
+    // Walk relative imports transitively; collect every external specifier.
+    const seen = new Set<string>()
+    const externals = new Set<string>()
+    const walk = (file: string): void => {
+      if (seen.has(file)) return
+      seen.add(file)
+      const src = readFileSync(file, 'utf-8')
+      for (const m of src.matchAll(
+        /from\s*["']([^"']+)["']|import\s*\(\s*["']([^"']+)["']\s*\)/g,
+      )) {
+        const spec = m[1] ?? m[2]
+        if (!spec) continue
+        if (spec.startsWith('.')) {
+          walk(resolve(dirname(file), spec))
+        } else {
+          externals.add(spec)
+        }
+      }
+    }
+    walk(entry)
+
+    const forbidden = [...externals].filter(
+      (s) =>
+        s === 'express' ||
+        s.startsWith('express/') ||
+        (s.startsWith('node:') && s !== 'node:async_hooks'),
+    )
+    expect(
+      forbidden,
+      `edge purity violated — dist/web.mjs graph imports: ${forbidden.join(', ')}`,
+    ).toEqual([])
+  })
+})

--- a/packages/kickjs/package.json
+++ b/packages/kickjs/package.json
@@ -103,6 +103,10 @@
     "./h3-web": {
       "import": "./dist/http/runtimes/h3-web.mjs",
       "types": "./dist/http/runtimes/h3-web.d.mts"
+    },
+    "./web": {
+      "import": "./dist/web.mjs",
+      "types": "./dist/web.d.mts"
     }
   },
   "files": [

--- a/packages/kickjs/src/core/asset-resolver-slot.ts
+++ b/packages/kickjs/src/core/asset-resolver-slot.ts
@@ -1,0 +1,32 @@
+/**
+ * Indirection slot between the DI container's `@Asset` property injection
+ * and the asset manager. The container must NOT import `./assets` directly —
+ * its eager `node:fs`/`node:path` imports would poison the edge-safe
+ * `@forinda/kickjs/web` entry graph (every graph includes the container).
+ *
+ * `./assets` registers the real resolver at module scope, so any node app
+ * that imports the asset manager (the core barrel does) gets full `@Asset`
+ * behavior; an edge bundle that never imports it gets a clear error on
+ * first `@Asset` property access instead of a broken bundle.
+ */
+
+type AssetResolver = (namespace: string, key: string) => unknown
+
+let impl: AssetResolver | null = null
+
+/** Called by `./assets` at module scope to install the real resolver. */
+export function _setAssetResolver(fn: AssetResolver): void {
+  impl = fn
+}
+
+/** Resolve an asset through the slot — throws when no asset manager is loaded. */
+export function resolveAssetViaSlot(namespace: string, key: string): unknown {
+  if (!impl) {
+    throw new Error(
+      `@Asset('${namespace}/${key}'): the asset manager is not loaded. ` +
+        "Import it (any import from '@forinda/kickjs' loads it) — note @Asset " +
+        'reads from the filesystem and is not supported on edge runtimes.',
+    )
+  }
+  return impl(namespace, key)
+}

--- a/packages/kickjs/src/core/assets.ts
+++ b/packages/kickjs/src/core/assets.ts
@@ -446,3 +446,10 @@ export const assets: KickAssets = createAssetProxy()
 export function useAssets(): KickAssets {
   return assets
 }
+
+// Install this module's resolver into the container's asset slot — the
+// container deliberately avoids importing this file (edge purity; see
+// asset-resolver-slot.ts). Runs at module scope so any node app that loads
+// the asset manager gets full @Asset injection.
+import { _setAssetResolver } from './asset-resolver-slot'
+_setAssetResolver(resolveAsset)

--- a/packages/kickjs/src/core/container.ts
+++ b/packages/kickjs/src/core/container.ts
@@ -6,7 +6,9 @@ import {
   type ClassKind,
   type PostConstructStatus,
 } from './interfaces'
-import { resolveAsset } from './assets'
+// Slot indirection, NOT `./assets` — that module's eager node:fs import
+// would poison the edge-safe web entry graph (see asset-resolver-slot.ts).
+import { resolveAssetViaSlot as resolveAsset } from './asset-resolver-slot'
 import {
   envValueMissingError,
   noProviderError,

--- a/packages/kickjs/src/http/middleware/upload-config.ts
+++ b/packages/kickjs/src/http/middleware/upload-config.ts
@@ -1,0 +1,164 @@
+// Pure (edge-safe) upload core — the engine-neutral half of the upload
+// middleware. Extracted from `upload.ts` so the `@forinda/kickjs/web` entry
+// graph can validate/shape buffered multipart parts WITHOUT dragging in
+// upload.ts's node-only surface (multer peer loading via `node:module`,
+// disk cleanup via `node:fs/promises`). `upload.ts` re-exports everything
+// here, so existing import sites are unchanged.
+
+import { HttpException, HttpStatus } from '../../core/errors'
+import type { BaseUploadOptions, FileUploadConfig } from '../../core/decorators'
+
+export const MIME_MAP: Record<string, string> = {
+  // Images
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  bmp: 'image/bmp',
+  ico: 'image/x-icon',
+  tiff: 'image/tiff',
+  tif: 'image/tiff',
+  avif: 'image/avif',
+  // Documents
+  pdf: 'application/pdf',
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xls: 'application/vnd.ms-excel',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ppt: 'application/vnd.ms-powerpoint',
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  odt: 'application/vnd.oasis.opendocument.text',
+  ods: 'application/vnd.oasis.opendocument.spreadsheet',
+  odp: 'application/vnd.oasis.opendocument.presentation',
+  rtf: 'application/rtf',
+  txt: 'text/plain',
+  csv: 'text/csv',
+  // Archives
+  zip: 'application/zip',
+  gz: 'application/gzip',
+  tar: 'application/x-tar',
+  rar: 'application/vnd.rar',
+  '7z': 'application/x-7z-compressed',
+  // Audio
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  ogg: 'audio/ogg',
+  flac: 'audio/flac',
+  aac: 'audio/aac',
+  // Video
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  avi: 'video/x-msvideo',
+  mov: 'video/quicktime',
+  mkv: 'video/x-matroska',
+  // Other
+  json: 'application/json',
+  xml: 'application/xml',
+  html: 'text/html',
+}
+
+/**
+ * Resolves a list of file type identifiers to MIME type strings.
+ * Accepts short extensions (`'jpg'`, `'pdf'`) or full MIME types (`'image/jpeg'`).
+ *
+ * @example
+ * ```ts
+ * resolveMimeTypes(['jpg', 'png', 'application/pdf'])
+ * // → ['image/jpeg', 'image/png', 'application/pdf']
+ * ```
+ */
+export function resolveMimeTypes(types: string[]): string[] {
+  return types.map((t) => {
+    const lower = t.toLowerCase().replace(/^\./, '')
+    return MIME_MAP[lower] ?? t
+  })
+}
+
+/**
+ * Build a runtime-agnostic `(mimetype, filename) => boolean` file-type filter
+ * from `allowedTypes` (a predicate, or a list of extensions / MIME types /
+ * wildcards). Returned by both the multer middleware (Express) and the
+ * Fastify / h3 / web multipart paths so the accept/reject rule stays
+ * identical across engines. No `allowedTypes` → accept everything.
+ */
+export function buildFileTypeFilter(
+  allowedTypes: BaseUploadOptions['allowedTypes'],
+  customMimeMap?: Record<string, string>,
+): (mimetype: string, filename: string) => boolean {
+  if (!allowedTypes) return () => true
+  if (typeof allowedTypes === 'function') return allowedTypes
+  const mimeMap = customMimeMap ? { ...MIME_MAP, ...customMimeMap } : MIME_MAP
+  const resolved = allowedTypes.map((t) => mimeMap[t.toLowerCase().replace(/^\./, '')] ?? t)
+  return (mimetype: string) =>
+    resolved.some((type) =>
+      type.endsWith('/*') ? mimetype.startsWith(type.replace('/*', '/')) : mimetype === type,
+    )
+}
+
+/** A multer-shaped uploaded file — what `ctx.file` / `ctx.files` expose. */
+export interface UploadedFileLike {
+  fieldname: string
+  originalname: string
+  encoding: string
+  mimetype: string
+  size: number
+  buffer: Buffer
+}
+
+/** A buffered multipart file part, as the runtime hands it to {@link applyUploadConfig}. */
+export interface RawUploadPart {
+  fieldname: string
+  filename: string
+  mimetype: string
+  buffer: Buffer
+}
+
+const DEFAULT_MAX_SIZE = 5 * 1024 * 1024
+
+/**
+ * Apply a `@FileUpload` config to already-buffered multipart parts and return
+ * the multer-shaped `file` / `files` for `ctx`. Enforces the field name, type
+ * filter, per-file size limit, and (array mode) max count — throwing
+ * `HttpException` on a violation, mirroring the Express/multer error path.
+ * Used by the Fastify, h3 and web runtimes; Express keeps using multer directly.
+ */
+export function applyUploadConfig(
+  parts: RawUploadPart[],
+  config: FileUploadConfig,
+): { file?: UploadedFileLike; files?: UploadedFileLike[] } {
+  if (config.mode === 'none') return {}
+
+  const field = config.fieldName ?? 'file'
+  const maxSize = config.maxSize ?? DEFAULT_MAX_SIZE
+  const typeAllowed = buildFileTypeFilter(config.allowedTypes, config.customMimeMap)
+
+  const matched = parts.filter((p) => p.fieldname === field)
+  const files: UploadedFileLike[] = matched.map((p) => {
+    if (!typeAllowed(p.mimetype, p.filename)) {
+      throw new HttpException(
+        HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+        `File type ${p.mimetype} is not allowed`,
+      )
+    }
+    if (p.buffer.length > maxSize) {
+      throw new HttpException(
+        HttpStatus.PAYLOAD_TOO_LARGE,
+        `File ${p.filename} exceeds the ${maxSize}-byte limit`,
+      )
+    }
+    return {
+      fieldname: p.fieldname,
+      originalname: p.filename,
+      encoding: '7bit',
+      mimetype: p.mimetype,
+      size: p.buffer.length,
+      buffer: p.buffer,
+    }
+  })
+
+  if (config.mode === 'single') return { file: files[0] }
+  const maxCount = config.maxCount ?? 10
+  return { files: files.slice(0, maxCount) }
+}

--- a/packages/kickjs/src/http/middleware/upload.ts
+++ b/packages/kickjs/src/http/middleware/upload.ts
@@ -2,12 +2,7 @@ import { unlink } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import type { Request, Response, NextFunction, RequestHandler } from 'express'
 import type { Options as MulterOptions } from 'multer'
-import {
-  HttpException,
-  HttpStatus,
-  type BaseUploadOptions,
-  type FileUploadConfig,
-} from '../../core'
+import type { BaseUploadOptions, FileUploadConfig } from '../../core'
 
 // `multer` is an optional peer dependency. We load it lazily via
 // `createRequire` so importing this module never touches `multer` —
@@ -35,164 +30,17 @@ function loadMulter(): MulterFactory {
   }
 }
 
-/**
- * Maps short file extensions to their MIME types.
- * Users can pass `['jpg', 'png', 'pdf']` instead of full MIME strings.
- */
-const MIME_MAP: Record<string, string> = {
-  // Images
-  jpg: 'image/jpeg',
-  jpeg: 'image/jpeg',
-  png: 'image/png',
-  gif: 'image/gif',
-  webp: 'image/webp',
-  svg: 'image/svg+xml',
-  bmp: 'image/bmp',
-  ico: 'image/x-icon',
-  tiff: 'image/tiff',
-  tif: 'image/tiff',
-  avif: 'image/avif',
-  // Documents
-  pdf: 'application/pdf',
-  doc: 'application/msword',
-  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  xls: 'application/vnd.ms-excel',
-  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-  ppt: 'application/vnd.ms-powerpoint',
-  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-  odt: 'application/vnd.oasis.opendocument.text',
-  ods: 'application/vnd.oasis.opendocument.spreadsheet',
-  odp: 'application/vnd.oasis.opendocument.presentation',
-  rtf: 'application/rtf',
-  txt: 'text/plain',
-  csv: 'text/csv',
-  // Archives
-  zip: 'application/zip',
-  gz: 'application/gzip',
-  tar: 'application/x-tar',
-  rar: 'application/vnd.rar',
-  '7z': 'application/x-7z-compressed',
-  // Audio
-  mp3: 'audio/mpeg',
-  wav: 'audio/wav',
-  ogg: 'audio/ogg',
-  flac: 'audio/flac',
-  aac: 'audio/aac',
-  // Video
-  mp4: 'video/mp4',
-  webm: 'video/webm',
-  avi: 'video/x-msvideo',
-  mov: 'video/quicktime',
-  mkv: 'video/x-matroska',
-  // Other
-  json: 'application/json',
-  xml: 'application/xml',
-  html: 'text/html',
-}
-
-/**
- * Resolves a list of file type identifiers to MIME type strings.
- * Accepts short extensions (`'jpg'`, `'pdf'`) or full MIME types (`'image/jpeg'`).
- *
- * @example
- * ```ts
- * resolveMimeTypes(['jpg', 'png', 'application/pdf'])
- * // → ['image/jpeg', 'image/png', 'application/pdf']
- * ```
- */
-export function resolveMimeTypes(types: string[]): string[] {
-  return types.map((t) => {
-    const lower = t.toLowerCase().replace(/^\./, '')
-    return MIME_MAP[lower] ?? t
-  })
-}
-
-/**
- * Build a runtime-agnostic `(mimetype, filename) => boolean` file-type filter
- * from `allowedTypes` (a predicate, or a list of extensions / MIME types /
- * wildcards). Returned by both the multer middleware (Express) and the
- * Fastify / h3 multipart paths so the accept/reject rule stays identical
- * across engines. No `allowedTypes` → accept everything.
- */
-export function buildFileTypeFilter(
-  allowedTypes: BaseUploadOptions['allowedTypes'],
-  customMimeMap?: Record<string, string>,
-): (mimetype: string, filename: string) => boolean {
-  if (!allowedTypes) return () => true
-  if (typeof allowedTypes === 'function') return allowedTypes
-  const mimeMap = customMimeMap ? { ...MIME_MAP, ...customMimeMap } : MIME_MAP
-  const resolved = allowedTypes.map((t) => mimeMap[t.toLowerCase().replace(/^\./, '')] ?? t)
-  return (mimetype: string) =>
-    resolved.some((type) =>
-      type.endsWith('/*') ? mimetype.startsWith(type.replace('/*', '/')) : mimetype === type,
-    )
-}
-
-/** A multer-shaped uploaded file — what `ctx.file` / `ctx.files` expose. */
-export interface UploadedFileLike {
-  fieldname: string
-  originalname: string
-  encoding: string
-  mimetype: string
-  size: number
-  buffer: Buffer
-}
-
-/** A buffered multipart file part, as the runtime hands it to {@link applyUploadConfig}. */
-export interface RawUploadPart {
-  fieldname: string
-  filename: string
-  mimetype: string
-  buffer: Buffer
-}
-
-const DEFAULT_MAX_SIZE = 5 * 1024 * 1024
-
-/**
- * Apply a `@FileUpload` config to already-buffered multipart parts and return
- * the multer-shaped `file` / `files` for `ctx`. Enforces the field name, type
- * filter, per-file size limit, and (array mode) max count — throwing
- * `HttpException` on a violation, mirroring the Express/multer error path.
- * Used by the Fastify and h3 runtimes; Express keeps using multer directly.
- */
-export function applyUploadConfig(
-  parts: RawUploadPart[],
-  config: FileUploadConfig,
-): { file?: UploadedFileLike; files?: UploadedFileLike[] } {
-  if (config.mode === 'none') return {}
-
-  const field = config.fieldName ?? 'file'
-  const maxSize = config.maxSize ?? DEFAULT_MAX_SIZE
-  const typeAllowed = buildFileTypeFilter(config.allowedTypes, config.customMimeMap)
-
-  const matched = parts.filter((p) => p.fieldname === field)
-  const files: UploadedFileLike[] = matched.map((p) => {
-    if (!typeAllowed(p.mimetype, p.filename)) {
-      throw new HttpException(
-        HttpStatus.UNSUPPORTED_MEDIA_TYPE,
-        `File type ${p.mimetype} is not allowed`,
-      )
-    }
-    if (p.buffer.length > maxSize) {
-      throw new HttpException(
-        HttpStatus.PAYLOAD_TOO_LARGE,
-        `File ${p.filename} exceeds the ${maxSize}-byte limit`,
-      )
-    }
-    return {
-      fieldname: p.fieldname,
-      originalname: p.filename,
-      encoding: '7bit',
-      mimetype: p.mimetype,
-      size: p.buffer.length,
-      buffer: p.buffer,
-    }
-  })
-
-  if (config.mode === 'single') return { file: files[0] }
-  const maxCount = config.maxCount ?? 10
-  return { files: files.slice(0, maxCount) }
-}
+// Pure upload core (MIME map, type filter, applyUploadConfig) moved to
+// `./upload-config` so the edge-safe web entry can use it without this
+// module's node-only surface. Re-exported here for compatibility.
+export {
+  buildFileTypeFilter,
+  resolveMimeTypes,
+  applyUploadConfig,
+  type UploadedFileLike,
+  type RawUploadPart,
+} from './upload-config'
+import { buildFileTypeFilter } from './upload-config'
 
 /**
  * Upload options for the middleware.

--- a/packages/kickjs/src/http/middleware/validate.ts
+++ b/packages/kickjs/src/http/middleware/validate.ts
@@ -1,5 +1,7 @@
 import type { Request, Response, NextFunction } from 'express'
-import { HttpException, HttpStatus } from '../../core'
+// core/errors directly (not the barrel) — keeps the edge-safe web entry
+// graph free of the barrel's eager node:fs asset-manager import.
+import { HttpException, HttpStatus } from '../../core/errors'
 import { detectSchema, type SchemaIssue } from '@forinda/kickjs-schema'
 
 export interface ValidationSchema {

--- a/packages/kickjs/src/http/router-builder.ts
+++ b/packages/kickjs/src/http/router-builder.ts
@@ -1,14 +1,12 @@
-import {
-  buildPipeline,
-  Container,
-  METADATA,
-  runContributors,
-  type ContributorRegistration,
-  type FileUploadConfig,
-  type MiddlewareHandler,
-  type RouteDefinition,
-  type SourcedRegistration,
-} from '../core'
+// Concrete-module imports (NOT the `../core` barrel): the barrel re-exports
+// the asset manager, whose eager `node:fs` import would poison the edge-safe
+// `@forinda/kickjs/web` entry graph that flows through this file.
+import { buildPipeline, type SourcedRegistration } from '../core/contributor-pipeline'
+import { runContributors } from '../core/contributor-runner'
+import { Container } from '../core/container'
+import { METADATA } from '../core/interfaces'
+import type { ContributorRegistration } from '../core/context-decorator'
+import type { FileUploadConfig, MiddlewareHandler, RouteDefinition } from '../core/decorators'
 import { getClassMeta, getMethodMeta, getMethodMetaOrUndefined } from '../core/metadata'
 import type { CtxHandler, RouteEntry, RouteMethod } from './runtime'
 

--- a/packages/kickjs/src/http/web/handler.ts
+++ b/packages/kickjs/src/http/web/handler.ts
@@ -7,7 +7,7 @@ import { RequestContext } from '../context'
 import { requestStore } from '../request-store'
 import { createRequestStore, disposeRequestStore } from '../middleware/request-scope'
 import { validate } from '../middleware/validate'
-import { applyUploadConfig, type RawUploadPart } from '../middleware/upload'
+import { applyUploadConfig, type RawUploadPart } from '../middleware/upload-config'
 import type { RouteEntry, RuntimeResponse } from '../runtime'
 import { WebRequestShim, WebResponseDriver } from './driver'
 

--- a/packages/kickjs/src/web.ts
+++ b/packages/kickjs/src/web.ts
@@ -1,0 +1,207 @@
+// `@forinda/kickjs/web` — the web-standard fetch entry for edge runtimes
+// (Cloudflare Workers), Bun, and Deno. See web-standards-edge-design.md §3.
+//
+// PURITY CONTRACT: this entry's import graph must stay free of node-only
+// runtime imports — no `node:http`, `node:cluster`, `node:fs`, `node:module`,
+// no `express`, no `Application`/`bootstrap`. The single sanctioned node API
+// is `node:async_hooks` (AsyncLocalStorage — available on Workers with
+// `nodejs_compat`, Deno, and Bun). Enforced by the bundle-graph purity test.
+//
+// ```ts
+// // Cloudflare Workers (wrangler.toml: compatibility_flags = ["nodejs_compat"])
+// import { createWebApp } from '@forinda/kickjs/web'
+// import * as h3 from 'h3'
+// import { modules } from './modules'
+//
+// const app = createWebApp({ h3, modules })
+// export default { fetch: (req: Request) => app.fetch(req) }
+//
+// // Bun
+// Bun.serve({ fetch: (req) => app.fetch(req) })
+// ```
+
+import { Container } from './core/container'
+import { MutableModuleRegistry } from './core/module-registry'
+import type { AppModule, AppModuleClass, AppModuleEntry } from './core/app-module'
+import type { ContributorRegistrations } from './core/context-decorator'
+import type { SourcedRegistration } from './core/contributor-pipeline'
+import { _setExternalContributorSources, buildRouteTable } from './http/router-builder'
+import { requestStore } from './http/request-store'
+import { compileWebRoute } from './http/web/handler'
+import { normalizePath } from './core/path'
+
+export { WebRequestShim, WebResponseDriver } from './http/web/driver'
+export { compileWebRoute } from './http/web/handler'
+
+// Minimal structural surface of h3 v2 used here (kept local so this entry
+// never imports the node-coupled h3-web runtime module).
+interface H3AppLike {
+  on(method: string, path: string, handler: (event: H3EventLike) => unknown): unknown
+  all(path: string, handler: (event: H3EventLike) => unknown): unknown
+  fetch(request: Request): Promise<Response>
+}
+interface H3EventLike {
+  req: Request
+  url: URL
+  context: { params?: Record<string, string> }
+}
+
+export interface CreateWebAppOptions {
+  /**
+   * The h3 v2 module, statically imported by the caller:
+   * `import * as h3 from 'h3'`. Passed in (rather than loaded here) because
+   * edge bundlers have no `createRequire`, and a static `import 'h3'` inside
+   * this entry would force the peer on every consumer of the subpath.
+   */
+  h3: unknown
+  /** App modules — same shapes `bootstrap({ modules })` accepts. */
+  modules: AppModuleEntry[]
+  /** Route prefix (default '/api') — parity with bootstrap. */
+  apiPrefix?: string
+  /** Default route version (default 1) — parity with bootstrap. */
+  defaultVersion?: number
+  /** Global Context Contributors — parity with `bootstrap({ contributors })`. */
+  contributors?: ContributorRegistrations
+  /**
+   * Env values for ConfigService/@Value resolution. On Workers, pass the
+   * `env` binding from the fetch handler (see `createFetchHandler`); on
+   * Bun/Deno, ambient `process.env` already works and this can be omitted.
+   */
+  env?: Record<string, string | undefined>
+}
+
+export interface WebApp {
+  /** Web-standard entry: `Request` in, `Response` out. */
+  fetch: (request: Request) => Promise<Response>
+  /** The underlying h3 v2 app, for advanced composition. */
+  h3: unknown
+}
+
+/**
+ * Build a KickJS app as a web-standard fetch handler — no node http server,
+ * no Application/bootstrap. Module registration, DI, and the contributor
+ * pipeline behave exactly like `bootstrap()`; routes are compiled once here
+ * and served through h3 v2's router.
+ */
+export function createWebApp(options: CreateWebAppOptions): WebApp {
+  const h3mod = options.h3 as { H3?: new () => H3AppLike }
+  if (typeof h3mod?.H3 !== 'function') {
+    throw new Error(
+      '@forinda/kickjs/web: pass the h3 v2 module — `createWebApp({ h3: await import("h3"), ... })`. ' +
+        "The installed h3 must be v2 (npm dist-tag 'latest'); v1 has no H3 class.",
+    )
+  }
+
+  const container = Container.getInstance()
+
+  // Wire ConfigService/@Value env resolution when the platform has no
+  // ambient process.env (Workers). Latest-wins like loadEnv().
+  if (options.env) {
+    const env = options.env
+    Container._envResolver = (key: string) => env[key]
+  }
+
+  // Request-scope provider — same wiring Application.setup() performs.
+  Container._requestStoreProvider = () => requestStore.getStore() ?? null
+
+  // Module mounting — mirrors Application.setup() steps 1:1 for the module
+  // path (plugins/adapters are out of scope for the edge entry at launch).
+  const registry = new MutableModuleRegistry()
+  for (const m of options.modules) registry.mount(m)
+  const modules = registry.entries.map((entry) => {
+    const mod: AppModule = typeof entry === 'function' ? new (entry as AppModuleClass)() : entry
+    mod.register?.(container)
+    return mod
+  })
+  container.bootstrap()
+
+  const app = new h3mod.H3()
+  const apiPrefix = options.apiPrefix ?? '/api'
+  const defaultVersion = options.defaultVersion ?? 1
+
+  const globalSources: SourcedRegistration[] = (options.contributors ?? []).map(
+    (registration): SourcedRegistration => ({
+      source: 'global',
+      registration: registration as SourcedRegistration['registration'],
+      label: 'createWebApp',
+    }),
+  )
+
+  for (const mod of modules) {
+    const declaredName = (mod as { name?: unknown }).name
+    const moduleLabel =
+      typeof declaredName === 'string' && declaredName.length > 0
+        ? declaredName
+        : (mod.constructor?.name ?? 'module')
+    const moduleSources: SourcedRegistration[] = (mod.contributors?.() ?? []).map(
+      (registration): SourcedRegistration => ({
+        source: 'module',
+        registration,
+        label: moduleLabel,
+      }),
+    )
+
+    _setExternalContributorSources([...moduleSources, ...globalSources])
+    try {
+      const result = mod.routes()
+      if (!result) continue
+      const routeSets = Array.isArray(result) ? result : [result]
+      for (const route of routeSets) {
+        if (!route.controller) {
+          throw new Error(
+            `@forinda/kickjs/web: module route at '${route.path}' has no controller. ` +
+              'Express-style `router` mounts are not supported on the web entry.',
+          )
+        }
+        const version = route.version ?? defaultVersion
+        const mountPath = `${apiPrefix}/v${version}${normalizePath(route.path)}`
+        for (const entry of buildRouteTable(route.controller)) {
+          const url = joinPath(mountPath, entry.path)
+          const run = compileWebRoute(entry)
+          app.on(entry.method, url, (event: H3EventLike) =>
+            run({
+              request: event.req,
+              url: event.url,
+              params: event.context.params ?? {},
+            }),
+          )
+        }
+      }
+    } finally {
+      _setExternalContributorSources([])
+    }
+  }
+
+  return {
+    fetch: (request: Request) => app.fetch(request),
+    h3: app,
+  }
+}
+
+/**
+ * Cloudflare Workers convenience: lazily build the app on the first request
+ * so the Workers `env` binding can seed config before any module resolves.
+ *
+ * ```ts
+ * export default createFetchHandler((env) => ({ h3, modules, env }))
+ * ```
+ */
+export function createFetchHandler(
+  build: (env: Record<string, string | undefined>) => CreateWebAppOptions,
+): { fetch: (request: Request, env?: Record<string, string | undefined>) => Promise<Response> } {
+  let app: WebApp | undefined
+  return {
+    fetch: (request, env = {}) => {
+      app ??= createWebApp(build(env))
+      return app.fetch(request)
+    },
+  }
+}
+
+/** Join a mount prefix and a route path into one URL, collapsing slashes. */
+function joinPath(mountPath: string, path: string): string {
+  const a = mountPath.endsWith('/') ? mountPath.slice(0, -1) : mountPath
+  if (path === '/' || path === '') return a === '' ? '/' : a
+  const b = path.startsWith('/') ? path : `/${path}`
+  return `${a}${b}`
+}

--- a/packages/kickjs/tsdown.config.ts
+++ b/packages/kickjs/tsdown.config.ts
@@ -6,6 +6,7 @@ const pkg = readPkg(import.meta.dirname)
 export default defineConfig({
   entry: {
     index: 'src/index.ts',
+    web: 'src/web.ts',
     'core/adapter': 'src/core/adapter.ts',
     'core/container': 'src/core/container.ts',
     'core/decorators': 'src/core/decorators.ts',


### PR DESCRIPTION
## Summary

Phase 2 of the web-standards/edge roadmap (`web-standards-edge-design.md`): **`@forinda/kickjs/web`** — a pure web-standard fetch entry so KickJS apps deploy to **Cloudflare Workers**, run on **Bun** and **Deno**, with zero node-server machinery in the bundle.

```ts
// Cloudflare Workers (wrangler.toml: compatibility_flags = ["nodejs_compat"])
import { createWebApp } from '@forinda/kickjs/web'
import * as h3 from 'h3' // v2
import { modules } from './modules'

const app = createWebApp({ h3, modules })
export default { fetch: (req: Request) => app.fetch(req) }

// Bun
Bun.serve({ fetch: (req) => app.fetch(req) })
```

## What's inside

- **`createWebApp({ h3, modules, apiPrefix?, defaultVersion?, contributors?, env? })`** — mirrors `Application.setup()`'s module path (registry → `register(container)` → `routes()` → route table) and mounts compiled routes on an h3 v2 app; returns `{ fetch, h3 }`. Reuses the P1 driver pair, so node bootstrap (`h3WebRuntime`) and edge serve identical request semantics.
- **`createFetchHandler((env) => options)`** — Workers convenience: lazy-builds on first request so the `env` binding seeds ConfigService/`@Value` (no ambient `process.env` needed).
- **h3 passed in by the caller** — edge bundlers have no `createRequire`, and a static `import 'h3'` would force the peer on every subpath consumer.

## Purity work (design §3.4)

The entry graph had three node poisons; all fixed without public API changes:

1. `router-builder`/`validate` imported the **core barrel**, which re-exports the asset manager (eager `node:fs`) → repointed to concrete core modules.
2. The **container** imported `resolveAsset` directly → new `asset-resolver-slot.ts` indirection; `assets.ts` self-registers at import. Node apps unchanged (the barrel loads assets); edge bundles get a clear `@Asset` error instead of `node:fs` in the graph.
3. `compileWebRoute` pulled `applyUploadConfig` from `upload.ts` (top-level `node:fs/promises` + `node:module`) → pure upload core extracted to `upload-config.ts`; `upload.ts` re-exports for compatibility.

**Enforced by test**: walks the built `dist/web.mjs` import graph transitively and fails on `express` or any `node:*` import except `node:async_hooks` (the sanctioned ALS dependency — available on Workers/Deno/Bun). This test caught all three poisons during development.

## Out of scope (per design)

Adapters/plugins on the edge entry, view engines/SPA/static, KV session/rate-limit stores, Netlify/Vercel Edge targets.

## Tests

625 passed — 5 new: decorated-module fetch round-trips (GET params + POST JSON through real DI/decorators), `apiPrefix`/`defaultVersion`, h3 v1 fail-fast, Workers-style env binding through `createFetchHandler`, and the bundle purity gate.

Changeset: minor. Next: P3 — examples + docs (wrangler/Bun/Deno entries, edge caveats page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new web entry for running KickJS in edge-friendly environments.
  * Introduced a `fetch`-based app handler and a convenience helper for lazy request-time setup.
  * Expanded file upload handling with broader type support and stricter file-size and type checks.

* **Bug Fixes**
  * Improved compatibility by avoiding Node-only dependencies in the web bundle.
  * Kept asset loading working in edge runtimes without filesystem access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->