### PR TITLE
feat(client): typed query strings + createTestClient

### DIFF
--- a/.changeset/client-typed-query-test-helper.md
+++ b/.changeset/client-typed-query-test-helper.md
@@ -1,0 +1,13 @@
+---
+'@forinda/kickjs-client': minor
+---
+
+feat: typed query strings + `createTestClient`
+
+- Routes with a statically-known query shape (Zod `query` schema or
+  `@ApiQueryParams`) now constrain `query` at the call site — sort fields
+  autocomplete (`'-createdAt' | 'createdAt' | …`), typos are compile errors.
+  Routes without one keep the loose record type.
+- `createTestClient(app)` wraps any web-standard app (`createWebApp` result)
+  for network-free, fully-typed integration tests; `baseUrl` defaults to
+  `http://test/api/v1`.

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -2,6 +2,22 @@
 
 The `@forinda/kickjs-testing` package provides utilities for integration testing KickJS applications. Works with Vitest and supertest.
 
+## Typed API tests with the client
+
+For request-level integration tests, [`@forinda/kickjs-client`](./typed-client.md)'s
+`createTestClient` drives a [`createWebApp`](./edge-deployment.md) app in-process —
+typed end to end, no ports, no supertest:
+
+```ts
+import { createTestClient } from '@forinda/kickjs-client'
+import { createWebApp } from '@forinda/kickjs/web'
+
+const app = createWebApp({ h3, modules })
+const api = createTestClient<KickRoutes.Api>(app)
+
+const created = await api.post('/tasks', { body: { title: 'x' } }) // created: Task
+```
+
 ## Setup
 
 ```bash

--- a/docs/guide/typed-client.md
+++ b/docs/guide/typed-client.md
@@ -66,19 +66,35 @@ try {
 }
 ```
 
-## Network-free testing
+## Typed query strings
 
-The client accepts a custom `fetch` — pass a
-[`createWebApp`](./edge-deployment.md) handler and integration-test the full
-stack in-process:
+Routes with a statically-known query shape — a Zod `query` schema or an
+`@ApiQueryParams` config — constrain `query` at the call site:
 
 ```ts
-const app = createWebApp({ h3, modules })
-const api = createClient<KickRoutes.Api>({
-  baseUrl: 'http://test/api/v1',
-  fetch: (req) => app.fetch(req),
-})
+await api.get('/tasks', { query: { sort: '-createdAt' } }) // sort autocompletes
+await api.get('/tasks', { query: { sort: 'created' } }) // ✗ compile error
 ```
+
+Routes without one accept a loose `Record<string, string | number | boolean | array>`.
+
+## Network-free testing
+
+`createTestClient` wraps any web-standard app (a
+[`createWebApp`](./edge-deployment.md) result) for in-process, fully-typed
+integration tests — no server, no ports:
+
+```ts
+import { createTestClient } from '@forinda/kickjs-client'
+
+const app = createWebApp({ h3, modules })
+const api = createTestClient<KickRoutes.Api>(app)
+
+expect(await api.get('/tasks/:id', { params: { id: '1' } })).toEqual(task)
+```
+
+`baseUrl` defaults to `http://test/api/v1`; pass
+`{ baseUrl: 'http://test/custom/v2' }` for non-default prefixes.
 
 ## Notes
 

--- a/packages/client/__tests__/client.test.ts
+++ b/packages/client/__tests__/client.test.ts
@@ -7,7 +7,7 @@ import { Container } from '@forinda/kickjs/container'
 import { Controller, Get, Post, Delete } from '@forinda/kickjs/decorators'
 import { reply, type RequestContext, type InferHandlerResponse } from '@forinda/kickjs'
 
-import { createClient, KickClientError, type RouteShapeLike } from '../src/index'
+import { createClient, createTestClient, KickClientError, type RouteShapeLike } from '../src/index'
 
 /**
  * End-to-end: real decorated controllers served through `createWebApp`,
@@ -44,7 +44,7 @@ interface Api {
   'GET /tasks': {
     params: Record<string, never>
     body: unknown
-    query: unknown
+    query: { filter?: string | string[]; sort?: 'createdAt' | '-createdAt'; q?: string }
     response: Task[]
   }
 }
@@ -138,8 +138,8 @@ describe('createClient — runtime against a real web app', () => {
         return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
       },
     })
-    await api.get('/tasks', { query: { sort: '-createdAt', tag: ['a', 'b'] } })
-    expect(seenUrl).toBe('http://api.test/api/v1/tasks?sort=-createdAt&tag=a&tag=b')
+    await api.get('/tasks', { query: { sort: '-createdAt', filter: ['a', 'b'] } })
+    expect(seenUrl).toBe('http://api.test/api/v1/tasks?sort=-createdAt&filter=a&filter=b')
   })
 
   it('header factory runs per request', async () => {
@@ -178,6 +178,9 @@ describe('createClient — type-level contract', () => {
     // @ts-expect-error — body.title is required for POST /tasks
     void api.post('/tasks', {})
 
+    // @ts-expect-error — 'created' is not a sortable field on GET /tasks
+    void api.get('/tasks', { query: { sort: 'created' } })
+
     expectTypeOf(api.get).parameter(0).toEqualTypeOf<'/tasks/:id' | '/tasks'>()
     expectTypeOf(api.get('/tasks/:id', { params: { id: 'x' } })).resolves.toEqualTypeOf<Task>()
     expectTypeOf(api.get('/tasks')).resolves.toEqualTypeOf<Task[]>()
@@ -187,5 +190,25 @@ describe('createClient — type-level contract', () => {
   it('type contract compiles (assertions live in the unexecuted closure)', () => {
     expect(typeof _typeOnly).toBe('function')
     expectTypeOf<InferHandlerResponse<(ctx: never) => Promise<Task>>>().toEqualTypeOf<Task>()
+  })
+})
+
+describe('createTestClient — network-free harness', () => {
+  it('wraps a web app with the default test baseUrl', async () => {
+    const api = createTestClient<Api>(makeApp())
+    const task = await api.get('/tasks/:id', { params: { id: '7' } })
+    expect(task).toEqual({ id: '7', title: 'task 7' })
+    expectTypeOf(task).toEqualTypeOf<Task>()
+  })
+
+  it('honors a custom baseUrl for non-default prefixes', async () => {
+    const app = makeApp()
+    let seenUrl = ''
+    const api = createTestClient<Api>(
+      { fetch: (r) => ((seenUrl = r.url), app.fetch(r)) },
+      { baseUrl: 'http://edge/api/v1' },
+    )
+    await api.get('/tasks')
+    expect(seenUrl).toBe('http://edge/api/v1/tasks')
   })
 })

--- a/packages/client/__tests__/client.test.ts
+++ b/packages/client/__tests__/client.test.ts
@@ -201,6 +201,13 @@ describe('createTestClient — network-free harness', () => {
     expectTypeOf(task).toEqualTypeOf<Task>()
   })
 
+  it('an explicit undefined baseUrl keeps the default (spread-order regression)', async () => {
+    const app = makeApp()
+    const api = createTestClient<Api>(app, { baseUrl: undefined })
+    const task = await api.get('/tasks/:id', { params: { id: '3' } })
+    expect(task).toEqual({ id: '3', title: 'task 3' })
+  })
+
   it('honors a custom baseUrl for non-default prefixes', async () => {
     const app = makeApp()
     let seenUrl = ''

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -50,15 +50,22 @@ type ParamsField<T> = unknown extends T
 
 type BodyField<T> = unknown extends T ? { body?: unknown } : { body: T }
 
+/** Loose fallback for routes without a statically-known query shape. */
+type LooseQuery = Record<string, string | number | boolean | Array<string | number>>
+
+// Routes with a typegen-known query shape (Zod schema or the
+// @ApiQueryParams-derived filter/sort/q/page/limit object) constrain
+// `query` — sort fields autocomplete as '-createdAt' | 'createdAt' | …
+type QueryField<T> = unknown extends T ? { query?: LooseQuery } : { query?: T }
+
 export type RequestOptions<S extends RouteShapeLike> = {
   /** Extra headers merged over the client-level ones. */
   headers?: Record<string, string>
   /** AbortSignal for cancellation. */
   signal?: AbortSignal
-  /** Query string values — serialized with URLSearchParams. */
-  query?: Record<string, string | number | boolean | Array<string | number>>
 } & ParamsField<S['params']> &
-  BodyField<S['body']>
+  BodyField<S['body']> &
+  QueryField<S['query']>
 
 export interface ClientOptions {
   /**
@@ -122,7 +129,7 @@ export interface KickClient<Api extends ApiMap> {
 interface AnyRequestOptions {
   headers?: Record<string, string>
   signal?: AbortSignal
-  query?: Record<string, string | number | boolean | Array<string | number>>
+  query?: Record<string, unknown>
   params?: Record<string, string | number>
   body?: unknown
 }
@@ -139,12 +146,11 @@ function fillPath(path: string, params?: Record<string, string | number>): strin
   return filled
 }
 
-function buildQuery(
-  query?: Record<string, string | number | boolean | Array<string | number>>,
-): string {
+function buildQuery(query?: Record<string, unknown>): string {
   if (!query) return ''
   const qs = new URLSearchParams()
   for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null) continue
     if (Array.isArray(value)) for (const v of value) qs.append(key, String(v))
     else qs.append(key, String(value))
   }
@@ -197,4 +203,32 @@ export function createClient<Api extends ApiMap>(options: ClientOptions): KickCl
     delete: (path, opts) => run('DELETE', path, opts as AnyRequestOptions),
     patch: (path, opts) => run('PATCH', path, opts as AnyRequestOptions),
   } as KickClient<Api>
+}
+
+/** Anything with a web-standard fetch — a `createWebApp()` result, a Worker, a mock. */
+export interface FetchLike {
+  fetch(request: Request): Promise<Response>
+}
+
+/**
+ * Typed client over an in-process app — network-free full-stack tests:
+ *
+ * ```ts
+ * const app = createWebApp({ h3, modules })
+ * const api = createTestClient<KickRoutes.Api>(app)
+ * expect(await api.get('/tasks/:id', { params: { id: '1' } })).toEqual(...)
+ * ```
+ *
+ * `baseUrl` defaults to `http://test/api/v1` (the bootstrap default prefix);
+ * override it when the server uses a custom `apiPrefix`/version.
+ */
+export function createTestClient<Api extends ApiMap>(
+  app: FetchLike,
+  options: Omit<ClientOptions, 'fetch' | 'baseUrl'> & { baseUrl?: string } = {},
+): KickClient<Api> {
+  return createClient<Api>({
+    baseUrl: options.baseUrl ?? 'http://test/api/v1',
+    ...options,
+    fetch: (request) => app.fetch(request),
+  })
 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -227,8 +227,10 @@ export function createTestClient<Api extends ApiMap>(
   options: Omit<ClientOptions, 'fetch' | 'baseUrl'> & { baseUrl?: string } = {},
 ): KickClient<Api> {
   return createClient<Api>({
-    baseUrl: options.baseUrl ?? 'http://test/api/v1',
     ...options,
+    // AFTER the spread — an explicit `baseUrl: undefined` key in options
+    // must not clobber the default (spread copies undefined-valued keys).
+    baseUrl: options.baseUrl ?? 'http://test/api/v1',
     fetch: (request) => app.fetch(request),
   })
 }


### PR DESCRIPTION
## Summary

Two follow-ups rounding out the typed client shipped in #446.

## 1 — Typed query strings

`KickRoutes.Api` already carried each route's query shape (Zod schema or the `@ApiQueryParams`-derived `filter/sort/q/page/limit` object) — the client just ignored it. Now `query` is constrained by the map:

```ts
await api.get('/tasks', { query: { sort: '-createdAt' } }) // autocompletes the sort union
await api.get('/tasks', { query: { sort: 'created' } })    // ✗ compile error
```

Routes without a known shape keep the loose record. Runtime serialization now also skips `null`/`undefined` values.

## 2 — `createTestClient`

The network-free testing pattern from the #446 test suite, promoted to API:

```ts
const app = createWebApp({ h3, modules })
const api = createTestClient<KickRoutes.Api>(app)   // baseUrl defaults to http://test/api/v1
expect(await api.post('/tasks', { body: { title: 'x' } })).toEqual(...)
```

Lives in `@forinda/kickjs-client` (takes a structural `{ fetch }` — zero server imports, `@forinda/kickjs-testing` stays dependency-free).

## Tests & docs

10 passed under `--typecheck` — new `@ts-expect-error` case for an invalid sort field, `createTestClient` round-trip + custom-baseUrl cases. Docs: typed-client guide gains "Typed query strings" + rewritten testing section; testing guide links the pattern.

Changeset: `@forinda/kickjs-client` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger typing for API query parameters, with autocomplete and compile-time errors for invalid values when query shapes are known.
  * Introduced a new in-process test client for network-free, fully typed integration tests, with a default test base URL and support for custom prefixes.

* **Documentation**
  * Updated testing and typed client guides with examples and guidance for the new query typing and test client workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->