### PR TITLE
feat(kickjs): KICK006 — boot-time duplicate-route guard

### DIFF
--- a/.changeset/duplicate-route-guard.md
+++ b/.changeset/duplicate-route-guard.md
@@ -1,0 +1,7 @@
+---
+'@forinda/kickjs': minor
+---
+
+Boot-time duplicate-route guard (KICK006). Two handlers claiming the same HTTP verb + mounted path now fail `Application.setup()` / `createWebApp()` with a structured `KickError` instead of silently losing the dispatch race — previously the engine served one handler while `kick typegen` and the typed client could describe the other. Param names are ignored when comparing (`GET /tasks/:id` and `GET /tasks/:taskId` collide). Same path under a different verb or module `version` is unaffected.
+
+Heads-up: an app that today registers the same route twice (a latent bug — only one handler ever ran) will now fail at boot with a KICK006 pointing at both registrations.

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -132,13 +132,14 @@ KICK001: No provider for UserService
 
 ### Catalog (current set)
 
-| Code      | When it fires                                                                |
-| --------- | ---------------------------------------------------------------------------- |
-| `KICK001` | DI: no provider registered for the requested token                           |
-| `KICK002` | DI: REQUEST-scoped binding resolved without request-scope middleware mounted |
-| `KICK003` | DI: REQUEST-scoped binding resolved outside an HTTP request                  |
-| `KICK004` | Config: `@Value('X')` resolved but env var not set and no default given      |
-| `KICK005` | Module: `routes()` declared a path without `controller` or `router`          |
+| Code      | When it fires                                                                                                                                               |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `KICK001` | DI: no provider registered for the requested token                                                                                                          |
+| `KICK002` | DI: REQUEST-scoped binding resolved without request-scope middleware mounted                                                                                |
+| `KICK003` | DI: REQUEST-scoped binding resolved outside an HTTP request                                                                                                 |
+| `KICK004` | Config: `@Value('X')` resolved but env var not set and no default given                                                                                     |
+| `KICK005` | Module: `routes()` declared a path without `controller` or `router`                                                                                         |
+| `KICK006` | Routing: two handlers claim the same verb + mounted path (param names ignored — `/:id` and `/:taskId` collide); thrown at boot on both node and web entries |
 
 More framework errors will migrate to `KickError` over time. Each new entry gets the next free code; codes are stable and never reused.
 

--- a/packages/kickjs/__tests__/duplicate-routes.test.ts
+++ b/packages/kickjs/__tests__/duplicate-routes.test.ts
@@ -1,0 +1,127 @@
+import 'reflect-metadata'
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as h3v2 from 'h3-v2'
+
+import { Application, Container, KickError } from '../src/index'
+import { createWebApp } from '../src/web'
+import { Controller, Get, Post } from '../src/core/decorators'
+import { defineModule } from '../src/core/define-module'
+import type { RequestContext } from '../src/http/context'
+
+/**
+ * KICK006 — duplicate verb + mounted path fails at boot on both the node
+ * (Application.setup) and web (createWebApp) mount paths. Without this the
+ * engine silently dispatches one handler while typegen/the typed client may
+ * describe the other.
+ */
+
+beforeEach(() => {
+  Container.reset()
+})
+
+function taskModule(path = '/tasks') {
+  @Controller()
+  class TasksController {
+    @Get('/:id')
+    async get(ctx: RequestContext): Promise<void> {
+      ctx.json({ id: ctx.params.id })
+    }
+  }
+  return defineModule({
+    name: `TasksModule-${path}`,
+    build: () => ({ routes: () => ({ path, controller: TasksController }) }),
+  })()
+}
+
+function expectKick006(fn: () => unknown | Promise<unknown>) {
+  return expect(async () => await fn()).rejects.toSatisfy(
+    (e: unknown) =>
+      e instanceof KickError && (e as KickError & { code: string }).code === 'KICK006',
+  )
+}
+
+describe('duplicate routes — Application (node)', () => {
+  it('throws KICK006 when one controller registers the same verb+path twice', async () => {
+    @Controller()
+    class DupController {
+      @Get('/items')
+      async a(ctx: RequestContext): Promise<void> {
+        ctx.json({ via: 'a' })
+      }
+      @Get('/items')
+      async b(ctx: RequestContext): Promise<void> {
+        ctx.json({ via: 'b' })
+      }
+    }
+    const mod = defineModule({
+      name: 'DupModule',
+      build: () => ({ routes: () => ({ path: '/dup', controller: DupController }) }),
+    })()
+    const app = new Application({ modules: [mod] })
+    await expectKick006(() => app.setup())
+  })
+
+  it('throws KICK006 across modules mounted on the same path', async () => {
+    const app = new Application({ modules: [taskModule(), taskModule()] })
+    await expectKick006(() => app.setup())
+  })
+
+  it('treats differing param names as the same route (/:id vs /:taskId)', async () => {
+    @Controller()
+    class ParamController {
+      @Get('/:id')
+      async byId(ctx: RequestContext): Promise<void> {
+        ctx.json({})
+      }
+      @Get('/:taskId')
+      async byTaskId(ctx: RequestContext): Promise<void> {
+        ctx.json({})
+      }
+    }
+    const mod = defineModule({
+      name: 'ParamModule',
+      build: () => ({ routes: () => ({ path: '/p', controller: ParamController }) }),
+    })()
+    const app = new Application({ modules: [mod] })
+    await expectKick006(() => app.setup())
+  })
+
+  it('same path under different verbs or versions is fine', async () => {
+    @Controller()
+    class OkController {
+      @Get('/items')
+      async list(ctx: RequestContext): Promise<void> {
+        ctx.json([])
+      }
+      @Post('/items')
+      async create(ctx: RequestContext): Promise<void> {
+        ctx.created({})
+      }
+    }
+    const v1 = defineModule({
+      name: 'V1',
+      build: () => ({ routes: () => ({ path: '/ok', controller: OkController }) }),
+    })()
+    const v2 = defineModule({
+      name: 'V2',
+      build: () => ({ routes: () => ({ path: '/ok', controller: OkController, version: 2 }) }),
+    })()
+    const app = new Application({ modules: [v1, v2] })
+    await expect(app.setup()).resolves.not.toThrow()
+  })
+})
+
+describe('duplicate routes — createWebApp (web)', () => {
+  it('throws KICK006 at build time for cross-module duplicates', () => {
+    expect(() => createWebApp({ h3: h3v2, modules: [taskModule(), taskModule()] })).toThrowError(
+      /KICK006|registered twice/,
+    )
+  })
+
+  it('boots and serves when routes are unique', async () => {
+    const app = createWebApp({ h3: h3v2, modules: [taskModule()] })
+    const res = await app.fetch(new Request('http://x/api/v1/tasks/7'))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ id: '7' })
+  })
+})

--- a/packages/kickjs/__tests__/duplicate-routes.test.ts
+++ b/packages/kickjs/__tests__/duplicate-routes.test.ts
@@ -58,7 +58,15 @@ describe('duplicate routes — Application (node)', () => {
       build: () => ({ routes: () => ({ path: '/dup', controller: DupController }) }),
     })()
     const app = new Application({ modules: [mod] })
-    await expectKick006(() => app.setup())
+    const err = await app.setup().then(
+      () => null,
+      (e: unknown) => e,
+    )
+    expect(err).toBeInstanceOf(KickError)
+    expect((err as KickError & { code: string }).code).toBe('KICK006')
+    // Owner granularity: both conflicting handlers are named, not just the class.
+    expect((err as Error).message).toContain('DupController.a')
+    expect((err as Error).message).toContain('DupController.b')
   })
 
   it('throws KICK006 across modules mounted on the same path', async () => {
@@ -113,9 +121,13 @@ describe('duplicate routes — Application (node)', () => {
 
 describe('duplicate routes — createWebApp (web)', () => {
   it('throws KICK006 at build time for cross-module duplicates', () => {
-    expect(() => createWebApp({ h3: h3v2, modules: [taskModule(), taskModule()] })).toThrowError(
-      /KICK006|registered twice/,
-    )
+    try {
+      createWebApp({ h3: h3v2, modules: [taskModule(), taskModule()] })
+      expect.unreachable('expected createWebApp to throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(KickError)
+      expect((e as KickError & { code: string }).code).toBe('KICK006')
+    }
   })
 
   it('boots and serves when routes are unique', async () => {

--- a/packages/kickjs/src/core/kick-errors.ts
+++ b/packages/kickjs/src/core/kick-errors.ts
@@ -197,3 +197,34 @@ Or pass \`router:\` for full control:
     context: { mountPath },
   })
 }
+
+/**
+ * KICK006 — Two handlers claim the same HTTP verb + mounted path. The
+ * engine would silently dispatch one of them (Express/h3: first wins,
+ * Fastify: its own throw), while typegen and the typed client may
+ * describe the other — so this fails at boot instead.
+ */
+export function duplicateRouteError(
+  method: string,
+  path: string,
+  owner: string,
+  prior: string,
+): KickError {
+  return new KickError({
+    code: 'KICK006',
+    summary: `Duplicate route: ${method} ${path} is registered twice`,
+    cause: `\`${owner}\` registers \`${method} ${path}\`, but that verb + path is
+already claimed by \`${prior}\`. Only one handler can win at dispatch
+time, and which one depends on the engine — while \`kick typegen\` and
+the typed client may describe the other. Param names are ignored when
+comparing (\`/:id\` and \`/:taskId\` are the same route).`,
+    fix: `Change one of the two paths, remove the duplicate handler, or mount
+the second controller under a different module path / version:
+
+      routes() {
+        return { path: '/tasks', controller: TasksController, version: 2 }
+      }`,
+    docsUrl: `${DOCS_BASE}/guide/modules`,
+    context: { method, path, owner, prior },
+  })
+}

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -5,6 +5,7 @@ import {
   createLogger,
   Logger,
   normalizePath,
+  joinPaths,
   tokenName,
   METADATA,
   type AppModule,
@@ -32,7 +33,11 @@ import { getClassMeta } from '../core/metadata'
 import { requestId } from './middleware/request-id'
 import { notFoundHandler, errorHandler } from './middleware/error-handler'
 import { requestScopeMiddleware, isRequestScopeMiddleware } from './middleware/request-scope'
-import { _setExternalContributorSources, buildRouteTable } from './router-builder'
+import {
+  _setExternalContributorSources,
+  assertRouteUnique,
+  buildRouteTable,
+} from './router-builder'
 import { expressRuntime } from './runtimes/express'
 import type {
   ActiveRuntime,
@@ -675,6 +680,11 @@ export class Application {
     // restarts) doesn't accumulate stale entries.
     this._moduleContributors = []
 
+    // Duplicate-route guard (KICK006): one registry across every module in
+    // this setup pass, so cross-module collisions fail at boot instead of
+    // silently losing the dispatch race.
+    const seenRoutes = new Map<string, string>()
+
     for (const mod of modules) {
       // Prefer the declared `name` field (set by `defineModule({ name: 'X', ... })`)
       // over `constructor.name`. Factory-built modules are plain objects whose
@@ -732,9 +742,12 @@ export class Application {
           if (route.router) {
             this.runtime.useConnect(this.app, route.router, { path: mountPath })
           } else if (route.controller) {
-            this.runtime.mountRoutes(this.app, [
-              { mountPath, routes: buildRouteTable(route.controller) },
-            ])
+            const routeTable = buildRouteTable(route.controller)
+            const owner = route.controller.name ?? 'controller'
+            for (const entry of routeTable) {
+              assertRouteUnique(seenRoutes, entry.method, joinPaths(mountPath, entry.path), owner)
+            }
+            this.runtime.mountRoutes(this.app, [{ mountPath, routes: routeTable }])
           } else {
             throw moduleRouteMissingControllerError(mountPath)
           }

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -743,8 +743,10 @@ export class Application {
             this.runtime.useConnect(this.app, route.router, { path: mountPath })
           } else if (route.controller) {
             const routeTable = buildRouteTable(route.controller)
-            const owner = route.controller.name ?? 'controller'
+            const ctrl = route.controller.name ?? 'controller'
             for (const entry of routeTable) {
+              // Per-handler owner so intra-controller duplicates name both methods.
+              const owner = `${ctrl}.${String(entry.meta.handlerName ?? '?')}`
               assertRouteUnique(seenRoutes, entry.method, joinPaths(mountPath, entry.path), owner)
             }
             this.runtime.mountRoutes(this.app, [{ mountPath, routes: routeTable }])

--- a/packages/kickjs/src/http/router-builder.ts
+++ b/packages/kickjs/src/http/router-builder.ts
@@ -8,6 +8,7 @@ import { METADATA } from '../core/interfaces'
 import type { ContributorRegistration } from '../core/context-decorator'
 import type { FileUploadConfig, MiddlewareHandler, RouteDefinition } from '../core/decorators'
 import { getClassMeta, getMethodMeta, getMethodMetaOrUndefined } from '../core/metadata'
+import { duplicateRouteError } from '../core/kick-errors'
 import type { CtxHandler, RouteEntry, RouteMethod } from './runtime'
 
 /**
@@ -30,6 +31,30 @@ let _externalContributorSources: readonly SourcedRegistration[] = []
 /** @internal — set by Application.setup() before each `mod.routes()` call. */
 export function _setExternalContributorSources(sources: readonly SourcedRegistration[]): void {
   _externalContributorSources = sources
+}
+
+/**
+ * Boot-time duplicate-route guard shared by the node and web mount loops.
+ *
+ * Registers `METHOD /mounted/path` into `registry` and throws
+ * {@link duplicateRouteError} (KICK006) if another handler already claimed
+ * it. Param *names* are ignored — `/tasks/:id` and `/tasks/:taskId` are the
+ * same route at dispatch time, so they collide here too.
+ *
+ * @internal
+ */
+export function assertRouteUnique(
+  registry: Map<string, string>,
+  method: string,
+  fullPath: string,
+  owner: string,
+): void {
+  const key = `${method.toUpperCase()} ${fullPath.replace(/:[^/]+/g, ':*')}`
+  const prior = registry.get(key)
+  if (prior !== undefined) {
+    throw duplicateRouteError(method.toUpperCase(), fullPath, owner, prior)
+  }
+  registry.set(key, owner)
 }
 
 export interface BuildRoutesOptions {

--- a/packages/kickjs/src/web.ts
+++ b/packages/kickjs/src/web.ts
@@ -167,7 +167,9 @@ export function createWebApp(options: CreateWebAppOptions): WebApp {
         const mountPath = `${apiPrefix}/v${version}${normalizePath(route.path)}`
         for (const entry of buildRouteTable(route.controller)) {
           const url = joinPath(mountPath, entry.path)
-          assertRouteUnique(seenRoutes, entry.method, url, route.controller.name ?? 'controller')
+          // Per-handler owner so intra-controller duplicates name both methods.
+          const owner = `${route.controller.name ?? 'controller'}.${String(entry.meta.handlerName ?? '?')}`
+          assertRouteUnique(seenRoutes, entry.method, url, owner)
           const run = compileWebRoute(entry)
           app.on(entry.method, url, (event: H3EventLike) =>
             run({

--- a/packages/kickjs/src/web.ts
+++ b/packages/kickjs/src/web.ts
@@ -25,7 +25,11 @@ import { MutableModuleRegistry } from './core/module-registry'
 import type { AppModule, AppModuleClass, AppModuleEntry } from './core/app-module'
 import type { ContributorRegistrations } from './core/context-decorator'
 import type { SourcedRegistration } from './core/contributor-pipeline'
-import { _setExternalContributorSources, buildRouteTable } from './http/router-builder'
+import {
+  _setExternalContributorSources,
+  assertRouteUnique,
+  buildRouteTable,
+} from './http/router-builder'
 import { requestStore } from './http/request-store'
 import { compileWebRoute } from './http/web/handler'
 import { normalizePath } from './core/path'
@@ -130,6 +134,9 @@ export function createWebApp(options: CreateWebAppOptions): WebApp {
     }),
   )
 
+  // Duplicate-route guard (KICK006) — same boot-time check as the node path.
+  const seenRoutes = new Map<string, string>()
+
   for (const mod of modules) {
     const declaredName = (mod as { name?: unknown }).name
     const moduleLabel =
@@ -160,6 +167,7 @@ export function createWebApp(options: CreateWebAppOptions): WebApp {
         const mountPath = `${apiPrefix}/v${version}${normalizePath(route.path)}`
         for (const entry of buildRouteTable(route.controller)) {
           const url = joinPath(mountPath, entry.path)
+          assertRouteUnique(seenRoutes, entry.method, url, route.controller.name ?? 'controller')
           const run = compileWebRoute(entry)
           app.on(entry.method, url, (event: H3EventLike) =>
             run({


### PR DESCRIPTION
## Why

Two handlers could claim the same `VERB /mounted/path` and nothing complained. The engine silently dispatched one (Express/h3: first registered wins; Fastify: its own `FST_ERR_DUPLICATED_ROUTE`), while `kick typegen` and the typed client could describe **the other** — a truth hole between server, types, and client. Deferred from the #448 review; now fixed at the source.

## What

- **KICK006** structured error: names both registrations, explains the dispatch race, suggests the fix (different path / removed handler / module `version`).
- `assertRouteUnique` in `router-builder` — shared by both mount loops: `Application.setup()` (node, all runtimes) and `createWebApp()` (web/edge). Throws at boot, not on first request.
- **Param names ignored** in comparison: `GET /tasks/:id` vs `GET /tasks/:taskId` collide (same route at dispatch time).
- Same path under a different verb or module `version` stays legal.
- Edge purity holds: `kick-errors` has zero imports; the `/web` bundle-graph test passes untouched.

## Tests

6 new (`duplicate-routes.test.ts`): same-controller dup, cross-module dup, param-name aliasing, verb/version non-collision, web-entry throw + clean-boot serve. Full kickjs suite 658/658. Docs: KICK006 row in the error catalog. Changeset: kickjs minor with a heads-up that latent duplicates now fail boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate HTTP routes now fail fast at startup with a structured error (`KICK006`) instead of silently losing dispatch behavior.
  * Route matching now treats parameterized paths with different parameter names as the same route shape.
  * Using the same path with different HTTP methods or app versions still works as before.
* **Documentation**
  * Updated the framework error guide with the new `KICK006` “routing collision” entry and fix hints.
* **Tests**
  * Added end-to-end coverage for duplicate-route detection in both server and web startup flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->