### PR TITLE
feat(cli,kickjs): KickRoutes.response via type-reference emission (R2)

### DIFF
--- a/.changeset/routes-response-typegen.md
+++ b/.changeset/routes-response-typegen.md
@@ -1,0 +1,24 @@
+---
+'@forinda/kickjs': minor
+'@forinda/kickjs-cli': minor
+---
+
+feat: response type inference — `KickRoutes[...].response` is now real
+
+`kick typegen` emits each route's `response` as a type reference to the
+controller handler itself:
+
+```ts
+response: import('@forinda/kickjs').InferHandlerResponse<_C0['get']>
+```
+
+Your tsc computes the actual type — the scanner stays checker-free and
+watch-fast. Return-value handlers yield their exact payload
+(`Reply<201, Task>` unwraps to `Task`); imperative `ctx.json` handlers
+degrade to `unknown` exactly as before.
+
+- `@forinda/kickjs`: new `InferHandlerResponse<H>` type (exported from the
+  root, `/web`, and the http barrel)
+- `@forinda/kickjs-cli`: hoisted controller `import type` per (file, class),
+  default-export controllers use a `default as` binding;
+  `DiscoveredRoute.controllerIsDefaultExport` on both scan paths (AST + regex)

--- a/packages/cli/__tests__/render-routes-response.test.ts
+++ b/packages/cli/__tests__/render-routes-response.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { renderRoutes } from '../src/typegen/render/routes'
+import type { DiscoveredRoute } from '../src/typegen/scanner'
+
+/**
+ * R2 (response-inference-design.md): `KickRoutes[...].response` is emitted as
+ * a TYPE REFERENCE to the controller method — the consumer's tsc computes the
+ * actual type via InferHandlerResponse. The scanner stays checker-free.
+ */
+
+function route(partial: Partial<DiscoveredRoute>): DiscoveredRoute {
+  return {
+    controller: 'UsersController',
+    method: 'get',
+    httpMethod: 'GET',
+    path: '/:id',
+    pathParams: ['id'],
+    queryFilterable: null,
+    querySortable: null,
+    querySearchable: null,
+    bodySchema: null,
+    querySchema: null,
+    paramsSchema: null,
+    filePath: '/app/src/modules/users/users.controller.ts',
+    relativePath: 'modules/users/users.controller.ts',
+    ...partial,
+  }
+}
+
+const OUT = '/app/.kickjs/types/kick__routes.ts'
+
+describe('renderRoutes — response inference emission', () => {
+  it('emits an InferHandlerResponse reference + hoisted controller import', () => {
+    const src = renderRoutes([route({})], OUT, 'zod')
+    expect(src).toContain(
+      "import type { UsersController as _C0 } from '../../src/modules/users/users.controller'",
+    )
+    expect(src).toContain("response: import('@forinda/kickjs').InferHandlerResponse<_C0['get']>")
+  })
+
+  it('reuses one alias per controller across multiple routes', () => {
+    const src = renderRoutes(
+      [route({}), route({ method: 'list', path: '/', pathParams: [] })],
+      OUT,
+      'zod',
+    )
+    expect(src.match(/import type \{ UsersController as _C0 \}/g)).toHaveLength(1)
+    expect(src).toContain("InferHandlerResponse<_C0['get']>")
+    expect(src).toContain("InferHandlerResponse<_C0['list']>")
+  })
+
+  it('uses a default-import binding for export-default controllers', () => {
+    const src = renderRoutes([route({ controllerIsDefaultExport: true })], OUT, 'zod')
+    expect(src).toContain(
+      "import type { default as _C0 } from '../../src/modules/users/users.controller'",
+    )
+  })
+
+  it('separate controllers in separate files get separate aliases', () => {
+    const src = renderRoutes(
+      [
+        route({}),
+        route({
+          controller: 'TasksController',
+          method: 'create',
+          httpMethod: 'POST',
+          filePath: '/app/src/modules/tasks/tasks.controller.ts',
+          relativePath: 'modules/tasks/tasks.controller.ts',
+        }),
+      ],
+      OUT,
+      'zod',
+    )
+    expect(src).toContain('UsersController as _C0')
+    expect(src).toContain('TasksController as _C1')
+    expect(src).toContain("InferHandlerResponse<_C1['create']>")
+  })
+})

--- a/packages/cli/src/typegen/extract-ast.ts
+++ b/packages/cli/src/typegen/extract-ast.ts
@@ -592,6 +592,7 @@ export function extractFileAst(source: string, filePath: string, cwd: string): F
           paramsSchema: schemaFieldRef(options, 'params', ctx),
           filePath,
           relativePath: relPath,
+          controllerIsDefaultExport: discovered.isDefault,
         })
       }
     }

--- a/packages/cli/src/typegen/render/routes.ts
+++ b/packages/cli/src/typegen/render/routes.ts
@@ -62,6 +62,21 @@ export {}
   // silently degrades to `unknown` with `moduleResolution: 'bundler'`.)
   const schemaImports = new Map<string, { identifier: string; specifier: string }>()
 
+  // Hoisted controller type imports for response inference — one alias per
+  // (file, class). The consumer's tsc computes the response from the
+  // handler's return type via InferHandlerResponse; the scanner never runs
+  // a type checker (response-inference-design.md R2).
+  const controllerImports = new Map<string, string>()
+  const planControllerImport = (m: DiscoveredRoute): string => {
+    const key = `${m.filePath}::${m.controller}`
+    let alias = controllerImports.get(key)
+    if (!alias) {
+      alias = `_C${controllerImports.size}`
+      controllerImports.set(key, alias)
+    }
+    return alias
+  }
+
   const renderField = (
     schema: { identifier: string; source: string | null } | null,
     m: DiscoveredRoute,
@@ -123,6 +138,12 @@ export {}
       const paramsType = paramsSchemaType ?? urlParamsType
       const bodyType = bodySchemaType ?? 'unknown'
       const queryType = querySchemaType ?? renderQueryShape(m)
+      // Response inference: reference the handler's own type and let the
+      // consumer's tsc compute it — return-value handlers yield their exact
+      // payload (Reply<S, T> unwraps to T); imperative ctx.json handlers
+      // degrade to `unknown` inside InferHandlerResponse, same as before.
+      const controllerAlias = planControllerImport(m)
+      const responseType = `import('@forinda/kickjs').InferHandlerResponse<${controllerAlias}['${m.method}']>`
       const docLines = renderQueryDocLines(m)
       lines.push(
         `      /**`,
@@ -133,7 +154,7 @@ export {}
         `        params: ${paramsType}`,
         `        body: ${bodyType}`,
         `        query: ${queryType}`,
-        `        response: unknown`,
+        `        response: ${responseType}`,
         `      }`,
       )
     }
@@ -141,7 +162,24 @@ export {}
     interfaces.push(lines.join('\n'))
   }
 
-  const importBlock = renderSchemaImports(schemaImports)
+  // Controller type imports — same hoisting rationale as schema imports.
+  // `source: ''` semantics of resolveSchemaImportSpecifier point the
+  // specifier at the controller file itself.
+  const controllerImportLines: string[] = []
+  const routeByKey = new Map<string, DiscoveredRoute>()
+  for (const r of routes) routeByKey.set(`${r.filePath}::${r.controller}`, r)
+  for (const [key, alias] of controllerImports) {
+    const route = routeByKey.get(key)!
+    const specifier = resolveSchemaImportSpecifier('', route.filePath, routesOutFile)
+    const binding = route.controllerIsDefaultExport
+      ? `default as ${alias}`
+      : `${route.controller} as ${alias}`
+    controllerImportLines.push(`import type { ${binding} } from '${specifier}'`)
+  }
+  const controllerImportBlock =
+    controllerImportLines.length > 0 ? controllerImportLines.join('\n') + '\n' : ''
+
+  const importBlock = renderSchemaImports(schemaImports) + controllerImportBlock
   const interfaceBlock = interfaces.join('\n')
 
   return `${ROUTES_HEADER}${importBlock}

--- a/packages/cli/src/typegen/scanner.ts
+++ b/packages/cli/src/typegen/scanner.ts
@@ -92,6 +92,12 @@ export interface DiscoveredRoute {
   filePath: string
   /** Path relative to scan root, with forward slashes */
   relativePath: string
+  /**
+   * True when the controller class is `export default` — the response
+   * typegen hoists `import type { default as _Cn }` instead of a named
+   * import. Optional so regex-path extraction and old fixtures stay valid.
+   */
+  controllerIsDefaultExport?: boolean
 }
 
 /** A statically-resolved schema identifier reference */
@@ -996,6 +1002,7 @@ export function extractRoutesFromSource(
           : null,
         filePath,
         relativePath: relPath,
+        controllerIsDefaultExport: cls.isDefault,
       })
     }
   }

--- a/packages/kickjs/__tests__/infer-handler-response.test.ts
+++ b/packages/kickjs/__tests__/infer-handler-response.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expectTypeOf } from 'vitest'
+
+import type { InferHandlerResponse, Reply } from '../src/http/reply'
+import type { RequestContext } from '../src/http/context'
+
+/**
+ * Type-level contract for InferHandlerResponse — what `kick typegen` R2
+ * emits into `KickRoutes[...].response`. Purely compile-time.
+ */
+
+interface User {
+  id: string
+  name: string
+}
+
+describe('InferHandlerResponse (type-level)', () => {
+  it('infers plain and async return types', () => {
+    expectTypeOf<InferHandlerResponse<(ctx: RequestContext) => User>>().toEqualTypeOf<User>()
+    expectTypeOf<InferHandlerResponse<(ctx: RequestContext) => Promise<User[]>>>().toEqualTypeOf<
+      User[]
+    >()
+  })
+
+  it('unwraps Reply<S, T> to T', () => {
+    expectTypeOf<
+      InferHandlerResponse<(ctx: RequestContext) => Promise<Reply<201, User>>>
+    >().toEqualTypeOf<User>()
+  })
+
+  it('imperative void handlers stay unknown', () => {
+    expectTypeOf<InferHandlerResponse<(ctx: RequestContext) => void>>().toEqualTypeOf<unknown>()
+    expectTypeOf<
+      InferHandlerResponse<(ctx: RequestContext) => Promise<void>>
+    >().toEqualTypeOf<unknown>()
+  })
+
+  it('drops undefined members from mixed imperative/return handlers', () => {
+    expectTypeOf<
+      InferHandlerResponse<(ctx: RequestContext) => Promise<User | undefined>>
+    >().toEqualTypeOf<User>()
+  })
+
+  it('non-function inputs degrade to unknown', () => {
+    expectTypeOf<InferHandlerResponse<string>>().toEqualTypeOf<unknown>()
+  })
+})

--- a/packages/kickjs/src/http/index.ts
+++ b/packages/kickjs/src/http/index.ts
@@ -8,7 +8,7 @@ export { bootstrap } from './bootstrap'
 export { RequestContext, type ContextMeta, type Ctx, type RouteShape } from './context'
 
 // Return-value handlers — `return reply(201, body)` / plain returns auto-send
-export { reply, isReply, applyHandlerResult, type Reply } from './reply'
+export { reply, isReply, applyHandlerResult, type Reply, type InferHandlerResponse } from './reply'
 export { defineHttpContextDecorator } from './define-http-context-decorator'
 export type { TypedParsedQuery, FieldsOf } from './query'
 

--- a/packages/kickjs/src/http/reply.ts
+++ b/packages/kickjs/src/http/reply.ts
@@ -47,6 +47,28 @@ reply.accepted = <T>(body: T): Reply<202, T> => reply(202, body)
 /** Empty 204 — maps to `ctx.noContent()`. */
 reply.noContent = (): Reply<204, undefined> => reply(204, undefined)
 
+/**
+ * The statically-inferred response type of a controller handler — what
+ * `kick typegen` emits into `KickRoutes[...].response`:
+ *
+ * - `Awaited<ReturnType>` of the method
+ * - `Reply<S, T>` unwraps to `T`
+ * - `void`/`undefined` members are dropped (imperative `ctx.json` branches);
+ *   a handler that never returns a value stays `unknown`, matching the
+ *   pre-inference emission
+ *
+ * ```ts
+ * type R = InferHandlerResponse<UsersController['get']> // → User
+ * ```
+ */
+export type InferHandlerResponse<H> = H extends (...args: never[]) => infer R
+  ? [Exclude<Awaited<R>, void | undefined>] extends [never]
+    ? unknown
+    : UnwrapReply<Exclude<Awaited<R>, void | undefined>>
+  : unknown
+
+type UnwrapReply<A> = A extends Reply<number, infer B> ? B : A
+
 export function isReply(value: unknown): value is Reply {
   return (
     typeof value === 'object' &&

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -19,6 +19,15 @@ export { isClusterPrimary, type ClusterOptions } from './http/cluster'
 export { RequestContext, type Ctx, type RouteShape, type DeepReadonly } from './http/context'
 export { defineHttpContextDecorator } from './http/define-http-context-decorator'
 
+// Return-value handlers + response inference (response-inference-design.md)
+export {
+  reply,
+  isReply,
+  applyHandlerResult,
+  type Reply,
+  type InferHandlerResponse,
+} from './http/reply'
+
 export { buildRouteTable } from './http/router-builder'
 export type { BuildRoutesOptions } from './http/router-builder'
 export { buildRoutes, materializeRouter, expressRuntime } from './http/runtimes/express'

--- a/packages/kickjs/src/web.ts
+++ b/packages/kickjs/src/web.ts
@@ -33,7 +33,7 @@ import { normalizePath } from './core/path'
 export { WebRequestShim, WebResponseDriver } from './http/web/driver'
 export { compileWebRoute } from './http/web/handler'
 // Return-value handler helpers — edge consumers can't import the main barrel.
-export { reply, isReply, type Reply } from './http/reply'
+export { reply, isReply, type Reply, type InferHandlerResponse } from './http/reply'
 
 // Minimal structural surface of h3 v2 used here (kept local so this entry
 // never imports the node-coupled h3-web runtime module).


### PR DESCRIPTION
## Summary

R2 of the typed-response roadmap (`response-inference-design.md`): `kick typegen` now emits a **real `response` type** for every route in the `KickRoutes` augmentation — previously hardcoded `unknown`.

## How — type references, not a type checker

The scanner is oxc-based (pure syntax, no tsc). Instead of computing types at generation time, the render emits a **reference to the handler itself** and lets the consumer's tsc do the work:

```ts
import type { UsersController as _C0 } from '../../src/modules/users/users.controller'

// inside KickRoutes:
get: {
  params: { id: string }
  body: unknown
  query: unknown
  response: import('@forinda/kickjs').InferHandlerResponse<_C0['get']>
}
```

Zero generation-time cost, always exact, stays fresh under `kick dev` watch (the reference doesn't change when the handler's return type does — tsc recomputes).

## `InferHandlerResponse<H>` (new, `@forinda/kickjs`)

- `Awaited<ReturnType>` of the handler
- `Reply<S, T>` (R1's wrapper) unwraps to `T`
- `void`/`undefined` members dropped — mixed `return x` / `ctx.json` branches infer to `x`'s type
- Handlers that never return a value → `unknown` (exactly the pre-R2 emission; imperative style loses nothing)

Exported from the root, `/web`, and the http barrel. (Fixing the root export surfaced that R1's `reply` exports never reached the root index — the main index is selective, not `export *`. Fixed here; the CLI's fixture-tsc tests caught it.)

## CLI plumbing

- `DiscoveredRoute.controllerIsDefaultExport` threaded through **both** scan paths (AST + regex — the parity suite enforces they agree)
- Render hoists one `import type` alias per (file, controller); `export default class` controllers bind `default as _Cn`

## Tests

- CLI: 478 passed — 4 new render-emission cases (reference shape, alias reuse, default-export binding, multi-controller) + the existing scaffold/module/leaf fixture tests now **compile the emitted references with real tsc** end-to-end
- kickjs: 652 passed — 5 type-level `InferHandlerResponse` cases via `vitest --typecheck`

Changesets: minor × 2 (`@forinda/kickjs`, `@forinda/kickjs-cli`).

Next: R3 — typed client consuming `KickRoutes` (path-keyed fetch wrapper, RFC 9457-typed errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route response types are now inferred automatically from controller handlers, giving more accurate generated typings.
  * Response types for reply-based handlers are unwrapped to the returned payload type.
  * Type helpers for response inference are now available across the package exports.

* **Bug Fixes**
  * Improved generated output for controllers defined as default exports.
  * Kept handlers without a concrete return value safely typed as unknown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->