### PR TITLE
feat(kickjs): edge-ready rate limiting + KV-backed stores

### DIFF
--- a/.changeset/edge-stores.md
+++ b/.changeset/edge-stores.md
@@ -1,0 +1,12 @@
+---
+'@forinda/kickjs': minor
+---
+
+Edge-ready rate limiting and sessions:
+
+- `rateLimitGuard()` — ctx-style rate limiter that runs on every runtime AND the `@forinda/kickjs/web` fetch entry (the connect-style `rateLimit()` stays node-only). Sends `X-RateLimit-*` / `Retry-After` headers, pluggable key generator (`cf-connecting-ip` → `x-forwarded-for` → `x-real-ip` by default).
+- `KvRateLimitStore` / `KvSessionStore` over a minimal `KvLike` interface — structurally a Cloudflare Workers `KVNamespace` binding, so `new KvRateLimitStore(env.MY_KV, { windowMs })` just works. `KvSessionStore` plugs into the existing node `session()` middleware.
+- `createWebApp({ middleware })` — global `(ctx, next)` middlewares on the web entry, the counterpart of `bootstrap({ middleware })`.
+- `ctx.setHeader(name, value)` — runtime-neutral response header setter on `RequestContext`.
+
+All new modules are zero-runtime-import and part of the edge purity graph.

--- a/docs/guide/edge-deployment.md
+++ b/docs/guide/edge-deployment.md
@@ -93,17 +93,62 @@ it.
 
 ## What's different on the edge
 
-| Concern                                            | Status                                                                          |
-| -------------------------------------------------- | ------------------------------------------------------------------------------- |
-| Routing, DI, decorators, validation, `ctx.problem` | ✅ identical                                                                    |
-| Context decorators / request-scoped DI             | ✅ (needs `nodejs_compat` on Workers)                                           |
-| SSE (`ctx.sse`)                                    | ✅ — streams over a web `Response`                                              |
-| File uploads (`@FileUpload`)                       | ✅ — web `FormData`, buffered in memory                                         |
-| `@PreDestroy` request teardown                     | ✅ — runs when the response closes                                              |
-| `ctx.render()` / view engines / SPA / static files | ❌ throws — serve assets from the platform CDN                                  |
-| In-memory `session()` / `rateLimit()` stores       | ❌ — no persistent process between requests; use a KV/Redis-backed custom store |
-| `@Asset` injection                                 | ❌ — reads the filesystem; clear error on access                                |
-| Adapters / plugins                                 | Not wired on the web entry at launch — use `bootstrap()` on node for those      |
+| Concern                                            | Status                                                                                                                           |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Routing, DI, decorators, validation, `ctx.problem` | ✅ identical                                                                                                                     |
+| Context decorators / request-scoped DI             | ✅ (needs `nodejs_compat` on Workers)                                                                                            |
+| SSE (`ctx.sse`)                                    | ✅ — streams over a web `Response`                                                                                               |
+| File uploads (`@FileUpload`)                       | ✅ — web `FormData`, buffered in memory                                                                                          |
+| `@PreDestroy` request teardown                     | ✅ — runs when the response closes                                                                                               |
+| `ctx.render()` / view engines / SPA / static files | ❌ throws — serve assets from the platform CDN                                                                                   |
+| Rate limiting                                      | ✅ — `rateLimitGuard()` + `KvRateLimitStore` over a Workers KV binding (below)                                                   |
+| Sessions                                           | ⚠️ — `KvSessionStore` plugs into the node `session()` middleware; the cookie middleware itself is not wired on the web entry yet |
+| `@Asset` injection                                 | ❌ — reads the filesystem; clear error on access                                                                                 |
+| Adapters / plugins                                 | Not wired on the web entry at launch — use `bootstrap()` on node for those                                                       |
+
+## Rate limiting on the edge
+
+In-memory counters die with the isolate, so the edge story is a `(ctx, next)`
+guard plus a KV-backed store. `KvLike` is structurally a Cloudflare
+`KVNamespace` — pass the binding straight in:
+
+```ts
+import { createWebApp, rateLimitGuard, KvRateLimitStore } from '@forinda/kickjs/web'
+
+export default {
+  fetch(req: Request, env: Env) {
+    const app = createWebApp({
+      h3,
+      modules,
+      env,
+      middleware: [
+        rateLimitGuard({
+          max: 60,
+          windowMs: 60_000,
+          store: new KvRateLimitStore(env.RATE_KV, { windowMs: 60_000 }),
+        }),
+      ],
+    })
+    return app.fetch(req)
+  },
+}
+```
+
+`createWebApp({ middleware })` runs ctx-style middlewares on every route —
+the web-entry counterpart of `bootstrap({ middleware })`. `rateLimitGuard`
+also works per-route on any runtime via `@Middleware(rateLimitGuard({ max: 10 }))`,
+and without a `store` it falls back to a per-process in-memory counter
+(fine on node, pointless on edge).
+
+Two caveats: KV is eventually consistent, so limiting is **approximate**
+under concurrent bursts (use a Durable Object or Redis store for exact
+quotas), and Cloudflare KV enforces a minimum 60-second TTL (shorter
+windows still limit correctly; the KV entry just lives a bit longer).
+
+Sessions: `KvSessionStore` implements the `SessionStore` contract for the
+node `session()` middleware — `new KvSessionStore(kv)` makes sessions
+survive restarts and horizontal scaling today. The cookie-handling
+middleware itself is not wired on the web entry yet.
 
 ### Runtime support (AsyncLocalStorage)
 

--- a/packages/kickjs/__tests__/edge-stores.test.ts
+++ b/packages/kickjs/__tests__/edge-stores.test.ts
@@ -156,4 +156,21 @@ describe('rateLimitGuard on the web entry', () => {
       expect((await app.fetch(req())).status).toBe(200)
     }
   })
+
+  it('default key prefers runtime-computed req.ip over spoofable headers', async () => {
+    const seen: string[] = []
+    const guard = rateLimitGuard({
+      max: 1000,
+      store: {
+        increment: async (key) => (seen.push(key), { totalHits: 1, resetTime: new Date() }),
+        decrement: async () => {},
+        reset: async () => {},
+      },
+    })
+    const fakeCtx = (ip: string | undefined, headers: Record<string, string>) =>
+      ({ req: { ip }, headers, setHeader: () => {}, json: () => {} }) as never
+    await guard(fakeCtx('10.0.0.1', { 'x-forwarded-for': 'spoofed' }), () => {})
+    await guard(fakeCtx(undefined, { 'x-forwarded-for': 'fallback, hop2' }), () => {})
+    expect(seen).toEqual(['10.0.0.1', 'fallback'])
+  })
 })

--- a/packages/kickjs/__tests__/edge-stores.test.ts
+++ b/packages/kickjs/__tests__/edge-stores.test.ts
@@ -1,0 +1,159 @@
+import 'reflect-metadata'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import * as h3v2 from 'h3-v2'
+
+import { createWebApp, KvRateLimitStore, KvSessionStore, rateLimitGuard } from '../src/web'
+import type { KvLike } from '../src/web'
+import { Container } from '../src/core/container'
+import { Controller, Get } from '../src/core/decorators'
+import { defineModule } from '../src/core/define-module'
+import type { RequestContext } from '../src/http/context'
+
+/**
+ * Edge-ready stores (KvLike) + the ctx-style rateLimitGuard — the pieces
+ * that make session persistence and rate limiting work where in-memory
+ * state dies with the isolate.
+ */
+
+/** Map-backed KvLike with real TTL semantics — what a Workers KV fake needs. */
+function fakeKv(): KvLike & { size(): number } {
+  const map = new Map<string, { value: string; expiresAt: number | null }>()
+  return {
+    async get(key) {
+      const e = map.get(key)
+      if (!e) return null
+      if (e.expiresAt !== null && Date.now() >= e.expiresAt) {
+        map.delete(key)
+        return null
+      }
+      return e.value
+    },
+    async put(key, value, options) {
+      map.set(key, {
+        value,
+        expiresAt: options?.expirationTtl ? Date.now() + options.expirationTtl * 1000 : null,
+      })
+    },
+    async delete(key) {
+      map.delete(key)
+    },
+    size: () => map.size,
+  }
+}
+
+beforeEach(() => {
+  Container.reset()
+  vi.useRealTimers()
+})
+
+describe('KvRateLimitStore', () => {
+  it('counts hits within the window and resets after it', async () => {
+    vi.useFakeTimers()
+    const store = new KvRateLimitStore(fakeKv(), { windowMs: 60_000 })
+    const first = await store.increment('ip1')
+    expect(first.totalHits).toBe(1)
+    expect((await store.increment('ip1')).totalHits).toBe(2)
+    expect((await store.increment('other')).totalHits).toBe(1)
+
+    vi.advanceTimersByTime(61_000)
+    expect((await store.increment('ip1')).totalHits).toBe(1)
+  })
+
+  it('decrement and reset behave like the in-memory store', async () => {
+    const store = new KvRateLimitStore(fakeKv(), { windowMs: 60_000 })
+    await store.increment('k')
+    await store.increment('k')
+    await store.decrement('k')
+    expect((await store.increment('k')).totalHits).toBe(2)
+    await store.reset('k')
+    expect((await store.increment('k')).totalHits).toBe(1)
+  })
+
+  it('clamps KV TTL up to the 60s Cloudflare minimum', async () => {
+    const kv = fakeKv()
+    const put = vi.spyOn(kv, 'put')
+    const store = new KvRateLimitStore(kv, { windowMs: 5_000 })
+    await store.increment('k')
+    expect(put.mock.calls[0][2]).toEqual({ expirationTtl: 60 })
+  })
+})
+
+describe('KvSessionStore', () => {
+  it('round-trips session data with TTL and destroys cleanly', async () => {
+    const kv = fakeKv()
+    const store = new KvSessionStore(kv)
+    await store.set('sid1', { userId: 7 }, 3_600_000)
+    expect(await store.get('sid1')).toEqual({ userId: 7 })
+
+    await store.destroy('sid1')
+    expect(await store.get('sid1')).toBeNull()
+    expect(await store.get('never-set')).toBeNull()
+  })
+
+  it('touch refreshes the TTL without changing data', async () => {
+    vi.useFakeTimers()
+    const store = new KvSessionStore(fakeKv())
+    await store.set('sid', { a: 1 }, 90_000)
+    vi.advanceTimersByTime(80_000)
+    await store.touch('sid', 90_000)
+    vi.advanceTimersByTime(80_000) // 160s total — dead without the touch
+    expect(await store.get('sid')).toEqual({ a: 1 })
+  })
+
+  it('keys are prefixed (no collision with rate-limit entries)', async () => {
+    const kv = fakeKv()
+    await new KvSessionStore(kv).set('x', { s: true }, 60_000)
+    await new KvRateLimitStore(kv, { windowMs: 60_000 }).increment('x')
+    expect(kv.size()).toBe(2)
+  })
+})
+
+describe('rateLimitGuard on the web entry', () => {
+  function makeApp(guard: ReturnType<typeof rateLimitGuard>) {
+    @Controller()
+    class PingController {
+      @Get('/ping')
+      async ping(ctx: RequestContext): Promise<void> {
+        ctx.json({ ok: true })
+      }
+    }
+    const mod = defineModule({
+      name: 'PingModule',
+      build: () => ({ routes: () => ({ path: '/p', controller: PingController }) }),
+    })()
+    return createWebApp({ h3: h3v2, modules: [mod], middleware: [guard] })
+  }
+
+  const req = (ip = '1.2.3.4') =>
+    new Request('http://edge/api/v1/p/ping', { headers: { 'cf-connecting-ip': ip } })
+
+  it('429s after max, with rate-limit + Retry-After headers', async () => {
+    const app = makeApp(
+      rateLimitGuard({
+        max: 2,
+        windowMs: 60_000,
+        store: new KvRateLimitStore(fakeKv(), { windowMs: 60_000 }),
+      }),
+    )
+    const ok1 = await app.fetch(req())
+    expect(ok1.status).toBe(200)
+    expect(ok1.headers.get('x-ratelimit-limit')).toBe('2')
+    expect(ok1.headers.get('x-ratelimit-remaining')).toBe('1')
+
+    await app.fetch(req())
+    const limited = await app.fetch(req())
+    expect(limited.status).toBe(429)
+    expect(await limited.json()).toEqual({ message: 'Too Many Requests' })
+    expect(Number(limited.headers.get('retry-after'))).toBeGreaterThan(0)
+
+    // Different client key — unaffected.
+    expect((await app.fetch(req('9.9.9.9'))).status).toBe(200)
+  })
+
+  it('skip() bypasses limiting', async () => {
+    const app = makeApp(rateLimitGuard({ max: 1, skip: () => true }))
+    for (let i = 0; i < 3; i++) {
+      expect((await app.fetch(req())).status).toBe(200)
+    }
+  })
+})

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -574,6 +574,16 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
 
   // ── Response Helpers ────────────────────────────────────────────────
 
+  /**
+   * Set a response header. Runtime-neutral — works on every engine and on
+   * the web/edge entry. No-op guards are the runtime's job (headers set
+   * after the response settles are ignored or throw per engine).
+   */
+  setHeader(name: string, value: string): this {
+    this._response.setHeader(name, value)
+    return this
+  }
+
   json(data: any, status = 200) {
     return this._response.status(status).json(data)
   }

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -579,7 +579,7 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
    * the web/edge entry. No-op guards are the runtime's job (headers set
    * after the response settles are ignored or throw per engine).
    */
-  setHeader(name: string, value: string): this {
+  setHeader(name: string, value: string | number | readonly string[]): this {
     this._response.setHeader(name, value)
     return this
   }

--- a/packages/kickjs/src/http/index.ts
+++ b/packages/kickjs/src/http/index.ts
@@ -52,6 +52,14 @@ export { requestLogger, type RequestLoggerOptions } from './middleware/request-l
 export { helmet, type HelmetOptions } from './middleware/helmet'
 export { cors, type CorsOptions } from './middleware/cors'
 export { rateLimit, type RateLimitOptions, type RateLimitStore } from './middleware/rate-limit'
+export { rateLimitGuard, type RateLimitGuardOptions } from './middleware/rate-limit-guard'
+export {
+  KvRateLimitStore,
+  KvSessionStore,
+  type KvLike,
+  type KvRateLimitStoreOptions,
+  type KvSessionStoreOptions,
+} from './middleware/kv-stores'
 export {
   session,
   type SessionOptions,

--- a/packages/kickjs/src/http/middleware/kv-stores.ts
+++ b/packages/kickjs/src/http/middleware/kv-stores.ts
@@ -1,0 +1,149 @@
+// Edge-safe store adapters over a minimal KV surface. Zero runtime imports —
+// this file must stay importable from the `@forinda/kickjs/web` purity graph.
+import type { RateLimitStore } from './rate-limit'
+import type { SessionData, SessionStore } from './session'
+
+/**
+ * The minimal async KV surface both stores need. Structurally compatible
+ * with a Cloudflare Workers `KVNamespace` binding — pass it straight in:
+ *
+ * ```ts
+ * export default {
+ *   fetch(req: Request, env: Env) {
+ *     const store = new KvRateLimitStore(env.MY_KV, { windowMs: 60_000 })
+ *     // ...
+ *   },
+ * }
+ * ```
+ *
+ * Anything with the same shape works too (Deno KV wrapper, Upstash Redis
+ * REST client adapter, a Map-backed fake in tests).
+ */
+export interface KvLike {
+  get(key: string): Promise<string | null>
+  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>
+  delete(key: string): Promise<void>
+}
+
+/** Cloudflare KV rejects TTLs under 60 seconds — clamp up, never down. */
+function kvTtlSeconds(ms: number): number {
+  return Math.max(60, Math.ceil(ms / 1000))
+}
+
+export interface KvRateLimitStoreOptions {
+  /** Window length in ms — must match the `windowMs` given to the limiter. */
+  windowMs: number
+  /** Key prefix in the KV namespace (default `'rl:'`). */
+  prefix?: string
+}
+
+/**
+ * {@link RateLimitStore} over a {@link KvLike} namespace, for edge deployments
+ * where in-memory counters reset on every isolate.
+ *
+ * KV is eventually consistent and this is a read-modify-write counter, so
+ * limiting is **approximate** under concurrency — bursts racing across
+ * isolates can each read the same count. That is the accepted trade-off for
+ * abuse throttling; use a Durable Object / Redis store when you need an
+ * exact ceiling (billing quotas, strict per-key locks).
+ */
+export class KvRateLimitStore implements RateLimitStore {
+  private readonly prefix: string
+  private readonly windowMs: number
+
+  constructor(
+    private readonly kv: KvLike,
+    options: KvRateLimitStoreOptions,
+  ) {
+    this.windowMs = options.windowMs
+    this.prefix = options.prefix ?? 'rl:'
+  }
+
+  async increment(key: string): Promise<{ totalHits: number; resetTime: Date }> {
+    const now = Date.now()
+    const entry = await this.read(key)
+    if (entry && entry.reset > now) {
+      entry.hits++
+      await this.write(key, entry)
+      return { totalHits: entry.hits, resetTime: new Date(entry.reset) }
+    }
+    const fresh = { hits: 1, reset: now + this.windowMs }
+    await this.write(key, fresh)
+    return { totalHits: 1, resetTime: new Date(fresh.reset) }
+  }
+
+  async decrement(key: string): Promise<void> {
+    const entry = await this.read(key)
+    if (entry && entry.hits > 0) {
+      entry.hits--
+      await this.write(key, entry)
+    }
+  }
+
+  async reset(key: string): Promise<void> {
+    await this.kv.delete(this.prefix + key)
+  }
+
+  private async read(key: string): Promise<{ hits: number; reset: number } | null> {
+    const raw = await this.kv.get(this.prefix + key)
+    if (raw === null) return null
+    try {
+      return JSON.parse(raw) as { hits: number; reset: number }
+    } catch {
+      return null
+    }
+  }
+
+  private async write(key: string, entry: { hits: number; reset: number }): Promise<void> {
+    await this.kv.put(this.prefix + key, JSON.stringify(entry), {
+      expirationTtl: kvTtlSeconds(Math.max(entry.reset - Date.now(), 1000)),
+    })
+  }
+}
+
+export interface KvSessionStoreOptions {
+  /** Key prefix in the KV namespace (default `'sess:'`). */
+  prefix?: string
+}
+
+/**
+ * {@link SessionStore} over a {@link KvLike} namespace. Plug into the node
+ * `session()` middleware today (e.g. backed by Upstash/Cloudflare KV via
+ * REST) so sessions survive restarts and horizontal scaling; TTL expiry is
+ * delegated to the KV layer via `expirationTtl`.
+ */
+export class KvSessionStore implements SessionStore {
+  private readonly prefix: string
+
+  constructor(
+    private readonly kv: KvLike,
+    options: KvSessionStoreOptions = {},
+  ) {
+    this.prefix = options.prefix ?? 'sess:'
+  }
+
+  async get(sid: string): Promise<SessionData | null> {
+    const raw = await this.kv.get(this.prefix + sid)
+    if (raw === null) return null
+    try {
+      return JSON.parse(raw) as SessionData
+    } catch {
+      return null
+    }
+  }
+
+  async set(sid: string, data: SessionData, maxAge: number): Promise<void> {
+    await this.kv.put(this.prefix + sid, JSON.stringify(data), {
+      expirationTtl: kvTtlSeconds(maxAge),
+    })
+  }
+
+  async destroy(sid: string): Promise<void> {
+    await this.kv.delete(this.prefix + sid)
+  }
+
+  async touch(sid: string, maxAge: number): Promise<void> {
+    const data = await this.get(sid)
+    if (data !== null) await this.set(sid, data, maxAge)
+  }
+}

--- a/packages/kickjs/src/http/middleware/kv-stores.ts
+++ b/packages/kickjs/src/http/middleware/kv-stores.ts
@@ -111,6 +111,10 @@ export interface KvSessionStoreOptions {
  * `session()` middleware today (e.g. backed by Upstash/Cloudflare KV via
  * REST) so sessions survive restarts and horizontal scaling; TTL expiry is
  * delegated to the KV layer via `expirationTtl`.
+ *
+ * Cost note: `touch()` is a get + put round-trip (KvLike has no TTL-only
+ * refresh), so `session({ rolling: true })` doubles KV operations per
+ * request — per-operation-billed platforms may prefer `rolling: false`.
  */
 export class KvSessionStore implements SessionStore {
   private readonly prefix: string

--- a/packages/kickjs/src/http/middleware/rate-limit-guard.ts
+++ b/packages/kickjs/src/http/middleware/rate-limit-guard.ts
@@ -1,0 +1,124 @@
+// Ctx-style rate limiter — runs on BOTH pipelines: the node runtimes (via
+// `@Middleware()` / class middleware) and the `@forinda/kickjs/web` fetch
+// entry (via `@Middleware()` or `createWebApp({ middleware })`), unlike the
+// connect-style `rateLimit()` which is node-only. Zero runtime imports —
+// part of the edge purity graph.
+import type { MiddlewareHandler } from '../../core/decorators'
+import type { RequestContext } from '../context'
+import type { RateLimitStore } from './rate-limit'
+
+export interface RateLimitGuardOptions {
+  /** Maximum number of requests per window (default: 100). */
+  max?: number
+  /** Time window in milliseconds (default: 60_000). */
+  windowMs?: number
+  /** Response message when the limit is exceeded (default: 'Too Many Requests'). */
+  message?: string
+  /** HTTP status code when the limit is exceeded (default: 429). */
+  statusCode?: number
+  /**
+   * Rate-limit key per request. Default: `cf-connecting-ip`, then the first
+   * hop of `x-forwarded-for`, then `x-real-ip`, then `'global'`. Return a
+   * user/tenant id here for authenticated quotas.
+   */
+  keyGenerator?: (ctx: RequestContext) => string
+  /** Send `X-RateLimit-*` / `Retry-After` headers (default: true). */
+  headers?: boolean
+  /**
+   * Counter backend. Defaults to a per-isolate in-memory map — fine for a
+   * single node process, useless on edge where isolates recycle: pass a
+   * `KvRateLimitStore` (or Redis-backed store) there.
+   */
+  store?: RateLimitStore
+  /** Skip limiting for a request (health checks, allowlists). */
+  skip?: (ctx: RequestContext) => boolean
+}
+
+/** Timer-free in-memory store: sweeps expired entries when the map grows. */
+class LazyMemoryStore implements RateLimitStore {
+  private readonly hits = new Map<string, { hits: number; reset: number }>()
+
+  constructor(private readonly windowMs: number) {}
+
+  async increment(key: string): Promise<{ totalHits: number; resetTime: Date }> {
+    const now = Date.now()
+    const entry = this.hits.get(key)
+    if (entry && entry.reset > now) {
+      entry.hits++
+      return { totalHits: entry.hits, resetTime: new Date(entry.reset) }
+    }
+    // ponytail: sweep-on-growth instead of a cleanup interval — no timer to
+    // dispose, edge-safe. Bound is 10k live keys before a full sweep.
+    if (this.hits.size > 10_000) {
+      for (const [k, e] of this.hits) if (e.reset <= now) this.hits.delete(k)
+    }
+    const fresh = { hits: 1, reset: now + this.windowMs }
+    this.hits.set(key, fresh)
+    return { totalHits: 1, resetTime: new Date(fresh.reset) }
+  }
+
+  async decrement(key: string): Promise<void> {
+    const entry = this.hits.get(key)
+    if (entry && entry.hits > 0) entry.hits--
+  }
+
+  async reset(key: string): Promise<void> {
+    this.hits.delete(key)
+  }
+}
+
+function defaultKey(ctx: RequestContext): string {
+  const h = ctx.headers
+  const first = (v: unknown): string | undefined =>
+    typeof v === 'string' && v.length > 0 ? v.split(',')[0].trim() : undefined
+  return (
+    first(h['cf-connecting-ip']) ?? first(h['x-forwarded-for']) ?? first(h['x-real-ip']) ?? 'global'
+  )
+}
+
+/**
+ * Rate limiting as a `(ctx, next)` middleware.
+ *
+ * ```ts
+ * // Edge (Cloudflare Workers) — app-wide:
+ * const app = createWebApp({
+ *   h3, modules,
+ *   middleware: [rateLimitGuard({ max: 60, windowMs: 60_000, store: new KvRateLimitStore(env.KV, { windowMs: 60_000 }) })],
+ * })
+ *
+ * // Any runtime — per controller/route:
+ * @Middleware(rateLimitGuard({ max: 10 }))
+ * @Post('/login')
+ * ```
+ */
+export function rateLimitGuard(options: RateLimitGuardOptions = {}): MiddlewareHandler {
+  const max = options.max ?? 100
+  const windowMs = options.windowMs ?? 60_000
+  const message = options.message ?? 'Too Many Requests'
+  const statusCode = options.statusCode ?? 429
+  const keyGenerator = options.keyGenerator ?? defaultKey
+  const sendHeaders = options.headers ?? true
+  const store = options.store ?? new LazyMemoryStore(windowMs)
+
+  return async (ctx: RequestContext, next: () => void): Promise<void> => {
+    if (options.skip?.(ctx)) return next()
+
+    const { totalHits, resetTime } = await store.increment(keyGenerator(ctx))
+    const remaining = Math.max(0, max - totalHits)
+
+    if (sendHeaders) {
+      ctx.setHeader('X-RateLimit-Limit', String(max))
+      ctx.setHeader('X-RateLimit-Remaining', String(remaining))
+      ctx.setHeader('X-RateLimit-Reset', String(Math.ceil(resetTime.getTime() / 1000)))
+    }
+
+    if (totalHits > max) {
+      const retryAfter = Math.max(1, Math.ceil((resetTime.getTime() - Date.now()) / 1000))
+      if (sendHeaders) ctx.setHeader('Retry-After', String(retryAfter))
+      ctx.json({ message }, statusCode)
+      return
+    }
+
+    next()
+  }
+}

--- a/packages/kickjs/src/http/middleware/rate-limit-guard.ts
+++ b/packages/kickjs/src/http/middleware/rate-limit-guard.ts
@@ -68,6 +68,12 @@ class LazyMemoryStore implements RateLimitStore {
 }
 
 function defaultKey(ctx: RequestContext): string {
+  // Prefer the runtime-computed client IP (Express derives req.ip from the
+  // app's `trust proxy` setting) — raw forwarded headers are client-spoofable
+  // on node deployments that don't normalize them. Header fallbacks cover
+  // runtimes without an `ip` field (the web/edge entry).
+  const reqIp = (ctx.req as { ip?: unknown }).ip
+  if (typeof reqIp === 'string' && reqIp.length > 0) return reqIp
   const h = ctx.headers
   const first = (v: unknown): string | undefined =>
     typeof v === 'string' && v.length > 0 ? v.split(',')[0].trim() : undefined

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -74,6 +74,14 @@ export { requestLogger, type RequestLoggerOptions } from './http/middleware/requ
 export { helmet, type HelmetOptions } from './http/middleware/helmet'
 export { cors, type CorsOptions } from './http/middleware/cors'
 export { rateLimit, type RateLimitOptions, type RateLimitStore } from './http/middleware/rate-limit'
+export { rateLimitGuard, type RateLimitGuardOptions } from './http/middleware/rate-limit-guard'
+export {
+  KvRateLimitStore,
+  KvSessionStore,
+  type KvLike,
+  type KvRateLimitStoreOptions,
+  type KvSessionStoreOptions,
+} from './http/middleware/kv-stores'
 export {
   session,
   type SessionOptions,

--- a/packages/kickjs/src/web.ts
+++ b/packages/kickjs/src/web.ts
@@ -24,6 +24,7 @@ import { Container } from './core/container'
 import { MutableModuleRegistry } from './core/module-registry'
 import type { AppModule, AppModuleClass, AppModuleEntry } from './core/app-module'
 import type { ContributorRegistrations } from './core/context-decorator'
+import type { MiddlewareHandler } from './core/decorators'
 import type { SourcedRegistration } from './core/contributor-pipeline'
 import {
   _setExternalContributorSources,
@@ -39,6 +40,15 @@ export { compileWebRoute } from './http/web/handler'
 // Return-value handler helpers — edge consumers can't import the main barrel.
 export { reply, isReply, type Reply, type InferHandlerResponse } from './http/reply'
 export type { SseHandler } from './http/context'
+// Edge-safe stores + ctx-style rate limiter (zero runtime imports).
+export {
+  KvRateLimitStore,
+  KvSessionStore,
+  type KvLike,
+  type KvRateLimitStoreOptions,
+  type KvSessionStoreOptions,
+} from './http/middleware/kv-stores'
+export { rateLimitGuard, type RateLimitGuardOptions } from './http/middleware/rate-limit-guard'
 
 // Minimal structural surface of h3 v2 used here (kept local so this entry
 // never imports the node-coupled h3-web runtime module).
@@ -75,6 +85,12 @@ export interface CreateWebAppOptions {
    * Bun/Deno, ambient `process.env` already works and this can be omitted.
    */
   env?: Record<string, string | undefined>
+  /**
+   * Global `(ctx, next)` middlewares, run before route middlewares on every
+   * route — the web-entry counterpart of `bootstrap({ middleware })`. Only
+   * ctx-style handlers are accepted (no connect/express middleware here).
+   */
+  middleware?: MiddlewareHandler[]
 }
 
 export interface WebApp {
@@ -125,6 +141,7 @@ export function createWebApp(options: CreateWebAppOptions): WebApp {
   const app = new h3mod.H3()
   const apiPrefix = options.apiPrefix ?? '/api'
   const defaultVersion = options.defaultVersion ?? 1
+  const globalMiddleware = options.middleware ?? []
 
   const globalSources: SourcedRegistration[] = (options.contributors ?? []).map(
     (registration): SourcedRegistration => ({
@@ -170,6 +187,9 @@ export function createWebApp(options: CreateWebAppOptions): WebApp {
           // Per-handler owner so intra-controller duplicates name both methods.
           const owner = `${route.controller.name ?? 'controller'}.${String(entry.meta.handlerName ?? '?')}`
           assertRouteUnique(seenRoutes, entry.method, url, owner)
+          if (globalMiddleware.length > 0) {
+            entry.middlewares = [...globalMiddleware, ...entry.middlewares]
+          }
           const run = compileWebRoute(entry)
           app.on(entry.method, url, (event: H3EventLike) =>
             run({


### PR DESCRIPTION
## Why

The edge guide's honesty table had one ❌ blocking *production* (not demo) Workers apps: in-memory `session()` / `rateLimit()` stores die with the isolate. This is the edge-spec §6 leftover.

## What

- **`rateLimitGuard()`** — a `(ctx, next)` rate limiter that runs on **every runtime and the `/web` fetch entry** (the connect-style `rateLimit()` stays node-only). `X-RateLimit-*` + `Retry-After` headers, pluggable `keyGenerator` (default `cf-connecting-ip` → first hop of `x-forwarded-for` → `x-real-ip`), `skip()`, and a timer-free in-memory default store (sweep-on-growth — no interval to dispose, edge-safe).
- **`KvLike`** — minimal `get/put/delete(+expirationTtl)` surface, structurally a Cloudflare `KVNamespace` binding: `new KvRateLimitStore(env.MY_KV, { windowMs })` with zero adapter code. Plus **`KvSessionStore`**, which plugs into the existing node `session()` middleware's `SessionStore` contract.
- **`createWebApp({ middleware })`** — global ctx-style middlewares on the web entry, the counterpart of `bootstrap({ middleware })`.
- **`ctx.setHeader(name, value)`** — runtime-neutral response header setter (the guard needed it; generally useful).

## Honest limits (documented in the edge guide)

- KV is eventually consistent → limiting is **approximate** under concurrent bursts; use a Durable Object/Redis store for exact quotas.
- Cloudflare KV's 60s minimum TTL is clamped up (shorter windows still limit correctly via the stored reset timestamp).
- Cookie-session middleware is still not wired on the web entry — `KvSessionStore` serves node deployments today; the edge table row is ⚠️ not ✅.

## Purity + tests

`kv-stores.ts` and `rate-limit-guard.ts` have **zero runtime imports** (types only) — the `/web` bundle-graph purity test passes untouched. 8 new tests: store semantics under fake timers, TTL clamp, prefix isolation, guard 429 e2e through `createWebApp` (headers asserted), `skip()`. Suite 660/660, typecheck clean, docs build green. Changeset: kickjs minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added edge-ready rate limiting for web apps, including request headers, retry timing, and optional skip logic.
  * Added support for global web middleware so shared handlers can run on every route.
  * Introduced KV-backed storage options for rate limits and sessions on edge deployments.
  * Added a response header helper for setting headers consistently across runtimes.

* **Documentation**
  * Expanded edge deployment guidance with updated support details, examples, and edge-specific behavior notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->