### PR TITLE
fix(cli,client): KickRoutes.Api keys use mount-joined paths

### DIFF
--- a/.changeset/api-map-mounted-paths.md
+++ b/.changeset/api-map-mounted-paths.md
@@ -1,0 +1,26 @@
+---
+'@forinda/kickjs-cli': patch
+'@forinda/kickjs-client': patch
+'@forinda/kickjs': patch
+---
+
+fix: `KickRoutes.Api` keys are now module-mount-joined paths
+
+The flat client map keyed on the bare decorator path (`'GET /:id'`) instead of
+the mounted path (`'GET /tasks/:id'`) — every mounted controller's typed calls
+404'd, and multi-resource apps collided on `/:id`-style keys with routes
+silently dropped. Fixed by threading `DiscoveredRoute.mountedPath` through both
+scan paths (AST + regex, parity preserved).
+
+Also from the same review pass:
+
+- fresh projects with zero routes now still emit an empty `KickRoutes.Api`, so
+  `createClient<KickRoutes.Api>` compiles before the first controller exists
+- a controller class named `Api` now triggers a typegen warning (it would
+  declaration-merge into the reserved flat map)
+- duplicate-route warnings now say what they mean (a genuine runtime verb+path
+  conflict) instead of firing false positives across controllers
+- client: `ShapeOf` fallback is `never` (was all-`unknown`) — generator/client
+  key drift fails loudly at the call site instead of silently untyping calls
+- kickjs: `KickRoutes` doc comment updated for the `Api` member + the actual
+  generated filename

--- a/packages/cli/__tests__/render-routes-response.test.ts
+++ b/packages/cli/__tests__/render-routes-response.test.ts
@@ -23,6 +23,7 @@ function route(partial: Partial<DiscoveredRoute>): DiscoveredRoute {
     paramsSchema: null,
     filePath: '/app/src/modules/users/users.controller.ts',
     relativePath: 'modules/users/users.controller.ts',
+    mountedPath: '/users/:id',
     ...partial,
   }
 }
@@ -78,18 +79,69 @@ describe('renderRoutes — response inference emission', () => {
 })
 
 describe('renderRoutes — KickRoutes.Api flat map', () => {
-  it('emits verb+path keys referencing the controller interfaces', () => {
+  it('emits MOUNTED verb+path keys referencing the controller interfaces', () => {
     const src = renderRoutes(
-      [route({}), route({ method: 'create', httpMethod: 'POST', path: '/', pathParams: [] })],
+      [
+        route({}),
+        route({
+          method: 'create',
+          httpMethod: 'POST',
+          path: '/',
+          pathParams: [],
+          mountedPath: '/users',
+        }),
+      ],
       OUT,
       'zod',
     )
-    expect(src).toContain("'GET /:id': UsersController['get']")
-    expect(src).toContain("'POST /': UsersController['create']")
+    expect(src).toContain("'GET /users/:id': UsersController['get']")
+    expect(src).toContain("'POST /users': UsersController['create']")
     expect(src).toContain('interface Api {')
   })
 
-  it('warns and keeps first on duplicate verb+path', () => {
+  it('falls back to the bare path when mountedPath is absent (old fixtures)', () => {
+    const src = renderRoutes([route({ mountedPath: undefined })], OUT, 'zod')
+    expect(src).toContain("'GET /:id': UsersController['get']")
+  })
+
+  it('same decorator path under different mounts does NOT collide', () => {
+    const warnings: string[] = []
+    const src = renderRoutes(
+      [
+        route({}),
+        route({
+          controller: 'TasksController',
+          method: 'get',
+          filePath: '/app/src/modules/tasks/tasks.controller.ts',
+          mountedPath: '/tasks/:id',
+        }),
+      ],
+      OUT,
+      'zod',
+      { onWarn: (w) => warnings.push(w) },
+    )
+    expect(src).toContain("'GET /users/:id': UsersController['get']")
+    expect(src).toContain("'GET /tasks/:id': TasksController['get']")
+    expect(warnings).toEqual([])
+  })
+
+  it('empty routes still emit an (empty) KickRoutes.Api', () => {
+    const src = renderRoutes([], OUT, 'zod')
+    expect(src).toContain('interface Api {}')
+  })
+
+  it("warns when a controller is named 'Api' (reserved for the flat map)", () => {
+    const warnings: string[] = []
+    renderRoutes(
+      [route({ controller: 'Api', filePath: '/app/src/api.controller.ts' })],
+      OUT,
+      'zod',
+      { onWarn: (w) => warnings.push(w) },
+    )
+    expect(warnings.some((w) => w.includes('reserved KickRoutes.Api'))).toBe(true)
+  })
+
+  it('warns and keeps first on a REAL duplicate (same mounted verb+path)', () => {
     const warnings: string[] = []
     const src = renderRoutes(
       [
@@ -98,13 +150,14 @@ describe('renderRoutes — KickRoutes.Api flat map', () => {
           controller: 'OtherController',
           method: 'also',
           filePath: '/app/src/other.controller.ts',
+          mountedPath: '/users/:id',
         }),
       ],
       OUT,
       'zod',
       { onWarn: (w) => warnings.push(w) },
     )
-    expect(src).toContain("'GET /:id': UsersController['get']")
+    expect(src).toContain("'GET /users/:id': UsersController['get']")
     expect(src).not.toContain("OtherController['also']")
     expect(warnings.some((w) => w.includes('duplicate route'))).toBe(true)
   })

--- a/packages/cli/__tests__/scanner-mount-path-params.test.ts
+++ b/packages/cli/__tests__/scanner-mount-path-params.test.ts
@@ -108,6 +108,20 @@ describe('forinda/kick-js#235 §3 — extractRoutesFromSource combines mount pat
     expect(byMethod.get('disable')).toEqual(['code', 'id'])
   })
 
+  it('mountedPath carries the mount-joined path for KickRoutes.Api keys', () => {
+    const mounts = new Map([['ExtensionsController', '/control/orgs/:id/extensions']])
+    const routes = extractRoutesFromSource(controllerSource, cls.filePath, FAKE_CWD, [cls], mounts)
+    const byMethod = new Map(routes.map((r) => [r.method, r.mountedPath]))
+    // @Delete('/:code') under the mount → full joined path, not the bare '/:code'.
+    expect(byMethod.get('disable')).toBe('/control/orgs/:id/extensions/:code')
+  })
+
+  it('mountedPath falls back to the own path with no mount map', () => {
+    const routes = extractRoutesFromSource(controllerSource, cls.filePath, FAKE_CWD, [cls])
+    const disable = routes.find((r) => r.method === 'disable')
+    expect(disable?.mountedPath).toBe('/:code')
+  })
+
   it('mount path without params is a no-op — base case stays unaffected', () => {
     const mounts = new Map([['ExtensionsController', '/static-prefix']])
     const routes = extractRoutesFromSource(controllerSource, cls.filePath, FAKE_CWD, [cls], mounts)

--- a/packages/cli/src/typegen/extract-ast.ts
+++ b/packages/cli/src/typegen/extract-ast.ts
@@ -593,6 +593,10 @@ export function extractFileAst(source: string, filePath: string, cwd: string): F
           filePath,
           relativePath: relPath,
           controllerIsDefaultExport: discovered.isDefault,
+          // Per-file contract: own path only (parity with the regex
+          // extractor's empty-mount default); joinExtracts overwrites with
+          // the cross-file mount-joined path.
+          mountedPath: path,
         })
       }
     }

--- a/packages/cli/src/typegen/render/routes.ts
+++ b/packages/cli/src/typegen/render/routes.ts
@@ -41,7 +41,11 @@ export function renderRoutes(
 //  @Get/@Post/@Put/@Delete/@Patch and re-run \`kick typegen\`)
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace KickRoutes {}
+  namespace KickRoutes {
+    // Always present so \`createClient<KickRoutes.Api>\` compiles before the
+    // first route exists (fresh project / pre-controller typegen runs).
+    interface Api {}
+  }
 }
 
 export {}
@@ -169,13 +173,24 @@ export {}
   // `/api/v{n}` prefix, which is not statically scannable.
   const apiEntries: string[] = []
   const seenApiKeys = new Set<string>()
+  // 'Api' is reserved for the flat map below — a user controller class named
+  // Api would declaration-merge its methods into the client map silently.
+  if (byController.has('Api')) {
+    opts.onWarn?.(
+      `controller class 'Api' collides with the reserved KickRoutes.Api client map — ` +
+        `its interface declaration-merges into the flat route map. Rename the controller.`,
+    )
+  }
   for (const [controller, methods] of byController) {
     for (const m of methods) {
-      const key = `${m.httpMethod} ${m.path}`
+      // Mount-joined path — the bare decorator path would collide across
+      // controllers ('GET /:id' everywhere) and 404 against real URLs.
+      const key = `${m.httpMethod} ${m.mountedPath ?? m.path}`
       if (seenApiKeys.has(key)) {
         opts.onWarn?.(
-          `duplicate route '${key}' (${controller}.${m.method}) — ` +
-            `KickRoutes.Api keeps the first registration; later ones are skipped.`,
+          `duplicate route '${key}' (${controller}.${m.method}) — two handlers claim the same ` +
+            `verb+path at runtime. KickRoutes.Api keeps the first (scan order, which may not match ` +
+            `runtime dispatch); resolve the conflict in the modules.`,
         )
         continue
       }

--- a/packages/cli/src/typegen/scanner.ts
+++ b/packages/cli/src/typegen/scanner.ts
@@ -98,6 +98,14 @@ export interface DiscoveredRoute {
    * import. Optional so regex-path extraction and old fixtures stay valid.
    */
   controllerIsDefaultExport?: boolean
+  /**
+   * Module-mount-joined path (`/tasks/:id` for a controller mounted at
+   * `/tasks` with `@Get('/:id')`). Excludes the bootstrap `/api/v{n}`
+   * prefix (not statically scannable). The KickRoutes.Api flat map keys
+   * on this — the bare `path` would collide across controllers and 404
+   * against real URLs. Optional for old fixtures; falls back to `path`.
+   */
+  mountedPath?: string
 }
 
 /** A statically-resolved schema identifier reference */
@@ -1003,6 +1011,7 @@ export function extractRoutesFromSource(
         filePath,
         relativePath: relPath,
         controllerIsDefaultExport: cls.isDefault,
+        mountedPath: fullPath,
       })
     }
   }
@@ -1631,9 +1640,9 @@ function joinExtracts(files: string[], extracts: (FileExtract | null)[]): Omit<S
       const mountPath = mountPathByController.get(route.controller)
       if (mountPath) {
         const fullPath = joinMountPath(mountPath, route.path)
-        routes.push({ ...route, pathParams: extractPathParams(fullPath) })
+        routes.push({ ...route, pathParams: extractPathParams(fullPath), mountedPath: fullPath })
       } else {
-        routes.push(route)
+        routes.push({ ...route, mountedPath: route.mountedPath ?? route.path })
       }
     }
   }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -15,7 +15,12 @@
 // Runtime-neutral: fetch/URL/Headers only — browsers, node ≥ 20, Bun, Deno,
 // and edge workers (pairs with `@forinda/kickjs/web` on the server side).
 
-/** The per-route shape `kick typegen` emits into `KickRoutes.Api`. */
+/**
+ * The per-route shape `kick typegen` emits into `KickRoutes.Api`.
+ * Deliberately re-declares (NOT imports) @forinda/kickjs's `RouteShape`:
+ * frontends installing this client must never need the server package.
+ * Keep the field list in sync with `RouteShape` in kickjs http/context.ts.
+ */
 export interface RouteShapeLike {
   params: unknown
   body: unknown
@@ -33,11 +38,14 @@ type PathsFor<Api extends ApiMap, M extends ClientMethod> = {
   [K in keyof Api]: K extends `${M} ${infer P}` ? P : never
 }[keyof Api]
 
+// Fallback is `never` ON PURPOSE: P is already constrained to PathsFor, so a
+// failed key lookup means the map and the client's key math drifted — that
+// must fail loudly at the call site, not silently degrade to unknown.
 type ShapeOf<
   Api extends ApiMap,
   M extends ClientMethod,
   P extends string,
-> = `${M} ${P}` extends keyof Api ? Api[`${M} ${P}`] : RouteShapeLike
+> = `${M} ${P}` extends keyof Api ? Api[`${M} ${P}`] : never
 
 // Paramless routes emit `params: {}` and unschema'd bodies emit
 // `body: unknown` — both become OPTIONAL fields; a concrete shape is

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -841,11 +841,13 @@ export type Ctx<TRoute extends RouteShape = RouteShape> = RequestContext<
 /**
  * Global ambient registry of typed routes, populated by `kick typegen`.
  *
- * Each interface inside `KickRoutes` corresponds to a controller class;
- * each property is one route method on that controller. The values
- * conform to `RouteShape`.
+ * Interfaces inside `KickRoutes` correspond to controller classes (each
+ * property one route method, conforming to `RouteShape`) — plus the
+ * reserved `KickRoutes.Api`: a flat `'METHOD /mounted/path'` map over the
+ * same shapes, consumed by `@forinda/kickjs-client`. Don't name a
+ * controller class `Api` — it would declaration-merge into that map.
  *
- * Empty by default — declarations come from `.kickjs/types/routes.d.ts`
+ * Empty by default — declarations come from `.kickjs/types/kick__routes.ts`
  * generated alongside the rest of the typegen output.
  */
 declare global {


### PR DESCRIPTION
## Summary

Fixes the findings from the manual review pass on merged #446 (CodeRabbit never reviewed it — rate-limited, and it doesn't review merged PRs).

## The bug (findings 1–2, CONFIRMED)

`KickRoutes.Api` keyed routes on the **bare decorator path**, not the mounted path: `TasksController` at `/tasks` with `@Get('/:id')` emitted `'GET /:id'` — so typed calls following the docs didn't compile, calls following the emitted key **404'd** (`baseUrl + '/42'`, no `/tasks` segment), and every multi-resource app collided on `'GET /:id'`-style keys with whole controllers silently dropped under bogus "duplicate route" warnings.

Root cause: `joinExtracts` re-applied module mounts to `pathParams` only — `DiscoveredRoute.path` stayed decorator-relative (an R3 assumption of mine that two independent finder agents disproved with the same line citations).

## The fix

- **`DiscoveredRoute.mountedPath`** threaded through both scan paths — regex (`fullPath`, already computed) and AST (per-file own path, refined by `joinExtracts` with cross-file mounts). The AST↔regex **parity suite stays green**.
- **Render** keys on `mountedPath ?? path`. New test: same `@Get('/:id')` under `/users` and `/tasks` mounts → two distinct keys, zero warnings.

## Also fixed (findings 3, 4, 6 + doc rot)

- **Empty-routes emission** now still declares `interface Api {}` — `createClient<KickRoutes.Api>` compiles on a fresh project before the first controller exists (was TS2694).
- **`Api` controller name** warns at typegen — the class would declaration-merge into the reserved flat map.
- **Client `ShapeOf` fallback → `never`** — generator/client key drift now fails loudly at the call site instead of silently degrading responses to `unknown`.
- Duplicate-route warning reworded for what it now actually detects (a genuine runtime verb+path conflict; first-wins caveat stated).
- `KickRoutes` doc comment in kickjs: documents the `Api` member + points at the real generated filename (`kick__routes.ts`, not the stale `routes.d.ts`).

## Deferred (filed in the review, not here)

Route verb+path uniqueness enforcement at the route-table level (altitude), verb-method copy-paste in the client interface, shared URL-join helper.

## Tests

cli **486** (new: scanner `mountedPath` join/fallback, mounted-key render, cross-mount no-collision, empty-Api, reserved-name warning) · kickjs **652** · client **11** under `--typecheck`. Changeset: patch ×3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
