### PR TITLE
fix(kickjs): drop h3 peer — ERESOLVE with the h3 v2 RC line

### DIFF
--- a/.changeset/h3-peer-range.md
+++ b/.changeset/h3-peer-range.md
@@ -1,0 +1,14 @@
+---
+'@forinda/kickjs': patch
+---
+
+fix: installing alongside `h3@latest` (the v2 RC line) no longer fails with ERESOLVE
+
+The `h3` peer range could not admit h3's RC releases: semver only lets a
+prerelease satisfy a range whose comparator shares its exact
+`major.minor.patch` tuple, and the RC line moves tuples (`2.0.1-rc.23`).
+No static range can express "any 2.x prerelease", so the optional `h3`
+peer declaration is removed entirely — the h3 runtimes already fail fast
+at load with clear guidance when the wrong major is installed (v1 for
+`h3Runtime()`, v2 for `h3WebRuntime()` / `@forinda/kickjs/web`). The peer
+constraint will return as `^1 || ^2` once h3 v2 ships stable.

--- a/packages/kickjs/package.json
+++ b/packages/kickjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forinda/kickjs",
   "version": "6.3.0",
-  "description": "A production-grade, decorator-driven Node.js framework for TypeScript — runs on Express, Fastify, or h3 (swap the engine in one line).",
+  "description": "A production-grade, decorator-driven Node.js framework for TypeScript \u2014 runs on Express, Fastify, or h3 (swap the engine in one line).",
   "keywords": [
     "kickjs",
     "nodejs",
@@ -131,7 +131,6 @@
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
     "fastify": "^5.0.0",
-    "h3": "^1.0.0 || ^2.0.0-rc || ^2.0.0",
     "multer": "^2.0.0",
     "serve-static": "^1.15.0 || ^2.0.0",
     "zod": "^4.0.0"
@@ -144,9 +143,6 @@
       "optional": true
     },
     "dotenv": {
-      "optional": true
-    },
-    "h3": {
       "optional": true
     },
     "fastify": {


### PR DESCRIPTION
Post-publish verification of 6.3.0 caught this: `npm i @forinda/kickjs h3@latest` → **ERESOLVE**. Not a range typo — semver cannot express 'any 2.x prerelease' (a prerelease only satisfies a comparator with its exact major.minor.patch tuple, and h3's RC line moves tuples: `2.0.1-rc.23` today, `.24` tomorrow).

Fix: remove the optional `h3` peer declaration. Version validation already lives in the right place — the runtimes fail fast at load with actionable messages (`h3Runtime()` demands v1, `h3WebRuntime()`/`/web` demand v2). Reinstate `^1 || ^2` when h3 v2 goes stable.

Proof: `pnpm pack` → fresh `npm i` of the tarball + `@forinda/kickjs-client@latest` + `h3@latest` succeeds; all exports resolve; `api.stream` functional against h3 2.0.1-rc.23. kickjs 652 tests green. Changeset: patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with `h3` prerelease and latest release candidates.
  * Removed a peer requirement that could block installs, so setup is now less likely to fail unexpectedly.
  * Existing startup checks still provide clear feedback if an incompatible major version is used.

* **Chores**
  * Updated package metadata for the patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->