### PR TITLE
docs: refresh root + kickjs READMEs (typed client, edge, fullstack)

### DIFF
--- a/.changeset/readme-refresh.md
+++ b/.changeset/readme-refresh.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs': patch
+---
+
+docs: README refresh — web-standard entries (`/h3-web`, `/web` for Workers/Bun/Deno), return-value handlers, and the typed-client loop

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ npx @forinda/kickjs-cli new my-api
 cd my-api && pnpm dev
 ```
 
+Or a fullstack workspace — KickJS API + Vite/React frontend, typed end to end:
+
+```bash
+npx @forinda/kickjs-cli new my-app --template fullstack
+cd my-app && pnpm dev   # server + web in parallel; rename a server field and the frontend stops compiling
+```
+
 ## Hello World
 
 A fresh `kick new my-api` scaffolds a complete project. Here are the files that matter, exactly as the CLI generates them:
@@ -133,7 +140,8 @@ container.register(REPO, PrismaUserRepo)
 **End-to-end type safety via typegen** — `kick typegen` (auto on `kick dev`) emits augmentations from source scan. `ctx.params/body/query`, `@Inject` literals, and asset paths all narrow as you save.
 
 ```ts
-KickRoutes // ctx.params / body / query per route
+KickRoutes // ctx.params / body / query / response per route
+KickRoutes.Api // flat 'METHOD /path' map — powers the typed client
 KickJsPluginRegistry // @Inject literals
 KickAssets // typed asset paths
 KickEnv // ConfigService.get keys
@@ -146,6 +154,17 @@ KickEnv // ConfigService.get keys
 @Service @Autowired @Middleware
 @Cacheable @Cron @Asset
 ```
+
+**Return-value handlers + typed client** — `return` the payload and the response type flows from the handler through `kick typegen` into [`@forinda/kickjs-client`](packages/client/): the frontend calls `api.get('/tasks/:id', …)` with the server's actual types. Declare `{ response: schema }` on a route and the same contract feeds the OpenAPI success response — docs and types can't drift.
+
+```ts
+@Get('/:id')
+async get(ctx: RequestContext) {
+  return this.tasks.find(ctx.params.id) // → 200 json; response type inferred end to end
+}
+```
+
+**Edge-ready web standards** — the same app runs as a `fetch(Request) → Response` handler on Cloudflare Workers, Bun, and Deno via [`@forinda/kickjs/web`](https://kickjs.app/guide/edge-deployment.html) (h3 v2 engine); a bundle-purity test keeps the entry free of node-only imports.
 
 **DDD generators** — full hook surface emitted so you delete what you don't need.
 
@@ -197,6 +216,8 @@ Everything else — swagger, the db family, queue, ws, devtools, drizzle, prisma
 kick add --list           # current optional catalog
 kick add swagger drizzle  # install several at once
 ```
+
+One optional package lives on the frontend side instead: [`@forinda/kickjs-client`](packages/client/) — the zero-dependency typed fetch client (`pnpm add @forinda/kickjs-client` in your web app; see the [typed client guide](https://kickjs.app/guide/typed-client.html)).
 
 Browse `packages/` in this repo for the full source layout.
 
@@ -258,19 +279,19 @@ kick tinker                          # Interactive REPL with full DI graph
 
 ## Runtime Compatibility
 
-| Feature         | Node 20+ | Node 22+ | Node 24+ | Bun          | Deno |
-| --------------- | -------- | -------- | -------- | ------------ | ---- |
-| Production      | Yes      | Yes      | Yes      | Experimental | No   |
-| Dev Mode (HMR)  | Yes      | Yes      | Yes      | No           | No   |
-| Tests (Vitest)  | Yes      | Yes      | Yes      | Partial      | No   |
-| CLI (`kick`)    | Yes      | Yes      | Yes      | Experimental | No   |
-| Pure ESM Import | Yes      | Yes      | Yes      | Yes          | Yes  |
+| Feature                      | Node 20+ | Bun          | Deno | Cloudflare Workers |
+| ---------------------------- | -------- | ------------ | ---- | ------------------ |
+| Production (node runtimes)   | Yes      | Yes          | —    | —                  |
+| Production (web fetch entry) | Yes      | Yes          | Yes  | Yes¹               |
+| Dev Mode (Vite HMR)          | Yes      | No           | No   | —                  |
+| Tests (Vitest)               | Yes      | Partial      | No   | —                  |
+| CLI (`kick`)                 | Yes      | Experimental | No   | —                  |
 
 > **Node 20** is the minimum supported version (LTS with native ESM).
 >
-> **Bun**: core DI and decorators work; full HTTP pipeline is experimental.
->
-> **Deno**: blocked by `reflect-metadata`. The default logger is `console`-based (zero deps), so logging is not a blocker.
+> ¹ Workers need `compatibility_flags = ["nodejs_compat"]` (AsyncLocalStorage). The
+> web fetch entry is [`@forinda/kickjs/web`](https://kickjs.app/guide/edge-deployment.html)
+> — `createWebApp({ h3, modules })` on the h3 v2 engine; Bun/Deno smoke tests run in CI.
 
 ## Documentation
 

--- a/packages/kickjs/README.md
+++ b/packages/kickjs/README.md
@@ -132,6 +132,18 @@ export const app = await bootstrap({ modules, runtime: fastifyRuntime() })
 
 `kick new --runtime express|fastify|h3` scaffolds the right peers. File uploads (`@FileUpload` → `ctx.file` / `ctx.files`) and the rest of the surface work the same on all three. See [HTTP Runtimes](https://kickjs.app/guide/http-runtimes.html).
 
+Two web-standard entries sit alongside them (h3 v2 engine — additive, the v1 runtime is untouched):
+
+```ts
+import { h3WebRuntime } from '@forinda/kickjs/h3-web' // bootstrap() on node, WHATWG pipeline
+import { createWebApp } from '@forinda/kickjs/web' // fetch(Request) → Response — Workers / Bun / Deno
+
+const app = createWebApp({ h3, modules })
+export default { fetch: (req: Request) => app.fetch(req) }
+```
+
+See [Edge Deployment](https://kickjs.app/guide/edge-deployment.html).
+
 ## Project Layout
 
 `kick new` produces this convention; everything except the bootstrap entry is configurable via `kick.config.ts`:
@@ -157,6 +169,7 @@ vite.config.ts              # Vite + KickJS HMR
 ## Core Concepts
 
 - **Pluggable HTTP runtimes** — one `HttpRuntime` seam over Express (default), Fastify, or h3. Swap the engine in one line; everything above stays the same. See [HTTP Runtimes](https://kickjs.app/guide/http-runtimes.html).
+- **Return-value handlers + typed client** — `return` the payload (`reply(201, body)` for other statuses) and the response type flows through `kick typegen` into `KickRoutes.Api`, consumed by [`@forinda/kickjs-client`](https://kickjs.app/guide/typed-client.html) on the frontend. Declare `{ response: schema }` on a route and the same contract feeds the OpenAPI success response. See [Controllers](https://kickjs.app/guide/controllers.html#return-value-handlers), [Typed Client](https://kickjs.app/guide/typed-client.html).
 - **First-class database** — `kick/db`: code-first schema, fully typed queries, and migrations for PostgreSQL / SQLite / MySQL. `kick add db` (or `pg` / `sqlite` / `mysql`). See [Database](https://kickjs.app/guide/database/).
 - **Custom DI container** — three scopes (singleton / transient / request), slash-delimited tokens (`createToken<T>('app/users/repository')`), constructor + property injection. No external DI dep. See [Dependency Injection](https://kickjs.app/guide/dependency-injection.html).
 - **Factory-first** — `defineAdapter()`, `definePlugin()`, `defineModule()`, `defineHttpContextDecorator()`. No class hierarchies to inherit from. See [Adapters](https://kickjs.app/guide/adapters.html), [Plugins](https://kickjs.app/guide/plugins.html).

--- a/packages/kickjs/README.md
+++ b/packages/kickjs/README.md
@@ -137,6 +137,8 @@ Two web-standard entries sit alongside them (h3 v2 engine — additive, the v1 r
 ```ts
 import { h3WebRuntime } from '@forinda/kickjs/h3-web' // bootstrap() on node, WHATWG pipeline
 import { createWebApp } from '@forinda/kickjs/web' // fetch(Request) → Response — Workers / Bun / Deno
+import * as h3 from 'h3' // v2 — passed in: edge bundlers have no createRequire
+import { modules } from './modules'
 
 const app = createWebApp({ h3, modules })
 export default { fetch: (req: Request) => app.fetch(req) }


### PR DESCRIPTION
Both READMEs caught up with everything shipped this cycle:

**Root**: fullstack template scaffold line; return-value-handlers + typed-client highlight; edge web-standards highlight; `KickRoutes.Api` in the typegen block; `@forinda/kickjs-client` called out (it installs on the frontend, so `kick add --list` never shows it); **Runtime Compatibility table rewritten** — the old table said Deno: No (reflect-metadata) and Bun: Experimental, which the `/web` fetch entry + CI smoke tests have since made false.

**packages/kickjs**: HTTP Runtimes section gains `/h3-web` + `/web` with the Workers export shape; Core Concepts gains the typed-response bullet.

kickjs patch changeset so npm shows the new README on next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the README with a new full-stack workspace setup example and clearer guidance for running server and web parts together.
  * Added more detail on typed routes, return values flowing into the typed client, and edge-friendly web-standard usage.
  * Updated runtime compatibility guidance and Cloudflare Workers notes.
  * Clarified that the client package is optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->