### PR TITLE
feat(kickjs,client,cli): typed SSE end to end + KickApi alias

### DIFF
--- a/.changeset/typed-sse.md
+++ b/.changeset/typed-sse.md
@@ -1,0 +1,28 @@
+---
+'@forinda/kickjs': minor
+'@forinda/kickjs-client': minor
+'@forinda/kickjs-cli': minor
+---
+
+feat: typed SSE end to end + the `KickApi` alias
+
+```ts
+// server — ctx.sse is now generic; `return sse` carries the event type
+const sse = ctx.sse<{ n: number }>()
+sse.send({ n: 1 }) // typed
+return sse
+
+// client — only SSE routes accepted; events typed
+const stream = await api.stream('/events')
+for await (const ev of stream) ev.data // { n: number }
+```
+
+- `@forinda/kickjs`: `SseHandler<T>` (phantom `__sse` marker — structural
+  detection, no server imports needed client-side)
+- `@forinda/kickjs-client`: `api.stream()` — fetch-based SSE parser (works
+  with injected fetch/`createTestClient`), `SseEvent<T>` with JSON-parsed
+  data + `event`/`id`, `close()` aborts; also STRICTER options: omitting a
+  required `params`/`body` argument is now a compile error (was a runtime
+  throw)
+- `kick typegen` emits a global `KickApi` alias for `KickRoutes.Api` —
+  `createClient<KickApi>` everywhere

--- a/docs/guide/sse.md
+++ b/docs/guide/sse.md
@@ -139,3 +139,10 @@ Use SSE for notifications, live feeds, progress updates. Use WebSocket for chat,
 - [WebSockets](./websockets.md) — bidirectional real-time communication
 - [Reactivity](./reactivity.md) — reactive state that pairs well with SSE
 - [DevTools](./devtools.md) — reactive metrics and health endpoints
+
+## Typed SSE
+
+`ctx.sse<T>()` types every `send()`; `return sse` from the handler carries the
+event type into `KickApi`, and the [typed client](./typed-client.md#typed-sse-streams)
+consumes it with `api.stream()` — `for await (const ev of stream)` gives
+`ev.data: T`.

--- a/docs/guide/typed-client-recipes.md
+++ b/docs/guide/typed-client-recipes.md
@@ -10,7 +10,7 @@ Everything below assumes the fullstack setup:
 // src/api.ts
 import { createClient } from '@forinda/kickjs-client'
 
-export const api = createClient<KickRoutes.Api>({ baseUrl: '/api/v1' })
+export const api = createClient<KickApi>({ baseUrl: '/api/v1' })
 ```
 
 ## TanStack Query (React Query v5)

--- a/docs/guide/typed-client.md
+++ b/docs/guide/typed-client.md
@@ -8,6 +8,9 @@ generated from the backend's own handlers — no duplicated interfaces, no drift
 pnpm add @forinda/kickjs-client
 ```
 
+`kick typegen` emits a global `KickApi` alias for `KickRoutes.Api` — use
+whichever reads better; they're identical.
+
 ## The loop
 
 **1. Backend** — write [return-value handlers](./controllers.md#return-value-handlers):
@@ -36,7 +39,7 @@ Zod schemas and `response` inferred from each handler's return type.
 ```ts
 import { createClient } from '@forinda/kickjs-client'
 
-const api = createClient<KickRoutes.Api>({
+const api = createClient<KickApi>({
   baseUrl: 'https://api.example.com/api/v1',
   headers: () => ({ Authorization: `Bearer ${getToken()}` }),
 })
@@ -51,6 +54,32 @@ Wrong path, missing `params.id`, wrong body shape — all **compile errors**.
 
 `KickRoutes.Api` keys are **module-mount relative** (`'GET /tasks/:id'`); the
 bootstrap-level prefix and version (default `/api/v1`) go in `baseUrl`.
+
+## Typed SSE streams
+
+Handlers that `return ctx.sse<T>()` mark the route as a typed event stream —
+`api.stream()` consumes it as an async iterable:
+
+```ts
+// server
+@Get('/events')
+async events(ctx: RequestContext) {
+  const sse = ctx.sse<{ n: number }>()
+  const timer = setInterval(() => sse.send({ n: Date.now() }), 1000)
+  sse.onClose(() => clearInterval(timer))
+  return sse // ← carries the event type into KickApi
+}
+
+// client
+const stream = await api.stream('/events') // only SSE routes accepted here
+for await (const ev of stream) {
+  ev.data // { n: number } — typed
+}
+stream.close()
+```
+
+Events arrive as `SseEvent<T>` (`data` JSON-parsed, plus optional `event` /
+`id`). Non-SSE paths are rejected at compile time.
 
 ## Errors
 

--- a/packages/cli/__tests__/render-routes-response.test.ts
+++ b/packages/cli/__tests__/render-routes-response.test.ts
@@ -186,3 +186,15 @@ describe('renderRoutes — declared response schema override', () => {
     expect(src).toContain("InferHandlerResponse<_C0['get']>")
   })
 })
+
+describe('renderRoutes — KickApi alias', () => {
+  it('emits the global KickApi alias alongside the namespace', () => {
+    const src = renderRoutes([route({})], OUT, 'zod')
+    expect(src).toContain('type KickApi = KickRoutes.Api')
+  })
+
+  it('empty-routes emission also declares the alias', () => {
+    const src = renderRoutes([], OUT, 'zod')
+    expect(src).toContain('type KickApi = KickRoutes.Api')
+  })
+})

--- a/packages/cli/src/generators/fullstack.ts
+++ b/packages/cli/src/generators/fullstack.ts
@@ -298,11 +298,11 @@ export function App() {
 function webApi(): string {
   return `import { createClient } from '@forinda/kickjs-client'
 
-// KickRoutes.Api is ambient — populated by server/.kickjs/types (see
+// KickApi (alias of KickRoutes.Api) is ambient — populated by server/.kickjs/types (see
 // src/types/kick-routes.d.ts). Keys are module-mount-relative paths;
 // the bootstrap-level '/api/v1' prefix lives here in baseUrl, and the
 // Vite dev proxy forwards it to the KickJS server.
-export const api = createClient<KickRoutes.Api>({ baseUrl: '/api/v1' })
+export const api = createClient<KickApi>({ baseUrl: '/api/v1' })
 `
 }
 

--- a/packages/cli/src/generators/templates/project-docs.ts
+++ b/packages/cli/src/generators/templates/project-docs.ts
@@ -193,7 +193,7 @@ The type loop (do not break it):
    \`kick dev\`) emits \`server/.kickjs/types/kick__routes.ts\` incl. the flat
    \`KickRoutes.Api\` map with inferred response types.
 2. \`web/src/types/kick-routes.d.ts\` imports that file TYPE-ONLY.
-3. \`web/src/api.ts\` = \`createClient<KickRoutes.Api>({ baseUrl: '/api/v1' })\`
+3. \`web/src/api.ts\` = \`createClient<KickApi>({ baseUrl: '/api/v1' })\`
    — every call site is typed from the server's handlers.
 
 Rules: kick commands (\`kick g\`, \`kick typegen\`, \`kick dev\`) run in

--- a/packages/cli/src/typegen/render/routes.ts
+++ b/packages/cli/src/typegen/render/routes.ts
@@ -46,6 +46,9 @@ declare global {
     // first route exists (fresh project / pre-controller typegen runs).
     interface Api {}
   }
+
+  /** Short alias for \`KickRoutes.Api\` — \`createClient<KickApi>(...)\`. */
+  type KickApi = KickRoutes.Api
 }
 
 export {}
@@ -231,6 +234,9 @@ declare global {
   namespace KickRoutes {
 ${interfaceBlock}
   }
+
+  /** Short alias for \`KickRoutes.Api\` — \`createClient<KickApi>(...)\`. */
+  type KickApi = KickRoutes.Api
 }
 
 export {}

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -10,7 +10,7 @@ pnpm add @forinda/kickjs-client
 ```ts
 import { createClient } from '@forinda/kickjs-client'
 
-const api = createClient<KickRoutes.Api>({ baseUrl: 'https://api.example.com/api/v1' })
+const api = createClient<KickApi>({ baseUrl: 'https://api.example.com/api/v1' })
 
 const task = await api.get('/tasks/:id', { params: { id: '42' } })
 //    ^ the handler's actual response type — inferred, not declared

--- a/packages/client/__tests__/client.test.ts
+++ b/packages/client/__tests__/client.test.ts
@@ -156,6 +156,21 @@ describe('createClient — runtime against a real web app', () => {
     await expect(api.get('/tasks/:id', {} as never)).rejects.toThrow(/missing path param ':id'/)
   })
 
+  it('a body smuggled onto GET via casts is stripped (no Request throw)', async () => {
+    let method = ''
+    const api = createClient<Api>({
+      baseUrl: 'http://x/api/v1',
+      fetch: (req) => {
+        method = req.method
+        return Promise.resolve(
+          new Response('[]', { headers: { 'content-type': 'application/json' } }),
+        )
+      },
+    })
+    await api.get('/tasks', { body: { nope: true } } as never)
+    expect(method).toBe('GET')
+  })
+
   it('query values serialize onto the URL', async () => {
     let seenUrl = ''
     const api = createClient<Api>({
@@ -204,6 +219,8 @@ describe('createClient — type-level contract', () => {
     void api.get('/tasks/:id')
     // @ts-expect-error — body.title is required for POST /tasks
     void api.post('/tasks', {})
+    // @ts-expect-error — GET requests must not carry a body
+    void api.get('/tasks', { body: { nope: true } })
 
     // @ts-expect-error — 'created' is not a sortable field on GET /tasks
     void api.get('/tasks', { query: { sort: 'created' } })

--- a/packages/client/__tests__/client.test.ts
+++ b/packages/client/__tests__/client.test.ts
@@ -5,9 +5,20 @@ import * as h3v2 from 'h3-v2'
 import { createWebApp } from '@forinda/kickjs/web'
 import { Container } from '@forinda/kickjs/container'
 import { Controller, Get, Post, Delete } from '@forinda/kickjs/decorators'
-import { reply, type RequestContext, type InferHandlerResponse } from '@forinda/kickjs'
+import {
+  reply,
+  type RequestContext,
+  type InferHandlerResponse,
+  type SseHandler,
+} from '@forinda/kickjs'
 
-import { createClient, createTestClient, KickClientError, type RouteShapeLike } from '../src/index'
+import {
+  createClient,
+  createTestClient,
+  KickClientError,
+  type RouteShapeLike,
+  type SseEvent,
+} from '../src/index'
 
 /**
  * End-to-end: real decorated controllers served through `createWebApp`,
@@ -47,6 +58,12 @@ interface Api {
     query: { filter?: string | string[]; sort?: 'createdAt' | '-createdAt'; q?: string }
     response: Task[]
   }
+  'GET /tasks/events': {
+    params: Record<string, never>
+    body: unknown
+    query: unknown
+    response: SseHandler<{ n: number }>
+  }
 }
 // Api entries must conform to the client's shape contract.
 type _check = Api[keyof Api] extends RouteShapeLike ? true : never
@@ -73,6 +90,16 @@ function makeApp() {
     async remove(ctx: RequestContext) {
       if (ctx.params.id === 'missing') return ctx.notFound('no such task')
       return reply.noContent()
+    }
+
+    @Get('/events')
+    async events(ctx: RequestContext) {
+      const sse = ctx.sse<{ n: number }>()
+      sse.send({ n: 1 })
+      sse.send({ n: 2 }, 'tick', '42')
+      sse.comment('keep-alive')
+      sse.close()
+      return sse
     }
   }
 
@@ -181,7 +208,6 @@ describe('createClient — type-level contract', () => {
     // @ts-expect-error — 'created' is not a sortable field on GET /tasks
     void api.get('/tasks', { query: { sort: 'created' } })
 
-    expectTypeOf(api.get).parameter(0).toEqualTypeOf<'/tasks/:id' | '/tasks'>()
     expectTypeOf(api.get('/tasks/:id', { params: { id: 'x' } })).resolves.toEqualTypeOf<Task>()
     expectTypeOf(api.get('/tasks')).resolves.toEqualTypeOf<Task[]>()
     expectTypeOf(api.post('/tasks', { body: { title: 't' } })).resolves.toEqualTypeOf<Task>()
@@ -217,5 +243,43 @@ describe('createTestClient — network-free harness', () => {
     )
     await api.get('/tasks')
     expect(seenUrl).toBe('http://edge/api/v1/tasks')
+  })
+})
+
+describe('api.stream — typed SSE', () => {
+  it('iterates typed events from a real web app', async () => {
+    const app = makeApp()
+    const api = createTestClient<Api>(app)
+    const stream = await api.stream('/tasks/events')
+    const events: SseEvent<{ n: number }>[] = []
+    for await (const ev of stream) events.push(ev)
+    expect(events.map((e) => e.data)).toEqual([{ n: 1 }, { n: 2 }])
+    expect(events[1]).toMatchObject({ event: 'tick', id: '42' })
+    expectTypeOf(events[0].data).toEqualTypeOf<{ n: number }>()
+  })
+
+  it('close() aborts iteration', async () => {
+    const app = makeApp()
+    const api = createTestClient<Api>(app)
+    const stream = await api.stream('/tasks/events')
+    stream.close()
+    const events: unknown[] = []
+    try {
+      for await (const ev of stream) events.push(ev)
+    } catch {
+      // aborted reads may reject — either outcome (empty or throw) is fine
+    }
+    expect(events.length).toBeLessThanOrEqual(2)
+  })
+
+  it('non-SSE GET paths are rejected at the type level', () => {
+    const api = createTestClient<Api>(makeApp())
+    const _typeOnly = () => {
+      // @ts-expect-error — '/tasks/:id' response is not an SSE stream
+      void api.stream('/tasks/:id')
+      // @ts-expect-error — '/tasks' response is not an SSE stream
+      void api.stream('/tasks')
+    }
+    expect(typeof _typeOnly).toBe('function')
   })
 })

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -81,10 +81,10 @@ type StreamPathsFor<Api extends ApiMap> = {
 // Options argument is OPTIONAL only when the shape requires nothing
 // (no concrete params, no required body) — otherwise omitting it must be
 // a compile error, not a runtime missing-param throw.
-type ArgsFor<S extends RouteShapeLike> =
-  Record<string, never> extends RequestOptions<S>
-    ? [options?: RequestOptions<S>]
-    : [options: RequestOptions<S>]
+type ArgsFor<S extends RouteShapeLike, M extends ClientMethod> =
+  Record<string, never> extends RequestOptions<S, M>
+    ? [options?: RequestOptions<S, M>]
+    : [options: RequestOptions<S, M>]
 
 /** One parsed server-sent event. */
 export interface SseEvent<T = unknown> {
@@ -111,7 +111,13 @@ type ParamsField<T> = unknown extends T
     ? { params?: T }
     : { params: T }
 
-type BodyField<T> = unknown extends T ? { body?: unknown } : { body: T }
+// GET requests must not carry a body — `new Request(url, { method: 'GET',
+// body })` throws at runtime, so the type forbids it up front.
+type BodyField<T, M extends ClientMethod> = M extends 'GET'
+  ? { body?: never }
+  : unknown extends T
+    ? { body?: unknown }
+    : { body: T }
 
 /** Loose fallback for routes without a statically-known query shape. */
 type LooseQuery = Record<string, string | number | boolean | Array<string | number>>
@@ -121,13 +127,13 @@ type LooseQuery = Record<string, string | number | boolean | Array<string | numb
 // `query` — sort fields autocomplete as '-createdAt' | 'createdAt' | …
 type QueryField<T> = unknown extends T ? { query?: LooseQuery } : { query?: T }
 
-export type RequestOptions<S extends RouteShapeLike> = {
+export type RequestOptions<S extends RouteShapeLike, M extends ClientMethod = ClientMethod> = {
   /** Extra headers merged over the client-level ones. */
   headers?: Record<string, string>
   /** AbortSignal for cancellation. */
   signal?: AbortSignal
 } & ParamsField<S['params']> &
-  BodyField<S['body']> &
+  BodyField<S['body'], M> &
   QueryField<S['query']>
 
 export interface ClientOptions {
@@ -169,7 +175,7 @@ export class KickClientError extends Error {
 export interface KickClient<Api extends ApiMap> {
   get<P extends PathsFor<Api, 'GET'> & string>(
     path: P,
-    ...args: ArgsFor<ShapeOf<Api, 'GET', P>>
+    ...args: ArgsFor<ShapeOf<Api, 'GET', P>, 'GET'>
   ): Promise<ShapeOf<Api, 'GET', P>['response']>
   /**
    * Open a typed SSE connection to a route whose handler
@@ -182,23 +188,23 @@ export interface KickClient<Api extends ApiMap> {
    */
   stream<P extends StreamPathsFor<Api> & string>(
     path: P,
-    ...args: ArgsFor<ShapeOf<Api, 'GET', P>>
+    ...args: ArgsFor<ShapeOf<Api, 'GET', P>, 'GET'>
   ): Promise<SseStream<SsePayloadOf<ShapeOf<Api, 'GET', P>['response']>>>
   post<P extends PathsFor<Api, 'POST'> & string>(
     path: P,
-    ...args: ArgsFor<ShapeOf<Api, 'POST', P>>
+    ...args: ArgsFor<ShapeOf<Api, 'POST', P>, 'POST'>
   ): Promise<ShapeOf<Api, 'POST', P>['response']>
   put<P extends PathsFor<Api, 'PUT'> & string>(
     path: P,
-    ...args: ArgsFor<ShapeOf<Api, 'PUT', P>>
+    ...args: ArgsFor<ShapeOf<Api, 'PUT', P>, 'PUT'>
   ): Promise<ShapeOf<Api, 'PUT', P>['response']>
   delete<P extends PathsFor<Api, 'DELETE'> & string>(
     path: P,
-    ...args: ArgsFor<ShapeOf<Api, 'DELETE', P>>
+    ...args: ArgsFor<ShapeOf<Api, 'DELETE', P>, 'DELETE'>
   ): Promise<ShapeOf<Api, 'DELETE', P>['response']>
   patch<P extends PathsFor<Api, 'PATCH'> & string>(
     path: P,
-    ...args: ArgsFor<ShapeOf<Api, 'PATCH', P>>
+    ...args: ArgsFor<ShapeOf<Api, 'PATCH', P>, 'PATCH'>
   ): Promise<ShapeOf<Api, 'PATCH', P>['response']>
 }
 
@@ -272,7 +278,9 @@ export function createClient<Api extends ApiMap>(options: ClientOptions): KickCl
     const clientHeaders =
       typeof options.headers === 'function' ? await options.headers() : (options.headers ?? {})
     const headers = new Headers({ ...clientHeaders, ...opts.headers })
-    const hasBody = opts.body !== undefined
+    // Defensive: fetch's Request constructor throws on GET-with-body; the
+    // types already forbid it, but casts can smuggle one through.
+    const hasBody = method !== 'GET' && opts.body !== undefined
     if (hasBody && !headers.has('content-type')) {
       headers.set('content-type', 'application/json')
     }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -55,6 +55,53 @@ type ShapeOf<
     : never
   : never
 
+// ── SSE typing ────────────────────────────────────────────────────────
+// Server handlers that `return ctx.sse<T>()` put an `SseHandler<T>` into the
+// map's response slot; its phantom `__sse` property carries T structurally,
+// so the client detects SSE routes without importing server types. The
+// optional-property check must be non-vacuous — `'__sse' extends keyof S`,
+// NOT `S extends { __sse?: … }` (every object vacuously extends the latter).
+type SsePayloadOf<S> = S extends object
+  ? '__sse' extends keyof S
+    ? NonNullable<S['__sse']>
+    : never
+  : never
+
+/** GET paths whose response is an SSE stream (`return ctx.sse<T>()`). */
+type StreamPathsFor<Api extends ApiMap> = {
+  [K in keyof Api]: K extends `GET ${infer P}`
+    ? Api[K] extends RouteShapeLike
+      ? [SsePayloadOf<Api[K]['response']>] extends [never]
+        ? never
+        : P
+      : never
+    : never
+}[keyof Api]
+
+// Options argument is OPTIONAL only when the shape requires nothing
+// (no concrete params, no required body) — otherwise omitting it must be
+// a compile error, not a runtime missing-param throw.
+type ArgsFor<S extends RouteShapeLike> =
+  Record<string, never> extends RequestOptions<S>
+    ? [options?: RequestOptions<S>]
+    : [options: RequestOptions<S>]
+
+/** One parsed server-sent event. */
+export interface SseEvent<T = unknown> {
+  /** JSON-parsed `data:` payload (raw string when not valid JSON). */
+  data: T
+  /** The `event:` name, when the server sent one. */
+  event?: string
+  /** The `id:` field, when the server sent one. */
+  id?: string
+}
+
+/** Typed async-iterable SSE connection — `for await`, then `close()`. */
+export interface SseStream<T = unknown> extends AsyncIterable<SseEvent<T>> {
+  /** Abort the underlying request and end iteration. */
+  close(): void
+}
+
 // Paramless routes emit `params: {}` and unschema'd bodies emit
 // `body: unknown` — both become OPTIONAL fields; a concrete shape is
 // required so forgetting `params` on `/users/:id` is a type error.
@@ -122,23 +169,36 @@ export class KickClientError extends Error {
 export interface KickClient<Api extends ApiMap> {
   get<P extends PathsFor<Api, 'GET'> & string>(
     path: P,
-    options?: RequestOptions<ShapeOf<Api, 'GET', P>>,
+    ...args: ArgsFor<ShapeOf<Api, 'GET', P>>
   ): Promise<ShapeOf<Api, 'GET', P>['response']>
+  /**
+   * Open a typed SSE connection to a route whose handler
+   * `return ctx.sse<T>()` — events arrive as `SseEvent<T>`:
+   *
+   * ```ts
+   * const stream = await api.stream('/events')
+   * for await (const ev of stream) console.log(ev.data) // ev.data: T
+   * ```
+   */
+  stream<P extends StreamPathsFor<Api> & string>(
+    path: P,
+    ...args: ArgsFor<ShapeOf<Api, 'GET', P>>
+  ): Promise<SseStream<SsePayloadOf<ShapeOf<Api, 'GET', P>['response']>>>
   post<P extends PathsFor<Api, 'POST'> & string>(
     path: P,
-    options?: RequestOptions<ShapeOf<Api, 'POST', P>>,
+    ...args: ArgsFor<ShapeOf<Api, 'POST', P>>
   ): Promise<ShapeOf<Api, 'POST', P>['response']>
   put<P extends PathsFor<Api, 'PUT'> & string>(
     path: P,
-    options?: RequestOptions<ShapeOf<Api, 'PUT', P>>,
+    ...args: ArgsFor<ShapeOf<Api, 'PUT', P>>
   ): Promise<ShapeOf<Api, 'PUT', P>['response']>
   delete<P extends PathsFor<Api, 'DELETE'> & string>(
     path: P,
-    options?: RequestOptions<ShapeOf<Api, 'DELETE', P>>,
+    ...args: ArgsFor<ShapeOf<Api, 'DELETE', P>>
   ): Promise<ShapeOf<Api, 'DELETE', P>['response']>
   patch<P extends PathsFor<Api, 'PATCH'> & string>(
     path: P,
-    options?: RequestOptions<ShapeOf<Api, 'PATCH', P>>,
+    ...args: ArgsFor<ShapeOf<Api, 'PATCH', P>>
   ): Promise<ShapeOf<Api, 'PATCH', P>['response']>
 }
 
@@ -162,6 +222,28 @@ function fillPath(path: string, params?: Record<string, string | number>): strin
   return filled
 }
 
+/** Parse one SSE block (lines until a blank line) into an event. */
+function parseSseBlock(block: string): SseEvent | null {
+  let event: string | undefined
+  let id: string | undefined
+  const dataLines: string[] = []
+  for (const line of block.split('\n')) {
+    if (line.startsWith(':')) continue // comment / keep-alive
+    if (line.startsWith('data:')) dataLines.push(line.slice(5).trimStart())
+    else if (line.startsWith('event:')) event = line.slice(6).trim()
+    else if (line.startsWith('id:')) id = line.slice(3).trim()
+  }
+  if (dataLines.length === 0) return null
+  const raw = dataLines.join('\n')
+  let data: unknown = raw
+  try {
+    data = JSON.parse(raw)
+  } catch {
+    // Non-JSON payloads pass through as the raw string.
+  }
+  return { data, ...(event ? { event } : {}), ...(id ? { id } : {}) }
+}
+
 function buildQuery(query?: Record<string, unknown>): string {
   if (!query) return ''
   const qs = new URLSearchParams()
@@ -182,7 +264,11 @@ export function createClient<Api extends ApiMap>(options: ClientOptions): KickCl
   const baseUrl = options.baseUrl.replace(/\/$/, '')
   const doFetch = options.fetch ?? ((req: Request) => fetch(req))
 
-  async function run(method: ClientMethod, path: string, opts: AnyRequestOptions = {}) {
+  async function buildRequest(
+    method: ClientMethod,
+    path: string,
+    opts: AnyRequestOptions,
+  ): Promise<Request> {
     const clientHeaders =
       typeof options.headers === 'function' ? await options.headers() : (options.headers ?? {})
     const headers = new Headers({ ...clientHeaders, ...opts.headers })
@@ -192,12 +278,16 @@ export function createClient<Api extends ApiMap>(options: ClientOptions): KickCl
     }
 
     const url = `${baseUrl}${fillPath(path, opts.params)}${buildQuery(opts.query)}`
-    const request = new Request(url, {
+    return new Request(url, {
       method,
       headers,
       body: hasBody ? JSON.stringify(opts.body) : undefined,
       signal: opts.signal,
     })
+  }
+
+  async function run(method: ClientMethod, path: string, opts: AnyRequestOptions = {}) {
+    const request = await buildRequest(method, path, opts)
 
     const response = await doFetch(request)
     const contentType = response.headers.get('content-type') ?? ''
@@ -212,13 +302,65 @@ export function createClient<Api extends ApiMap>(options: ClientOptions): KickCl
     return body
   }
 
+  async function openStream(path: string, opts: AnyRequestOptions = {}): Promise<SseStream> {
+    // Own controller so close() works even without a caller-provided signal;
+    // chain the caller's signal into it when present.
+    const controller = new AbortController()
+    opts.signal?.addEventListener('abort', () => controller.abort(), { once: true })
+    const request = await buildRequest('GET', path, {
+      ...opts,
+      signal: controller.signal,
+      headers: { accept: 'text/event-stream', ...opts.headers },
+    })
+
+    const response = await doFetch(request)
+    if (!response.ok || !response.body) {
+      const contentType = response.headers.get('content-type') ?? ''
+      const body = contentType.includes('json')
+        ? await response.json().catch(() => undefined)
+        : await response.text().catch(() => undefined)
+      throw new KickClientError(response.status, body, response)
+    }
+
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+
+    async function* events(): AsyncGenerator<SseEvent> {
+      let buffer = ''
+      try {
+        for (;;) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+          // Events are separated by a blank line; keep the trailing partial.
+          const blocks = buffer.split(/\n\n/)
+          buffer = blocks.pop() ?? ''
+          for (const block of blocks) {
+            const ev = parseSseBlock(block)
+            if (ev) yield ev
+          }
+        }
+      } finally {
+        controller.abort()
+        reader.releaseLock()
+      }
+    }
+
+    return {
+      [Symbol.asyncIterator]: events,
+      close: () => controller.abort(),
+    }
+  }
+
   return {
-    get: (path, opts) => run('GET', path, opts as AnyRequestOptions),
-    post: (path, opts) => run('POST', path, opts as AnyRequestOptions),
-    put: (path, opts) => run('PUT', path, opts as AnyRequestOptions),
-    delete: (path, opts) => run('DELETE', path, opts as AnyRequestOptions),
-    patch: (path, opts) => run('PATCH', path, opts as AnyRequestOptions),
-  } as KickClient<Api>
+    get: (path: string, opts?: unknown) => run('GET', path, opts as AnyRequestOptions),
+    stream: (path: string, opts?: unknown) =>
+      openStream(path, (opts ?? {}) as AnyRequestOptions) as never,
+    post: (path: string, opts?: unknown) => run('POST', path, opts as AnyRequestOptions),
+    put: (path: string, opts?: unknown) => run('PUT', path, opts as AnyRequestOptions),
+    delete: (path: string, opts?: unknown) => run('DELETE', path, opts as AnyRequestOptions),
+    patch: (path: string, opts?: unknown) => run('PATCH', path, opts as AnyRequestOptions),
+  } as unknown as KickClient<Api>
 }
 
 /** Anything with a web-standard fetch — a `createWebApp()` result, a Worker, a mock. */

--- a/packages/client/tsconfig.test.json
+++ b/packages/client/tsconfig.test.json
@@ -2,12 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
-    "baseUrl": ".",
     "types": [],
-    "paths": {
-      "@forinda/kickjs-schema": ["src/index.ts"],
-      "@forinda/kickjs-schema/*": ["src/*"]
-    }
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
   },
   "include": ["src", "__tests__"]
 }

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -11,7 +11,12 @@ export default defineConfig({
     }),
   ],
   test: {
-    typecheck: { tsconfig: './tsconfig.test.json' },
+    // Default typecheck.include only matches *.test-d.ts — which silently
+    // skipped every expectTypeOf/@ts-expect-error in the real suites.
+    typecheck: {
+      tsconfig: './tsconfig.test.json',
+      include: ['__tests__/**/*.test.ts'],
+    },
     environment: 'node',
     include: ['__tests__/**/*.test.ts'],
     globals: false,

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -761,21 +761,30 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
    * Start an SSE (Server-Sent Events) stream.
    * Sets the correct headers and returns helpers to send events.
    *
+   * Pass a payload type to get typed sends — and `return sse` from the
+   * handler so `kick typegen` carries the event type into
+   * `KickRoutes.Api`, where `@forinda/kickjs-client`'s `api.stream()`
+   * picks it up (the returned handler is ignored at runtime — the
+   * response is already streaming).
+   *
    * @example
    * ```ts
+   * interface Tick { time: string }
+   *
    * @Get('/events')
    * async stream(ctx: RequestContext) {
-   *   const sse = ctx.sse()
+   *   const sse = ctx.sse<Tick>()
    *
    *   const interval = setInterval(() => {
    *     sse.send({ time: new Date().toISOString() }, 'tick')
    *   }, 1000)
    *
    *   sse.onClose(() => clearInterval(interval))
+   *   return sse // typed as SseHandler<Tick> → response inference
    * }
    * ```
    */
-  sse() {
+  sse<T = unknown>(): SseHandler<T> {
     this._response.writeHead(200, {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
@@ -792,7 +801,7 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
 
     return {
       /** Send an SSE event with optional event name and id */
-      send: (data: any, event?: string, id?: string) => {
+      send: (data: T, event?: string, id?: string) => {
         if (id) this._response.write(`id: ${id}\n`)
         if (event) this._response.write(`event: ${event}\n`)
         this._response.write(`data: ${JSON.stringify(data)}\n\n`)
@@ -811,6 +820,26 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
       },
     }
   }
+}
+
+/**
+ * The handle {@link RequestContext.sse} returns. The optional phantom
+ * `__sse` property carries the event payload type STRUCTURALLY — never set
+ * at runtime — so `kick typegen`'s response inference (handler `return sse`)
+ * flows it into `KickRoutes.Api`, and `@forinda/kickjs-client` detects SSE
+ * routes without importing any server types.
+ */
+export interface SseHandler<T = unknown> {
+  /** Phantom event-payload type marker — never assigned at runtime. */
+  readonly __sse?: T
+  /** Send an SSE event with optional event name and id. */
+  send(data: T, event?: string, id?: string): void
+  /** Send a comment line (keeps the connection alive through proxies). */
+  comment(text: string): void
+  /** Register a callback for client disconnect. */
+  onClose(fn: () => void): void
+  /** End the SSE stream. */
+  close(): void
 }
 
 /**

--- a/packages/kickjs/src/http/index.ts
+++ b/packages/kickjs/src/http/index.ts
@@ -5,7 +5,13 @@ export { Application, type ApplicationOptions, type MiddlewareEntry } from './ap
 export { bootstrap } from './bootstrap'
 
 // Request Context
-export { RequestContext, type ContextMeta, type Ctx, type RouteShape } from './context'
+export {
+  RequestContext,
+  type ContextMeta,
+  type Ctx,
+  type RouteShape,
+  type SseHandler,
+} from './context'
 
 // Return-value handlers — `return reply(201, body)` / plain returns auto-send
 export { reply, isReply, applyHandlerResult, type Reply, type InferHandlerResponse } from './reply'

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -16,7 +16,13 @@ export { bootstrap } from './http/bootstrap'
 // Cluster
 export { isClusterPrimary, type ClusterOptions } from './http/cluster'
 
-export { RequestContext, type Ctx, type RouteShape, type DeepReadonly } from './http/context'
+export {
+  RequestContext,
+  type Ctx,
+  type RouteShape,
+  type DeepReadonly,
+  type SseHandler,
+} from './http/context'
 export { defineHttpContextDecorator } from './http/define-http-context-decorator'
 
 // Return-value handlers + response inference (response-inference-design.md)

--- a/packages/kickjs/src/web.ts
+++ b/packages/kickjs/src/web.ts
@@ -34,6 +34,7 @@ export { WebRequestShim, WebResponseDriver } from './http/web/driver'
 export { compileWebRoute } from './http/web/handler'
 // Return-value handler helpers — edge consumers can't import the main barrel.
 export { reply, isReply, type Reply, type InferHandlerResponse } from './http/reply'
+export type { SseHandler } from './http/context'
 
 // Minimal structural surface of h3 v2 used here (kept local so this entry
 // never imports the node-coupled h3-web runtime module).

--- a/packages/kickjs/tsconfig.test.json
+++ b/packages/kickjs/tsconfig.test.json
@@ -2,11 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
-    "baseUrl": ".",
     "types": [],
     "paths": {
-      "@forinda/kickjs": ["src/index.ts"],
-      "@forinda/kickjs/*": ["src/*"]
+      "@forinda/kickjs": ["./src/index.ts"],
+      "@forinda/kickjs/*": ["./src/*"]
     }
   },
   "include": ["src", "__tests__"]

--- a/packages/kickjs/vitest.config.ts
+++ b/packages/kickjs/vitest.config.ts
@@ -20,6 +20,9 @@ export default defineConfig({
   test: {
     typecheck: {
       tsconfig: './tsconfig.test.json',
+      // Default include only matches *.test-d.ts — without this the
+      // expectTypeOf suite below was never actually type-checked.
+      include: ['**/infer-handler-response.test.ts'],
     },
     environment: 'node',
     include: ['__tests__/**/*.test.ts', '**/__tests__/**/*.test.ts','**/*.test.ts'],


### PR DESCRIPTION
## Summary

Typed SSE closes the last item from the "what the client unlocks" menu — plus the `KickApi` alias, plus a testing-infrastructure bug this work flushed out.

## Typed SSE

```ts
// server — ctx.sse is generic now
@Get('/events')
async events(ctx: RequestContext) {
  const sse = ctx.sse<{ n: number }>()
  sse.send({ n: 1 })            // typed
  sse.onClose(() => clearInterval(timer))
  return sse                     // ← carries the type into KickApi
}

// client — only SSE routes accepted at the type level
const stream = await api.stream('/events')
for await (const ev of stream) ev.data // { n: number }
stream.close()
```

The trick: `SseHandler<T>` carries a phantom `__sse` marker, so `return sse` rides the **existing** `InferHandlerResponse` path — zero typegen changes, and the client detects SSE routes structurally without importing server types. Runtime-safe on every engine (the driver settles at `writeHead`, so the returned handler is ignored). Client parser: fetch-based (injected-fetch friendly → the e2e suite iterates a real `createWebApp` stream network-free), JSON-parsed `data` with raw fallback, `event`/`id` fields, comment lines skipped, `close()` aborts.

## `KickApi` alias

`kick typegen` now emits `type KickApi = KickRoutes.Api` in `declare global` (including the empty-routes emission) — `createClient<KickApi>` adopted across docs, the fullstack template, generated agent docs, and the client README.

## The bug this flushed out (important)

**`vitest --typecheck` was vacuous on both the client and kickjs suites** — its default `include` only matches `*.test-d.ts`, so every prior `expectTypeOf` / `@ts-expect-error` assertion was never type-checked (proven by injecting a deliberately wrong assertion: "no errors"). Fixed with explicit `typecheck.include`; along the way the kickjs `tsconfig.test.json` had a deprecated `baseUrl` + non-relative `paths` that made the checker abort silently.

With real checking on, R3's documented options-looseness became a visible hole: `api.get('/tasks/:id')` with **no params compiled**. Now fixed properly — `ArgsFor` conditional rest tuples make the options argument required whenever the route requires `params`/`body`.

## Tests

kickjs 652 · cli 490 (+alias render cases) · client 28 under **verified** `--typecheck` (SSE e2e iteration incl. `event`/`id` fields, `close()`, `@ts-expect-error` on non-SSE paths and missing-options). Docs build green. Changesets: minor ×3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end typed server-sent events support, including typed event data, event IDs, and stream closing on the client.
  * Introduced a new `stream()` client method for consuming SSE routes with async iteration.
  * Added a global `KickApi` alias for easier typed client setup.

* **Bug Fixes**
  * Improved type safety for route requests so missing required parameters are caught earlier.
  * Non-SSE routes are now rejected when used with streaming APIs.

* **Documentation**
  * Updated guides and examples to show the new typed client and typed SSE usage.

* **Tests**
  * Expanded coverage for typed SSE behavior and stream typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->