### PR TITLE
feat(client,cli): @forinda/kickjs-client — typed fetch client (R3)

### DIFF
--- a/.changeset/typed-client.md
+++ b/.changeset/typed-client.md
@@ -1,0 +1,24 @@
+---
+'@forinda/kickjs-client': minor
+'@forinda/kickjs-cli': minor
+---
+
+feat: `@forinda/kickjs-client` — typed fetch client (R3, closes the response-inference roadmap)
+
+`kick typegen` now also emits a flat `KickRoutes.Api` map (`'GET /tasks/:id'`
+keys referencing the controller route shapes). The new zero-dependency client
+consumes it:
+
+```ts
+import { createClient } from '@forinda/kickjs-client'
+
+const api = createClient<KickRoutes.Api>({ baseUrl: 'https://x/api/v1' })
+const task = await api.get('/tasks/:id', { params: { id: '42' } })
+//    ^ your handler's actual return type
+```
+
+- Paths, params and body constrained per verb at compile time; responses flow
+  from return-value handlers via `InferHandlerResponse`
+- Runtime-neutral (fetch/URL/Headers) — browsers, node, Bun, Deno, edge
+- `KickClientError` carries status + parsed RFC 9457 problem body
+- Injectable `fetch` — pass `createWebApp().fetch` for network-free tests

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -23,6 +23,7 @@ const guideSidebar = [
       { text: 'Modules', link: '/guide/modules' },
       { text: 'Controllers & Routes', link: '/guide/controllers' },
       { text: 'Type Generation', link: '/guide/typegen' },
+      { text: 'Typed Client', link: '/guide/typed-client' },
       { text: 'Middleware', link: '/guide/middleware' },
       { text: 'HTTP Runtimes (Express / Fastify / h3)', link: '/guide/http-runtimes' },
       { text: 'Edge Deployment (Workers / Bun / Deno)', link: '/guide/edge-deployment' },

--- a/docs/guide/typed-client.md
+++ b/docs/guide/typed-client.md
@@ -1,0 +1,88 @@
+# Typed Client
+
+`@forinda/kickjs-client` closes the type loop from controller to consumer: the
+frontend calls your API with **full autocomplete and inferred response types**,
+generated from the backend's own handlers — no duplicated interfaces, no drift.
+
+```bash
+pnpm add @forinda/kickjs-client
+```
+
+## The loop
+
+**1. Backend** — write [return-value handlers](./controllers.md#return-value-handlers):
+
+```ts
+@Controller()
+class TasksController {
+  @Get('/:id')
+  async get(ctx: RequestContext): Promise<Task> {
+    return this.tasks.find(ctx.params.id)
+  }
+
+  @Post('/', { body: createTaskSchema })
+  async create(ctx: RequestContext) {
+    return reply(201, await this.tasks.create(ctx.body))
+  }
+}
+```
+
+**2. `kick typegen`** (runs automatically under `kick dev`) emits the
+`KickRoutes.Api` map — verb+path keys with `params`/`body`/`query` from your
+Zod schemas and `response` inferred from each handler's return type.
+
+**3. Frontend** — one client, typed end to end:
+
+```ts
+import { createClient } from '@forinda/kickjs-client'
+
+const api = createClient<KickRoutes.Api>({
+  baseUrl: 'https://api.example.com/api/v1',
+  headers: () => ({ Authorization: `Bearer ${getToken()}` }),
+})
+
+const task = await api.get('/tasks/:id', { params: { id: '42' } }) // task: Task
+const made = await api.post('/tasks', { body: { title: 'Ship' } }) // made: Task
+```
+
+Wrong path, missing `params.id`, wrong body shape — all **compile errors**.
+
+## baseUrl and route keys
+
+`KickRoutes.Api` keys are **module-mount relative** (`'GET /tasks/:id'`); the
+bootstrap-level prefix and version (default `/api/v1`) go in `baseUrl`.
+
+## Errors
+
+Non-2xx responses throw `KickClientError` with `status`, the parsed `body`
+(RFC 9457 problem details when the server used `ctx.problem`), and the raw
+`Response`:
+
+```ts
+try {
+  await api.get('/tasks/:id', { params: { id: 'nope' } })
+} catch (e) {
+  if (e instanceof KickClientError && e.status === 404) showNotFound()
+}
+```
+
+## Network-free testing
+
+The client accepts a custom `fetch` — pass a
+[`createWebApp`](./edge-deployment.md) handler and integration-test the full
+stack in-process:
+
+```ts
+const app = createWebApp({ h3, modules })
+const api = createClient<KickRoutes.Api>({
+  baseUrl: 'http://test/api/v1',
+  fetch: (req) => app.fetch(req),
+})
+```
+
+## Notes
+
+- Query values pass through `URLSearchParams` (arrays append repeated keys).
+- `204` responses resolve to `undefined`.
+- Imperative `ctx.json` handlers infer `response: unknown` — switch them to
+  return-value style (or a `Reply`) for exact types.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -16,6 +16,7 @@
 - [Validation](https://kickjs.app/guide/validation.html): Zod / Valibot / Yup body, query, and param validation.
 - [Configuration](https://kickjs.app/guide/configuration.html): Typed env via `defineEnv`, `ConfigService`, `@Value`.
 - [Type Generation](https://kickjs.app/guide/typegen.html): `kick typegen` for fully-typed route params/body/query and env.
+- [Typed Client](https://kickjs.app/guide/typed-client.html): `@forinda/kickjs-client` — end-to-end response types from your handlers.
 - [Error Handling](https://kickjs.app/guide/error-handling.html): `HttpException`, RFC 9457 problem details, global error handler.
 
 ## Features

--- a/packages/cli/__tests__/render-routes-response.test.ts
+++ b/packages/cli/__tests__/render-routes-response.test.ts
@@ -76,3 +76,36 @@ describe('renderRoutes — response inference emission', () => {
     expect(src).toContain("InferHandlerResponse<_C1['create']>")
   })
 })
+
+describe('renderRoutes — KickRoutes.Api flat map', () => {
+  it('emits verb+path keys referencing the controller interfaces', () => {
+    const src = renderRoutes(
+      [route({}), route({ method: 'create', httpMethod: 'POST', path: '/', pathParams: [] })],
+      OUT,
+      'zod',
+    )
+    expect(src).toContain("'GET /:id': UsersController['get']")
+    expect(src).toContain("'POST /': UsersController['create']")
+    expect(src).toContain('interface Api {')
+  })
+
+  it('warns and keeps first on duplicate verb+path', () => {
+    const warnings: string[] = []
+    const src = renderRoutes(
+      [
+        route({}),
+        route({
+          controller: 'OtherController',
+          method: 'also',
+          filePath: '/app/src/other.controller.ts',
+        }),
+      ],
+      OUT,
+      'zod',
+      { onWarn: (w) => warnings.push(w) },
+    )
+    expect(src).toContain("'GET /:id': UsersController['get']")
+    expect(src).not.toContain("OtherController['also']")
+    expect(warnings.some((w) => w.includes('duplicate route'))).toBe(true)
+  })
+})

--- a/packages/cli/src/typegen/render/routes.ts
+++ b/packages/cli/src/typegen/render/routes.ts
@@ -162,6 +162,30 @@ export {}
     interfaces.push(lines.join('\n'))
   }
 
+  // Flat verb+path map for the typed client (`@forinda/kickjs-client`):
+  // `KickRoutes.Api['GET /users/:id']` → the same shape as the controller
+  // interface entry (referenced, not duplicated). Paths are module-mount
+  // relative — the client's `baseUrl` carries the bootstrap-level
+  // `/api/v{n}` prefix, which is not statically scannable.
+  const apiEntries: string[] = []
+  const seenApiKeys = new Set<string>()
+  for (const [controller, methods] of byController) {
+    for (const m of methods) {
+      const key = `${m.httpMethod} ${m.path}`
+      if (seenApiKeys.has(key)) {
+        opts.onWarn?.(
+          `duplicate route '${key}' (${controller}.${m.method}) — ` +
+            `KickRoutes.Api keeps the first registration; later ones are skipped.`,
+        )
+        continue
+      }
+      seenApiKeys.add(key)
+      apiEntries.push(`      '${key}': ${controller}['${m.method}']`)
+    }
+  }
+  const apiInterface = [`    interface Api {`, ...apiEntries, `    }`].join('\n')
+  interfaces.push(apiInterface)
+
   // Controller type imports — same hoisting rationale as schema imports.
   // `source: ''` semantics of resolveSchemaImportSpecifier point the
   // specifier at the controller file itself.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,0 +1,31 @@
+# @forinda/kickjs-client
+
+Typed fetch client for [KickJS](https://kickjs.app/) APIs — end-to-end response
+types powered by `kick typegen`'s `KickRoutes.Api` map.
+
+```bash
+pnpm add @forinda/kickjs-client
+```
+
+```ts
+import { createClient } from '@forinda/kickjs-client'
+
+const api = createClient<KickRoutes.Api>({ baseUrl: 'https://api.example.com/api/v1' })
+
+const task = await api.get('/tasks/:id', { params: { id: '42' } })
+//    ^ the handler's actual response type — inferred, not declared
+
+const created = await api.post('/tasks', { body: { title: 'Ship it' } })
+```
+
+- **Paths + params + body typed** from the generated `KickRoutes.Api`; response
+  types flow from your controller handlers (return-value style) via
+  `InferHandlerResponse`.
+- **Runtime-neutral**: fetch/URL/Headers only — browsers, node ≥ 20, Bun, Deno,
+  edge workers. Zero dependencies.
+- **Typed errors**: non-2xx throws `KickClientError` carrying the parsed body
+  (RFC 9457 problem details when the server used `ctx.problem`).
+- **Injectable fetch**: pass `{ fetch: app.fetch }` from `@forinda/kickjs/web`
+  for network-free integration tests.
+
+Docs: [kickjs.app/guide/typed-client](https://kickjs.app/guide/typed-client.html)

--- a/packages/client/__tests__/client.test.ts
+++ b/packages/client/__tests__/client.test.ts
@@ -1,0 +1,191 @@
+import 'reflect-metadata'
+import { describe, it, expect, expectTypeOf, beforeEach } from 'vitest'
+import * as h3v2 from 'h3-v2'
+
+import { createWebApp } from '@forinda/kickjs/web'
+import { Container } from '@forinda/kickjs/container'
+import { Controller, Get, Post, Delete } from '@forinda/kickjs/decorators'
+import { reply, type RequestContext, type InferHandlerResponse } from '@forinda/kickjs'
+
+import { createClient, KickClientError, type RouteShapeLike } from '../src/index'
+
+/**
+ * End-to-end: real decorated controllers served through `createWebApp`,
+ * consumed through the typed client with `fetch` injected — the full R1→R3
+ * loop, network-free. The hand-written Api map below mirrors what
+ * `kick typegen` emits into `KickRoutes.Api`.
+ */
+
+interface Task {
+  id: string
+  title: string
+}
+
+// What kick typegen would emit (KickRoutes.Api) for the fixture controller.
+interface Api {
+  'GET /tasks/:id': {
+    params: { id: string }
+    body: unknown
+    query: unknown
+    response: Task
+  }
+  'POST /tasks': {
+    params: Record<string, never>
+    body: { title: string }
+    query: unknown
+    response: Task
+  }
+  'DELETE /tasks/:id': {
+    params: { id: string }
+    body: unknown
+    query: unknown
+    response: unknown
+  }
+  'GET /tasks': {
+    params: Record<string, never>
+    body: unknown
+    query: unknown
+    response: Task[]
+  }
+}
+// Api entries must conform to the client's shape contract.
+type _check = Api[keyof Api] extends RouteShapeLike ? true : never
+
+function makeApp() {
+  @Controller()
+  class TasksController {
+    @Get('/:id')
+    async get(ctx: RequestContext): Promise<Task> {
+      return { id: ctx.params.id, title: `task ${ctx.params.id}` }
+    }
+
+    @Get('/')
+    async list(_ctx: RequestContext): Promise<Task[]> {
+      return [{ id: '1', title: 'one' }]
+    }
+
+    @Post('/')
+    async create(ctx: RequestContext) {
+      return reply(201, { id: 'new', title: (ctx.body as { title: string }).title })
+    }
+
+    @Delete('/:id')
+    async remove(ctx: RequestContext) {
+      if (ctx.params.id === 'missing') return ctx.notFound('no such task')
+      return reply.noContent()
+    }
+  }
+
+  return createWebApp({
+    h3: h3v2,
+    modules: [{ routes: () => ({ path: '/tasks', controller: TasksController }) } as never],
+  })
+}
+
+beforeEach(() => {
+  Container.reset()
+})
+
+describe('createClient — runtime against a real web app', () => {
+  function makeClient() {
+    const app = makeApp()
+    return createClient<Api>({
+      baseUrl: 'http://api.test/api/v1',
+      fetch: (req) => app.fetch(req),
+    })
+  }
+
+  it('GET with params — response typed and correct', async () => {
+    const api = makeClient()
+    const task = await api.get('/tasks/:id', { params: { id: '42' } })
+    expect(task).toEqual({ id: '42', title: 'task 42' })
+    expectTypeOf(task).toEqualTypeOf<Task>()
+  })
+
+  it('POST with body — 201 payload comes back typed', async () => {
+    const api = makeClient()
+    const created = await api.post('/tasks', { body: { title: 'ship it' } })
+    expect(created).toEqual({ id: 'new', title: 'ship it' })
+    expectTypeOf(created).toEqualTypeOf<Task>()
+  })
+
+  it('DELETE 204 resolves to undefined', async () => {
+    const api = makeClient()
+    await expect(api.delete('/tasks/:id', { params: { id: '9' } })).resolves.toBeUndefined()
+  })
+
+  it('non-2xx throws KickClientError carrying the body', async () => {
+    const api = makeClient()
+    const err = await api
+      .delete('/tasks/:id', { params: { id: 'missing' } })
+      .then(() => null)
+      .catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(KickClientError)
+    expect((err as KickClientError).status).toBe(404)
+  })
+
+  it('missing path params throw a clear client-side error', async () => {
+    const api = makeClient()
+    await expect(api.get('/tasks/:id', {} as never)).rejects.toThrow(/missing path param ':id'/)
+  })
+
+  it('query values serialize onto the URL', async () => {
+    let seenUrl = ''
+    const api = createClient<Api>({
+      baseUrl: 'http://api.test/api/v1',
+      fetch: (req) => {
+        seenUrl = req.url
+        return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+      },
+    })
+    await api.get('/tasks', { query: { sort: '-createdAt', tag: ['a', 'b'] } })
+    expect(seenUrl).toBe('http://api.test/api/v1/tasks?sort=-createdAt&tag=a&tag=b')
+  })
+
+  it('header factory runs per request', async () => {
+    let token = 't1'
+    let seen: string | null = null
+    const api = createClient<Api>({
+      baseUrl: 'http://x/api/v1',
+      headers: () => ({ authorization: `Bearer ${token}` }),
+      fetch: (req) => {
+        seen = req.headers.get('authorization')
+        return Promise.resolve(
+          new Response('[]', { headers: { 'content-type': 'application/json' } }),
+        )
+      },
+    })
+    await api.get('/tasks')
+    expect(seen).toBe('Bearer t1')
+    token = 't2'
+    await api.get('/tasks')
+    expect(seen).toBe('Bearer t2')
+  })
+})
+
+describe('createClient — type-level contract', () => {
+  // NEVER INVOKED — these closures exist purely for the type checker.
+  // Calling the client here would fire real fetches (unhandled rejections).
+  const api = createClient<Api>({ baseUrl: 'http://x' })
+
+  const _typeOnly = () => {
+    // @ts-expect-error — '/nope' is not a registered GET path
+    void api.get('/nope')
+    // @ts-expect-error — '/tasks/:id' is not registered under POST
+    void api.post('/tasks/:id')
+    // @ts-expect-error — params.id is required for '/tasks/:id'
+    void api.get('/tasks/:id')
+    // @ts-expect-error — body.title is required for POST /tasks
+    void api.post('/tasks', {})
+
+    expectTypeOf(api.get).parameter(0).toEqualTypeOf<'/tasks/:id' | '/tasks'>()
+    expectTypeOf(api.get('/tasks/:id', { params: { id: 'x' } })).resolves.toEqualTypeOf<Task>()
+    expectTypeOf(api.get('/tasks')).resolves.toEqualTypeOf<Task[]>()
+    expectTypeOf(api.post('/tasks', { body: { title: 't' } })).resolves.toEqualTypeOf<Task>()
+  }
+
+  it('type contract compiles (assertions live in the unexecuted closure)', () => {
+    expect(typeof _typeOnly).toBe('function')
+    expectTypeOf<InferHandlerResponse<(ctx: never) => Promise<Task>>>().toEqualTypeOf<Task>()
+  })
+})

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@forinda/kickjs-client",
+  "version": "0.0.0",
+  "description": "Typed fetch client for KickJS APIs — end-to-end response types from the kick typegen KickRoutes augmentation",
+  "keywords": [
+    "kickjs",
+    "typed-client",
+    "fetch",
+    "typescript",
+    "rpc",
+    "api-client"
+  ],
+  "type": "module",
+  "main": "dist/index.mjs",
+  "types": "dist/index.d.mts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.mts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsgo --noEmit",
+    "clean": "rm -rf dist .wireit"
+  },
+  "devDependencies": {
+    "@forinda/kickjs": "workspace:*",
+    "h3-v2": "npm:h3@2.0.1-rc.22",
+    "reflect-metadata": "^0.2.2",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "author": "Felix Orinda",
+  "engines": {
+    "node": ">=20.0"
+  },
+  "homepage": "https://kickjs.app/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/forinda/kick-js.git",
+    "directory": "packages/client"
+  },
+  "bugs": {
+    "url": "https://github.com/forinda/kick-js/issues"
+  }
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,0 +1,200 @@
+// @forinda/kickjs-client — typed fetch client for KickJS APIs.
+//
+// Consumes the flat `KickRoutes.Api` map that `kick typegen` emits
+// (response-inference-design.md R3): keys are `'METHOD /path'`, values are
+// the route shapes (`params` / `body` / `query` / `response`). The client is
+// a ~150-line fetch wrapper — every type below exists so the CALL SITE
+// infers exactly:
+//
+// ```ts
+// const api = createClient<KickRoutes.Api>({ baseUrl: 'https://x/api/v1' })
+// const task = await api.post('/tasks/:id', { params: { id }, body })
+// //    ^ the handler's actual response type
+// ```
+//
+// Runtime-neutral: fetch/URL/Headers only — browsers, node ≥ 20, Bun, Deno,
+// and edge workers (pairs with `@forinda/kickjs/web` on the server side).
+
+/** The per-route shape `kick typegen` emits into `KickRoutes.Api`. */
+export interface RouteShapeLike {
+  params: unknown
+  body: unknown
+  query: unknown
+  response: unknown
+}
+
+type ApiMap = Record<string, RouteShapeLike>
+
+/** HTTP verbs the route decorators produce. */
+export type ClientMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
+
+/** Paths in the map registered under a given verb. */
+type PathsFor<Api extends ApiMap, M extends ClientMethod> = {
+  [K in keyof Api]: K extends `${M} ${infer P}` ? P : never
+}[keyof Api]
+
+type ShapeOf<
+  Api extends ApiMap,
+  M extends ClientMethod,
+  P extends string,
+> = `${M} ${P}` extends keyof Api ? Api[`${M} ${P}`] : RouteShapeLike
+
+// Paramless routes emit `params: {}` and unschema'd bodies emit
+// `body: unknown` — both become OPTIONAL fields; a concrete shape is
+// required so forgetting `params` on `/users/:id` is a type error.
+type ParamsField<T> = unknown extends T
+  ? { params?: Record<string, string | number> }
+  : Record<string, never> extends T
+    ? { params?: T }
+    : { params: T }
+
+type BodyField<T> = unknown extends T ? { body?: unknown } : { body: T }
+
+export type RequestOptions<S extends RouteShapeLike> = {
+  /** Extra headers merged over the client-level ones. */
+  headers?: Record<string, string>
+  /** AbortSignal for cancellation. */
+  signal?: AbortSignal
+  /** Query string values — serialized with URLSearchParams. */
+  query?: Record<string, string | number | boolean | Array<string | number>>
+} & ParamsField<S['params']> &
+  BodyField<S['body']>
+
+export interface ClientOptions {
+  /**
+   * Base URL INCLUDING the mount prefix + version the server adds at
+   * bootstrap (default `/api/v1`) — `KickRoutes.Api` keys are module-mount
+   * relative: `'GET /users/:id'` + baseUrl `https://x/api/v1`.
+   */
+  baseUrl: string
+  /** Static headers, or a factory invoked per request (auth tokens). */
+  headers?:
+    | Record<string, string>
+    | (() => Record<string, string> | Promise<Record<string, string>>)
+  /**
+   * Custom fetch — inject a platform fetch, a mock, or a KickJS web app's
+   * own handler for network-free tests: `{ fetch: app.fetch }`.
+   */
+  fetch?: (request: Request) => Promise<Response>
+}
+
+/** Non-2xx responses throw this — carries the parsed body (RFC 9457 problem details when the server used `ctx.problem`). */
+export class KickClientError extends Error {
+  constructor(
+    readonly status: number,
+    readonly body: unknown,
+    readonly response: Response,
+  ) {
+    super(
+      typeof body === 'object' && body !== null && 'detail' in body
+        ? String((body as { detail: unknown }).detail)
+        : typeof body === 'object' && body !== null && 'error' in body
+          ? String((body as { error: unknown }).error)
+          : `Request failed with status ${status}`,
+    )
+    this.name = 'KickClientError'
+  }
+}
+
+export interface KickClient<Api extends ApiMap> {
+  get<P extends PathsFor<Api, 'GET'> & string>(
+    path: P,
+    options?: RequestOptions<ShapeOf<Api, 'GET', P>>,
+  ): Promise<ShapeOf<Api, 'GET', P>['response']>
+  post<P extends PathsFor<Api, 'POST'> & string>(
+    path: P,
+    options?: RequestOptions<ShapeOf<Api, 'POST', P>>,
+  ): Promise<ShapeOf<Api, 'POST', P>['response']>
+  put<P extends PathsFor<Api, 'PUT'> & string>(
+    path: P,
+    options?: RequestOptions<ShapeOf<Api, 'PUT', P>>,
+  ): Promise<ShapeOf<Api, 'PUT', P>['response']>
+  delete<P extends PathsFor<Api, 'DELETE'> & string>(
+    path: P,
+    options?: RequestOptions<ShapeOf<Api, 'DELETE', P>>,
+  ): Promise<ShapeOf<Api, 'DELETE', P>['response']>
+  patch<P extends PathsFor<Api, 'PATCH'> & string>(
+    path: P,
+    options?: RequestOptions<ShapeOf<Api, 'PATCH', P>>,
+  ): Promise<ShapeOf<Api, 'PATCH', P>['response']>
+}
+
+interface AnyRequestOptions {
+  headers?: Record<string, string>
+  signal?: AbortSignal
+  query?: Record<string, string | number | boolean | Array<string | number>>
+  params?: Record<string, string | number>
+  body?: unknown
+}
+
+/** Substitute `:param` segments; throw on any left unfilled. */
+function fillPath(path: string, params?: Record<string, string | number>): string {
+  const filled = path.replace(/:([A-Za-z0-9_]+)/g, (_, name: string) => {
+    const value = params?.[name]
+    if (value === undefined) {
+      throw new Error(`@forinda/kickjs-client: missing path param ':${name}' for '${path}'`)
+    }
+    return encodeURIComponent(String(value))
+  })
+  return filled
+}
+
+function buildQuery(
+  query?: Record<string, string | number | boolean | Array<string | number>>,
+): string {
+  if (!query) return ''
+  const qs = new URLSearchParams()
+  for (const [key, value] of Object.entries(query)) {
+    if (Array.isArray(value)) for (const v of value) qs.append(key, String(v))
+    else qs.append(key, String(value))
+  }
+  const s = qs.toString()
+  return s ? `?${s}` : ''
+}
+
+/**
+ * Create a typed client over a `KickRoutes.Api`-shaped map.
+ * Generic-only consumption — no runtime dependency on the generated file.
+ */
+export function createClient<Api extends ApiMap>(options: ClientOptions): KickClient<Api> {
+  const baseUrl = options.baseUrl.replace(/\/$/, '')
+  const doFetch = options.fetch ?? ((req: Request) => fetch(req))
+
+  async function run(method: ClientMethod, path: string, opts: AnyRequestOptions = {}) {
+    const clientHeaders =
+      typeof options.headers === 'function' ? await options.headers() : (options.headers ?? {})
+    const headers = new Headers({ ...clientHeaders, ...opts.headers })
+    const hasBody = opts.body !== undefined
+    if (hasBody && !headers.has('content-type')) {
+      headers.set('content-type', 'application/json')
+    }
+
+    const url = `${baseUrl}${fillPath(path, opts.params)}${buildQuery(opts.query)}`
+    const request = new Request(url, {
+      method,
+      headers,
+      body: hasBody ? JSON.stringify(opts.body) : undefined,
+      signal: opts.signal,
+    })
+
+    const response = await doFetch(request)
+    const contentType = response.headers.get('content-type') ?? ''
+    const body =
+      response.status === 204
+        ? undefined
+        : contentType.includes('json')
+          ? await response.json().catch(() => undefined)
+          : await response.text()
+
+    if (!response.ok) throw new KickClientError(response.status, body, response)
+    return body
+  }
+
+  return {
+    get: (path, opts) => run('GET', path, opts as AnyRequestOptions),
+    post: (path, opts) => run('POST', path, opts as AnyRequestOptions),
+    put: (path, opts) => run('PUT', path, opts as AnyRequestOptions),
+    delete: (path, opts) => run('DELETE', path, opts as AnyRequestOptions),
+    patch: (path, opts) => run('PATCH', path, opts as AnyRequestOptions),
+  } as KickClient<Api>
+}

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    // Runtime-neutral package (browsers/node/edge) — no node type surface;
+    // fetch/URL/Headers come from the DOM/ES libs.
+    "types": [],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src"]
+}

--- a/packages/client/tsconfig.test.json
+++ b/packages/client/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "baseUrl": ".",
+    "types": [],
+    "paths": {
+      "@forinda/kickjs-schema": ["src/index.ts"],
+      "@forinda/kickjs-schema/*": ["src/*"]
+    }
+  },
+  "include": ["src", "__tests__"]
+}

--- a/packages/client/tsdown.config.ts
+++ b/packages/client/tsdown.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsdown'
+import { createBanner, readPkg } from '../../build.utils.mjs'
+
+const pkg = readPkg(import.meta.dirname)
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm'],
+  // Neutral platform: the client runs in browsers, node, and edge — zero
+  // node APIs, zero dependencies, fetch/URL/Headers only.
+  platform: 'neutral',
+  minify: { compress: true, mangle: false },
+  dts: { tsgo: true },
+  external: [],
+  banner: { js: createBanner(pkg.name, pkg.version) },
+})

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config'
+import swc from 'unplugin-swc'
+
+export default defineConfig({
+  plugins: [
+    swc.vite({
+      jsc: {
+        parser: { syntax: 'typescript', decorators: true },
+        transform: { legacyDecorator: true, decoratorMetadata: true },
+      },
+    }),
+  ],
+  test: {
+    typecheck: { tsconfig: './tsconfig.test.json' },
+    environment: 'node',
+    include: ['__tests__/**/*.test.ts'],
+    globals: false,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,24 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/client:
+    devDependencies:
+      '@forinda/kickjs':
+        specifier: workspace:*
+        version: link:../kickjs
+      h3-v2:
+        specifier: npm:h3@2.0.1-rc.22
+        version: h3@2.0.1-rc.22
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(vite@8.1.3(@types/node@25.9.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/db:
     dependencies:
       '@forinda/kickjs-cli-kit':


### PR DESCRIPTION
## Summary

R3 — final phase of `response-inference-design.md`: **`@forinda/kickjs-client`**, a typed fetch client consuming the new flat `KickRoutes.Api` map `kick typegen` now emits. The full loop is closed:

```ts
// backend (R1)
@Get('/:id')
async get(ctx: RequestContext): Promise<Task> { return this.tasks.find(ctx.params.id) }

// kick typegen (R2 + this PR) → KickRoutes.Api['GET /tasks/:id'].response = Task

// frontend (R3)
const api = createClient<KickRoutes.Api>({ baseUrl: 'https://x/api/v1' })
const task = await api.get('/tasks/:id', { params: { id: '42' } })  // task: Task
```

Wrong path, missing `params.id`, wrong body shape — compile errors.

## New package: `@forinda/kickjs-client`

- **Zero dependencies, runtime-neutral** (`platform: 'neutral'`, `types: []`) — fetch/URL/Headers only: browsers, node ≥ 20, Bun, Deno, edge
- Per-verb path constraint via template-literal types; `params` required when the route has them, optional for `{}`; `body` required when schema-typed
- Non-2xx → `KickClientError` with `status` + parsed body (RFC 9457 problem details from `ctx.problem`) + raw `Response`
- `headers` as static object or per-request (async) factory; injectable `fetch` — **`{ fetch: app.fetch }` from `createWebApp` gives network-free full-stack tests**, which is exactly how this PR's e2e suite works

## CLI: `KickRoutes.Api` emission

The routes render adds a flat interface referencing the existing controller shapes (no duplication):

```ts
interface Api {
  'GET /tasks/:id': TasksController['get']
  'POST /tasks': TasksController['create']
}
```

Keys are module-mount relative — the bootstrap-level `/api/v{n}` prefix isn't statically scannable, so it lives in the client's `baseUrl`. Duplicate verb+path pairs warn and keep the first registration.

## Docs

`guide/typed-client.md` (the vision doc's DX, now real) + sidebar + llms.txt + package README.

## Tests

- Client: 8 — e2e through a **real decorated controller served by `createWebApp`** (typed GET/POST, 204→`undefined`, 404→`KickClientError`, missing-param client error, query serialization, header factory) + type-level contract under `--typecheck` with `@ts-expect-error` misuse cases
- CLI: render suite extended (Api-map shape, duplicate handling); 480 total green
- Turbo: 48/48 tasks

Changesets: `@forinda/kickjs-client` (first publish) + `@forinda/kickjs-cli` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
