### PR TITLE
docs: meta-docs stale sweep — CLAUDE.md, AGENTS.md, CONTRIBUTING (audit PR B)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -4,7 +4,7 @@ This guide helps AI agents (Claude, Copilot, etc.) work effectively on the KickJ
 
 ## Engine & package layout (read first — avoids the two most common mistakes)
 
-- **KickJS is engine-pluggable, not Express-only.** It runs on **Express (default), Fastify, or h3** behind one `HttpRuntime` seam (`bootstrap({ runtime })`). Controllers, modules, DI, and context decorators are engine-neutral — write to `ctx` (`ctx.json`/`ctx.body`/`ctx.params`/`ctx.sse`), not raw Express APIs. The runtimes + cross-engine file uploads currently ship on the **`alpha`** channel.
+- **KickJS is engine-pluggable, not Express-only.** It runs on **Express (default), Fastify, or h3** behind one `HttpRuntime` seam (`bootstrap({ runtime })`). Controllers, modules, DI, and context decorators are engine-neutral — write to `ctx` (`ctx.json`/`ctx.body`/`ctx.params`/`ctx.sse`), not raw Express APIs. The runtimes (incl. the h3 v2 web-standard entries `./h3-web` and `./web` for edge/Bun/Deno) + cross-engine file uploads ship in the **stable** release.
 - **The framework lives in `packages/kickjs`** (`@forinda/kickjs`) — DI core under `src/core/`, HTTP layer under `src/http/`, runtimes under `src/http/runtimes/{express,fastify,h3}.ts`. The old `packages/core` + `packages/http` split (referenced in some tables below) **no longer exists**; map any such path to `packages/kickjs/src/{core,http}`.
 
 ## Before You Start
@@ -37,7 +37,7 @@ This guide helps AI agents (Claude, Copilot, etc.) work effectively on the KickJ
 | Config/env           | `packages/config/src/`                                                     |
 | CLI commands         | `packages/cli/src/commands/`                                               |
 | Code generators      | `packages/cli/src/generators/`                                             |
-| Generator patterns   | `packages/cli/src/generators/patterns/{rest,ddd,cqrs,minimal}.ts`          |
+| Generator patterns   | `packages/cli/src/generators/patterns/{rest,minimal}.ts`                   |
 | Template functions   | `packages/cli/src/generators/templates/`                                   |
 | Drizzle templates    | `packages/cli/src/generators/templates/drizzle/`                           |
 | Prisma templates     | `packages/cli/src/generators/templates/prisma/`                            |
@@ -71,25 +71,25 @@ This guide helps AI agents (Claude, Copilot, etc.) work effectively on the KickJ
 
 When adding new features, use these as templates:
 
-| Task              | Reference File                                                         |
-| ----------------- | ---------------------------------------------------------------------- |
-| New middleware    | `packages/http/src/middleware/csrf.ts`                                 |
-| New adapter       | `packages/swagger/src/swagger.adapter.ts`                              |
-| New package       | `packages/prisma/` (full package structure)                            |
-| New example app   | `examples/minimal-api/` (simple) or `examples/task-prisma-api/` (full) |
-| New test file     | `tests/container.test.ts`                                              |
-| Package exports   | `packages/http/package.json` (exports map)                             |
-| Vite build config | `packages/http/vite.config.ts` (multi-entry)                           |
+| Task            | Reference File                                                                |
+| --------------- | ----------------------------------------------------------------------------- |
+| New middleware  | `packages/kickjs/src/http/middleware/csrf.ts`                                 |
+| New adapter     | `packages/swagger/src/swagger.adapter.ts`                                     |
+| New package     | `packages/schema/` (tsdown-based structure — the repo standard)               |
+| New example app | [kickjs-examples-archive](https://github.com/forinda/kickjs-examples-archive) |
+| New test file   | `packages/kickjs/__tests__/` (per-package) or root `__tests__/` (integration) |
+| Package exports | `packages/kickjs/package.json` (exports map — verify against tsdown output)   |
+| Build config    | `packages/kickjs/tsdown.config.ts` (multi-entry)                              |
 
 ## Checklist: Adding a Feature
 
 ### New Middleware
 
-- [ ] Create `packages/http/src/middleware/<name>.ts`
+- [ ] Create `packages/kickjs/src/http/middleware/<name>.ts`
 - [ ] Export factory function: `export function name(options = {}) { return (req, res, next) => ... }`
-- [ ] Add to `packages/http/vite.config.ts` `build.lib.entry` object
-- [ ] Add to `packages/http/package.json` exports map
-- [ ] Add re-export to `packages/http/src/index.ts`
+- [ ] Add to `packages/kickjs/tsdown.config.ts` `entry` object
+- [ ] Add to `packages/kickjs/package.json` exports map
+- [ ] Add re-export to `packages/kickjs/src/http/index.ts` (+ `src/index.ts` if public — the root index is selective)
 - [ ] Add docs page at `docs/guide/<name>.md`
 - [ ] Add to sidebar in `docs/.vitepress/config.mts`
 - [ ] Run `pnpm build && pnpm test`
@@ -110,7 +110,7 @@ When adding new features, use these as templates:
 
 ### New Example App
 
-- [ ] Scaffold with CLI: `cd examples && node ../packages/cli/bin.js new <name> --template ddd --pm pnpm --repo inmemory --no-git --no-install --force`
+- [ ] Scaffold with CLI: `cd examples && node ../packages/cli/bin.js new <name> --template rest --pm pnpm --repo inmemory --no-git --no-install --force`
 - [ ] Add `package.json` (private: true, `workspace:*` deps — examples don't publish; their version is irrelevant)
 - [ ] Add the package name to `.changeset/config.json:ignore` so changesets doesn't try to version it
 - [ ] Add docs page at `docs/examples/<name>.md`
@@ -154,7 +154,7 @@ node ../packages/cli/bin.js new upload-api --yes --no-install --force
 
 # Or specify each flag for a non-default scaffold
 node ../packages/cli/bin.js new upload-api \
-  --template ddd --pm pnpm --repo prisma --no-git --no-install --force
+  --template rest --pm pnpm --repo prisma --no-git --no-install --force
 
 # Generate modules inside the example
 cd upload-api
@@ -163,7 +163,7 @@ node ../../packages/cli/bin.js g module upload
 
 `--yes` (alias `--non-interactive`, short `-y`) bypasses every prompt. Without it, missing flags trigger interactive selection.
 
-Available flags for `new`: `--template rest|ddd|cqrs|minimal`, `--pm pnpm|npm|yarn|bun`, `--repo prisma|drizzle|inmemory|custom`, `--packages auth,swagger,...`, `--no-git`, `--no-install`, `--force`, `-y / --yes / --non-interactive`.
+Available flags for `new`: `--template rest|minimal|fullstack`, `--pm pnpm|npm|yarn|bun`, `--repo prisma|drizzle|inmemory|custom`, `--packages auth,swagger,...`, `--no-git`, `--no-install`, `--force`, `-y / --yes / --non-interactive`.
 
 After scaffolding, customize the generated code for the example's purpose.
 
@@ -191,13 +191,13 @@ ORM-specific templates live in subfolders:
 
 Pattern generators are in `generators/patterns/`:
 
-- `rest.ts`, `ddd.ts`, `cqrs.ts`, `minimal.ts` — each exports a `generate*Files(ctx: ModuleContext)` function
+- `rest.ts`, `minimal.ts` — each exports a `generate*Files(ctx: ModuleContext)` function
 
 ### Key Config: kick.config.ts
 
 ```ts
 export default defineConfig({
-  pattern: 'ddd',
+  pattern: 'rest',
   modules: {
     dir: 'src/modules',
     repo: 'prisma', // 'drizzle' | 'inmemory' | 'prisma' | { name: 'custom' }
@@ -236,7 +236,7 @@ Use feature branches and PRs — never commit directly to `main`:
 git checkout -b feat/route-table-on-startup
 
 # 2. Make changes, commit with conventional commits
-git add packages/http/
+git add packages/kickjs/
 git commit -m "feat: print route table on application startup (#31)"
 
 # 3. Push and create PR (rich bodies go through a temp file — see below)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,9 @@
 
 KickJS is a decorator-driven Node.js framework for TypeScript. The HTTP engine is pluggable — it runs on **Express (default), Fastify, or h3**, selected via `bootstrap({ runtime })`; controllers/modules/DI/context decorators are engine-neutral. Monorepo managed with pnpm workspaces and Turbo.
 
-> The real framework package is `packages/kickjs` (`@forinda/kickjs`) — it holds the DI core, HTTP layer, RequestContext, and the runtime seam (`src/http/runtimes/{express,fastify,h3}.ts`). The `packages/core` + `packages/http` split described in older parts of this doc is **stale**; treat `packages/kickjs/src/{core,http}` as the source of truth. Fastify/h3 runtimes + cross-engine uploads currently ship on the `alpha` channel.
+> The real framework package is `packages/kickjs` (`@forinda/kickjs`) — it holds the DI core, HTTP layer, RequestContext, and the runtime seam (`src/http/runtimes/{express,fastify,h3}.ts`). The `packages/core` + `packages/http` split described in older parts of this doc is **stale**; treat `packages/kickjs/src/{core,http}` as the source of truth. Fastify/h3 runtimes, the h3 v2 web-standard entries (`./h3-web`, `./web` — edge/Bun/Deno), and cross-engine uploads all ship in the **stable** release.
 
-**18 published packages** under `@forinda/kickjs-*`, **10 example apps**, CLI with generators, Prisma/Drizzle/custom ORM support.
+**30+ workspace packages** (published under `@forinda/kickjs*` unless private), CLI with generators + a fullstack template, typed client, Prisma/Drizzle/kick-db support. Runnable example apps live in [forinda/kickjs-examples-archive](https://github.com/forinda/kickjs-examples-archive); `examples/` in-repo holds only test fixtures.
 
 ## Quick Commands
 
@@ -30,33 +30,25 @@ pnpm changeset:status   # Preview pending bumps
 ## Repository Structure
 
 ```
-packages/               # Published @forinda/kickjs-* packages
-  core/                 # DI container, 20+ decorators, module system, logger, reactivity
-  http/                 # Express 5, routing, middleware, RequestContext, query parsing
-  config/               # Zod-based env validation, ConfigService, @Value decorator
-  cli/                  # Project scaffolding, DDD generators, kick add, kick remove
-  swagger/              # OpenAPI spec generation from decorators
-  testing/              # createTestApp, createTestModule helpers
-  prisma/               # Prisma adapter (v5/6/7), PrismaModelDelegate, query building
-  drizzle/              # Drizzle adapter, DrizzleQueryAdapter
-  auth/                 # JWT, API key, OAuth strategies, @Public, @Roles
-  ws/                   # WebSocket with @WsController, rooms, heartbeat
-  queue/                # BullMQ/RabbitMQ/Kafka with @Job, @Process
-  cron/                 # Cron scheduling with @Cron decorator
-  mailer/               # SMTP, Resend, SES, ConsoleProvider
-  graphql/              # @Resolver, @Query, @Mutation, GraphiQL
-  otel/                 # OpenTelemetry tracing and metrics
-  devtools/             # Debug dashboard at /_debug
-  notifications/        # Multi-channel: email, Slack, Discord, webhook
-  multi-tenant/         # Tenant resolution middleware
-examples/                       # Non-published example apps (private, not on npm)
-  minimal-api/                  # Simplest possible app (~10 lines)
-  task-drizzle-api/             # Full task management app — PostgreSQL + Drizzle
-  task-mongoose-api/            # Full task management app — MongoDB + Mongoose
-  task-prisma-api/              # Full task management app — PostgreSQL + Prisma 7
-  multi-tenant-drizzle-api/     # Multi-tenant pattern — PostgreSQL + Drizzle
-  multi-tenant-mongoose-api/    # Multi-tenant pattern — MongoDB + Mongoose
-  multi-tenant-prisma-api/      # Multi-tenant pattern — PostgreSQL + Prisma
+packages/               # Workspace packages (@forinda/kickjs* on npm unless private)
+  kickjs/               # THE framework — DI core, decorators, http layer,
+                        #   RequestContext, runtimes (express/fastify/h3/h3-web),
+                        #   web fetch entry (src/web.ts → @forinda/kickjs/web)
+  cli/                  # kick new (rest|minimal|fullstack), generators, typegen,
+                        #   kick add / doctor / agents
+  client/               # @forinda/kickjs-client — typed fetch client (frontend)
+  vite/                 # Vite HMR plugin + typegen watcher
+  schema/               # Schema-agnostic validation (Zod/Valibot/Yup/StdSchema)
+  swagger/              # OpenAPI from decorators + declared response schemas
+  db/ db-pg/ db-mysql/ db-sqlite/  # kick/db code-first database family
+  testing/              # createTestApp, createTestModule, plugin harness
+  devtools/ devtools-kit/          # /_debug dashboard + adapter tab kit
+  ai/ mcp/ graphql/ ws/ queue/ cron/ mailer/ otel/
+  notifications/ multi-tenant/ auth/ prisma/ drizzle/
+  cli-kit/ lint/ vscode-extension/
+  core/ http/ config/   # LEGACY split — superseded by packages/kickjs; do not edit
+examples/               # Test fixtures only (typegen-test). Runnable apps live in
+                        #   github.com/forinda/kickjs-examples-archive
 articles/               # Blog articles (dev.to)
 scripts/                # release.js (versioning)
 docs/                   # VitePress documentation site
@@ -79,20 +71,20 @@ docs/                   # VitePress documentation site
 
 ## Key Patterns
 
-### Adding Middleware (to `packages/http`)
+### Adding Middleware (to `packages/kickjs`)
 
-1. Create `packages/http/src/middleware/<name>.ts`
-2. Add entry to `packages/http/vite.config.ts` `build.lib.entry` object
-3. Add export map entry to `packages/http/package.json`
-4. Add re-export to `packages/http/src/index.ts`
+1. Create `packages/kickjs/src/http/middleware/<name>.ts`
+2. Add entry to `packages/kickjs/tsdown.config.ts` `entry` object
+3. Add export map entry to `packages/kickjs/package.json`
+4. Add re-export to `packages/kickjs/src/http/index.ts` (and `src/index.ts` if it's public API — the root index is selective, not `export *`)
 
 ### Adding a Package
 
-1. Create `packages/<name>/` with `package.json`, `tsconfig.json`, `tsconfig.build.json`, `vite.config.ts`
+1. Create `packages/<name>/` with `package.json`, `tsconfig.json`, `tsdown.config.ts`, `vitest.config.ts` (copy `packages/schema/` as the template — tsdown is the repo standard; the old vite-library recipe is retired)
 2. Name it `@forinda/kickjs-<name>`, start at `0.0.0` — changesets will set the first published version on the next release PR
 3. Use `workspace:*` for internal deps
-4. Set `minify: 'esbuild'` in vite.config.ts, add all runtime deps to `rollupOptions.external`
-5. Build script: `"build": "vite build && pnpm build:types"`, `"build:types": "tsc -p tsconfig.build.json"`
+4. tsdown config: `format: ['esm']`, `dts: { tsgo: true }`, all runtime deps in `external`
+5. Scripts: `"build": "tsdown"`, `"typecheck": "tsgo --noEmit"` — and CHECK the exports map matches what tsdown emits (`dist/index.js` + `dist/index.d.ts`; a mismatch shipped an unresolvable package once)
 
 ### Adding an Adapter
 
@@ -119,12 +111,12 @@ node ../packages/cli/bin.js new my-example-api --yes --no-install --force
 
 # Or specify each flag explicitly when you want a non-default template/repo
 node ../packages/cli/bin.js new my-example-api \
-  --template ddd --pm pnpm --repo prisma --no-git --no-install --force
+  --template rest --pm pnpm --repo prisma --no-git --no-install --force
 ```
 
 `--yes` (alias `--non-interactive`) bypasses every prompt with safe defaults; explicit flags override individual answers. Without `--yes`, every unset flag prompts interactively.
 
-Available flags: `--template rest|ddd|cqrs|minimal`, `--pm pnpm|npm|yarn|bun`, `--repo prisma|drizzle|inmemory|custom`, `--packages auth,swagger,...`, `--no-git`, `--no-install`, `--force`, `-y / --yes / --non-interactive`.
+Available flags: `--template rest|minimal|fullstack`, `--pm pnpm|npm|yarn|bun`, `--repo prisma|drizzle|inmemory|custom`, `--packages auth,swagger,...`, `--no-git`, `--no-install`, `--force`, `-y / --yes / --non-interactive`.
 
 3. Update generated `package.json`:
    - Rename to `@forinda/kickjs-example-<name>`
@@ -267,7 +259,7 @@ src/
     module.ts                     # generateModule orchestrator
     remove-module.ts              # removeModule + index.ts cleanup
     patterns/                     # Pattern-specific generators
-      rest.ts, ddd.ts, cqrs.ts, minimal.ts
+      rest.ts, minimal.ts
       types.ts                    # ModuleContext interface
     templates/                    # Code template functions
       types.ts                    # TemplateContext interface
@@ -281,7 +273,7 @@ src/
 
 ```ts
 export default defineConfig({
-  pattern: 'ddd',
+  pattern: 'rest',
   modules: {
     dir: 'src/modules',
     repo: 'prisma',                     // 'drizzle' | 'inmemory' | 'prisma' | { name: 'custom' }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,40 +124,32 @@ pnpm test:coverage      # Run tests with coverage report
 pnpm test:e2e           # Run end-to-end tests
 
 # Code Quality
-pnpm lint               # Run ESLint
-pnpm lint:fix           # Fix ESLint issues
-pnpm type-check         # Run TypeScript type checking
-pnpm format             # Format code with Prettier
-
-# Examples
-pnpm example:basic-todo     # Run basic todo example
-pnpm example:medium-kanban  # Run kanban example
-pnpm example:complex-analytics # Run analytics example
+pnpm lint               # oxlint over packages/
+pnpm lint:fix           # oxlint --fix
+pnpm typecheck          # tsgo/tsc across packages (turbo)
+pnpm format             # oxfmt --write (repo standard; no ESLint/Prettier)
 ```
+
+Runnable example apps live in
+[forinda/kickjs-examples-archive](https://github.com/forinda/kickjs-examples-archive) —
+clone that repo to run them; `examples/` here holds test fixtures only.
 
 ## 📁 Project Structure
 
 Understanding the project structure will help you navigate and contribute effectively:
 
 ```
-kickjs/
-├── src/                          # Source code
-│   ├── core/                     # Core framework code
-│   │   ├── app/                  # Application management
-│   │   ├── decorators/           # Framework decorators
-│   │   ├── types/                # TypeScript type definitions
-│   │   ├── utils/                # Utility functions
-│   │   └── constants/            # Constants and keys
-│   ├── cli/                      # CLI tooling
-│   └── index.ts                  # Main export file
-├── examples/                     # Example applications
-│   ├── basic-todo/               # Simple CRUD example
-│   ├── medium-kanban/            # Kanban board example
-│   └── complex-analytics/        # Analytics dashboard example
-├── tests/                        # Test files
-├── docs/                         # Documentation
-├── dist/                         # Built files (generated)
-└── README.md                     # Main documentation
+kick-js/                          # pnpm + Turbo monorepo
+├── packages/
+│   ├── kickjs/                   # THE framework (DI core, http, runtimes, /web entry)
+│   ├── cli/                      # kick new / generators / typegen
+│   ├── client/                   # typed fetch client (frontend)
+│   ├── vite/ schema/ swagger/ testing/ …   # the rest of the @forinda/kickjs* family
+│   └── <pkg>/__tests__/          # per-package tests (vitest)
+├── __tests__/                    # root integration tests
+├── examples/                     # test fixtures only (apps → kickjs-examples-archive)
+├── docs/                         # VitePress site (kickjs.app)
+└── CLAUDE.md / .agents/          # AI agent context
 ```
 
 ### Key Directories
@@ -241,7 +233,7 @@ There is no separate `dev` branch in this flow. Pre-release windows are explicit
    ```
 
    ::: warning
-   If you change any framework package (`packages/*`), always run `pnpm build:examples` before submitting your PR. Example apps depend on the framework packages — a breaking change in `@forinda/kickjs-core` or `@forinda/kickjs-http` can silently break examples that CI may not catch in every job.
+   If you change any framework package (`packages/*`), always run `pnpm build:examples` before submitting your PR. Example apps depend on the framework packages — a breaking change in `@forinda/kickjs` can silently break examples that CI may not catch in every job.
    :::
 
 4. **Commit your changes**:
@@ -499,12 +491,6 @@ tests/
    pnpm lint
    pnpm type-check
    pnpm build
-   ```
-
-3. **Test examples**:
-   ```bash
-   pnpm example:basic-todo
-   pnpm example:medium-kanban
    ```
 
 ### PR Template


### PR DESCRIPTION
Second audit PR. Headline: **CLAUDE.md/AGENTS.md claimed fastify/h3 ship on the alpha channel** — stable 6.2.x exports `./fastify ./h3 ./h3-web ./web`. Also: dead `--template ddd|cqrs` everywhere, repo-structure sections describing the deleted core/http split + seven deleted example apps, middleware/package recipes teaching the retired vite-library shape (now tsdown, with an exports-vs-emitted check — the exact bug class that shipped an unresolvable client), CONTRIBUTING's ESLint/Prettier/single-package fiction replaced with oxlint/oxfmt/monorepo reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)