### PR TITLE
feat(kickjs): return-value handlers across all runtimes (R1)

### DIFF
--- a/.changeset/return-value-handlers.md
+++ b/.changeset/return-value-handlers.md
@@ -1,0 +1,27 @@
+---
+'@forinda/kickjs': minor
+---
+
+feat: return-value handlers — `return` the payload instead of calling `ctx.json`
+
+Handlers on every runtime (Express, Fastify, h3, h3-web, `@forinda/kickjs/web`)
+may now return their response:
+
+```ts
+@Get('/:id')
+async get(ctx: RequestContext) {
+  return this.users.find(ctx.params.id)          // → 200 json
+}
+
+@Post('/')
+async create(ctx: RequestContext) {
+  return reply(201, await this.users.create(ctx.body)) // → 201
+}
+```
+
+- `reply(status, body)` + sugars (`created`/`accepted`/`noContent`) carry the
+  status in the type (`Reply<201, Task>`) for upcoming response inference
+- Fully additive: `ctx.json` style unchanged and always wins over a return
+  value; `undefined` returns keep prior behavior exactly
+- Foundation for typed response inference in `kick typegen` and the typed
+  client (`response-inference-design.md`)

--- a/docs/guide/controllers.md
+++ b/docs/guide/controllers.md
@@ -219,6 +219,47 @@ SSE helpers:
 | `sse.onClose(fn)`             | Register disconnect callback |
 | `sse.close()`                 | End the stream               |
 
+## Return-Value Handlers
+
+Handlers may **return** the response payload instead of calling `ctx.json` —
+the runtime auto-sends it as `200 application/json` when the handler wrote
+nothing. Works on every runtime (Express, Fastify, h3, h3-web, and the
+[edge fetch entry](./edge-deployment.md)):
+
+```ts
+@Get('/:id')
+async get(ctx: RequestContext) {
+  return this.users.find(ctx.params.id) // → 200 json
+}
+```
+
+For a non-200 status, wrap with `reply()` — the wrapper carries the status in
+its type, so response inference stays exact:
+
+```ts
+import { reply } from '@forinda/kickjs'
+
+@Post('/')
+async create(ctx: RequestContext) {
+  return reply(201, await this.users.create(ctx.body)) // → 201 json
+}
+
+@Delete('/:id')
+async remove(ctx: RequestContext) {
+  await this.users.remove(ctx.params.id)
+  return reply.noContent() // → empty 204
+}
+```
+
+Rules of precedence:
+
+- A `ctx.*` response (e.g. `ctx.json`) always wins — a return value after it is ignored.
+- Returning `undefined`/`void` changes nothing — pure imperative handlers behave exactly as before.
+- Sugars: `reply.created(body)` (201), `reply.accepted(body)` (202), `reply.noContent()` (204).
+
+Returning values is what makes the handler's **response type statically
+inferable** — the foundation for typed-client generation.
+
 ## Middleware on Controllers
 
 Use `@Middleware()` at the class or method level. See [Middleware](./middleware.md) for the full guide.

--- a/packages/kickjs/__tests__/return-value-handlers.test.ts
+++ b/packages/kickjs/__tests__/return-value-handlers.test.ts
@@ -44,6 +44,12 @@ function makeControllers() {
       return reply.noContent()
     }
 
+    @Get('/accepted-empty')
+    // Undefined body must NOT coerce the declared status to 204.
+    acceptedEmpty(_ctx: RequestContext) {
+      return reply(202, undefined)
+    }
+
     @Get('/ctx-wins')
     ctxWins(ctx: RequestContext) {
       ctx.json({ via: 'ctx' })
@@ -102,6 +108,11 @@ for (const rt of RUNTIMES) {
     it('reply.noContent() sends an empty 204', async () => {
       const app = await makeApp()
       await request(app.handle.bind(app)).get('/api/v1/r/gone').expect(204)
+    })
+
+    it('an undefined body does not coerce the status to 204', async () => {
+      const app = await makeApp()
+      await request(app.handle.bind(app)).get('/api/v1/r/accepted-empty').expect(202)
     })
 
     it('ctx.json wins over a return value', async () => {

--- a/packages/kickjs/__tests__/return-value-handlers.test.ts
+++ b/packages/kickjs/__tests__/return-value-handlers.test.ts
@@ -1,0 +1,143 @@
+import 'reflect-metadata'
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import * as h3v2 from 'h3-v2'
+
+import { Application } from '../src/http/application'
+import { Container } from '../src/core/container'
+import { Controller, Get, Post } from '../src/core/decorators'
+import { reply } from '../src/http/reply'
+import { expressRuntime } from '../src/http/runtimes/express'
+import { fastifyRuntime } from '../src/http/runtimes/fastify'
+import { h3Runtime } from '../src/http/runtimes/h3'
+import { createWebApp } from '../src/web'
+import type { HttpRuntime } from '../src/http/runtime'
+import type { RequestContext } from '../src/http/context'
+
+/**
+ * Return-value handlers (response-inference-design.md R1): handlers may
+ * RETURN the payload instead of calling ctx.json; runtimes auto-send when
+ * the pipeline finished with nothing written. Conformance across express /
+ * fastify / h3 v1 (supertest) and the web entry (fetch).
+ */
+
+function makeControllers() {
+  @Controller()
+  class ReturnsController {
+    @Get('/plain')
+    plain(_ctx: RequestContext) {
+      return { via: 'return' }
+    }
+
+    @Get('/async')
+    async asyncPlain(_ctx: RequestContext) {
+      return [1, 2, 3]
+    }
+
+    @Post('/created')
+    create(_ctx: RequestContext) {
+      return reply(201, { id: 'x1' })
+    }
+
+    @Get('/gone')
+    gone(_ctx: RequestContext) {
+      return reply.noContent()
+    }
+
+    @Get('/ctx-wins')
+    ctxWins(ctx: RequestContext) {
+      ctx.json({ via: 'ctx' })
+      return { via: 'return-must-be-ignored' }
+    }
+
+    @Get('/void')
+    // Returns undefined AND writes via ctx — prior behavior untouched.
+    voidStyle(ctx: RequestContext) {
+      ctx.json({ via: 'imperative' })
+    }
+  }
+  return ReturnsController
+}
+
+const RUNTIMES: Array<{ name: string; make: () => HttpRuntime }> = [
+  { name: 'express', make: () => expressRuntime() },
+  { name: 'fastify', make: () => fastifyRuntime() },
+  { name: 'h3', make: () => h3Runtime() },
+]
+
+beforeEach(() => {
+  Container.reset()
+})
+
+for (const rt of RUNTIMES) {
+  describe(`return-value handlers — ${rt.name}`, () => {
+    async function makeApp() {
+      const app = new Application({
+        runtime: rt.make(),
+        modules: [{ routes: () => ({ path: '/r', controller: makeControllers() }) } as never],
+      })
+      await app.setup()
+      return app
+    }
+
+    it('auto-sends a returned object as 200 json', async () => {
+      const app = await makeApp()
+      const res = await request(app.handle.bind(app)).get('/api/v1/r/plain').expect(200)
+      expect(res.body).toEqual({ via: 'return' })
+      expect(res.headers['content-type']).toMatch(/json/)
+    })
+
+    it('auto-sends an async returned array', async () => {
+      const app = await makeApp()
+      const res = await request(app.handle.bind(app)).get('/api/v1/r/async').expect(200)
+      expect(res.body).toEqual([1, 2, 3])
+    })
+
+    it('reply(201, body) sets the status', async () => {
+      const app = await makeApp()
+      const res = await request(app.handle.bind(app)).post('/api/v1/r/created').expect(201)
+      expect(res.body).toEqual({ id: 'x1' })
+    })
+
+    it('reply.noContent() sends an empty 204', async () => {
+      const app = await makeApp()
+      await request(app.handle.bind(app)).get('/api/v1/r/gone').expect(204)
+    })
+
+    it('ctx.json wins over a return value', async () => {
+      const app = await makeApp()
+      const res = await request(app.handle.bind(app)).get('/api/v1/r/ctx-wins').expect(200)
+      expect(res.body).toEqual({ via: 'ctx' })
+    })
+
+    it('imperative style is untouched', async () => {
+      const app = await makeApp()
+      const res = await request(app.handle.bind(app)).get('/api/v1/r/void').expect(200)
+      expect(res.body).toEqual({ via: 'imperative' })
+    })
+  })
+}
+
+describe('return-value handlers — web entry (fetch)', () => {
+  it('returned payloads, reply() statuses, and ctx precedence all hold', async () => {
+    const app = createWebApp({
+      h3: h3v2,
+      modules: [{ routes: () => ({ path: '/r', controller: makeControllers() }) } as never],
+    })
+
+    const plain = await app.fetch(new Request('http://x/api/v1/r/plain'))
+    expect(plain.status).toBe(200)
+    expect(await plain.json()).toEqual({ via: 'return' })
+
+    const created = await app.fetch(new Request('http://x/api/v1/r/created', { method: 'POST' }))
+    expect(created.status).toBe(201)
+    expect(await created.json()).toEqual({ id: 'x1' })
+
+    const gone = await app.fetch(new Request('http://x/api/v1/r/gone'))
+    expect(gone.status).toBe(204)
+    expect(await gone.text()).toBe('')
+
+    const ctxWins = await app.fetch(new Request('http://x/api/v1/r/ctx-wins'))
+    expect(await ctxWins.json()).toEqual({ via: 'ctx' })
+  })
+})

--- a/packages/kickjs/src/http/index.ts
+++ b/packages/kickjs/src/http/index.ts
@@ -6,6 +6,9 @@ export { bootstrap } from './bootstrap'
 
 // Request Context
 export { RequestContext, type ContextMeta, type Ctx, type RouteShape } from './context'
+
+// Return-value handlers — `return reply(201, body)` / plain returns auto-send
+export { reply, isReply, applyHandlerResult, type Reply } from './reply'
 export { defineHttpContextDecorator } from './define-http-context-decorator'
 export type { TypedParsedQuery, FieldsOf } from './query'
 

--- a/packages/kickjs/src/http/reply.ts
+++ b/packages/kickjs/src/http/reply.ts
@@ -1,0 +1,81 @@
+// Return-value handler support (response-inference-design.md §3.1).
+//
+// Handlers may RETURN their response payload instead of calling `ctx.json`:
+// the runtime auto-sends it when the pipeline finishes with nothing written.
+// `reply(status, body)` wraps a payload with a non-200 status while staying
+// transparent to type inference (`Reply<201, Task>` carries both statically).
+//
+// Edge-safe: no node imports — shared by all four runtimes including the
+// `@forinda/kickjs/web` entry.
+
+import type { RequestContext } from './context'
+
+// `Symbol.for` so the brand survives duplicate module copies (workspace-linked
+// + published package in one process — same rationale as the request-scope
+// middleware marker).
+const REPLY_BRAND = Symbol.for('kickjs.reply')
+
+/**
+ * A status-carrying response payload for return-value handlers. Create via
+ * {@link reply} — the brand is what runtimes detect, and the generics are
+ * what the `kick/routes` response typegen unwraps (`Reply<S, T>` → `T`).
+ */
+export interface Reply<S extends number = number, T = unknown> {
+  readonly [REPLY_BRAND]: true
+  readonly status: S
+  readonly body: T
+}
+
+/**
+ * Wrap a return-value handler's payload with an explicit status code:
+ *
+ * ```ts
+ * @Post('/')
+ * async create(ctx: RequestContext) {
+ *   return reply(201, await this.tasks.create(ctx.body))
+ * }
+ * ```
+ */
+export function reply<S extends number, T>(status: S, body: T): Reply<S, T> {
+  return { [REPLY_BRAND]: true, status, body }
+}
+
+/** `reply(201, body)` */
+reply.created = <T>(body: T): Reply<201, T> => reply(201, body)
+/** `reply(202, body)` */
+reply.accepted = <T>(body: T): Reply<202, T> => reply(202, body)
+/** Empty 204 — maps to `ctx.noContent()`. */
+reply.noContent = (): Reply<204, undefined> => reply(204, undefined)
+
+export function isReply(value: unknown): value is Reply {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Record<symbol, unknown>)[REPLY_BRAND] === true
+  )
+}
+
+/**
+ * Send a handler's RETURN value when the pipeline finished without anything
+ * having written a response. Callers guard on "driver/response unsettled" —
+ * this only decides how to send:
+ *
+ * - `undefined` → not handled (returns false; runtime keeps today's behavior)
+ * - `Reply` wrapper → status + body (204 → `ctx.noContent()`)
+ * - anything else → `ctx.json(value)` (200)
+ *
+ * Returns true when a response was produced.
+ */
+export function applyHandlerResult(ctx: RequestContext, result: unknown): boolean {
+  if (result === undefined) return false
+  if (isReply(result)) {
+    if (result.status === 204 || result.body === undefined) {
+      ctx.noContent()
+      return true
+    }
+    ctx.json(result.body, result.status)
+    return true
+  }
+  ctx.json(result)
+  return true
+}

--- a/packages/kickjs/src/http/reply.ts
+++ b/packages/kickjs/src/http/reply.ts
@@ -69,7 +69,10 @@ export function isReply(value: unknown): value is Reply {
 export function applyHandlerResult(ctx: RequestContext, result: unknown): boolean {
   if (result === undefined) return false
   if (isReply(result)) {
-    if (result.status === 204 || result.body === undefined) {
+    // Only 204 maps to noContent — an undefined body must NOT coerce the
+    // declared status (reply(304, undefined) keeps its 304; the json body
+    // is simply empty).
+    if (result.status === 204) {
       ctx.noContent()
       return true
     }

--- a/packages/kickjs/src/http/runtimes/express.ts
+++ b/packages/kickjs/src/http/runtimes/express.ts
@@ -17,6 +17,7 @@ import express, {
 
 import { buildRouteTable, type BuildRoutesOptions } from '../router-builder'
 import { RequestContext } from '../context'
+import { applyHandlerResult } from '../reply'
 import { validate } from '../middleware/validate'
 import { buildUploadMiddleware } from '../middleware/upload'
 import type {
@@ -79,7 +80,10 @@ export function materializeRouter(entries: RouteEntry[]): Router {
     handlers.push(async (req: Request, res: Response, next: NextFunction) => {
       const ctx = new RequestContext(req, res, next)
       try {
-        await entry.handler(ctx)
+        const result = await entry.handler(ctx)
+        // Return-value handlers (reply.ts): auto-send the returned payload
+        // when the handler wrote nothing. `undefined` keeps prior behavior.
+        if (!res.headersSent) applyHandlerResult(ctx, result)
       } catch (err) {
         next(err)
       }

--- a/packages/kickjs/src/http/runtimes/fastify.ts
+++ b/packages/kickjs/src/http/runtimes/fastify.ts
@@ -18,6 +18,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import { createRequire } from 'node:module'
 
 import { RequestContext } from '../context'
+import { applyHandlerResult } from '../reply'
 import { requestStore } from '../request-store'
 import { createRequestStore, disposeRequestStore } from '../middleware/request-scope'
 import { validate } from '../middleware/validate'
@@ -258,7 +259,9 @@ function routeHandler(entry: RouteEntry): FastifyHandler {
 
       if (entry.contributorRunner) await entry.contributorRunner(ctx)
       if (reply.sent) return
-      await entry.handler(ctx)
+      const result = await entry.handler(ctx)
+      // Return-value handlers (reply.ts): auto-send when nothing was written.
+      if (!reply.sent) applyHandlerResult(ctx, result)
     })
   }
 }

--- a/packages/kickjs/src/http/runtimes/h3.ts
+++ b/packages/kickjs/src/http/runtimes/h3.ts
@@ -20,6 +20,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import { createRequire } from 'node:module'
 
 import { RequestContext } from '../context'
+import { applyHandlerResult } from '../reply'
 import { requestStore } from '../request-store'
 import { createRequestStore, disposeRequestStore } from '../middleware/request-scope'
 import { validate } from '../middleware/validate'
@@ -202,7 +203,9 @@ function makeEventHandler(entry: RouteEntry): (event: H3EventLike) => Promise<vo
 
       if (entry.contributorRunner) await entry.contributorRunner(ctx)
       if (res.writableEnded) return
-      await entry.handler(ctx)
+      const result = await entry.handler(ctx)
+      // Return-value handlers (reply.ts): auto-send when nothing was written.
+      if (!res.writableEnded && !res.headersSent) applyHandlerResult(ctx, result)
     })
   }
 }

--- a/packages/kickjs/src/http/web/handler.ts
+++ b/packages/kickjs/src/http/web/handler.ts
@@ -4,6 +4,7 @@
 // Edge-safe: no node imports beyond the sanctioned ALS request store.
 
 import { RequestContext } from '../context'
+import { applyHandlerResult } from '../reply'
 import { requestStore } from '../request-store'
 import { createRequestStore, disposeRequestStore } from '../middleware/request-scope'
 import { validate } from '../middleware/validate'
@@ -134,7 +135,10 @@ export function compileWebRoute(
 
       if (entry.contributorRunner) await entry.contributorRunner(ctx)
       if (driver.settled) return
-      await entry.handler(ctx)
+      const result = await entry.handler(ctx)
+      // Return-value handlers (reply.ts): auto-send when nothing was written.
+      // `undefined` falls through to the canonical 404 below.
+      if (!driver.settled) applyHandlerResult(ctx, result)
     })
 
     try {

--- a/packages/kickjs/src/web.ts
+++ b/packages/kickjs/src/web.ts
@@ -32,6 +32,8 @@ import { normalizePath } from './core/path'
 
 export { WebRequestShim, WebResponseDriver } from './http/web/driver'
 export { compileWebRoute } from './http/web/handler'
+// Return-value handler helpers — edge consumers can't import the main barrel.
+export { reply, isReply, type Reply } from './http/reply'
 
 // Minimal structural surface of h3 v2 used here (kept local so this entry
 // never imports the node-coupled h3-web runtime module).

--- a/response-inference-design.md
+++ b/response-inference-design.md
@@ -1,0 +1,177 @@
+# Typed Response Inference — Return-Value Handlers, KickRoutes.response, Typed Client
+
+> Status: **DRAFT — spec only, no implementation yet** (2026-07-06)
+> Decision owner: @forinda
+> Prior art in-repo: `docs/guide/tutorial-typed-client.md` (the vision), `kick typegen`'s
+> `kick/routes` plugin (the vehicle), the edge/web-standards rollout (the process template).
+
+## 1. Goal
+
+Close the type loop from controller to consumer: the response type of every route is
+**known statically** — surfaced in the `KickRoutes` augmentation next to the existing
+`params`/`body`/`query`, and consumable by a generated tRPC-style client:
+
+```ts
+const api = createClient<KickApi>({ baseUrl: 'https://api.example.com' })
+
+const task = await api.post('/api/v1/projects/:projectId/tasks', {
+  params: { projectId: 'p1' },
+  body: { title: 'Fix bug', priority: 'high' }, // typed from the Zod schema
+})
+// task: { id: string; title: string; ... }  ← inferred from the handler
+```
+
+## 2. Facts this design rests on
+
+### Why inference is blocked today
+
+Handlers respond **imperatively** — `ctx.json(data)` / `ctx.created(x)` — so every
+handler's declared type is `Promise<void>`. The response type exists only as an argument
+at a call site, invisible to `ReturnType<>`. Confirmed in all four runtimes: the terminal
+handler is invoked as `await entry.handler(ctx)` and any return value is dropped
+(`runtimes/express.ts:83`, fastify/h3 equivalents, `web/handler.ts` — which today answers
+"pipeline finished without responding" with a canonical 404).
+
+### Why decorators can't do it at the type level
+
+TS decorators cannot change or export the type of the thing they decorate, and the route
+path/verb are runtime strings in metadata — their literal types never attach to the class
+type. So a purely type-level `InferApi<Controller>` can recover **response types only**
+(method return types), not paths, verbs, or body/query. Chained-builder frameworks (Hono,
+Elysia) infer fully because routes are _value expressions_ with accumulating generics —
+not KickJS's identity.
+
+### What already exists
+
+- **`kick typegen` → `kick/routes` plugin** (`packages/cli/src/typegen/builtin/routes.ts`):
+  scans `src/**/*.controller.ts` + modules via a shared AST scan, renders a `KickRoutes`
+  augmentation with per-route `params`/`body`/`query` (Zod-aware via
+  `typegen.schemaValidator`), emits `.ts` with hoisted `import type` so schema types
+  resolve. Re-runs on watch in `kick dev`.
+- **The web pipeline precedent**: `web/handler.ts` already has the exact branch point
+  ("pipeline done + driver unsettled") where auto-send slots in.
+- h3 v2 / Hono / Elysia all standardized on **return-the-value** handlers — adopters
+  arriving from those expect it.
+
+## 3. Architecture
+
+Three layers, each independently useful:
+
+### 3.1 Layer A — return-value handlers (runtime)
+
+Handlers may **return** the response payload; the runtime auto-sends it when the pipeline
+completes with the driver unsettled:
+
+```ts
+@Get('/:id')
+async get(ctx: RequestContext) {
+  return this.users.find(ctx.params.id) // → 200 application/json
+}
+```
+
+Rules (all four runtimes — express materializer, fastify, h3 v1, web/h3-web):
+
+| Handler outcome                        | Behavior                                                                           |
+| -------------------------------------- | ---------------------------------------------------------------------------------- |
+| `ctx.json/...` called (driver settled) | unchanged — return value ignored                                                   |
+| returns `undefined` / `void`           | unchanged — falls through to today's behavior (404 on web, notFound chain on node) |
+| returns object/array/primitive         | `ctx.json(value)` — 200                                                            |
+| returns a `Reply` wrapper (below)      | status + body from the wrapper                                                     |
+| throws                                 | unchanged — error pipeline                                                         |
+
+Status codes without `ctx`: a tiny value wrapper, transparent to inference:
+
+```ts
+return reply(201, task) // Reply<201, Task> — typed status + body
+return reply.created(task) // sugar for the common codes
+```
+
+`Reply<S, T>` is a plain `{ status: S; body: T }` brand the runtimes unwrap and the
+type layer (3.2) understands (`InferResponse<Reply<201, Task>> = Task`).
+
+**Fully additive.** Imperative `ctx` style remains first-class; return style is opt-in
+per handler. `ctx.paginate(...)` already returns its payload — under return-style it
+just works (handler returns what paginate produced; driver settled either way).
+
+### 3.2 Layer B — `response` in KickRoutes (typegen)
+
+The `kick/routes` scan gains response extraction per route, in priority order:
+
+1. **Return type** of the handler method (via the TS checker the scanner already runs) —
+   `Awaited<ReturnType>`, unwrapping `Reply<S, T>` → `T`, dropping `void`/`undefined`
+   members. This is why Layer A matters: return-style handlers make this exact.
+2. **`ctx.json(arg)` / `ctx.created(arg)` argument types** (AST call-site scan) for
+   imperative handlers — best-effort union when multiple call sites.
+3. **Declared override** — `@ApiResponse({ schema })` / a `response` slot in the route
+   decorator's validation object, when adopters want the schema (not the impl) to be
+   the contract. Wins over 1–2 when present.
+
+Emission: `KickRoutes[path][method].response` alongside the existing fields. Nothing
+about the emission pipeline changes — same plugin, same watch loop, one more rendered
+field.
+
+### 3.3 Layer C — typed client (`@forinda/kickjs-client` or `kick generate:client`)
+
+A ~100-line fetch wrapper typed by the augmentation:
+
+```ts
+import { createClient } from '@forinda/kickjs-client'
+import type { KickApi } from './.kickjs/types/kick__routes'
+
+const api = createClient<KickApi>({ baseUrl, headers: () => ({ Authorization: ... }) })
+const task = await api.post('/api/v1/tasks/:id', { params: { id }, body })
+```
+
+- Path-keyed (template-literal param substitution), NOT proxy-RPC — matches REST identity
+  and the existing `KickRoutes` shape.
+- Fetch-based → runs in browsers, node ≥ 20, and on the edge (pairs with
+  `@forinda/kickjs/web` — same web standards on both ends).
+- Error channel: non-2xx → typed `KickClientError` carrying the RFC 9457 problem body
+  (`ctx.problem` is already the canonical error shape).
+- Delivery: prefer a small published package consuming the generated types over
+  `generate:client` codegen — less generated surface, same DX. Decide at C.
+
+## 4. Phases
+
+| Phase  | Content                                                                                                                                                                                         | Breaking?                       | Size |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ---- |
+| **R1** | Return-value handlers in all 4 runtimes + `reply()` wrapper + docs. Web handler: replace the "finished without responding → 404" branch with auto-json-if-returned (404 stays for `undefined`). | No — additive                   | S–M  |
+| **R2** | `kick/routes` response extraction (return-type first, `ctx.json` call-site fallback, declared override) + `response` field in the render + `KickRoutes` type tests                              | No — augmentation gains a field | M    |
+| **R3** | Typed client package + docs (`tutorial-typed-client.md` graduates from vision to guide)                                                                                                         | No — new package                | M    |
+
+R1 lands alone and is useful without any types (less boilerplate). R2 depends on R1 only
+for _precision_ (call-site fallback covers imperative handlers regardless). R3 depends on R2.
+
+## 5. Testing
+
+- R1: per-runtime fetch/supertest round-trips — returned object → 200 json; `reply(201, x)`
+  → 201; `undefined` → unchanged 404/notFound; `ctx.json` + return → ctx wins. Lifecycle
+  suite re-run (auto-send must not fight `@PreDestroy`/SSE paths).
+- R2: typegen snapshot tests (existing harness) — return-style, imperative multi-callsite
+  union, `Reply` unwrap, declared override precedence.
+- R3: type-level tests (`expectTypeOf`) against a fixture `KickRoutes` + one runtime
+  round-trip against a `createWebApp` fetch handler (no server needed).
+
+## 6. Open questions
+
+1. **`reply()` naming/shape** — `reply(status, body)` vs `ctx`-free `respond()` vs
+   reusing `HttpStatus` enums. Also: headers in the wrapper or ctx-only?
+2. **Union responses** — handler with branches returning different shapes: emit the union
+   (honest) or require a declared override (strict)? Proposal: emit the union.
+3. **Streaming/SSE routes** — `response: never` or a branded `SseStream` type in the map?
+4. **`successResponse(...)` envelope pattern** (from the vision doc) — generic passthrough
+   is automatic via return types; no special handling needed. Confirm with a fixture.
+5. **Client package name** — `@forinda/kickjs-client` (new package) vs a `client` subpath
+   of `@forinda/kickjs` (but the client must not drag the server graph — subpath purity
+   would need the same bundle test as `/web`).
+6. **OpenAPI reuse** — should R2's extracted response types also feed the Swagger
+   adapter's response schemas? (Today `@ApiResponse` is manual.) Likely yes, later.
+
+## 7. Non-goals
+
+- Full tRPC-style procedure RPC (`api.tasks.create(...)`) — path-keyed client first;
+  a proxy sugar layer can sit on top later without new inference.
+- Runtime response validation (schemas validating what handlers return) — separate
+  feature, separate cost/benefit.
+- Inferring body/query purely at the type level — stays typegen's job (decorator type
+  erasure makes it impossible without changing how routes are declared).


### PR DESCRIPTION
## Summary

R1 of the typed-response-inference roadmap (spec: `response-inference-design.md`, included in this PR): **handlers can return their response payload** on every runtime — Express, Fastify, h3 v1, h3-web, and the `@forinda/kickjs/web` edge entry.

```ts
@Get('/:id')
async get(ctx: RequestContext) {
  return this.users.find(ctx.params.id)                 // → 200 json
}

@Post('/')
async create(ctx: RequestContext) {
  return reply(201, await this.users.create(ctx.body))  // → 201, Reply<201, Task>
}
```

## Why

`ctx.json(data)` types every handler as `Promise<void>` — the response type is invisible to TypeScript. Return-style handlers make `Awaited<ReturnType<...>>` THE response type: the foundation for R2 (`KickRoutes.response` via `kick typegen`) and R3 (tRPC-style typed client). Also just less boilerplate, and the convention Hono/Elysia/h3 v2 users expect.

## Semantics (all runtimes identical)

| Handler outcome | Behavior |
|---|---|
| `ctx.*` responded | unchanged — return value ignored (ctx wins) |
| returns `undefined`/`void` | unchanged — exactly prior behavior |
| returns a value | auto `ctx.json(value)` → 200 |
| returns `reply(S, body)` | status `S` + json body; `reply.noContent()` → empty 204 |
| throws | unchanged — error pipeline |

`Reply` is branded via `Symbol.for` (survives duplicate module copies). `applyHandlerResult` lives in edge-safe `src/http/reply.ts` — no node imports, exported from both the main barrel and `/web`.

## Tests

644 passed — 19 new: the same six-case fixture (plain return, async return, `reply(201)`, `reply.noContent()`, ctx-wins-over-return, imperative-untouched) run as conformance across express/fastify/h3 via supertest, plus the web entry via `app.fetch(new Request(...))`.

Docs: controllers guide gains a "Return-Value Handlers" section. Changeset: minor.

Next: R2 — `kick/routes` typegen emits `response` (return-type first, `ctx.json` call-site fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Handlers can now return response data directly instead of always writing it imperatively.
  * Added status-aware reply helpers for common responses like created, accepted, and no content.
  * Return-based responses now work across multiple runtimes and the web entry.

* **Bug Fixes**
  * Existing direct response writes still take priority over returned values.
  * Returning `undefined` continues to preserve prior behavior.

* **Documentation**
  * Added guidance and examples for the new return-value handler pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->