### PR TITLE
feat(swagger,cli,kickjs): declared response schemas — one source for docs + types

### DIFF
--- a/.changeset/swagger-response-schema.md
+++ b/.changeset/swagger-response-schema.md
@@ -1,0 +1,23 @@
+---
+'@forinda/kickjs': patch
+'@forinda/kickjs-swagger': minor
+'@forinda/kickjs-cli': minor
+---
+
+feat: declared response schemas — one declaration feeds Swagger AND the typed client
+
+```ts
+@Get('/', { response: taskSchema })
+list() { return this.tasks.all() }
+```
+
+- `RouteDefinition.validation.response` (`@forinda/kickjs`): a declared,
+  never-runtime-validated response contract
+- `@forinda/kickjs-swagger`: the schema documents the auto-generated success
+  response (`200`/`201`) as `application/json` content in
+  `components/schemas`; explicit `@ApiResponse` entries still win; `204`
+  defaults stay body-less
+- `kick typegen`: a declared `response` schema overrides return-type inference
+  for that route in `KickRoutes[...].response` (both scan paths)
+
+Docs, server types, and the typed client now share one source of truth per route.

--- a/docs/guide/swagger.md
+++ b/docs/guide/swagger.md
@@ -29,6 +29,28 @@ Visit:
 - `http://localhost:3000/redoc` — ReDoc
 - `http://localhost:3000/openapi.json` — Raw JSON spec
 
+## Declared response schemas
+
+Give the route a `response` schema and the success response documents itself —
+the SAME declaration `kick typegen` uses for `KickRoutes[...].response`, so
+docs, server types, and the [typed client](./typed-client.md) can't drift:
+
+```ts
+const taskSchema = z.object({ id: z.string(), title: z.string() })
+
+@Get('/', { response: taskSchema })
+list() {
+  return this.tasks.all()
+}
+```
+
+- The schema lands on the auto-generated success response (`200`/`201`) as
+  `application/json` content, registered under `components/schemas`.
+- It is **never validated at runtime** — it's a documented contract.
+- Explicit `@ApiResponse(...)` entries on the method still win wholesale.
+- In `kick typegen`, a declared `response` schema overrides return-type
+  inference for that route.
+
 ## Decorators
 
 ### @ApiTags

--- a/docs/guide/typed-client.md
+++ b/docs/guide/typed-client.md
@@ -101,7 +101,9 @@ expect(await api.get('/tasks/:id', { params: { id: '1' } })).toEqual(task)
 - Query values pass through `URLSearchParams` (arrays append repeated keys).
 - `204` responses resolve to `undefined`.
 - Imperative `ctx.json` handlers infer `response: unknown` — switch them to
-  return-value style (or a `Reply`) for exact types.
+  return-value style (or a `Reply`) for exact types, or declare the contract
+  with `@Get('/', { response: schema })` (which also feeds
+  [Swagger](./swagger.md#declared-response-schemas)).
 
 Using TanStack Query or SWR? See the
 [recipes](./typed-client-recipes.md) — the client's inference flows straight

--- a/packages/cli/__tests__/render-routes-response.test.ts
+++ b/packages/cli/__tests__/render-routes-response.test.ts
@@ -162,3 +162,27 @@ describe('renderRoutes — KickRoutes.Api flat map', () => {
     expect(warnings.some((w) => w.includes('duplicate route'))).toBe(true)
   })
 })
+
+describe('renderRoutes — declared response schema override', () => {
+  it('a validation.response schema wins over return-type inference', () => {
+    const src = renderRoutes(
+      [
+        route({
+          responseSchema: { identifier: 'taskSchema', source: '' },
+        }),
+      ],
+      OUT,
+      'zod',
+    )
+    expect(src).toContain("response: import('zod').infer<typeof _S0>")
+    expect(src).toContain(
+      "import type { taskSchema as _S0 } from '../../src/modules/users/users.controller'",
+    )
+    expect(src).not.toContain("InferHandlerResponse<_C0['get']>")
+  })
+
+  it('routes without a declared schema keep InferHandlerResponse', () => {
+    const src = renderRoutes([route({})], OUT, 'zod')
+    expect(src).toContain("InferHandlerResponse<_C0['get']>")
+  })
+})

--- a/packages/cli/src/typegen/extract-ast.ts
+++ b/packages/cli/src/typegen/extract-ast.ts
@@ -590,6 +590,7 @@ export function extractFileAst(source: string, filePath: string, cwd: string): F
           bodySchema: schemaFieldRef(options, 'body', ctx),
           querySchema: schemaFieldRef(options, 'query', ctx),
           paramsSchema: schemaFieldRef(options, 'params', ctx),
+          responseSchema: schemaFieldRef(options, 'response', ctx),
           filePath,
           relativePath: relPath,
           controllerIsDefaultExport: discovered.isDefault,

--- a/packages/cli/src/typegen/render/routes.ts
+++ b/packages/cli/src/typegen/render/routes.ts
@@ -84,7 +84,7 @@ export {}
   const renderField = (
     schema: { identifier: string; source: string | null } | null,
     m: DiscoveredRoute,
-    field: 'body' | 'query' | 'params',
+    field: 'body' | 'query' | 'params' | 'response',
   ): string | null => {
     const alias = planSchemaImport(
       schema,
@@ -142,12 +142,16 @@ export {}
       const paramsType = paramsSchemaType ?? urlParamsType
       const bodyType = bodySchemaType ?? 'unknown'
       const queryType = querySchemaType ?? renderQueryShape(m)
-      // Response inference: reference the handler's own type and let the
-      // consumer's tsc compute it — return-value handlers yield their exact
-      // payload (Reply<S, T> unwraps to T); imperative ctx.json handlers
-      // degrade to `unknown` inside InferHandlerResponse, same as before.
+      // Response type, priority order:
+      //   1. Declared contract (`@Get('/', { response: schema })`) — the
+      //      schema's inferred type; same declaration feeds Swagger.
+      //   2. Return-type inference via InferHandlerResponse (return-value
+      //      handlers exact; imperative ctx.json degrades to unknown).
+      const responseSchemaType = renderField(m.responseSchema ?? null, m, 'response')
       const controllerAlias = planControllerImport(m)
-      const responseType = `import('@forinda/kickjs').InferHandlerResponse<${controllerAlias}['${m.method}']>`
+      const responseType =
+        responseSchemaType ??
+        `import('@forinda/kickjs').InferHandlerResponse<${controllerAlias}['${m.method}']>`
       const docLines = renderQueryDocLines(m)
       lines.push(
         `      /**`,

--- a/packages/cli/src/typegen/scanner.ts
+++ b/packages/cli/src/typegen/scanner.ts
@@ -88,6 +88,13 @@ export interface DiscoveredRoute {
   bodySchema: SchemaRef | null
   querySchema: SchemaRef | null
   paramsSchema: SchemaRef | null
+  /**
+   * Declared response contract from the route decorator
+   * (`@Get('/', { response: schema })`). When present it WINS over
+   * return-type inference in the emitted `response` field — and the same
+   * declaration drives the Swagger success-response schema.
+   */
+  responseSchema?: SchemaRef | null
   /** Absolute file path of the controller */
   filePath: string
   /** Path relative to scan root, with forward slashes */
@@ -982,6 +989,7 @@ export function extractRoutesFromSource(
       const bodyId = extractObjectFieldIdentifier(routeArgs, 'body')
       const queryId = extractObjectFieldIdentifier(routeArgs, 'query')
       const paramsId = extractObjectFieldIdentifier(routeArgs, 'params')
+      const responseId = extractObjectFieldIdentifier(routeArgs, 'response')
 
       // forinda/kick-js#235 §3 — when the controller is mounted under a path
       // with `:params` (e.g. `/orgs/:id/extensions`), surface those
@@ -1007,6 +1015,9 @@ export function extractRoutesFromSource(
           : null,
         paramsSchema: paramsId
           ? { identifier: paramsId, source: resolveImportSource(source, paramsId) }
+          : null,
+        responseSchema: responseId
+          ? { identifier: responseId, source: resolveImportSource(source, responseId) }
           : null,
         filePath,
         relativePath: relPath,

--- a/packages/kickjs/src/core/decorators.ts
+++ b/packages/kickjs/src/core/decorators.ts
@@ -419,6 +419,13 @@ export interface RouteDefinition {
     query?: any
     /** JSON Schema object for validating URL params */
     params?: any
+    /**
+     * DECLARED response schema — never validated at runtime. Feeds two
+     * consumers from one source of truth: the Swagger adapter's success
+     * response schema, and `kick typegen`'s `KickRoutes[...].response`
+     * (winning over return-type inference when present).
+     */
+    response?: any
     /** Schema name in OpenAPI components/schemas for the request body. Auto-generated from handler name if omitted. */
     name?: string
   }

--- a/packages/swagger/__tests__/swagger.test.ts
+++ b/packages/swagger/__tests__/swagger.test.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata'
 import { describe, it, expect, beforeEach } from 'vitest'
+import { z } from 'zod'
 import {
   ApiOperation,
   ApiResponse,
@@ -911,5 +912,68 @@ describe('registerControllerForDocs — per-scope isolation', () => {
 
     expect(buildOpenAPISpec(keepOpts).paths['/api/keep']).toBeDefined()
     expect(buildOpenAPISpec(dropOpts).paths['/api/drop']).toBeUndefined()
+  })
+})
+
+describe('declared response schema (validation.response)', () => {
+  beforeEach(() => {
+    Container.reset()
+    clearRegisteredRoutes()
+  })
+
+  it('feeds the default success response content schema', () => {
+    const taskSchema = z.object({ id: z.string(), title: z.string() })
+
+    @Controller()
+    class TasksController {
+      @Get('/', { response: taskSchema })
+      list() {}
+    }
+
+    registerControllerForDocs(TasksController, '/tasks')
+    const spec = buildOpenAPISpec()
+
+    const op = spec.paths['/tasks']?.get
+    expect(op).toBeDefined()
+    const success = op.responses['200']
+    expect(success.description).toBe('Successful operation')
+    const ref = success.content['application/json'].schema.$ref as string
+    expect(ref).toContain('listResponse')
+    const registered = spec.components.schemas['listResponse']
+    expect(registered.properties.id.type).toBe('string')
+    expect(registered.properties.title.type).toBe('string')
+  })
+
+  it('explicit @ApiResponse still wins over validation.response', () => {
+    const taskSchema = z.object({ id: z.string() })
+
+    @Controller()
+    class OverrideController {
+      @ApiResponse({ status: 200, description: 'manual wins' })
+      @Get('/', { response: taskSchema })
+      list() {}
+    }
+
+    registerControllerForDocs(OverrideController, '/ovr')
+    const spec = buildOpenAPISpec()
+    const success = spec.paths['/ovr']?.get.responses['200']
+    expect(success.description).toBe('manual wins')
+    expect(success.content).toBeUndefined()
+  })
+
+  it('204 default (DELETE) never gets a response body schema', () => {
+    const gone = z.object({ ok: z.boolean() })
+
+    @Controller()
+    class GoneController {
+      @Delete('/:id', { response: gone })
+      remove() {}
+    }
+
+    registerControllerForDocs(GoneController, '/gone')
+    const spec = buildOpenAPISpec()
+    const success = spec.paths['/gone/{id}']?.delete.responses['204']
+    expect(success.description).toBe('Successful operation')
+    expect(success.content).toBeUndefined()
   })
 })

--- a/packages/swagger/src/openapi-builder.ts
+++ b/packages/swagger/src/openapi-builder.ts
@@ -681,7 +681,20 @@ function buildOpenAPISpecUncached(options: SwaggerOptions = {}): any {
       } else {
         // Auto-generate default responses
         const defaultStatus = method === 'post' ? '201' : method === 'delete' ? '204' : '200'
-        op.responses[defaultStatus] = { description: 'Successful operation' }
+        const success: Record<string, unknown> = { description: 'Successful operation' }
+        // Declared response contract (`@Get('/', { response: schema })`) —
+        // the same declaration `kick typegen` consumes, so docs and types
+        // can't drift. Explicit @ApiResponse entries above still win.
+        if (route.validation?.response && defaultStatus !== '204') {
+          const converted = toJsonSchema(route.validation.response)
+          if (converted) {
+            const schemaName = `${route.validation.name || route.handlerName}Response`
+            success.content = {
+              'application/json': { schema: registerSchema(converted, schemaName) },
+            }
+          }
+        }
+        op.responses[defaultStatus] = success
 
         if (route.validation?.body) {
           op.responses['422'] = { description: 'Validation error' }


### PR DESCRIPTION
## Summary

Closes the last open question from `response-inference-design.md` (§6 Q6): **one declared schema per route now feeds both OpenAPI docs and the typed client** — the two can no longer drift.

```ts
const taskSchema = z.object({ id: z.string(), title: z.string() })

@Get('/', { response: taskSchema })
list() { return this.tasks.all() }
```

## What each package does with it

- **`@forinda/kickjs`** — `RouteDefinition.validation.response`: a declared response contract. Runtime-inert by construction (`validate()` reads only `body`/`query`/`params`); it exists for consumers below.
- **`@forinda/kickjs-swagger`** — the auto-generated success response (`200`/`201`) gains `application/json` content: schema converted via the configured parser (Zod etc.) and registered under `components/schemas` as `<name|handler>Response`. Explicit `@ApiResponse(...)` entries still win wholesale; `204` defaults (DELETE) stay body-less.
- **`kick typegen`** — a declared `response` schema **overrides return-type inference** for that route (`z.infer<typeof schema>` in `KickRoutes[...].response`), extracted on both scan paths with the AST↔regex parity suite green. Return-value handlers stay the zero-ceremony default; declaration is for schema-first teams and imperative handlers.

## Why declaration (not type→JSON-schema)

OpenAPI needs a runtime JSON schema; inferred TS types don't exist at runtime, and the scanner is deliberately checker-free. A declared Zod schema is the only source that can honestly serve both consumers — so it wins over inference when present.

## Tests

- swagger **57**: success-content `$ref` + `components` registration, `@ApiResponse` precedence, 204 body-less
- cli **488**: render override (`z.infer` + hoisted import, no `InferHandlerResponse`), fallback preserved, parity green
- kickjs **652** · docs build green

Changesets: swagger + cli minor, kickjs patch. Docs: swagger guide section + typed-client cross-link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
