### PR TITLE
feat(client,cli): tRPC-style RPC sugar — createRpc(api, kickRpc)

### DIFF
--- a/.changeset/rpc-sugar.md
+++ b/.changeset/rpc-sugar.md
@@ -1,0 +1,21 @@
+---
+'@forinda/kickjs-client': minor
+'@forinda/kickjs-cli': minor
+---
+
+feat: tRPC-style RPC sugar — `createRpc(api, kickRpc)`
+
+```ts
+import { kickRpc } from './.kickjs/types/kick__routes'
+
+const rpc = createRpc(api, kickRpc)
+const task = await rpc.tasks.get({ params: { id: '42' } }) // typed end to end
+```
+
+- `kick typegen` now also emits a runtime `kickRpc` manifest in
+  `kick__routes.ts` (`controller.method → 'VERB /mounted/path'`, friendly
+  namespaces: `TasksController` → `tasks`; stays in lockstep with the
+  `KickRoutes.Api` map incl. duplicate handling)
+- `createRpc` builds a plain typed namespace over the existing client — no
+  Proxy, no new inference; required params/body enforced, SSE routes typed
+  `never` (use `api.stream`)

--- a/docs/guide/typed-client.md
+++ b/docs/guide/typed-client.md
@@ -55,6 +55,28 @@ Wrong path, missing `params.id`, wrong body shape — all **compile errors**.
 `KickRoutes.Api` keys are **module-mount relative** (`'GET /tasks/:id'`); the
 bootstrap-level prefix and version (default `/api/v1`) go in `baseUrl`.
 
+## RPC-style calls
+
+Prefer `rpc.tasks.get(...)` over path strings? `kick typegen` also emits a
+runtime manifest (`kickRpc`) — `createRpc` builds a typed namespace over the
+same client:
+
+```ts
+import { createRpc } from '@forinda/kickjs-client'
+import { kickRpc } from './server-types' // re-export of .kickjs/types/kick__routes
+
+const rpc = createRpc(api, kickRpc)
+
+const task = await rpc.tasks.get({ params: { id: '42' } }) // task: Task
+const made = await rpc.tasks.create({ body: { title: 'Ship' } })
+```
+
+Same types, same runtime behavior (headers, errors, query serialization) —
+every call delegates to the path-keyed client. Namespaces come from
+controller names (`TasksController` → `tasks`), methods from handler names.
+SSE routes are typed `never` on the RPC surface — open those with
+`api.stream(path)`.
+
 ## Typed SSE streams
 
 Handlers that `return ctx.sse<T>()` mark the route as a typed event stream —

--- a/packages/cli/__tests__/render-routes-response.test.ts
+++ b/packages/cli/__tests__/render-routes-response.test.ts
@@ -198,3 +198,48 @@ describe('renderRoutes — KickApi alias', () => {
     expect(src).toContain('type KickApi = KickRoutes.Api')
   })
 })
+
+describe('renderRoutes — kickRpc runtime manifest', () => {
+  it('emits controller.method → verb+path entries with friendly keys', () => {
+    const src = renderRoutes(
+      [
+        route({}),
+        route({ method: 'create', httpMethod: 'POST', path: '/', mountedPath: '/users' }),
+      ],
+      OUT,
+      'zod',
+    )
+    expect(src).toContain('export const kickRpc = {')
+    expect(src).toContain('users: {')
+    expect(src).toContain("get: 'GET /users/:id',")
+    expect(src).toContain("create: 'POST /users',")
+  })
+
+  it('skips duplicate-dropped routes and warns on controller-key collisions', () => {
+    const warnings: string[] = []
+    const src = renderRoutes(
+      [
+        route({}),
+        route({
+          controller: 'Users',
+          method: 'also',
+          filePath: '/app/src/other.controller.ts',
+          mountedPath: '/users/:id',
+        }),
+      ],
+      OUT,
+      'zod',
+      { onWarn: (w) => warnings.push(w) },
+    )
+    // duplicate verb+path dropped from Api map → also absent from manifest
+    const manifest = src.slice(src.indexOf('export const kickRpc'))
+    expect(manifest).not.toContain('also:')
+    // UsersController and Users both → 'users'
+    expect(warnings.some((w) => w.includes("controller key 'users'"))).toBe(true)
+  })
+
+  it('empty routes emit an empty kickRpc', () => {
+    const src = renderRoutes([], OUT, 'zod')
+    expect(src).toContain('export const kickRpc = {} as const')
+  })
+})

--- a/packages/cli/src/typegen/render/routes.ts
+++ b/packages/cli/src/typegen/render/routes.ts
@@ -51,7 +51,8 @@ declare global {
   type KickApi = KickRoutes.Api
 }
 
-export {}
+/** Empty until the first route exists — see kick typegen. */
+export const kickRpc = {} as const
 `
   }
 
@@ -180,6 +181,9 @@ export {}
   // `/api/v{n}` prefix, which is not statically scannable.
   const apiEntries: string[] = []
   const seenApiKeys = new Set<string>()
+  // (controller, method) pairs that made it into the Api map — the RPC
+  // manifest below mirrors exactly this set.
+  const acceptedApi = new Set<string>()
   // 'Api' is reserved for the flat map below — a user controller class named
   // Api would declaration-merge its methods into the client map silently.
   if (byController.has('Api')) {
@@ -202,11 +206,49 @@ export {}
         continue
       }
       seenApiKeys.add(key)
+      acceptedApi.add(`${controller}.${m.method}`)
       apiEntries.push(`      '${key}': ${controller}['${m.method}']`)
     }
   }
   const apiInterface = [`    interface Api {`, ...apiEntries, `    }`].join('\n')
   interfaces.push(apiInterface)
+
+  // Runtime RPC manifest (`kickRpc`) — controller.method → 'VERB /mounted/path'.
+  // A VALUE export (this file is .ts, not .d.ts) consumed by
+  // `createRpc(api, kickRpc)` in @forinda/kickjs-client. Keys are friendly
+  // controller names (TasksController → tasks). Routes skipped from the Api
+  // map (duplicates) are skipped here too, so the two stay in lockstep.
+  const rpcEntries: string[] = []
+  const seenRpcKeys = new Set<string>()
+  for (const [controller, methods] of byController) {
+    const friendly = friendlyControllerKey(controller)
+    if (seenRpcKeys.has(friendly)) {
+      opts.onWarn?.(
+        `RPC manifest: controller key '${friendly}' (from ${controller}) collides with another ` +
+          `controller — keeping the first; rename one class for distinct RPC namespaces.`,
+      )
+      continue
+    }
+    seenRpcKeys.add(friendly)
+    const fnEntries: string[] = []
+    for (const m of methods) {
+      if (!acceptedApi.has(`${controller}.${m.method}`)) continue // dropped as duplicate above
+      const key = `${m.httpMethod} ${m.mountedPath ?? m.path}`
+      fnEntries.push(`    ${m.method}: '${key}',`)
+    }
+    if (fnEntries.length > 0) {
+      rpcEntries.push(`  ${friendly}: {\n${fnEntries.join('\n')}\n  },`)
+    }
+  }
+  const rpcManifest = [
+    `/**`,
+    ` * Runtime route manifest for the tRPC-style sugar:`,
+    ` * \`createRpc(api, kickRpc)\` from @forinda/kickjs-client.`,
+    ` */`,
+    `export const kickRpc = {`,
+    ...rpcEntries,
+    `} as const`,
+  ].join('\n')
 
   // Controller type imports — same hoisting rationale as schema imports.
   // `source: ''` semantics of resolveSchemaImportSpecifier point the
@@ -239,7 +281,7 @@ ${interfaceBlock}
   type KickApi = KickRoutes.Api
 }
 
-export {}
+${rpcManifest}
 `
 }
 
@@ -340,4 +382,13 @@ function resolveSchemaImportSpecifier(
   rel = rel.replace(/\.(ts|tsx|mts|cts)$/i, '')
   if (!rel.startsWith('.')) rel = './' + rel
   return rel
+}
+
+/** TasksController → tasks, UserProfileController → userProfile. */
+function friendlyControllerKey(controller: string): string {
+  const stripped = controller.endsWith('Controller')
+    ? controller.slice(0, -'Controller'.length)
+    : controller
+  const base = stripped.length > 0 ? stripped : controller
+  return base.charAt(0).toLowerCase() + base.slice(1)
 }

--- a/packages/client/__tests__/client.test.ts
+++ b/packages/client/__tests__/client.test.ts
@@ -14,6 +14,7 @@ import {
 
 import {
   createClient,
+  createRpc,
   createTestClient,
   KickClientError,
   type RouteShapeLike,
@@ -298,5 +299,50 @@ describe('api.stream — typed SSE', () => {
       void api.stream('/tasks')
     }
     expect(typeof _typeOnly).toBe('function')
+  })
+})
+
+describe('createRpc — tRPC-style sugar', () => {
+  // Mirrors what kick typegen emits as `kickRpc` for the fixture controller.
+  const manifest = {
+    tasks: {
+      get: 'GET /tasks/:id',
+      list: 'GET /tasks',
+      create: 'POST /tasks',
+      remove: 'DELETE /tasks/:id',
+      events: 'GET /tasks/events',
+    },
+  } as const
+
+  it('round-trips through a real web app with full typing', async () => {
+    const api = createTestClient<Api>(makeApp())
+    const rpc = createRpc(api, manifest)
+
+    const task = await rpc.tasks.get({ params: { id: '9' } })
+    expect(task).toEqual({ id: '9', title: 'task 9' })
+    expectTypeOf(task).toEqualTypeOf<Task>()
+
+    const made = await rpc.tasks.create({ body: { title: 'via rpc' } })
+    expect(made).toEqual({ id: 'new', title: 'via rpc' })
+    expectTypeOf(made).toEqualTypeOf<Task>()
+
+    await expect(rpc.tasks.remove({ params: { id: '1' } })).resolves.toBeUndefined()
+    const all = await rpc.tasks.list()
+    expectTypeOf(all).toEqualTypeOf<Task[]>()
+  })
+
+  it('type contract: required options enforced; SSE routes are never', () => {
+    const api = createTestClient<Api>(makeApp())
+    const rpc = createRpc(api, manifest)
+    const _typeOnly = () => {
+      // @ts-expect-error — params.id required
+      void rpc.tasks.get()
+      // @ts-expect-error — body.title required
+      void rpc.tasks.create({})
+      // @ts-expect-error — SSE routes are not callable via rpc (use api.stream)
+      void rpc.tasks.events()
+    }
+    expect(typeof _typeOnly).toBe('function')
+    expectTypeOf(rpc.tasks.events).toEqualTypeOf<never>()
   })
 })

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -400,3 +400,61 @@ export function createTestClient<Api extends ApiMap>(
     fetch: (request) => app.fetch(request),
   })
 }
+
+// ── RPC sugar ─────────────────────────────────────────────────────────
+// tRPC-style call shape over the SAME path-keyed map — no new inference,
+// no Proxy magic. `kick typegen` emits the runtime manifest (`kickRpc` in
+// kick__routes.ts): controller.method → 'VERB /mounted/path'; the types
+// below re-derive everything from KickApi via ShapeOf/ArgsFor.
+
+/** Shape of the generated `kickRpc` manifest. */
+export type RpcManifest = Record<string, Record<string, string>>
+
+type RpcMethod<Api extends ApiMap, K> = K extends `${infer V} ${infer P}`
+  ? V extends ClientMethod
+    ? [SsePayloadOf<ShapeOf<Api, V, P>['response']>] extends [never]
+      ? (...args: ArgsFor<ShapeOf<Api, V, P>, V>) => Promise<ShapeOf<Api, V, P>['response']>
+      : never // SSE routes stay explicit — use api.stream(path)
+    : never
+  : never
+
+/** The typed RPC surface derived from a manifest + the Api map. */
+export type KickRpc<Api extends ApiMap, M extends RpcManifest> = {
+  [C in keyof M]: { [F in keyof M[C]]: RpcMethod<Api, M[C][F]> }
+}
+
+/**
+ * tRPC-style sugar over a typed client:
+ *
+ * ```ts
+ * import { kickRpc } from './.kickjs/types/kick__routes'
+ *
+ * const rpc = createRpc(api, kickRpc)
+ * const task = await rpc.tasks.get({ params: { id: '42' } })
+ * const made = await rpc.tasks.create({ body: { title: 'Ship' } })
+ * ```
+ *
+ * A plain nested object built eagerly from the manifest — every call
+ * delegates to the corresponding `api.<verb>()` with the manifest's path,
+ * so behavior (headers, errors, query serialization) is identical to the
+ * path-keyed surface. SSE routes are typed `never` here — open those with
+ * `api.stream(path)`.
+ */
+export function createRpc<Api extends ApiMap, const M extends RpcManifest>(
+  api: KickClient<Api>,
+  manifest: M,
+): KickRpc<Api, M> {
+  const rpc: Record<string, Record<string, unknown>> = {}
+  for (const [controller, methods] of Object.entries(manifest)) {
+    const ns: Record<string, unknown> = {}
+    for (const [fn, key] of Object.entries(methods)) {
+      const space = key.indexOf(' ')
+      const verb = key.slice(0, space).toLowerCase() as Lowercase<ClientMethod>
+      const path = key.slice(space + 1)
+      ns[fn] = (opts?: unknown) =>
+        (api[verb] as (p: string, o?: unknown) => Promise<unknown>)(path, opts)
+    }
+    rpc[controller] = ns
+  }
+  return rpc as KickRpc<Api, M>
+}


### PR DESCRIPTION
## Summary

The last parked item from the typed-client roadmap: **tRPC-style call sugar** over the existing path-keyed client.

```ts
import { createRpc } from '@forinda/kickjs-client'
import { kickRpc } from './.kickjs/types/kick__routes'

const rpc = createRpc(api, kickRpc)

const task = await rpc.tasks.get({ params: { id: '42' } })   // task: Task
const made = await rpc.tasks.create({ body: { title: 'x' } }) // typed body + response
```

## How

- **`kick typegen`** emits a runtime `kickRpc` manifest into `kick__routes.ts` (already a value-capable `.ts` module): `controller.method → 'VERB /mounted/path'`. Friendly namespaces (`TasksController` → `tasks`), controller-key collision warnings, exact lockstep with `KickRoutes.Api`'s duplicate handling via accepted-pair tracking, empty manifest on fresh projects so `createRpc` always compiles.
- **`createRpc`** is a plain nested object (no Proxy) — every call delegates to `api.<verb>(path, opts)`, so headers/errors/query behavior is byte-identical to the path-keyed surface. Types re-derive from `KickApi` through the existing `ShapeOf`/`ArgsFor` machinery: zero new inference.
- **SSE routes are `never`** on the RPC surface — streams stay explicit via `api.stream(path)` (the runtime manifest can't know SSE-ness; the type system can, and honesty wins).
- Design note: both generics must infer from arguments — `createRpc<Api>(api, manifest)` with an explicit type arg silently degraded every method to `never` (the partial-inference trap), so the signature has no default that would permit it, and the docs/tests use the inferred form.

## Tests

cli **493** (manifest emission, friendly keys, duplicate + collision handling, empty emission) · client **34** under verified `--typecheck` (rpc round-trips against a real `createWebApp` app with `expectTypeOf` on results; `@ts-expect-error` for missing params/body and SSE-route calls). Docs: typed-client guide gains the RPC section; docs build green. Changesets: client + cli minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
