### PR TITLE
docs: Support section (Buy Me a Coffee) first in the sidebar

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -3,6 +3,10 @@ import { defineConfig } from 'vitepress'
 
 const guideSidebar = [
   {
+    text: 'Support',
+    items: [{ text: '☕ Support KickJS', link: '/guide/support' }],
+  },
+  {
     text: 'Introduction',
     items: [
       { text: 'What is KickJS?', link: '/guide/what-is-kickjs' },

--- a/docs/guide/support.md
+++ b/docs/guide/support.md
@@ -1,0 +1,31 @@
+# Support KickJS
+
+KickJS is built and maintained by [Felix Orinda](https://github.com/forinda) —
+the framework, the CLI, the typed client, the docs, all of it open source under
+MIT.
+
+If KickJS saves you time, here's how to give some back:
+
+## ☕ Buy me a coffee
+
+<a href="https://buymeacoffee.com/forinda82c" target="_blank" rel="noopener">
+  <img src="https://img.buymeacoffee.com/button-api/?text=Buy me a coffee&emoji=☕&slug=forinda82c&button_colour=FACC15&font_colour=1f2937&font_family=Inter&outline_colour=1f2937&coffee_colour=ffffff" alt="Buy Me A Coffee" />
+</a>
+
+Every coffee funds maintenance time: dependency upgrades, issue triage, and
+the next feature on the [roadmap](./roadmap.md).
+
+## Other ways to help
+
+- **Star the repo** — [github.com/forinda/kick-js](https://github.com/forinda/kick-js)
+  helps others find the project.
+- **Report bugs / request features** —
+  [open an issue](https://github.com/forinda/kick-js/issues); minimal
+  reproductions get fixed fastest.
+- **Contribute** — see the
+  [contributing guide](https://github.com/forinda/kick-js/blob/main/CONTRIBUTING.md);
+  `good first issue` labels are curated.
+- **Spread the word** — a blog post, a talk, or a "we use KickJS" mention goes
+  further than you'd think.
+
+Thank you. 💛


### PR DESCRIPTION
New `guide/support.md` with the [buymeacoffee.com/forinda82c](https://buymeacoffee.com/forinda82c) button (BMC's image-button API, brand-yellow to match the site) + the non-monetary support list (star / issues / contributing / word of mouth). 'Support' group sits at the top of the guide sidebar. Docs build green.

Note: the button image loads from img.buymeacoffee.com — external images render fine on the docs site (only the docs *build* is self-contained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Support” guide with ways to support the project, including a donation link and other contribution options.
  * Added a “Support” entry to the documentation navigation for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->