### PR TITLE
docs: stale-claim sweep across the guides (audit PR A)

### DIFF
--- a/docs/guide/cli-commands.md
+++ b/docs/guide/cli-commands.md
@@ -104,7 +104,7 @@ Any explicit flag overrides the matching default — `--yes --template minimal -
 
 When run without `--yes` (and without specific flags), the CLI prompts for:
 
-1. **Project template** — REST or Minimal
+1. **Project template** — REST, Minimal, or Fullstack (server + typed web app)
 2. **Package manager** — pnpm, npm, yarn, or bun
 3. **Default repository** — In-Memory or a custom DB name (e.g. `postgres`, `mongo`)
 4. **Optional packages** — auth, swagger, ws, queue, devtools
@@ -113,7 +113,7 @@ When run without `--yes` (and without specific flags), the CLI prompts for:
 
 | Flag                             | Description                                                            | Default                                  |
 | -------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------- |
-| `-t, --template <type>`          | Project template: `rest`, `minimal`                                    | Prompted (or `rest` with `--yes`)        |
+| `-t, --template <type>`          | Project template: `rest`, `minimal`, `fullstack`                       | Prompted (or `rest` with `--yes`)        |
 | `-r, --repo <name>`              | Repository name: `inmemory` (default) or any DB name (e.g. `postgres`) | Prompted (or `inmemory` with `--yes`)    |
 | `-d, --directory <dir>`          | Target directory                                                       | Project name                             |
 | `--pm <manager>`                 | Package manager: `pnpm`, `npm`, `yarn`, or `bun`                       | Prompted (or auto-detected with `--yes`) |
@@ -125,10 +125,15 @@ When run without `--yes` (and without specific flags), the CLI prompts for:
 
 ### Templates
 
-| Template         | Adapters           | Packages installed                  |
-| ---------------- | ------------------ | ----------------------------------- |
-| `rest` (default) | Swagger + DevTools | kickjs, kickjs-vite, kickjs-swagger |
-| `minimal`        | None               | kickjs, kickjs-vite                 |
+| Template         | Adapters           | Packages installed                                             |
+| ---------------- | ------------------ | -------------------------------------------------------------- |
+| `rest` (default) | Swagger + DevTools | kickjs, kickjs-vite, kickjs-swagger                            |
+| `minimal`        | None               | kickjs, kickjs-vite                                            |
+| `fullstack`      | None (minimal API) | server: kickjs, kickjs-vite · web: kickjs-client, React + Vite |
+
+`fullstack` scaffolds a pnpm workspace — `server/` (KickJS API) + `web/`
+(Vite + React typed against the API via the
+[typed client](./typed-client.md)); `pnpm dev` runs both.
 
 Use `.` as the project name to scaffold in the current directory (the folder name becomes the project name).
 
@@ -663,6 +668,10 @@ Controls the default generator behavior and project template style.
 | ----------- | ----------------------------------------------------------- |
 | `'rest'`    | Express + Swagger, flat module layout (default)             |
 | `'minimal'` | Bare Express with no scaffolding (module + controller only) |
+
+(`kick new` additionally offers the `fullstack` workspace template — it scaffolds
+a `rest`/`minimal`-style server plus a typed web app; the `pattern` config above
+applies to the server side.)
 
 ### `copyDirs`
 

--- a/docs/guide/decorators.md
+++ b/docs/guide/decorators.md
@@ -115,6 +115,23 @@ class CacheService {
 }
 ```
 
+### @PreDestroy()
+
+The teardown counterpart. For REQUEST-scoped services it runs when the
+request's scope closes (response finished or aborted) — release transactions,
+handles, and subscriptions there. Async hooks are fired without blocking the
+response; errors are logged and swallowed.
+
+```ts
+@Service({ scope: Scope.REQUEST })
+class TxService {
+  @PreDestroy()
+  async close() {
+    await this.tx.rollbackIfOpen()
+  }
+}
+```
+
 ## Method & Class Decorators
 
 ### @Middleware(...handlers)
@@ -434,6 +451,7 @@ class TaskController {
 | `@Repository`                | Class                | core    | Data access class                                   |
 | `@Get/Post/Put/Delete/Patch` | Method               | core    | HTTP route handler                                  |
 | `@PostConstruct`             | Method               | core    | Post-instantiation hook                             |
+| `@PreDestroy`                | Method               | core    | Teardown hook (request-scope close)                 |
 | `@Middleware`                | Class/Method         | core    | Attach middleware                                   |
 | `@FileUpload`                | Method               | core    | Configure file upload                               |
 | `@Autowired`                 | Property / Parameter | core    | Dependency injection — either position works        |

--- a/docs/guide/dependency-injection.md
+++ b/docs/guide/dependency-injection.md
@@ -198,6 +198,30 @@ class CacheService {
 }
 ```
 
+### @PreDestroy
+
+The teardown counterpart. For REQUEST-scoped services it runs when the
+request's scope closes (response finished or aborted) — release per-request
+resources there:
+
+```ts
+@Service({ scope: Scope.REQUEST })
+class TxService {
+  @PostConstruct()
+  begin() {
+    this.tx = db.beginTransaction()
+  }
+
+  @PreDestroy()
+  async close() {
+    await this.tx.rollbackIfOpen()
+  }
+}
+```
+
+Hooks may be async; errors are logged and swallowed so one failing teardown
+can't break request completion.
+
 ## Environment Injection
 
 Use `@Value` to inject environment variables. When `kick typegen` has populated the project's `KickEnv` global from `src/env.ts`, the key autocompletes and the `Env<K>` type alias resolves to the schema-inferred type — see [Configuration](configuration.md) and [Type Generation](typegen.md#how-env-vars-are-typed) for the full pipeline.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -79,12 +79,12 @@ src/modules/users/
     users.repository.test.ts
 ```
 
-`rest` is the default pattern; pass `--template minimal` for just a controller + module. Need a real database? Pick a repo by name (`--repo postgres`) for a stub you wire yourself, or reach for the first-party [`@forinda/kickjs-db`](./database/) layer.
+`rest` is the default pattern; pass `--template minimal` for just a controller + module, or `--template fullstack` for a server + typed-web-app workspace (see the [typed client](./typed-client.md)). Need a real database? Pick a repo by name (`--repo postgres`) for a stub you wire yourself, or reach for the first-party [`@forinda/kickjs-db`](./database/) layer.
 
 ## Your First Controller
 
 ```ts
-import { Controller, Get, Post, type Ctx } from '@forinda/kickjs'
+import { Controller, Get, Post, reply, type Ctx } from '@forinda/kickjs'
 import { z } from 'zod'
 
 const createUserSchema = z.object({
@@ -95,17 +95,23 @@ const createUserSchema = z.object({
 @Controller()
 export class UserController {
   @Get('/')
-  async list(ctx: Ctx<KickRoutes.UserController['list']>) {
-    ctx.json([{ id: '1', name: 'Alice' }])
+  async list(_ctx: Ctx<KickRoutes.UserController['list']>) {
+    // Return-value handlers: the runtime sends this as 200 json, and
+    // `kick typegen` infers the response type for the typed client.
+    return [{ id: '1', name: 'Alice' }]
   }
 
   @Post('/', { body: createUserSchema, name: 'CreateUser' })
   async create(ctx: Ctx<KickRoutes.UserController['create']>) {
     // ctx.body is validated and typed from the Zod schema
-    ctx.created({ id: '2', ...ctx.body })
+    return reply(201, { id: '2', ...ctx.body })
   }
 }
 ```
+
+(`ctx.json(...)` / `ctx.created(...)` remain fully supported — returning the
+payload is what makes the response type statically inferable. See
+[Return-Value Handlers](./controllers.md#return-value-handlers).)
 
 ## Your First Module
 
@@ -214,4 +220,5 @@ pnpm kick start
 - [Controllers & Routes](./controllers.md) — route decorators and validation
 - [Middleware](./middleware.md) — class and method middleware
 - [Plugins](./plugins.md) — bundle modules, adapters, middleware, and DI bindings into one reusable unit with `definePlugin()` and mount them via `bootstrap({ plugins: [...] })`
+- [Typed Client](./typed-client.md) — call the API from your frontend with response types inferred from these handlers
 - [Examples](../examples/index.md) — see complete example applications

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -110,6 +110,11 @@ beforeStart(ctx)
 | `afterStart(ctx)`          | After the HTTP server is listening              | Attach upgrade handlers (Socket.IO, gRPC), warm caches                                         |
 | `shutdown()`               | On SIGTERM/SIGINT                               | Close DB pools, flush logs, disconnect WS — runs concurrently via `Promise.allSettled`         |
 
+Per-request teardown is separate from process shutdown: a REQUEST-scoped
+service method decorated with `@PreDestroy()` runs when its request's scope
+closes (response finished or aborted) — the counterpart to `@PostConstruct`.
+See [Dependency Injection → Lifecycle Hooks](./dependency-injection.md#predestroy).
+
 See [Adapters](./adapters.md) for the full `defineAdapter()` reference.
 
 ## Middleware Phases

--- a/docs/guide/samples.md
+++ b/docs/guide/samples.md
@@ -4,7 +4,7 @@ A copy-pasteable tour of the patterns KickJS leans on. Each sample is the **reco
 
 If you're new, read [What is KickJS](./what-is-kickjs.md) and [Getting Started](./getting-started.md) first, then skim this page top-to-bottom — it doubles as the mental model.
 
-> **The mental model in one breath:** decorate classes (`@Controller`, `@Service`), let the DI container wire them, group them into modules, and `bootstrap()`. `kick typegen` scans your source and feeds the editor types (routes, env, DI tokens, context keys) so the framework stays "just TypeScript" with no codegen you hand-maintain.
+> **The mental model in one breath:** decorate classes (`@Controller`, `@Service`), let the DI container wire them, group them into modules, and `bootstrap()`. `kick typegen` scans your source and feeds the editor types (routes (params/body/query/response), env, DI tokens, context keys) so the framework stays "just TypeScript" with no codegen you hand-maintain.
 
 ---
 

--- a/docs/guide/typegen.md
+++ b/docs/guide/typegen.md
@@ -17,7 +17,9 @@ After running `kick typegen` (or starting `kick dev`), you'll have:
     kick__modules.d.ts          # ModuleToken string-literal union
     kick__plugins.d.ts          # KickJsPluginRegistry augmentation (narrows dependsOn)
     kick__augmentations.d.ts    # defineAugmentation catalogue (docs-only)
-    kick__routes.ts             # KickRoutes namespace augmentation (typed Ctx<>)
+    kick__routes.ts             # KickRoutes augmentation — typed Ctx<>, per-route
+                                #   response types, and the flat KickRoutes.Api map
+                                #   ('METHOD /mounted/path' keys) for the typed client
     kick__env.ts                # KickEnv + NodeJS.ProcessEnv augmentation (when src/env.ts exists)
     kick__assets.d.ts           # KickAssets augmentation (when assetMap is set)
     kick__db.d.ts               # DB model types (when a DB adapter is configured)
@@ -33,12 +35,13 @@ sweeps the old `index.d.ts` / `registry.d.ts` / `services.d.ts` /
 `modules.d.ts` / `plugins.d.ts` / `augmentations.d.ts` files
 automatically.)
 
-Four things become type-safe as a result:
+Five things become type-safe as a result:
 
 1. **`container.resolve('UserService')`** returns `UserService` instead of `any`.
 2. **`ctx.params`, `ctx.body`, `ctx.query`** are typed per route — including the inferred shape of any Zod schema you wired into the route decorator.
-3. **`ctx.qs(config as const)`** narrows `parsed.filters[].field` and `parsed.sort[].field` to the literal whitelist you passed.
-4. **`@Value('DATABASE_URL')` and `process.env.DATABASE_URL`** are typed from your project's `src/env.ts` schema — autocomplete on keys, tsc errors on typos, and `Env<'PORT'>` looks up the inferred type.
+3. **Response types** — inferred from each handler's return type ([return-value handlers](./controllers.md#return-value-handlers); `Reply<S, T>` unwraps; a declared `{ response: schema }` on the route wins). Emitted both per controller and as the flat `KickRoutes.Api` map that powers the [typed client](./typed-client.md).
+4. **`ctx.qs(config as const)`** narrows `parsed.filters[].field` and `parsed.sort[].field` to the literal whitelist you passed.
+5. **`@Value('DATABASE_URL')` and `process.env.DATABASE_URL`** are typed from your project's `src/env.ts` schema — autocomplete on keys, tsc errors on typos, and `Env<'PORT'>` looks up the inferred type.
 
 ## Quick start
 
@@ -495,7 +498,7 @@ Each call surfaces in `.kickjs/types/augmentations.d.ts` as a documentation-only
 
 These are known and deliberate for the current release; some will be lifted in follow-up work:
 
-- **Response types are not generated.** Handler return types are not statically inferable without a heavyweight TypeScript compiler-API integration. There's no `response` typing today.
+- **Imperative `ctx.json(...)` handlers infer `response: unknown`.** Response types come from handler RETURN types (emitted as `InferHandlerResponse<Controller['method']>` references your own tsc computes — no compiler-API integration in the scanner). Use [return-value handlers](./controllers.md#return-value-handlers) or declare `{ response: schema }` on the route for exact types.
 - **Joi and JSON Schema are not yet supported.** `typegen.schemaValidator: 'kickjs-schema'` already covers Zod, Valibot, Yup, and Standard Schema v1 — Joi and JSON Schema need a `@forinda/kickjs-schema` adapter first (PRs welcome).
 - **Schema references must be bare top-level identifiers.** Member access, function calls, and inline compositions silently fall back to `body: unknown` (see [What the scanner cannot resolve](#what-the-scanner-cannot-resolve-falls-back-to-unknown)).
 - **Column-object `@ApiQueryParams` configs (Drizzle-style) are recognised but not narrowed.** Use the string-array form (or `ctx.qs(config as const)`) for typed query field names.

--- a/docs/guide/what-is-kickjs.md
+++ b/docs/guide/what-is-kickjs.md
@@ -1,6 +1,6 @@
 # What is KickJS?
 
-KickJS is a production-grade, decorator-driven Node.js framework for TypeScript. It provides the developer experience of NestJS without the heavy dependencies — and the HTTP engine is **pluggable**: the same controllers, modules, and context decorators run on **Express** (the zero-config default), **Fastify**, or **h3**. Swap the engine in one line at bootstrap; see [HTTP Runtimes](./http-runtimes.md).
+KickJS is a production-grade, decorator-driven Node.js framework for TypeScript. It provides the developer experience of NestJS without the heavy dependencies — and the HTTP engine is **pluggable**: the same controllers, modules, and context decorators run on **Express** (the zero-config default), **Fastify**, or **h3** — and as a web-standard `fetch` handler on **Cloudflare Workers, Bun, and Deno**. Swap the engine in one line at bootstrap; see [HTTP Runtimes](./http-runtimes.md) and [Edge Deployment](./edge-deployment.md).
 
 ## Why KickJS?
 
@@ -49,3 +49,4 @@ db  swagger  ws  devtools  ...
 - **@forinda/kickjs-cli** — Project scaffolding, DDD code generators, custom commands
 - **@forinda/kickjs-vite** — Vite HMR plugin, envWatchPlugin, dev tooling
 - **@forinda/kickjs-testing** — Test utilities for integration testing
+- **@forinda/kickjs-client** — Typed fetch client for the frontend: response types inferred from your handlers, end to end ([guide](./typed-client.md))

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -15,7 +15,7 @@
 - [Middleware](https://kickjs.app/guide/middleware.html): Built-ins (helmet, cors, requestId, rate-limit, …) and custom.
 - [Validation](https://kickjs.app/guide/validation.html): Zod / Valibot / Yup body, query, and param validation.
 - [Configuration](https://kickjs.app/guide/configuration.html): Typed env via `defineEnv`, `ConfigService`, `@Value`.
-- [Type Generation](https://kickjs.app/guide/typegen.html): `kick typegen` for fully-typed route params/body/query and env.
+- [Type Generation](https://kickjs.app/guide/typegen.html): `kick typegen` for fully-typed route params/body/query/response (incl. the KickRoutes.Api map for the typed client) and env.
 - [Typed Client](https://kickjs.app/guide/typed-client.html): `@forinda/kickjs-client` — end-to-end response types from your handlers.
 - [Typed Client Recipes](https://kickjs.app/guide/typed-client-recipes.html): TanStack Query + SWR patterns over the typed client.
 - [Error Handling](https://kickjs.app/guide/error-handling.html): `HttpException`, RFC 9457 problem details, global error handler.


### PR DESCRIPTION
First of three PRs from the docs staleness audit — the site guides. Headline: **typegen.md claimed response types are not generated** ("no response typing today") while swagger.md documented the declared-schema override — direct self-contradiction, now rewritten around InferHandlerResponse + KickRoutes.Api. Also: fullstack in all five cli-commands template lists, @PreDestroy documented in DI/decorators/lifecycle, getting-started example modernized to return-value handlers (imperative style explicitly still supported), what-is-kickjs gains the client + edge surface, samples/llms.txt enumerations updated. Docs build green. PR B (CLAUDE.md/AGENTS.md/CONTRIBUTING) and PR C (agent-docs generator) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)