### PR TITLE
fix(ci): exclude CHANGELOG.md from lefthook format hook (unblocks release)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,6 +22,11 @@ pre-commit:
     # `format:check` script.
     format:
       glob: '{packages/*/src/**/*.{ts,tsx,js,mjs,cjs},packages/*/__tests__/**/*.{ts,tsx},packages/*/spa/src/**/*.{ts,tsx},docs/**/*.md,docs/.vitepress/**/*.{ts,mts,vue},tutorials/**/*.md,scripts/*.{ts,js,mjs},*.md}'
+      # CHANGELOGs are changesets-generated and oxfmt-ignored (.oxfmtrc).
+      # Without this exclude, the release bot's version commit stages ONLY
+      # changelogs, oxfmt sees zero unignored targets, exits 2, and the
+      # pre-commit hook kills the changesets action's commit.
+      exclude: '**/CHANGELOG.md'
       run: pnpm exec oxfmt --check {staged_files}
     # ESLint-replacement linter via oxlint (Rust, sub-second on full
     # repo). Runs only when a TS file under packages/ is staged so


### PR DESCRIPTION
The `.oxfmtrc` CHANGELOG ignore from #452 makes `oxfmt --check` exit 2 when a commit stages only changelogs — exactly the shape of the changesets version commit, so the post-merge Release run failed at the bot's `git commit` (run 28807707571). `exclude: '**/CHANGELOG.md'` on the hook restores it. After merge, re-run the Release workflow (workflow_dispatch) to cut the pending versions incl. `@forinda/kickjs-client@0.1.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)