### PR TITLE
docs: edge deployment guide + h3 v2 runtime docs (P3)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -25,6 +25,7 @@ const guideSidebar = [
       { text: 'Type Generation', link: '/guide/typegen' },
       { text: 'Middleware', link: '/guide/middleware' },
       { text: 'HTTP Runtimes (Express / Fastify / h3)', link: '/guide/http-runtimes' },
+      { text: 'Edge Deployment (Workers / Bun / Deno)', link: '/guide/edge-deployment' },
       { text: 'Context Decorators', link: '/guide/context-decorators' },
       { text: 'Validation', link: '/guide/validation' },
       { text: 'Schema (Zod / Valibot / Yup)', link: '/guide/schema' },

--- a/docs/guide/edge-deployment.md
+++ b/docs/guide/edge-deployment.md
@@ -1,0 +1,124 @@
+# Edge Deployment (Workers / Bun / Deno)
+
+KickJS apps can run as a **web-standard `fetch(Request) → Response` handler** —
+no node http server, no `bootstrap()`. Same modules, controllers, DI, and
+context decorators; the entry file is the only thing that changes.
+
+Two pieces make this work:
+
+- **`@forinda/kickjs/web`** — `createWebApp()` builds your app as a pure fetch
+  handler for edge runtimes (Cloudflare Workers), Bun, and Deno.
+- **`@forinda/kickjs/h3-web`** — the same web-standard engine (h3 v2) behind
+  the classic `bootstrap()` for node servers, so local dev and edge share one
+  request pipeline.
+
+Both need **h3 v2** (the web-standards line — `npm i h3@latest`). The
+[v1 h3 runtime](./http-runtimes.md#h3) is unaffected and keeps working.
+
+## The fetch entry
+
+```ts
+// app.ts — shared by every target
+import { createWebApp } from '@forinda/kickjs/web'
+import * as h3 from 'h3' // v2
+import { modules } from './modules'
+
+export const app = createWebApp({ h3, modules })
+```
+
+`createWebApp` accepts the same module shapes as `bootstrap({ modules })`, plus
+`apiPrefix` (default `/api`), `defaultVersion` (default `1`),
+`contributors` (global context contributors), and `env` (see
+[Environment](#environment--config)).
+
+The h3 module is **passed in by you** rather than imported internally — edge
+bundlers have no `createRequire`, and this keeps the peer optional for everyone
+not using the subpath.
+
+## Cloudflare Workers
+
+```toml
+# wrangler.toml
+name = "my-kick-app"
+main = "src/worker.ts"
+compatibility_date = "2026-01-01"
+compatibility_flags = ["nodejs_compat"]   # required — AsyncLocalStorage
+```
+
+```ts
+// src/worker.ts
+import { createFetchHandler } from '@forinda/kickjs/web'
+import * as h3 from 'h3'
+import { modules } from './modules'
+
+export default createFetchHandler((env) => ({ h3, modules, env }))
+```
+
+`createFetchHandler` builds the app lazily on the **first request** so the
+Workers `env` binding can seed configuration before any module resolves —
+Workers have no ambient `process.env`.
+
+The `nodejs_compat` flag is required: request-scoped DI and `ctx.set`/`ctx.get`
+ride on `AsyncLocalStorage`.
+
+## Bun
+
+Bun runs node APIs natively, so both entries work:
+
+```ts
+// Web-standard (recommended — same code as Workers/Deno)
+Bun.serve({ port: 3000, fetch: (req) => app.fetch(req) })
+```
+
+```ts
+// Or classic bootstrap on the h3 v2 engine
+import { bootstrap } from '@forinda/kickjs'
+import { h3WebRuntime } from '@forinda/kickjs/h3-web'
+
+await bootstrap({ modules, runtime: h3WebRuntime() })
+```
+
+## Deno
+
+```ts
+Deno.serve({ port: 3000 }, (req) => app.fetch(req))
+```
+
+## Environment & config
+
+On node/Bun/Deno, `process.env` + [`loadEnv()`](./configuration.md) work as
+usual. On Workers, pass the `env` binding through `createFetchHandler` (above)
+or `createWebApp({ env })` — `ConfigService.get()` and `@Value()` resolve from
+it.
+
+## What's different on the edge
+
+| Concern                                            | Status                                                                          |
+| -------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Routing, DI, decorators, validation, `ctx.problem` | ✅ identical                                                                    |
+| Context decorators / request-scoped DI             | ✅ (needs `nodejs_compat` on Workers)                                           |
+| SSE (`ctx.sse`)                                    | ✅ — streams over a web `Response`                                              |
+| File uploads (`@FileUpload`)                       | ✅ — web `FormData`, buffered in memory                                         |
+| `@PreDestroy` request teardown                     | ✅ — runs when the response closes                                              |
+| `ctx.render()` / view engines / SPA / static files | ❌ throws — serve assets from the platform CDN                                  |
+| In-memory `session()` / `rateLimit()` stores       | ❌ — no persistent process between requests; use a KV/Redis-backed custom store |
+| `@Asset` injection                                 | ❌ — reads the filesystem; clear error on access                                |
+| Adapters / plugins                                 | Not wired on the web entry at launch — use `bootstrap()` on node for those      |
+
+### Runtime support (AsyncLocalStorage)
+
+| Runtime                | Supported | Notes                                                                            |
+| ---------------------- | --------- | -------------------------------------------------------------------------------- |
+| Cloudflare Workers     | ✅        | `compatibility_flags = ["nodejs_compat"]`                                        |
+| Deno / Deno Deploy     | ✅        | built-in node compat                                                             |
+| Bun                    | ✅        | native                                                                           |
+| Vercel (Node runtime)  | ✅        | use their Node functions — Vercel recommends Node over their legacy Edge runtime |
+| Netlify Edge Functions | ❌        | no AsyncLocalStorage — use Netlify's regular (Node) Functions instead            |
+
+## One pipeline, two entries
+
+`createWebApp` and `h3WebRuntime()` share the same request pipeline (the web
+driver pair), so behavior is identical between `bootstrap()` on your dev
+machine and the deployed fetch handler. The package also enforces a **bundle
+purity contract** in CI: the built `@forinda/kickjs/web` graph contains no
+`express` and no `node:*` import besides `node:async_hooks`.

--- a/docs/guide/http-runtimes.md
+++ b/docs/guide/http-runtimes.md
@@ -79,30 +79,51 @@ import { h3Runtime } from '@forinda/kickjs/h3'
 export const app = await bootstrap({ modules, runtime: h3Runtime() })
 ```
 
-The binding targets **h3 v1** (the stable, node-based surface). h3 v2's
-web-standard `Request` / `Response` core is the eventual target via a future
-web-standard driver — see the [design spec](../http/spec-http-runtimes.md) §8.
+The binding targets **h3 v1** (the stable, node-based surface).
 
 Same surface as Fastify: routing, JSON / HTML, connect middleware (via h3's
 `fromNodeMiddleware`), context decorators, errors / 404, SSE, body validation,
 native body parsing, and file uploads (`@FileUpload` → `ctx.file` / `ctx.files`,
 via h3's built-in `readMultipartFormData` — no driver to install).
 
+## h3 v2 (web standards)
+
+h3 v2 rebased on WHATWG `Request` / `Response` — KickJS supports it through a
+**separate, additive runtime**, so v1 adopters are untouched:
+
+```bash
+pnpm add h3@latest   # the v2 line
+```
+
+```ts
+import { h3WebRuntime } from '@forinda/kickjs/h3-web'
+
+export const app = await bootstrap({ modules, runtime: h3WebRuntime() })
+```
+
+Each runtime fail-fasts with guidance when the wrong h3 major is installed.
+The v2 runtime shares its request pipeline with the
+[`@forinda/kickjs/web` fetch entry](./edge-deployment.md), which is how the
+same app deploys to Cloudflare Workers, Bun, and Deno. One caveat vs v1: no
+Vite dev-server fall-through (h3 v2 owns the full request) — use the v1 h3
+runtime or Express for Vite-integrated dev.
+
 ## Capability matrix
 
 Some `ctx` features depend on the engine. Calling an unsupported one raises a
 clear error rather than failing silently.
 
-| Capability                | Express     | Fastify                 | h3 (v1)                 |
-| ------------------------- | ----------- | ----------------------- | ----------------------- |
-| Routing + `ctx.json`      | ✅          | ✅                      | ✅                      |
-| Connect middleware        | ✅          | ✅ (via middie)         | ✅ (fromNodeMiddleware) |
-| Context decorators        | ✅          | ✅                      | ✅                      |
-| Errors / 404              | ✅          | ✅                      | ✅                      |
-| Server-Sent Events        | ✅          | ✅                      | ✅                      |
-| Validation                | ✅          | ✅                      | ✅                      |
-| `ctx.render` (views)      | ✅          | ❌ (no view engine)     | ❌ (no view engine)     |
-| File uploads (`ctx.file`) | ✅ (multer) | ✅ (@fastify/multipart) | ✅ (native multipart)   |
+| Capability                | Express     | Fastify                 | h3 (v1)                 | h3 v2 (`h3-web`)                        |
+| ------------------------- | ----------- | ----------------------- | ----------------------- | --------------------------------------- |
+| Routing + `ctx.json`      | ✅          | ✅                      | ✅                      | ✅                                      |
+| Connect middleware        | ✅          | ✅ (via middie)         | ✅ (fromNodeMiddleware) | ✅ (fromNodeHandler)                    |
+| Context decorators        | ✅          | ✅                      | ✅                      | ✅                                      |
+| Errors / 404              | ✅          | ✅                      | ✅                      | ✅                                      |
+| Server-Sent Events        | ✅          | ✅                      | ✅                      | ✅ (web streams)                        |
+| Validation                | ✅          | ✅                      | ✅                      | ✅                                      |
+| `ctx.render` (views)      | ✅          | ❌ (no view engine)     | ❌ (no view engine)     | ❌ (no view engine)                     |
+| File uploads (`ctx.file`) | ✅ (multer) | ✅ (@fastify/multipart) | ✅ (native multipart)   | ✅ (web `FormData`)                     |
+| Edge / Bun / Deno deploy  | ❌          | ❌                      | ❌                      | ✅ (via [`/web`](./edge-deployment.md)) |
 
 ## The engine-native escape hatch
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -10,6 +10,7 @@
 - [Dependency Injection](https://kickjs.app/guide/dependency-injection.html): The container, `@Service`, `@Inject`, scopes.
 - [Modules](https://kickjs.app/guide/modules.html): `defineModule`, route mounting, registration.
 - [HTTP Runtimes (Express / Fastify / h3)](https://kickjs.app/guide/http-runtimes.html): Pick the engine at bootstrap; capability matrix; writing a custom runtime.
+- [Edge Deployment (Workers / Bun / Deno)](https://kickjs.app/guide/edge-deployment.html): `createWebApp` fetch entry, wrangler `nodejs_compat`, Bun/Deno serve, edge caveats.
 - [Context Decorators](https://kickjs.app/guide/context-decorators.html): Typed, ordered `ctx` population via `defineContextDecorator`.
 - [Middleware](https://kickjs.app/guide/middleware.html): Built-ins (helmet, cors, requestId, rate-limit, …) and custom.
 - [Validation](https://kickjs.app/guide/validation.html): Zod / Valibot / Yup body, query, and param validation.

--- a/web-standards-edge-design.md
+++ b/web-standards-edge-design.md
@@ -1,6 +1,8 @@
 # Web Standards & Edge Runtime Design — KickJS on h3 v2
 
-> Status: **DRAFT — spec only, no implementation yet** (2026-07-05)
+> Status: **SHIPPED** — P0 (#440), P1 `h3WebRuntime` (#441), P2 `@forinda/kickjs/web` (#442),
+> P3 docs (`docs/guide/edge-deployment.md`). Remaining follow-ups live in §6 open questions
+> (KV stores, adapters-on-edge, `ctx.waitUntil`).
 > Decision owner: @forinda
 > Engine decision: **h3 v2 as the web-standard engine** (chosen over a zero-dep hand-rolled runtime)
 > Channel: TBD after spec review (precedent: fastify/h3 runtimes shipped via `alpha`)


### PR DESCRIPTION
## Summary

Phase 3 (final) of the web-standards/edge roadmap: documentation for everything P0–P2 shipped.

## New: Edge Deployment guide (`guide/edge-deployment.md`)

- `createWebApp({ h3, modules })` fetch entry — one `app.ts` for every target
- **Cloudflare Workers**: full `wrangler.toml` (`nodejs_compat` required for ALS) + `createFetchHandler((env) => …)` for env-binding config seeding
- **Bun** (`Bun.serve`) and **Deno** (`Deno.serve`) one-liners; Bun also documented on classic `bootstrap({ runtime: h3WebRuntime() })`
- **"What's different on the edge"** table — what's identical (routing/DI/SSE/uploads/@PreDestroy) vs unsupported (views/SPA/static, in-memory session/rate-limit stores, `@Asset`, adapters at launch)
- ALS runtime-support matrix (Workers ✅ / Deno ✅ / Bun ✅ / Vercel-Node ✅ / Netlify Edge ❌)
- Bundle purity contract noted as CI-enforced

## Updated

- `http-runtimes.md`: new **"h3 v2 (web standards)"** section — additive `h3WebRuntime`, fail-fast wrong-major guidance, Vite fall-through caveat; capability matrix gains the `h3-web` column and an Edge/Bun/Deno row; removed the stale "web-standard driver is future work" claim
- Sidebar + `llms.txt` index entries
- Design spec status: DRAFT → **SHIPPED** with PR refs (#440/#441/#442)

Docs build verified (`pnpm docs:build` green). Docs-only — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
