### PR TITLE
fix: close context-value guarantees, repair --check and doctor extends

### DIFF
--- a/.changeset/context-guarantees-and-typegen-check.md
+++ b/.changeset/context-guarantees-and-typegen-check.md
@@ -1,0 +1,23 @@
+---
+'@forinda/kickjs': minor
+'@forinda/kickjs-cli': patch
+'@forinda/kickjs-testing': patch
+---
+
+Close the gap between what context decorators guarantee and what the type system knows, and fix two checks that reported the wrong thing.
+
+**`ctx.require(key)`** — reads a value a contributor is expected to have produced and throws `MissingContextValueError` (naming the key and route) when it hasn't. `ctx.get(key)` returns `T | undefined` for every key, so consuming a guaranteed value meant `ctx.get(key)!` — an assertion that compiles whether or not the producing decorator is applied to the route. On an authorization value that fails open and silently. `require()` returns `NonNullable<MetaValue<K>>`, so the `!` goes away too. `null` still counts as present; only `undefined` throws.
+
+Compile-time narrowing (making a dropped decorator a `tsc` error) needs per-route context-key unions from typegen and is deferred — the design is recorded in `architecture.md` §20.14.
+
+**Required params are enforced at the call site.** A required field of `P` with no `paramDefaults` entry must now be supplied wherever the decorator is applied; the bare `@Foo` form, `@Foo()`, and `.registration` are compile errors for such a decorator. Previously `paramDefaults` was the only way to satisfy a required field, which pushed adopters into inventing placeholder defaults (`action: 'settings:read'` on a permission contributor every call site overrides) — and a route that then forgot the argument silently gated on the placeholder. The new optional `requiredParams: ['action']` enforces the same rule at runtime for plain-JS and `as any` call sites.
+
+**`kick typegen --check` actually fails now.** The wrapper that keeps a transiently-broken plugin from crashing `kick dev` was also catching the deliberate drift error, downgrading it to a `console.warn("… skipped")` and returning an empty result set — so the command exited 0 on drift, for every plugin, since the flag was introduced. Drift now propagates as `TypegenDriftError` listing every stale file in one pass, and a plugin that fails to generate under `--check` fails the gate instead of passing on "keeping previous output".
+
+**`kick doctor` no longer false-alarms on extended tsconfigs.** The loader followed exactly one level of `extends`, only when it was a string, resolved relative paths against the project root rather than the extending file, looked for bare specifiers only in the project's own `node_modules`, and parsed parent configs as strict JSON. Any one of those made a project that sets `experimentalDecorators` / `emitDecoratorMetadata` in a shared base config get told it was missing them — and lean per-package configs in a monorepo hit all of them. Now: chains of any depth, array `extends` (TS 5.0+), `node_modules` lookup walking up the tree (pnpm hoisting), directory specifiers resolving to `tsconfig.json`, and JSONC parsing (comments and trailing commas) throughout. A tsconfig that exists but can't be parsed now reports as unreadable rather than as missing.
+
+**Agent docs and the contributor scaffold teach the full surface.** `kick g agents` output covered context contributors thinly enough that agents routinely missed the call-site rules: the `.registration` / `.with({...}).registration` forms that module, adapter, and bootstrap sites actually take (passing the decorator itself is the most common wiring bug), when to reach for `.withParams<P>()`, and how to read a value back. Both the `AGENTS.md` section and the `kickjs-context-contributor` skill now carry the five registration sites, the params rules, the read-back table, and `ctx.get(key)!` / `contributors: [Decorator]` as named red flags.
+
+`kick g contributor --params` no longer scaffolds placeholder `paramDefaults` (`action: ''`). It emits `requiredParams` instead, so the generated contributor demands its params at every call site — the scaffold was previously teaching the exact pattern that made forgotten arguments silent.
+
+`ExecutionContext` gains a `require` member. Hand-written implementations of that interface need to add it; `RequestContext` and the `@forinda/kickjs-testing` fake contexts already do.

--- a/.changeset/context-guarantees-and-typegen-check.md
+++ b/.changeset/context-guarantees-and-typegen-check.md
@@ -6,7 +6,7 @@
 
 Close the gap between what context decorators guarantee and what the type system knows, and fix two checks that reported the wrong thing.
 
-**`ctx.require(key)`** — reads a value a contributor is expected to have produced and throws `MissingContextValueError` (naming the key and route) when it hasn't. `ctx.get(key)` returns `T | undefined` for every key, so consuming a guaranteed value meant `ctx.get(key)!` — an assertion that compiles whether or not the producing decorator is applied to the route. On an authorization value that fails open and silently. `require()` returns `NonNullable<MetaValue<K>>`, so the `!` goes away too. `null` still counts as present; only `undefined` throws.
+**`ctx.require(key)`** — reads a value a contributor is expected to have produced and throws `MissingContextValueError` (naming the key and route) when it hasn't. `ctx.get(key)` returns `T | undefined` for every key, so consuming a guaranteed value meant `ctx.get(key)!` — an assertion that compiles whether or not the producing decorator is applied to the route. On an authorization value that fails open and silently. `require()` returns `Exclude<MetaValue<K>, undefined>`, so the `!` goes away too. `null` still counts as present — only `undefined` throws, which is why the return type excludes `undefined` rather than using `NonNullable`.
 
 Compile-time narrowing (making a dropped decorator a `tsc` error) needs per-route context-key unions from typegen and is deferred — the design is recorded in `architecture.md` §20.14.
 

--- a/architecture.md
+++ b/architecture.md
@@ -3396,6 +3396,109 @@ Audit results from grepping `__ctxMeta`, `requestStore`, `tenantStorage`, `getCu
 | `examples/task-drizzle-api` (or new example)          | Add `LoadTenant` contributor showing class-level + method-level + adapter-level use in one app          |
 | `examples/multi-tenant-{drizzle,prisma,mongoose}-api` | Optional: convert hand-written tenant resolution middleware to a contributor (showcases migration path) |
 
+### 20.14 Compile-time context narrowing (deferred — RFC)
+
+**Status:** deferred. `ctx.require()` ships as the runtime half; this section
+records the design for the compile-time half so it isn't relitigated.
+
+#### The gap
+
+`ctx.get(key)` returns `MetaValue<K> | undefined` for every key, unconditionally.
+A contributor guarantees its key is populated, but the type system has no way to
+know which contributors a given route carries, so the guarantee can't be
+expressed. Every consumer of a guaranteed value ends up writing:
+
+```ts
+const perm = ctx.get('operatorPerm')! // non-null assertion
+```
+
+The assertion is the problem. It compiles identically whether or not
+`@OperatorPerm` is actually applied to the route. Drop the decorator during a
+refactor and there is no diagnostic anywhere: `tsc` is satisfied, the pipeline
+runs fine, and the handler reads `undefined` where it expected a permission.
+On an authorization gate that is the worst possible thing to leave untypeable —
+the failure is silent and it fails open.
+
+This was surfaced by an adopter sweeping ~155 call sites across 39 routes: with
+no compile-time signal available, verifying the sweep fell back to parity
+counting and live `curl`s.
+
+#### What shipped instead
+
+`ctx.require(key)` (`packages/kickjs/src/http/context.ts`) returns
+`NonNullable<MetaValue<K>>` and throws `MissingContextValueError` naming the key
+and route when the value is absent. That converts a silent `undefined` into a
+loud, attributable failure, and removes the `!` from call sites.
+
+It is strictly a runtime guarantee. A dropped decorator still compiles; it now
+fails on the first request instead of authorizing against `undefined`.
+
+The sibling gap — `paramDefaults` having no "required" mode, which pushed
+adopters into inventing placeholder defaults like `action: 'settings:read'` for
+params every call site overrides — **was** fixable at compile time and is fixed:
+see `CallSiteParams` / `MissingParamKeys` in `context-decorator.ts`. Both issues
+had the same root cause (the type system knowing less than the decorator does);
+only one of them needed typegen to close.
+
+#### Design for the compile-time half
+
+The information needed already exists at build time. `kick typegen` scans every
+controller and knows, per route, which context decorators are applied — that's
+the same scan that produces `KickRoutes`. The missing piece is emitting it as a
+per-route key union and threading it through the handler signature.
+
+Sketch:
+
+1. **Emit per-route context keys.** The `kick/routes` typegen plugin gains a
+   `contextKeys` member per route, collected from method-, class-, and
+   module-level contributor registrations:
+
+   ```ts
+   interface KickRoutes {
+     'GET /projects/:id': {
+       handler: ...
+       contextKeys: 'tenant' | 'project' | 'operatorPerm'
+     }
+   }
+   ```
+
+   Adapter- and bootstrap-level contributors are global, so they union into
+   every route.
+
+2. **Parameterise the context type.** `RequestContext<TBody, TParams, TQuery>`
+   gains a `TKeys extends string = string` parameter, with:
+
+   ```ts
+   get<K extends TKeys>(key: K): MetaValue<K>              // no `| undefined`
+   get<K extends string>(key: K): MetaValue<K> | undefined // ad-hoc keys
+   ```
+
+3. **Bind the route's keys to its handler.** The generated route types already
+   drive `KickRoutes.X['handler']` param/body/query typing; `contextKeys` rides
+   the same channel so a handler on a route without `@OperatorPerm` sees
+   `ctx.get('operatorPerm')` as `undefined`, and `ctx.require('operatorPerm')`
+   as a compile error.
+
+#### Why it's deferred
+
+- The narrowing is only sound if typegen sees _every_ registration site. Five
+  exist (method, class, module, adapter, global) and the last two are resolved
+  from runtime values in `bootstrap()`, which a static scan can't always follow.
+  An unsound narrowing is worse than none: it would turn today's honest
+  `| undefined` into a false guarantee.
+- It only holds while generated types are current. That makes it depend on the
+  `--check` CI gate actually working — which, until it was fixed alongside this
+  work, it did not for any plugin.
+- Handler-signature changes are the highest-blast-radius edit in the codebase.
+
+#### Prerequisites
+
+- [x] `--check` genuinely fails on stale generated types
+- [ ] Typegen can enumerate adapter- and bootstrap-level contributors, or the
+      design explicitly degrades to `string` when it can't prove completeness
+- [ ] `contextKeys` emitted per route by the `kick/routes` plugin
+- [ ] `RequestContext` carries `TKeys` end to end
+
 ---
 
 ## 21. Plugin Ecosystem — improvement landscape

--- a/docs/api/testing.md
+++ b/docs/api/testing.md
@@ -104,7 +104,7 @@ const LoadProject = defineContextDecorator({
   key: 'project',
   dependsOn: ['tenant'],
   deps: { repo: ProjectsRepo },
-  resolve: (ctx, { repo }) => (repo as ProjectsRepo).find(ctx.get('tenant')!.id, 'p-1'),
+  resolve: (ctx, { repo }) => (repo as ProjectsRepo).find(ctx.require('tenant').id, 'p-1'),
 })
 
 const { value } = await runContributor(LoadProject, {

--- a/docs/db/architecture.md
+++ b/docs/db/architecture.md
@@ -554,7 +554,7 @@ bootstrap({ contributors: [TenantDb], ... })
 class ProjectsController {
   @Get('/:id')
   show(ctx: RequestContext) {
-    const db = ctx.get('db')!     // typed against ContextMeta['db']
+    const db = ctx.require('db')     // typed against ContextMeta['db']
     return db.query.projects.findUnique({ where: (p, { eq }) => eq(p.id, ctx.params.id) })
   }
 }

--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -268,7 +268,7 @@ Drop the decorator during a refactor and nothing complains. `tsc` is satisfied, 
 const perm = ctx.require('operatorPerm')
 ```
 
-It returns `NonNullable<MetaValue<K>>` — no `!`, no `| undefined` — and throws `MissingContextValueError` when the value isn't there. The message names the key and the route, and points at the two causes: the producing contributor isn't applied to that route, or it ran and resolved to `undefined`.
+It returns `Exclude<MetaValue<K>, undefined>` — no `!`, no `| undefined` — and throws `MissingContextValueError` when the value isn't there. The message names the key and the route, and points at the two causes: the producing contributor isn't applied to that route, or it ran and resolved to `undefined`.
 
 **Use `require` for preconditions, `get` for optional extras:**
 
@@ -1592,9 +1592,20 @@ const OperatorPerm = defineHttpContextDecorator.withParams<PermParams>()({
   resolve: (ctx, _deps, { action }) => checkPermission(ctx, action),
 })
 
-@OperatorPerm                       // ✗ TS error — `action` missing
-@OperatorPerm({})                   // ✗ TS error — `action` missing
-@OperatorPerm({ action: 'audit:read' })   // ✓
+@Controller()
+class AuditController {
+  @OperatorPerm // ✗ TS error — `action` missing
+  @Get('/a')
+  a(ctx: RequestContext) {}
+
+  @OperatorPerm({}) // ✗ TS error — `action` missing
+  @Get('/b')
+  b(ctx: RequestContext) {}
+
+  @OperatorPerm({ action: 'audit:read' }) // ✓
+  @Get('/c')
+  c(ctx: RequestContext) {}
+}
 ```
 
 For such a decorator the bare `@Foo` form, the zero-arg `@Foo()` form, and the `.registration` accessor **do not exist** — none of them can supply the value. Use `Foo.with({ action: '…' }).registration` at module / adapter / bootstrap registration sites.

--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -205,7 +205,7 @@ const LoadProject = defineContextDecorator({
   key: 'project',
   dependsOn: ['tenant'],
   resolve: async (ctx) => {
-    const tenant = ctx.get('tenant')! // guaranteed present — the framework ran LoadTenant first
+    const tenant = ctx.require('tenant') // throws if LoadTenant didn't run
     return projectsRepo.findFor(tenant.id, ctx.params.id)
   },
 })
@@ -246,6 +246,45 @@ declare module '@forinda/kickjs' {
 }
 ```
 
+:::
+
+## Reading guaranteed values: `ctx.require()`
+
+`ctx.get(key)` returns `T | undefined` for **every** key, including keys a contributor guarantees. The type system doesn't know which contributors a given route carries, so the guarantee can't be expressed in `get`'s return type.
+
+The tempting fix is a non-null assertion — and it's a trap:
+
+```ts
+// ⚠️ compiles whether or not @OperatorPerm is applied to this route
+const perm = ctx.get('operatorPerm')!
+```
+
+Drop the decorator during a refactor and nothing complains. `tsc` is satisfied, the pipeline runs, and your handler reads `undefined` where it expected a permission. On an authorization gate that fails **open**, silently.
+
+`ctx.require(key)` is the same read with the guarantee enforced:
+
+```ts
+// ✅ throws MissingContextValueError naming the key and the route
+const perm = ctx.require('operatorPerm')
+```
+
+It returns `NonNullable<MetaValue<K>>` — no `!`, no `| undefined` — and throws `MissingContextValueError` when the value isn't there. The message names the key and the route, and points at the two causes: the producing contributor isn't applied to that route, or it ran and resolved to `undefined`.
+
+**Use `require` for preconditions, `get` for optional extras:**
+
+| Value                                            | Read with       |
+| ------------------------------------------------ | --------------- |
+| Permission, tenant, the route's resolved subject | `ctx.require()` |
+| Anything a contributor marked `optional: true`   | `ctx.get()`     |
+| Ad-hoc keys nothing is guaranteed to write       | `ctx.get()`     |
+
+`null` counts as present — only `undefined` throws. A contributor that deliberately resolves to `null` is saying "looked, found nothing", which is a real answer.
+
+::: warning This is a runtime guarantee, not a compile-time one
+
+`ctx.require()` turns a silent `undefined` into a loud, named failure on the first request. It **cannot** make a missing decorator a compile error — proving that needs per-route context-key unions out of typegen. The design is written up in `architecture.md` §20.14; until it lands, a dropped decorator fails fast at runtime rather than at build time.
+
+Integration tests that exercise each route are still the thing that catches a dropped decorator before production.
 :::
 
 ## Error handling
@@ -737,7 +776,7 @@ const AssignAbBucket = defineHttpContextDecorator({
   key: 'abBucket',
   dependsOn: ['featureFlags'], // typed against ContextMeta — typos are TS errors
   resolve: (ctx) => {
-    const flags = ctx.get('featureFlags')! // guaranteed by dependsOn
+    const flags = ctx.require('featureFlags') // guaranteed by dependsOn
     if (!flags['new-checkout']) return 'control'
     // Stable per-user bucket from a hash of the user id — kept here for brevity
     const userId = ctx.req.headers['x-user-id'] as string | undefined
@@ -885,7 +924,7 @@ bootstrap({ modules, adapters: [GeoAdapter()] })
 @ResolveGeo
 @Get('/nearby')
 nearby(ctx: RequestContext) {
-  ctx.json({ country: ctx.get('geo')!.country })
+  ctx.json({ country: ctx.require('geo').country })
 }
 ```
 
@@ -1043,7 +1082,7 @@ export const LoadTenantDb = defineHttpContextDecorator.withParams<LoadTenantDbPa
   resolve: (ctx, { dbPool }, _params) => {
     // `params.pool === 'replica'` would route to a read-replica DSN
     // here — wired the same way; omitted for brevity.
-    const tenant = ctx.get('tenant')!
+    const tenant = ctx.require('tenant')
     return dbPool.for(tenant)
   },
 })
@@ -1278,7 +1317,7 @@ const Greet = defineHttpContextDecorator({
   key: 'greeting',
   dependsOn: ['locale'],
   resolve: (ctx) => {
-    const { language } = ctx.get('locale')! // guaranteed by dependsOn at runtime
+    const { language } = ctx.require('locale') // guaranteed by dependsOn at runtime
     return language === 'fr' ? 'Bonjour' : 'Hello'
   },
 })
@@ -1539,6 +1578,44 @@ export const LoadTenant = defineHttpContextDecorator.withParams<LoadTenantParams
 ```
 
 Use the core `defineContextDecorator.withParams<P>()(spec)` form when authoring contributors for non-HTTP transports (WebSocket, queue, cron) or when sharing one definition across transports — the resolver then sticks to the `ExecutionContext` surface (`ctx.get`, `ctx.set`, `ctx.requestId`).
+
+### Required params — don't invent a default
+
+`paramDefaults` is optional per field. Any field of `P` that is **required** and has **no** entry in `paramDefaults` must be supplied at every call site, and the compiler enforces it:
+
+```ts
+type PermParams = { action: string; scope?: string }
+
+const OperatorPerm = defineHttpContextDecorator.withParams<PermParams>()({
+  key: 'operatorPerm',
+  // no paramDefaults.action — every route must name its own action
+  resolve: (ctx, _deps, { action }) => checkPermission(ctx, action),
+})
+
+@OperatorPerm                       // ✗ TS error — `action` missing
+@OperatorPerm({})                   // ✗ TS error — `action` missing
+@OperatorPerm({ action: 'audit:read' })   // ✓
+```
+
+For such a decorator the bare `@Foo` form, the zero-arg `@Foo()` form, and the `.registration` accessor **do not exist** — none of them can supply the value. Use `Foo.with({ action: '…' }).registration` at module / adapter / bootstrap registration sites.
+
+This exists so you never have to invent a placeholder default just to satisfy the type. A default like `action: 'settings:read'` on a permission contributor every call site overrides is worse than no default: forget the argument on one route and it silently gates on the placeholder instead of failing to compile.
+
+Give a field a `paramDefaults` entry **only when the default is genuinely correct for an undecorated route** — `headerName: 'x-tenant-id'` yes, a permission string almost never.
+
+#### Runtime enforcement for JS call sites
+
+The compile-time check covers TypeScript. For plain-JS adopters, `as any` escapes, and params assembled dynamically, add `requiredParams`:
+
+```ts
+const OperatorPerm = defineHttpContextDecorator.withParams<PermParams>()({
+  key: 'operatorPerm',
+  requiredParams: ['action'],
+  resolve: (ctx, _deps, { action }) => checkPermission(ctx, action),
+})
+```
+
+A missing field then throws `TypeError` at the point of use — decoration time for `@Foo`, call time for `@Foo({...})` and `.with({...})` — naming the decorator and the field. Partial coverage is fine: list only the fields whose absence is a correctness bug.
 
 ### Positional form (no params)
 

--- a/docs/guide/dependency-injection.md
+++ b/docs/guide/dependency-injection.md
@@ -369,7 +369,7 @@ const LoadCurrentUser = defineHttpContextDecorator({
 const LoadTenantId = defineHttpContextDecorator({
   key: 'tenantId',
   dependsOn: ['currentUser'],
-  resolve: (ctx) => ctx.get('currentUser')!.tenantId,
+  resolve: (ctx) => ctx.require('currentUser').tenantId,
 })
 
 @Controller()

--- a/packages/cli/__tests__/doctor.test.ts
+++ b/packages/cli/__tests__/doctor.test.ts
@@ -246,9 +246,173 @@ describe('checkDecoratorTsConfig', () => {
   })
 
   it('fails when tsconfig.json is missing entirely', () => {
-    const rs = checkDecoratorTsConfig(ctx('/x', { tsconfig: null }))
+    const rs = checkDecoratorTsConfig(ctx('/x', { tsconfig: undefined }))
     expect(rs[0]?.status).toBe('fail')
+    expect(rs[0]?.name).toContain('present')
     expect(rs[0]?.fix).toContain('tsconfig.json')
+  })
+
+  it('warns (does not fail the flags) when tsconfig exists but cannot be parsed', () => {
+    // Reporting "experimentalDecorators missing" for a config we failed
+    // to read is a guess, and usually a wrong one.
+    const rs = checkDecoratorTsConfig(ctx('/x', { tsconfig: null }))
+    expect(rs[0]?.status).toBe('warn')
+    expect(rs[0]?.name).toContain('readable')
+    expect(rs.some((r) => r.name.includes('experimentalDecorators'))).toBe(false)
+  })
+})
+
+// ── tsconfig `extends` resolution ─────────────────────────────────────
+
+/**
+ * Regression suite: `kick doctor` used to report
+ * experimentalDecorators / emitDecoratorMetadata as missing whenever
+ * they were set in a config the project extends rather than inline.
+ * The old loader followed exactly one level, only for a string
+ * `extends`, resolved relative paths against the project root instead
+ * of the containing file, resolved bare specifiers only in the
+ * project's own node_modules, and parsed parents as strict JSON. Lean
+ * per-package configs in a monorepo tripped all five.
+ */
+describe('doctor tsconfig extends chain', () => {
+  const DECORATOR_OPTS = `{
+    "compilerOptions": {
+      "experimentalDecorators": true,
+      "emitDecoratorMetadata": true
+    }
+  }`
+
+  async function decoratorResults(dir: string) {
+    const rs = await runChecks(dir)
+    return rs.filter((r) => r.name.startsWith('tsconfig'))
+  }
+
+  /**
+   * Both decorator flags resolved to `pass`. Asserts the two results are
+   * actually present first — a bare `.every()` is vacuously true when the
+   * config failed to load and the decorator checks never ran, which would
+   * make these tests pass against the very bug they exist to catch.
+   */
+  const bothPass = (rs: { name: string; status: string }[]) => {
+    const flags = rs.filter((r) => r.name.includes('Decorator'))
+    expect(flags.map((r) => r.name).toSorted()).toEqual([
+      'tsconfig: emitDecoratorMetadata',
+      'tsconfig: experimentalDecorators',
+    ])
+    return flags.every((r) => r.status === 'pass')
+  }
+
+  it('inherits from a directly extended base config', async () => {
+    const dir = tempProject({
+      'tsconfig.base.json': DECORATOR_OPTS,
+      'tsconfig.json': '{ "extends": "./tsconfig.base.json" }',
+    })
+    expect(bothPass(await decoratorResults(dir))).toBe(true)
+  })
+
+  it('follows a chain more than one level deep', async () => {
+    const dir = tempProject({
+      'tsconfig.root.json': DECORATOR_OPTS,
+      'tsconfig.base.json': '{ "extends": "./tsconfig.root.json" }',
+      'tsconfig.json': '{ "extends": "./tsconfig.base.json" }',
+    })
+    expect(bothPass(await decoratorResults(dir))).toBe(true)
+  })
+
+  it('resolves relative extends against the extending file, not the project root', async () => {
+    const dir = tempProject({
+      'config/tsconfig.root.json': DECORATOR_OPTS,
+      // `./tsconfig.root.json` here is relative to config/, not the root.
+      'config/tsconfig.base.json': '{ "extends": "./tsconfig.root.json" }',
+      'tsconfig.json': '{ "extends": "./config/tsconfig.base.json" }',
+    })
+    expect(bothPass(await decoratorResults(dir))).toBe(true)
+  })
+
+  it('supports the TS 5.0 array form of extends', async () => {
+    const dir = tempProject({
+      'a.json': '{ "compilerOptions": { "experimentalDecorators": true } }',
+      'b.json': '{ "compilerOptions": { "emitDecoratorMetadata": true } }',
+      'tsconfig.json': '{ "extends": ["./a.json", "./b.json"] }',
+    })
+    expect(bothPass(await decoratorResults(dir))).toBe(true)
+  })
+
+  it('lets later array entries and the child win over earlier ones', async () => {
+    const dir = tempProject({
+      'a.json': '{ "compilerOptions": { "experimentalDecorators": false } }',
+      'b.json': DECORATOR_OPTS,
+      'tsconfig.json': '{ "extends": ["./a.json", "./b.json"] }',
+    })
+    expect(bothPass(await decoratorResults(dir))).toBe(true)
+  })
+
+  it('finds a bare specifier hoisted to a parent node_modules', async () => {
+    // The pnpm/monorepo case: the preset is not in the package's own
+    // node_modules, it's at the workspace root.
+    const dir = tempProject({
+      'node_modules/@tsconfig/kick/tsconfig.json': DECORATOR_OPTS,
+      'packages/api/tsconfig.json': '{ "extends": "@tsconfig/kick" }',
+    })
+    expect(bothPass(await decoratorResults(join(dir, 'packages/api')))).toBe(true)
+  })
+
+  it('resolves a directory specifier to its tsconfig.json', async () => {
+    const dir = tempProject({
+      'node_modules/@tsconfig/node20/tsconfig.json': DECORATOR_OPTS,
+      'tsconfig.json': '{ "extends": "@tsconfig/node20" }',
+    })
+    expect(bothPass(await decoratorResults(dir))).toBe(true)
+  })
+
+  it('appends .json to an extensionless specifier', async () => {
+    const dir = tempProject({
+      'base.json': DECORATOR_OPTS,
+      'tsconfig.json': '{ "extends": "./base" }',
+    })
+    expect(bothPass(await decoratorResults(dir))).toBe(true)
+  })
+
+  it('parses comments and trailing commas anywhere in the chain', async () => {
+    const dir = tempProject({
+      'tsconfig.base.json': `{
+        // decorator support
+        "compilerOptions": {
+          "experimentalDecorators": true,
+          /* required by the DI container */
+          "emitDecoratorMetadata": true,
+        },
+      }`,
+      'tsconfig.json': '{ "extends": "./tsconfig.base.json", }',
+    })
+    expect(bothPass(await decoratorResults(dir))).toBe(true)
+  })
+
+  it('does not report an existing-but-unreadable tsconfig as missing', async () => {
+    const dir = tempProject({ 'tsconfig.json': '{ this is not json at all' })
+    const rs = await decoratorResults(dir)
+    expect(rs[0]?.status).toBe('warn')
+    expect(rs[0]?.name).toContain('readable')
+  })
+
+  it('terminates on a circular extends chain', async () => {
+    const dir = tempProject({
+      'a.json': '{ "extends": "./b.json" }',
+      'b.json': '{ "extends": "./a.json" }',
+      'tsconfig.json': '{ "extends": "./a.json" }',
+    })
+    // Should return, not hang or blow the stack.
+    const rs = await decoratorResults(dir)
+    expect(rs.length).toBeGreaterThan(0)
+  })
+
+  it('still fails the flags when nothing in the chain sets them', async () => {
+    const dir = tempProject({
+      'tsconfig.base.json': '{ "compilerOptions": { "strict": true } }',
+      'tsconfig.json': '{ "extends": "./tsconfig.base.json" }',
+    })
+    const rs = await decoratorResults(dir)
+    expect(rs.find((r) => r.name.includes('experimentalDecorators'))?.status).toBe('fail')
   })
 })
 

--- a/packages/cli/__tests__/leaf-generators.test.ts
+++ b/packages/cli/__tests__/leaf-generators.test.ts
@@ -135,8 +135,28 @@ describe('kick g <leaf>', () => {
       expect(content).toContain('source: string')
       expect(content).toContain('region: number')
       expect(content).toContain('.withParams<TenantParams>()')
-      expect(content).toContain('paramDefaults')
       expect(content).toContain('(ctx, _deps, params)')
+      // Scaffolded params are required at every call site, enforced at
+      // runtime too. The generator must NOT emit placeholder defaults
+      // (`source: ''`) — a default that is never correct means a call
+      // site that forgets the argument runs with the placeholder instead
+      // of failing to compile.
+      expect(content).toContain("requiredParams: ['source', 'region']")
+      // Anchored to a property line — the scaffold's guidance comment
+      // mentions `paramDefaults` on purpose, which is not the same thing.
+      expect(content).not.toMatch(/^\s*paramDefaults:/m)
+      expect(content).not.toContain("source: ''")
+      expect(content).not.toContain('region: 0')
+    })
+
+    it('points at .registration (not the decorator) for non-decorator sites', () => {
+      // Passing the decorator itself to `contributors: []` is the most
+      // common wiring mistake; the scaffold header should model the fix.
+      runCli(fixture, ['g', 'contributor', 'tenant'])
+      const content = readFileSync(join(fixture, 'src/contributors/tenant.contributor.ts'), 'utf-8')
+      expect(content).toContain('.registration')
+      expect(content).toContain('ctx.require(')
+      expect(content).not.toMatch(/ctx\.get\('tenant'\)!/)
     })
 
     it('honours an explicit --key', () => {

--- a/packages/cli/__tests__/leaf-generators.test.ts
+++ b/packages/cli/__tests__/leaf-generators.test.ts
@@ -149,6 +149,23 @@ describe('kick g <leaf>', () => {
       expect(content).not.toContain('region: 0')
     })
 
+    it('keeps the usage example transport-appropriate for --type bare', () => {
+      // ExecutionContext has no @Get route and no ctx.json — an HTTP
+      // example here hands the adopter a snippet that does not compile
+      // against the contributor they just generated.
+      runCli(fixture, ['g', 'contributor', 'audit-log', '--type', 'bare'])
+      const bare = readFileSync(join(fixture, 'src/contributors/audit-log.contributor.ts'), 'utf-8')
+      expect(bare).not.toContain('ctx.json(')
+      expect(bare).not.toContain("@Get('/')")
+      expect(bare).toContain("ctx.require('auditLog')")
+
+      // The http form still demonstrates the HTTP surface.
+      runCli(fixture, ['g', 'contributor', 'tenant'])
+      const http = readFileSync(join(fixture, 'src/contributors/tenant.contributor.ts'), 'utf-8')
+      expect(http).toContain("@Get('/')")
+      expect(http).toContain("ctx.json(ctx.require('tenant'))")
+    })
+
     it('points at .registration (not the decorator) for non-decorator sites', () => {
       // Passing the decorator itself to `contributors: []` is the most
       // common wiring mistake; the scaffold header should model the fix.

--- a/packages/cli/__tests__/typegen-check-gate.test.ts
+++ b/packages/cli/__tests__/typegen-check-gate.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtemp, rm } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import path from 'node:path'
+import path, { join } from 'node:path'
 
 // The real builtins module transitively imports every command (init.ts
 // reads package.json relative to dist/), which can't load from src under
@@ -109,6 +110,20 @@ describe('runAllPluginTypegens — --check gate', () => {
       check: true,
     })
     expect(results.every((r) => r.status === 'unchanged')).toBe(true)
+  })
+
+  it('leaves the working tree untouched — creates no output directory', async () => {
+    // A CI gate that dirties a clean checkout just by running is not a
+    // gate. Nothing on the --check path writes, including the mkdir that
+    // the write path needs.
+    await expect(
+      runAllPluginTypegens({
+        cwd: dir,
+        config: configWith([echo('export type A = 1')]),
+        check: true,
+      }),
+    ).rejects.toBeInstanceOf(TypegenDriftError)
+    expect(existsSync(join(dir, '.kickjs'))).toBe(false)
   })
 
   it('fails the gate when a plugin cannot generate at all', async () => {

--- a/packages/cli/__tests__/typegen-check-gate.test.ts
+++ b/packages/cli/__tests__/typegen-check-gate.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+// The real builtins module transitively imports every command (init.ts
+// reads package.json relative to dist/), which can't load from src under
+// vitest. These tests only care about the wrapper's error handling, so
+// the built-in plugin list is stubbed empty and fixtures come in via
+// `config.plugins`.
+vi.mock('../src/plugin/builtins', () => ({ builtinCliPlugins: [] }))
+
+import { runAllPluginTypegens } from '../src/typegen/run-plugins'
+import { TypegenDriftError, type TypegenPlugin } from '../src/typegen/plugin'
+import { defineCliPlugin } from '../src/plugin/types'
+import type { KickConfig } from '../src/config'
+
+// Regression suite for the `--check` CI gate.
+//
+// The bug: `runAllPluginTypegens` wraps the whole plugin pass in a catch
+// that downgrades failures to a `console.warn` so a transiently-broken
+// plugin can't crash the `kick dev` loop. That catch also swallowed the
+// deliberate drift throw and returned `[]`, so the command's
+// `results.some(r => r.status === 'written')` check saw an empty array
+// and exited 0. `--check` never failed a build for any plugin.
+//
+// `typegen-runner.test.ts` covered the runner, which threw correctly all
+// along — the swallow was one layer up, which is why the existing test
+// stayed green. These tests pin the wrapper.
+
+let dir: string
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), 'kick-check-gate-'))
+})
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+  vi.restoreAllMocks()
+})
+
+function configWith(typegens: TypegenPlugin[]): KickConfig {
+  return {
+    plugins: [defineCliPlugin({ name: 'test/fixture', typegens })],
+  } as unknown as KickConfig
+}
+
+const echo = (body: string): TypegenPlugin => ({
+  id: 'test/echo',
+  inputs: [],
+  async generate() {
+    return body
+  },
+})
+
+describe('runAllPluginTypegens — --check gate', () => {
+  it('propagates drift instead of swallowing it (the regression)', async () => {
+    // Seed the on-disk output.
+    await runAllPluginTypegens({ cwd: dir, config: configWith([echo('export type A = 1')]) })
+
+    // Same plugin id, different output → drift.
+    await expect(
+      runAllPluginTypegens({
+        cwd: dir,
+        config: configWith([echo('export type A = 2')]),
+        check: true,
+      }),
+    ).rejects.toBeInstanceOf(TypegenDriftError)
+  })
+
+  it('does not report drift as a warning + empty result set', async () => {
+    await runAllPluginTypegens({ cwd: dir, config: configWith([echo('export type A = 1')]) })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(
+      runAllPluginTypegens({
+        cwd: dir,
+        config: configWith([echo('export type A = 2')]),
+        check: true,
+      }),
+    ).rejects.toThrow()
+
+    // The old behaviour: warn("… skipped (…)") and return [] → exit 0.
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('skipped'))
+  })
+
+  it('names every drifted file so one CI run reports the full list', async () => {
+    const two = (a: string, b: string): TypegenPlugin[] => [
+      { id: 'test/one', inputs: [], generate: async () => a },
+      { id: 'test/two', inputs: [], generate: async () => b },
+    ]
+    await runAllPluginTypegens({ cwd: dir, config: configWith(two('one', 'two')) })
+
+    const err = await runAllPluginTypegens({
+      cwd: dir,
+      config: configWith(two('one-changed', 'two-changed')),
+      check: true,
+    }).catch((e: unknown) => e)
+
+    expect(err).toBeInstanceOf(TypegenDriftError)
+    const drifted = (err as TypegenDriftError).drifted.map((d) => d.id)
+    expect(drifted).toEqual(['test/one', 'test/two'])
+    expect((err as TypegenDriftError).message).toContain('kick typegen')
+  })
+
+  it('passes cleanly when generated output matches disk', async () => {
+    await runAllPluginTypegens({ cwd: dir, config: configWith([echo('export type A = 1')]) })
+    const results = await runAllPluginTypegens({
+      cwd: dir,
+      config: configWith([echo('export type A = 1')]),
+      check: true,
+    })
+    expect(results.every((r) => r.status === 'unchanged')).toBe(true)
+  })
+
+  it('fails the gate when a plugin cannot generate at all', async () => {
+    // A gate that cannot verify a file must not pass it.
+    const broken: TypegenPlugin = {
+      id: 'test/broken',
+      inputs: [],
+      async generate() {
+        throw new Error('boom')
+      },
+    }
+    await expect(
+      runAllPluginTypegens({ cwd: dir, config: configWith([broken]), check: true }),
+    ).rejects.toThrow(/failed to generate/)
+  })
+
+  it('still shields the dev loop from a broken plugin when not checking', async () => {
+    // The catch exists for a reason — preserve it outside --check.
+    const broken: TypegenPlugin = {
+      id: 'test/broken',
+      inputs: [],
+      async generate() {
+        throw new Error('boom')
+      },
+    }
+    const results = await runAllPluginTypegens({ cwd: dir, config: configWith([broken]) })
+    expect(results.find((r) => r.id === 'test/broken')?.status).toBe('error')
+  })
+})

--- a/packages/cli/__tests__/typegen-runner.test.ts
+++ b/packages/cli/__tests__/typegen-runner.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 import { runTypegen } from '../src/typegen/runner'
-import type { TypegenPlugin } from '../src/typegen/plugin'
+import { TypegenDriftError, type TypegenPlugin } from '../src/typegen/plugin'
 
 let dir: string
 beforeEach(async () => {
@@ -48,7 +48,44 @@ describe('runTypegen', () => {
     }
     await expect(
       runTypegen({ cwd: dir, config: {} as never, plugins: [drifted], check: true }),
-    ).rejects.toThrow(/drift detected/)
+    ).rejects.toThrow(/out of date/)
+  })
+
+  it('--check reports every drifted plugin, not just the first', async () => {
+    const a = (body: string): TypegenPlugin => ({
+      id: 'test/a',
+      inputs: [],
+      generate: async () => body,
+    })
+    const b = (body: string): TypegenPlugin => ({
+      id: 'test/b',
+      inputs: [],
+      generate: async () => body,
+    })
+    await runTypegen({ cwd: dir, config: {} as never, plugins: [a('1'), b('1')] })
+
+    const err = await runTypegen({
+      cwd: dir,
+      config: {} as never,
+      plugins: [a('2'), b('2')],
+      check: true,
+    }).catch((e: unknown) => e as TypegenDriftError)
+
+    expect(err).toBeInstanceOf(TypegenDriftError)
+    expect(err.drifted.map((d) => d.id)).toEqual(['test/a', 'test/b'])
+  })
+
+  it('--check writes nothing', async () => {
+    await runTypegen({ cwd: dir, config: {} as never, plugins: [plugin] })
+    const before = await readFile(path.join(dir, '.kickjs/types/test__echo.d.ts'), 'utf8')
+    await runTypegen({
+      cwd: dir,
+      config: {} as never,
+      plugins: [{ ...plugin, generate: async () => 'export type Echo = "drift"' }],
+      check: true,
+    }).catch(() => {})
+    const after = await readFile(path.join(dir, '.kickjs/types/test__echo.d.ts'), 'utf8')
+    expect(after).toBe(before)
   })
 
   it('skips plugin when generate returns null', async () => {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -28,7 +28,13 @@ import { intro, outro, log } from '../utils/prompts'
 export interface DoctorContext {
   cwd: string
   pkg: any | null
-  tsconfig: any | null
+  /**
+   * The project's tsconfig with its full `extends` chain already merged
+   * into `compilerOptions`. `undefined` = no tsconfig.json; `null` = one
+   * exists but couldn't be parsed. Checks should distinguish the two —
+   * they call for different advice.
+   */
+  tsconfig: any | null | undefined
   /**
    * The project's HTTP runtime — from kick.config `runtime`, else sniffed from
    * deps, else `express`. Lets engine-aware checks (engine peers, the upload
@@ -143,45 +149,151 @@ function safeRead(filepath: string): string | null {
   }
 }
 
+/** Depth cap for `extends` chains — well past any real-world config. */
+const MAX_EXTENDS_DEPTH = 16
+
 /**
- * Read tsconfig.json with `extends` followed one level. Most adopters
- * use a single config; for those that extend kickjs-cli's preset, we
- * pick up the inherited `compilerOptions`. Avoids pulling in `tsc` just
- * to resolve the chain.
+ * Parse a tsconfig's JSONC: block comments, line comments, and trailing
+ * commas are all legal in tsconfig.json and all illegal in `JSON.parse`.
+ *
+ * Trailing commas matter more than they look: a plain `JSON.parse` throw
+ * used to make `loadTsConfig` return null, which the decorator check
+ * reports as "tsconfig.json present → fail" for a file that is sitting
+ * right there. A formatting nicety became a phantom missing file.
  */
-function loadTsConfig(cwd: string): any | null {
-  const tsconfigPath = join(cwd, 'tsconfig.json')
-  const raw = safeRead(tsconfigPath)
-  if (!raw) return null
-  // tsconfig files often contain comments; strip them before parsing.
-  const stripped = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
-  let cfg: any
+function parseJsonc(raw: string): any | null {
+  const stripped = raw
+    // Block comments, but not inside strings — approximated by requiring
+    // the `/*` to not be preceded by a `:` + quote start. Good enough for
+    // config files; a full JSONC parser isn't worth the dependency here.
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:"'\\])\/\/.*$/gm, '$1')
+    // Trailing commas before } or ]
+    .replace(/,(\s*[}\]])/g, '$1')
   try {
-    cfg = JSON.parse(stripped)
+    return JSON.parse(stripped)
   } catch {
     return null
   }
-  if (typeof cfg?.extends === 'string') {
-    const extendsPath = resolveExtends(cwd, cfg.extends)
-    if (extendsPath) {
-      const parent = safeReadJson(extendsPath) ?? {}
-      cfg.compilerOptions = {
-        ...parent.compilerOptions,
-        ...cfg.compilerOptions,
-      }
-    }
+}
+
+/**
+ * Read a tsconfig and resolve its full `extends` chain.
+ *
+ * Previously this followed exactly one level, only when `extends` was a
+ * string, resolved relative paths against the project root rather than
+ * the containing file, and parsed parents with a bare `JSON.parse`. Any
+ * of those produced the same symptom: a project whose decorator options
+ * live in a shared base config got told it was missing
+ * `experimentalDecorators` / `emitDecoratorMetadata` that it plainly
+ * sets. Lean per-package configs in a monorepo hit every one of them at
+ * once.
+ *
+ * Now: chains of any depth, array `extends` (TS 5.0+), node_modules
+ * lookup walking up from the config's own directory (pnpm/monorepo
+ * hoisting), directory specifiers resolving to `tsconfig.json`, and
+ * JSONC parsing for every file in the chain.
+ *
+ * Returns `undefined` when no tsconfig.json exists, and `null` when one
+ * exists but couldn't be parsed — callers report those differently.
+ *
+ * Relative paths *inside* inherited options (`baseUrl`, `paths`,
+ * `outDir`) are NOT rebased onto the child's directory the way `tsc`
+ * does it. Every check that reads this cares only about booleans; revisit
+ * if a path-sensitive check is ever added.
+ */
+function loadTsConfig(cwd: string): any | null | undefined {
+  const tsconfigPath = join(cwd, 'tsconfig.json')
+  if (!existsSync(tsconfigPath)) return undefined
+  return loadTsConfigFrom(tsconfigPath, new Set())
+}
+
+function loadTsConfigFrom(filePath: string, seen: Set<string>): any | null {
+  if (seen.has(filePath) || seen.size >= MAX_EXTENDS_DEPTH) return null
+  seen.add(filePath)
+
+  const raw = safeRead(filePath)
+  if (raw === null) return null
+  const cfg = parseJsonc(raw)
+  if (cfg === null || typeof cfg !== 'object') return null
+
+  // `extends` is a string or, since TS 5.0, an array applied left to
+  // right with later entries overriding earlier ones.
+  const parents = Array.isArray(cfg.extends)
+    ? cfg.extends
+    : typeof cfg.extends === 'string'
+      ? [cfg.extends]
+      : []
+
+  // Mutating accumulator rather than re-spreading per iteration — later
+  // entries override earlier ones, which is the same result.
+  const inherited: Record<string, any> = {}
+  for (const ext of parents) {
+    if (typeof ext !== 'string') continue
+    const parentPath = resolveExtends(dirname(filePath), ext)
+    if (!parentPath) continue
+    const parent = loadTsConfigFrom(parentPath, seen)
+    if (!parent) continue
+    Object.assign(inherited, parent.compilerOptions)
   }
+
+  cfg.compilerOptions = { ...inherited, ...cfg.compilerOptions }
   return cfg
 }
 
-function resolveExtends(cwd: string, ext: string): string | null {
-  if (ext.startsWith('.')) {
-    const resolved = resolve(cwd, ext)
-    return existsSync(resolved) ? resolved : null
+/**
+ * Resolve one `extends` entry to an absolute file path, mirroring how
+ * `tsc` resolves them.
+ *
+ * `fromDir` is the directory of the config doing the extending — NOT the
+ * project root. A chain of relative extends only resolves correctly when
+ * each hop is relative to its own file.
+ *
+ * Handles: relative paths with an implied `.json`, bare package
+ * specifiers (`@tsconfig/node20`, `@acme/tsconfig/base.json`), directory
+ * specifiers that mean `<dir>/tsconfig.json`, and node_modules
+ * directories anywhere up the tree — the last of which is what pnpm
+ * workspaces need, since the preset is usually hoisted to the repo root
+ * rather than sitting in the package's own node_modules.
+ */
+function resolveExtends(fromDir: string, ext: string): string | null {
+  if (ext.startsWith('.') || ext.startsWith('/')) {
+    return resolveConfigTarget(resolve(fromDir, ext))
   }
-  const mod = join(cwd, 'node_modules', ext)
-  if (existsSync(mod)) return mod
+
+  // Bare specifier — walk up looking for node_modules/<specifier>.
+  let dir = fromDir
+  for (;;) {
+    const candidate = resolveConfigTarget(join(dir, 'node_modules', ext))
+    if (candidate) return candidate
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
   return null
+}
+
+/**
+ * Turn a resolved specifier into an actual config file: the path itself,
+ * the path with `.json` appended, or `<path>/tsconfig.json` when it names
+ * a directory. `@tsconfig/node20` resolves to a directory, and the old
+ * code handed that straight to `JSON.parse` — an EISDIR that silently
+ * became "no inherited options".
+ */
+function resolveConfigTarget(target: string): string | null {
+  if (existsSync(target)) {
+    try {
+      if (statSync(target).isDirectory()) {
+        const nested = join(target, 'tsconfig.json')
+        return existsSync(nested) ? nested : null
+      }
+    } catch {
+      return null
+    }
+    return target
+  }
+  const withJson = `${target}.json`
+  return existsSync(withJson) ? withJson : null
 }
 
 function escapeRegExp(s: string): string {
@@ -350,12 +462,26 @@ export function checkReflectMetadata(ctx: DoctorContext): DoctorResult {
 }
 
 export function checkDecoratorTsConfig(ctx: DoctorContext): DoctorResult[] {
-  if (!ctx.tsconfig) {
+  if (ctx.tsconfig === undefined) {
     return [
       {
         name: 'tsconfig.json present',
         status: 'fail',
         fix: 'Create a tsconfig.json with `experimentalDecorators: true` and `emitDecoratorMetadata: true`. `kick new` scaffolds one automatically.',
+      },
+    ]
+  }
+  if (ctx.tsconfig === null) {
+    // The file exists but we couldn't read it (or something in its
+    // `extends` chain). Reporting the decorator options as missing here
+    // would be a guess, and a wrong one more often than not — say what
+    // actually happened instead.
+    return [
+      {
+        name: 'tsconfig.json readable',
+        status: 'warn',
+        message: 'could not parse tsconfig.json (or a config it extends)',
+        fix: 'Check tsconfig.json for a syntax error, and that every path in its `extends` chain resolves. Decorator options could not be verified.',
       },
     ]
   }

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -10,7 +10,13 @@
 
 import type { Command } from 'commander'
 import { resolve } from 'node:path'
-import { runTypegen, writeTypegenArtifacts, TokenCollisionError, watchTypegen } from '../typegen'
+import {
+  runTypegen,
+  writeTypegenArtifacts,
+  TokenCollisionError,
+  TypegenDriftError,
+  watchTypegen,
+} from '../typegen'
 import { runAllPluginTypegens } from '../typegen/run-plugins'
 import { loadKickConfig } from '../config'
 import { findProjectRoot } from '../utils/project-root'
@@ -79,7 +85,10 @@ export function registerTypegenCommand(program: Command): void {
       '--env-file <path>',
       "Path to env schema file for KickEnv typing (default 'src/env.ts'; pass 'false' to disable)",
     )
-    .option('--check', 'CI gate: fail on plugin-typegen drift instead of writing')
+    .option(
+      '--check',
+      'CI gate: exit non-zero if any generated file in .kickjs/types/ is out of date (routes, env, db, assets, adopter plugins) instead of writing it',
+    )
     .option(
       '--fix',
       "Patch module import.meta.glob() calls to cover decorated classes that aren't loaded by any glob (orphans)",
@@ -193,6 +202,9 @@ export function registerTypegenCommand(program: Command): void {
       } catch (err: unknown) {
         if (err instanceof TokenCollisionError) {
           console.error('\n' + err.message + '\n')
+        } else if (err instanceof TypegenDriftError) {
+          // Already formatted as a multi-line report by the error class.
+          console.error('\n  ' + err.message + '\n')
         } else if (err instanceof Error) {
           console.error(`\n  kick typegen failed: ${err.message}`)
         } else {

--- a/packages/cli/src/generators/contributor.ts
+++ b/packages/cli/src/generators/contributor.ts
@@ -127,6 +127,24 @@ export async function generateContributor(options: GenerateContributorOptions): 
       ? `    // \`params\` is typed as ${pascal}Params (call-site params merged onto any paramDefaults).`
       : `    // \`ctx\` is a ${ctxType} — read ctx.req / ctx.headers / ctx.params (http) or ctx.get (bare).`
 
+  // The usage example has to match the transport. A `bare` contributor
+  // resolves against `ExecutionContext`, which has no `@Get` route and no
+  // `ctx.json` — showing an HTTP handler there hands the adopter a
+  // snippet that doesn't compile for the thing they just generated.
+  const usageExample =
+    type === 'http'
+      ? ` *   @${pascal}${params.length > 0 ? `({ ${params[0]?.name}: … })` : ''}
+ *   @Get('/')
+ *   handler(ctx: ${ctxType}) {
+ *     return ctx.json(ctx.require('${key}'))
+ *   }`
+      : ` *   // Any transport whose handler receives an ExecutionContext
+ *   // (WebSocket, queue, cron). Attach via that transport's decorator,
+ *   // or register the contributor at a module / bootstrap site below.
+ *   handler(ctx: ${ctxType}) {
+ *     const value = ctx.require('${key}')
+ *   }`
+
   const content = `import { ${factory} } from '@forinda/kickjs'
 import type { ${ctxType} } from '@forinda/kickjs'
 
@@ -139,11 +157,7 @@ import type { ${ctxType} } from '@forinda/kickjs'
  *
  * Apply per method/class:
  *
- *   @${pascal}${params.length > 0 ? `({ ${params[0]?.name}: … })` : ''}
- *   @Get('/')
- *   handler(ctx: ${ctxType}) {
- *     return ctx.json(ctx.require('${key}'))
- *   }
+${usageExample}
  *
  * Or register at a module / adapter / bootstrap site — those take a
  * \`ContributorRegistration\`, not the decorator itself:

--- a/packages/cli/src/generators/contributor.ts
+++ b/packages/cli/src/generators/contributor.ts
@@ -65,22 +65,6 @@ export function parseContributorParams(raw: string | undefined): ContributorPara
     .filter((p) => p.name.length > 0)
 }
 
-/** Safe primitive default for `paramDefaults` so the scaffold compiles. */
-function defaultForType(type: string): string | null {
-  switch (type) {
-    case 'string':
-      return "''"
-    case 'number':
-      return '0'
-    case 'boolean':
-      return 'false'
-    default:
-      // Non-primitive — omit from paramDefaults (the field is `Partial<P>`)
-      // so we don't emit an un-typeable placeholder.
-      return null
-  }
-}
-
 export async function generateContributor(options: GenerateContributorOptions): Promise<string[]> {
   const { name, moduleName, modulesDir, pattern } = options
   const type: ContributorType = options.type ?? 'http'
@@ -119,17 +103,28 @@ export async function generateContributor(options: GenerateContributorOptions): 
   // plain `factory({...})` form otherwise.
   const callOpen = params.length > 0 ? `${factory}.withParams<${pascal}Params>()({` : `${factory}({`
 
-  const paramDefaultsEntries = params
-    .map((p) => ({ name: p.name, def: defaultForType(p.type) }))
-    .filter((p) => p.def !== null)
-    .map((p) => `    ${p.name}: ${p.def},`)
-  const paramDefaultsBlock =
-    params.length > 0 ? `  paramDefaults: {\n${paramDefaultsEntries.join('\n')}\n  },\n` : ''
+  // Deliberately NO `paramDefaults` placeholders.
+  //
+  // This scaffold used to emit `paramDefaults: { action: '' }` — a
+  // primitive stand-in per param, purely so the file compiled. That
+  // taught the wrong pattern: a default that is never correct means a
+  // call site which forgets the argument silently runs with the
+  // placeholder instead of failing to compile. Scaffolded params are
+  // required in `<Pascal>Params`, so leaving them undefaulted makes the
+  // compiler demand them at every call site — and `requiredParams`
+  // enforces the same at runtime for JS callers.
+  const requiredParamsBlock =
+    params.length > 0
+      ? `  // Every call site must supply these — no placeholder defaults.\n` +
+        `  // Add \`paramDefaults: { … }\` for any field whose default is\n` +
+        `  // genuinely correct for an undecorated route, and drop it from here.\n` +
+        `  requiredParams: [${params.map((p) => `'${p.name}'`).join(', ')}],\n`
+      : ''
 
   const resolveSig = params.length > 0 ? '(ctx, _deps, params)' : '(ctx)'
   const resolveHint =
     params.length > 0
-      ? `    // \`params\` is typed as ${pascal}Params (call-site overrides merged onto paramDefaults).`
+      ? `    // \`params\` is typed as ${pascal}Params (call-site params merged onto any paramDefaults).`
       : `    // \`ctx\` is a ${ctxType} — read ctx.req / ctx.headers / ctx.params (http) or ctx.get (bare).`
 
   const content = `import { ${factory} } from '@forinda/kickjs'
@@ -142,17 +137,23 @@ import type { ${ctxType} } from '@forinda/kickjs'
  * matched handler runs — the typed, ordered alternative to
  * \`@Middleware()\` when the only job is to populate \`ctx\`.
  *
- * Apply per method/class, or register globally via
- * \`bootstrap({ contributors: [${pascal}] })\`:
+ * Apply per method/class:
  *
  *   @${pascal}${params.length > 0 ? `({ ${params[0]?.name}: … })` : ''}
  *   @Get('/')
  *   handler(ctx: ${ctxType}) {
- *     return ctx.json(ctx.get('${key}'))
+ *     return ctx.json(ctx.require('${key}'))
  *   }
+ *
+ * Or register at a module / adapter / bootstrap site — those take a
+ * \`ContributorRegistration\`, not the decorator itself:
+ *
+ *   bootstrap({ contributors: [${pascal}${
+   params.length > 0 ? `.with({ ${params[0]?.name}: … })` : ''
+ }.registration] })
  */
 
-// Register '${key}' so \`ctx.get('${key}')\` is typed and \`dependsOn: ['${key}']\`
+// Register '${key}' so \`ctx.require('${key}')\` is typed and \`dependsOn: ['${key}']\`
 // is checked. Replace \`unknown\` with the resolved value's real type.
 // (For a key you only depend on — no value type needed — declare it in
 // \`interface ContextKeys\` instead.)
@@ -164,7 +165,7 @@ declare module '@forinda/kickjs' {
 ${paramsInterface}
 export const ${pascal} = ${callOpen}
   key: '${key}',
-${paramDefaultsBlock}  resolve: ${resolveSig} => {
+${requiredParamsBlock}  resolve: ${resolveSig} => {
 ${resolveHint}
     // TODO: compute and return the value written to ctx.set('${key}', …)
     throw new Error("${pascal} contributor: resolve() not implemented")

--- a/packages/cli/src/generators/templates/project-docs.ts
+++ b/packages/cli/src/generators/templates/project-docs.ts
@@ -663,16 +663,52 @@ Typed, ordered way to populate \`ctx.set/get\` keys before the handler runs.
 Use this **instead of \`@Middleware()\`** when the middleware's only output
 is a value other code reads off \`ctx\`.
 
+**Authoring** — pick the right factory:
+
+| Factory | When |
+|---------|------|
+| \`defineHttpContextDecorator(spec)\` | HTTP only (the common case). \`Ctx\` is \`RequestContext\`, so \`ctx.req\` / \`ctx.params\` / \`ctx.query\` are typed. |
+| \`defineContextDecorator(spec)\` | Transport-agnostic (HTTP + WS + queue + cron). \`Ctx\` is \`ExecutionContext\` — only \`get\` / \`require\` / \`set\` / \`requestId\`. |
+| \`<either>.withParams<P>()(spec)\` | The contributor takes per-call params. **Always use the curried form for params** — the positional form forces you to spell \`K\` and \`D\` and loses \`deps\` inference. |
+
+Spec fields: \`{ key, deps, dependsOn, optional, paramDefaults, requiredParams, onError, resolve }\`.
+
+**Call sites — all five, precedence high → low:**
+
+| # | Site | Form |
+|---|------|------|
+| 1 | Method | \`@LoadX\` / \`@LoadX({ ... })\` above a controller method |
+| 2 | Class | \`@LoadX\` / \`@LoadX({ ... })\` above the controller class |
+| 3 | Module | \`defineModule({ build: () => ({ contributors: () => [LoadX.registration] }) })\` — or \`AppModule.contributors?()\` in class form |
+| 4 | Adapter | \`AppAdapter.contributors?(): ContributorRegistration[]\` |
+| 5 | Global | \`bootstrap({ contributors: [LoadX.registration] })\` |
+
+Sites 3–5 take **registrations**, not decorators:
+
+- \`LoadX.registration\` — uses \`paramDefaults\` as-is.
+- \`LoadX.with({ ...params }).registration\` — call-site params merged over \`paramDefaults\`.
+
+Duplicate keys are resolved by precedence; the lower-precedence one is
+dropped silently, which is how a method-level decorator overrides an
+adapter-shipped default.
+
+**Params:** a **required** field of \`P\` with no \`paramDefaults\` entry must be
+supplied at every call site — \`@LoadX\` bare, \`@LoadX()\`, and \`.registration\`
+are compile errors for such a decorator. Never invent a placeholder default
+just to make the type check; add \`requiredParams: ['field']\` for runtime
+enforcement at JS call sites.
+
+**Reading values:** \`ctx.require('key')\` for values a contributor guarantees
+(throws \`MissingContextValueError\`, returns a non-optional type);
+\`ctx.get('key')\` for \`optional: true\` contributors and ad-hoc keys (returns
+\`| undefined\`). Never \`ctx.get('key')!\` — it compiles even when the producing
+decorator isn't applied to the route.
+
 | Concept | Where it lives |
 |---------|----------------|
-| \`defineContextDecorator({ key, deps, dependsOn, optional, onError, resolve })\` | \`@forinda/kickjs\` |
-| Method/class decorator | \`@LoadX\` on a controller method/class |
-| Module hook | \`build: () => ({ contributors() { return [...] } })\` (\`defineModule\`) — or \`AppModule.contributors?()\` for class form |
-| Adapter hook | \`AppAdapter.contributors?(): ContributorRegistration[]\` |
-| Global registration | \`bootstrap({ contributors: [LoadX.registration] })\` |
-| Type augmentation | \`declare module '@forinda/kickjs' { interface ContextMeta { ... } }\` |
+| Type augmentation (value types) | \`declare module '@forinda/kickjs' { interface ContextMeta { ... } }\` |
+| Type augmentation (key-only) | \`declare module '@forinda/kickjs' { interface ContextKeys { ... } }\` — valid in \`dependsOn\`, value stays \`unknown\` |
 
-Precedence high → low: **method > class > module > adapter > global**.
 Cycles and missing \`dependsOn\` keys throw at \`app.setup()\` (boot fails
 fast). The \`onError\` hook is async-permitted.
 
@@ -1173,6 +1209,10 @@ Same-key collisions WITHIN a precedence level throw \`DuplicateContributorError\
 **Don't use this for**: response short-circuit, stream mutation, or pre-route-matching work — keep \`@Middleware()\` for those.
 
 **Red flags**:
+- \`ctx.get('key')!\` — the non-null assertion compiles even when the producing decorator isn't on the route. Use \`ctx.require('key')\`.
+- \`contributors: [LoadX]\` at a module / adapter / bootstrap site — those take registrations: \`LoadX.registration\` or \`LoadX.with({ ... }).registration\`.
+- A \`paramDefaults\` value that every call site overrides (\`action: 'settings:read'\`) — drop it and let the compiler require the field at each site.
+- \`defineContextDecorator<'k', Deps, Params>(spec)\` positional form for a parameterised contributor — use \`.withParams<Params>()(spec)\` or \`deps\` inference is lost.
 - \`ctx.tenant = x\` instead of returning the value from \`resolve\` — sticks to one instance only.
 - \`defineAugmentation\` without the \`declare module\` block (or vice-versa) — discoverability and types drift apart; \`ctx.get('tenant')\` becomes \`unknown\`.
 - Plugin / adapter authors using bare keys (\`'state'\`) instead of namespaced (\`'@my-plugin/state'\`) — collides with adopter keys.
@@ -1599,7 +1639,7 @@ export const app = await bootstrap({ modules, middleware, plugins, adapters })
 
 \`\`\`yaml
 name: kickjs-context-contributor
-description: Use when a middleware's only job is to set ctx values consumed elsewhere — replace with defineHttpContextDecorator (HTTP) or defineContextDecorator (transport-agnostic).
+description: Authoring, registering, and reading KickJS context contributors. Use when a middleware's only job is to set ctx values consumed elsewhere; when wiring a contributor at a method/class/module/adapter/bootstrap site; when a contributor needs per-call params; or when reading a contributed value off ctx.
 \`\`\`
 
 **Pattern** (HTTP — most common):
@@ -1616,19 +1656,82 @@ const LoadTenant = defineHttpContextDecorator({
 const LoadProject = defineHttpContextDecorator({
   key: 'project',
   dependsOn: ['tenant'],
-  resolve: (ctx) => projectsRepo.find(ctx.get('tenant')!.id, ctx.params.id),
+  resolve: (ctx) => projectsRepo.find(ctx.require('tenant').id, ctx.params.id),
 })
 
 @LoadTenant
 @LoadProject
 @Get('/projects/:id')
-getProject(ctx: RequestContext) { ctx.json(ctx.get('project')) }
+getProject(ctx: RequestContext) { ctx.json(ctx.require('project')) }
 \`\`\`
 
-Use \`defineContextDecorator\` (no Http prefix) when authoring a contributor that must run across HTTP, WebSocket, queue, and cron transports — \`Ctx\` defaults to the smaller \`ExecutionContext\` surface (\`get\` / \`set\` / \`requestId\` only, no \`req\`).
+Use \`defineContextDecorator\` (no Http prefix) when authoring a contributor that must run across HTTP, WebSocket, queue, and cron transports — \`Ctx\` defaults to the smaller \`ExecutionContext\` surface (\`get\` / \`require\` / \`set\` / \`requestId\` only, no \`req\`).
 
-Precedence high → low: **method > class > module > adapter > global**.
-Cycles or unmet \`dependsOn\` keys throw \`MissingContributorError\` at boot.
+**Parameterised contributors** — always use the curried \`.withParams<P>()\` form. The positional form (\`defineContextDecorator<K, D, P, Ctx>\`) forces you to spell \`K\` and \`D\` by hand and loses \`deps\` inference in the resolver:
+
+\`\`\`ts
+type PermParams = { action: string; scope?: string }
+
+const OperatorPerm = defineHttpContextDecorator.withParams<PermParams>()({
+  key: 'operatorPerm',
+  deps: { perms: PERMISSIONS_SERVICE },
+  requiredParams: ['action'],       // runtime guard for JS call sites
+  resolve: (ctx, { perms }, { action }) => perms.check(ctx, action),
+})
+
+@OperatorPerm({ action: 'audit:read' })
+@Get('/audit')
+audit(ctx: RequestContext) { ... }
+\`\`\`
+
+**Params rules:**
+- A **required** field of \`P\` with no \`paramDefaults\` entry must be supplied at every call site. \`@Foo\` bare, \`@Foo()\`, and \`.registration\` are compile errors for such a decorator.
+- **Never invent a placeholder default** just to satisfy the type (\`action: 'settings:read'\` on a permission contributor). A default that is never correct means a call site that forgets the argument silently gates on the placeholder instead of failing to compile. Omit it and let the compiler demand it.
+- Give a \`paramDefaults\` entry only when the default is genuinely correct for an undecorated route — \`headerName: 'x-tenant-id'\` yes, a permission string no.
+- \`requiredParams: ['action']\` adds the same check at runtime (throws \`TypeError\` naming the decorator + field) for plain-JS and \`as any\` call sites the types can't reach.
+
+**All five call sites**, precedence high → low — **method > class > module > adapter > global**:
+
+| # | Site | Form |
+|---|------|------|
+| 1 | Method | \`@LoadX\` / \`@LoadX({ ... })\` above a controller method |
+| 2 | Class | \`@LoadX\` / \`@LoadX({ ... })\` above the controller class |
+| 3 | Module | \`defineModule({ build: () => ({ contributors: () => [LoadX.registration] }) })\`, or \`AppModule.contributors?()\` in class form |
+| 4 | Adapter | \`AppAdapter.contributors?(): ContributorRegistration[]\` |
+| 5 | Global | \`bootstrap({ contributors: [LoadX.registration] })\` |
+
+Sites 3–5 take **registrations**, not decorators — this is the most common
+thing agents get wrong:
+
+\`\`\`ts
+LoadTenant.registration                              // paramDefaults as-is
+LoadTenant.with({ source: 'subdomain' }).registration // params merged over defaults
+\`\`\`
+
+Passing the decorator itself (\`contributors: [LoadTenant]\`) is wrong — it's a
+function, not a \`ContributorRegistration\`. For a decorator with undefaulted
+required params, \`.registration\` doesn't exist; use \`.with({ ... }).registration\`.
+
+When the same key is registered at two levels, the higher-precedence one wins
+and the other is **dropped silently** — that's the mechanism for overriding an
+adapter-shipped contributor on a single route.
+
+Cycles or unmet \`dependsOn\` keys throw \`MissingContributorError\` /
+\`ContributorCycleError\` at \`app.setup()\` — boot fails, not the request.
+
+**Reading values back:**
+
+| Value | Read with |
+|-------|-----------|
+| Anything a contributor guarantees (tenant, permission, resolved subject) | \`ctx.require('key')\` — throws \`MissingContextValueError\`, returns a **non-optional** type |
+| \`optional: true\` contributors, ad-hoc keys | \`ctx.get('key')\` — returns \`\\| undefined\` |
+| From a service with no \`ctx\` | \`getRequestValue('key')\` — returns \`\\| undefined\` |
+
+**Never write \`ctx.get('key')!\`.** The assertion compiles whether or not the
+producing decorator is applied to the route, so dropping the decorator during a
+refactor is invisible to \`tsc\` and the handler reads \`undefined\`. On an auth
+value that fails open. Use \`ctx.require()\` — same read, loud failure.
+(\`null\` counts as present; only \`undefined\` throws.)
 
 **Critical rules — all stem from the same shared-via-ALS instance model**:
 - Every per-request stage (middleware → contributors → handler) gets its OWN \`RequestContext\` instance, but they all read/write the SAME \`AsyncLocalStorage\`-backed bag.

--- a/packages/cli/src/typegen/index.ts
+++ b/packages/cli/src/typegen/index.ts
@@ -34,6 +34,7 @@ export type {
   ScanResult,
 } from './scanner'
 export { TokenCollisionError } from './render/manifest'
+export { TypegenDriftError } from './plugin'
 export { validateTokenConventions, type TokenConventionWarning } from './token-conventions'
 
 /**

--- a/packages/cli/src/typegen/plugin.ts
+++ b/packages/cli/src/typegen/plugin.ts
@@ -73,8 +73,35 @@ export interface TypegenPlugin {
 
 export interface TypegenPluginResult {
   id: string
-  status: 'written' | 'unchanged' | 'skipped' | 'error'
+  status: 'written' | 'unchanged' | 'skipped' | 'error' | 'drifted'
   outFile?: string
+}
+
+/**
+ * Thrown by the runner under `--check` when a plugin's generated output
+ * differs from what's on disk. Carries every drifted plugin, not just
+ * the first, so one CI run reports the full list.
+ *
+ * This has its own class for a load-bearing reason: `runAllPluginTypegens`
+ * wraps the pass in a catch that downgrades plugin failures to a warning
+ * so a transiently-broken plugin can't crash the `kick dev` loop. That
+ * catch used to swallow this error too, which made `--check` exit 0 on
+ * *every* drift — the gate silently passed while printing "skipped".
+ * The catch now rethrows this type. Do not make it a plain `Error`.
+ */
+export class TypegenDriftError extends Error {
+  /** Plugin ids whose output drifted, in run order. */
+  readonly drifted: readonly { id: string; outFile: string }[]
+
+  constructor(drifted: readonly { id: string; outFile: string }[]) {
+    const list = drifted.map((d) => `    ${d.id} → ${d.outFile}`).join('\n')
+    super(
+      `kick typegen --check: ${drifted.length} generated file(s) are out of date:\n${list}\n` +
+        `  Run \`kick typegen\` and commit the result.`,
+    )
+    this.name = 'TypegenDriftError'
+    this.drifted = drifted
+  }
 }
 
 /**

--- a/packages/cli/src/typegen/run-plugins.ts
+++ b/packages/cli/src/typegen/run-plugins.ts
@@ -4,15 +4,17 @@
 //
 // Loads built-ins + adopter plugins, merges them, filters by
 // `kick.config.ts > typegen.disable`, runs every typegen via the T7
-// runner. In silent mode errors are swallowed so a transiently-broken
-// plugin doesn't crash the dev loop. Returns the per-plugin status
-// array — callers may log it, exit non-zero on drift (--check), etc.
+// runner. Plugin errors are downgraded to a warning so a transiently-
+// broken plugin doesn't crash the dev loop — EXCEPT under `--check`,
+// where every failure propagates so the CI gate can actually fail.
+// Returns the per-plugin status array — callers may log it, etc.
 
 import type { KickConfig } from '../config'
 import { mergeCliPlugins } from '../plugin'
 import { builtinCliPlugins } from '../plugin/builtins'
 import { runTypegen as runPluginTypegens } from './runner'
 import type { ScanDelta } from './scanner'
+import { TypegenDriftError } from './plugin'
 import type { TypegenPluginResult } from './plugin'
 import { applyDisableFilter } from './disable-filter'
 
@@ -91,6 +93,12 @@ export async function runAllPluginTypegens(
     }
     return results
   } catch (err) {
+    // `--check` failures are the whole point of `--check` — never
+    // downgrade them to a warning. This catch exists so a transiently
+    // broken plugin doesn't crash the `kick dev` loop; swallowing the
+    // drift error here made the CI gate exit 0 on every drift while
+    // printing "skipped", so the flag never once failed a build.
+    if (err instanceof TypegenDriftError || opts.check) throw err
     if (!opts.silent) {
       const msg = err instanceof Error ? err.message : String(err)
       console.warn(`  kick typegen plugins: skipped (${msg})`)

--- a/packages/cli/src/typegen/runner.ts
+++ b/packages/cli/src/typegen/runner.ts
@@ -52,7 +52,15 @@ export interface RunTypegenOptions {
 
 export async function runTypegen(opts: RunTypegenOptions): Promise<TypegenPluginResult[]> {
   const typesDirAbs = path.resolve(opts.cwd, TYPES_DIR)
-  await mkdir(typesDirAbs, { recursive: true })
+  // `--check` is read-only: it must not touch the working tree at all.
+  // Creating the output directory here would leave a clean checkout dirty
+  // just by running the gate. Everything the check path does is reads
+  // (`existsSync` + `readFile`), which work fine when the dir is absent —
+  // a missing directory simply means every plugin drifts, which is the
+  // correct verdict for a repo with no generated types committed.
+  if (!opts.check) {
+    await mkdir(typesDirAbs, { recursive: true })
+  }
 
   // Per-pass memoization of scanProject. Cache keyed by a stable
   // serialization of the resolved scan options so two plugins asking

--- a/packages/cli/src/typegen/runner.ts
+++ b/packages/cli/src/typegen/runner.ts
@@ -2,7 +2,8 @@
 //
 // Sequentially invokes each plugin's generate(), prepends a banner, and
 // writes the result to `.kickjs/types/<id>.d.ts` only when the content
-// changes. `--check` mode skips writing and throws on the first drift —
+// changes. `--check` mode skips writing, collects every plugin whose
+// output drifted, and throws `TypegenDriftError` listing all of them —
 // CI gate so generated files in git stay in sync with code.
 //
 // Sequential (not parallel) on purpose: plugins are cheap, ordering keeps
@@ -22,6 +23,7 @@ import {
   type ScanOptions,
   type ScanResult,
 } from './scanner'
+import { TypegenDriftError } from './plugin'
 import type { TypegenContext, TypegenPlugin, TypegenPluginResult } from './plugin'
 
 const TYPES_DIR = '.kickjs/types'
@@ -98,6 +100,7 @@ export async function runTypegen(opts: RunTypegenOptions): Promise<TypegenPlugin
   }
 
   const results: TypegenPluginResult[] = []
+  const drifted: { id: string; outFile: string }[] = []
   for (const plugin of opts.plugins) {
     // Slashes in ids (kick/db) → __ on disk so they're valid filenames.
     // Default extension is .d.ts (declaration only); plugins emitting
@@ -119,6 +122,14 @@ export async function runTypegen(opts: RunTypegenOptions): Promise<TypegenPlugin
       // aborted the whole loop, so kick/routes never ran and the sweep
       // then deleted the stale-looking controller route types).
       const msg = err instanceof Error ? err.message : String(err)
+      // Under --check there is no "previous output" to keep — we aren't
+      // writing. A plugin that can't generate means the gate cannot
+      // verify that file, and a gate that can't verify must not pass.
+      if (opts.check) {
+        throw new Error(`kick typegen --check: ${plugin.id} failed to generate (${msg})`, {
+          cause: err,
+        })
+      }
       ctx.log.error(`  ${plugin.id}: typegen failed (${msg}) — keeping previous output`)
       results.push({ id: plugin.id, status: 'error', outFile: file })
       continue
@@ -140,11 +151,18 @@ export async function runTypegen(opts: RunTypegenOptions): Promise<TypegenPlugin
     }
 
     if (opts.check) {
-      throw new Error(`kick typegen --check: drift detected for ${plugin.id} (${file})`)
+      // Record and keep going — a CI run should report every stale file
+      // in one pass, not make the adopter re-run the gate N times to
+      // discover them one at a time.
+      drifted.push({ id: plugin.id, outFile: file })
+      results.push({ id: plugin.id, status: 'drifted', outFile: file })
+      continue
     }
     await writeFile(file, next, 'utf8')
     results.push({ id: plugin.id, status: 'written', outFile: file })
   }
+
+  if (drifted.length > 0) throw new TypegenDriftError(drifted)
 
   return results
 }

--- a/packages/kickjs/__tests__/context-require.test.ts
+++ b/packages/kickjs/__tests__/context-require.test.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, expectTypeOf } from 'vitest'
 import {
   MissingContextValueError,
   RequestContext,
@@ -70,6 +70,17 @@ describe('RequestContext.require', () => {
       const ctx = new RequestContext(mockReq(), ...mockResNext())
       expect(ctx.require('lookup')).toBeNull()
     })
+  })
+
+  it('keeps null in the return type — Exclude<…, undefined>, not NonNullable', () => {
+    // The runtime hands `null` back, so a `NonNullable` return type would
+    // be a lie: callers would be told the value is non-null and then get
+    // null. Only `undefined` is excluded, because only `undefined` throws.
+    type Meta = { nullable: { id: string } | null; plain: string }
+    expectTypeOf<Exclude<Meta['nullable'], undefined>>().toEqualTypeOf<{ id: string } | null>()
+    expectTypeOf<Exclude<Meta['plain'], undefined>>().toEqualTypeOf<string>()
+    // The distinction this pins down:
+    expectTypeOf<NonNullable<Meta['nullable']>>().toEqualTypeOf<{ id: string }>()
   })
 
   it('throws for a key explicitly set to undefined', () => {

--- a/packages/kickjs/__tests__/context-require.test.ts
+++ b/packages/kickjs/__tests__/context-require.test.ts
@@ -1,0 +1,104 @@
+import 'reflect-metadata'
+import { describe, it, expect } from 'vitest'
+import {
+  MissingContextValueError,
+  RequestContext,
+  requestStore,
+  type RequestStore,
+} from '../src/index'
+
+// `ctx.get(key)` returns `T | undefined` for every key, so the only way
+// to consume a value a contributor guarantees was `ctx.get(key)!` — a
+// non-null assertion that compiles whether or not the producing
+// contributor is applied to the route. On an authorization value that
+// makes a dropped decorator invisible to both tsc and the runtime.
+// `ctx.require()` is the loud version.
+
+function mockReq(over: Record<string, unknown> = {}) {
+  return { body: {}, params: {}, query: {}, headers: {}, ...over } as any
+}
+
+function mockResNext() {
+  return [{ json: () => undefined } as any, (() => undefined) as any] as const
+}
+
+function withStore<T>(fn: (store: RequestStore) => T): T {
+  const store: RequestStore = { requestId: 'r-test', instances: new Map(), values: new Map() }
+  return requestStore.run(store, () => fn(store))
+}
+
+describe('RequestContext.require', () => {
+  it('returns the value when a contributor produced it', () => {
+    withStore((store) => {
+      store.values.set('tenant', { id: 't-9' })
+      const ctx = new RequestContext(mockReq(), ...mockResNext())
+      expect(ctx.require('tenant')).toEqual({ id: 't-9' })
+    })
+  })
+
+  it('throws MissingContextValueError when the key was never written', () => {
+    withStore(() => {
+      const ctx = new RequestContext(mockReq(), ...mockResNext())
+      expect(() => ctx.require('tenantPerm')).toThrow(MissingContextValueError)
+    })
+  })
+
+  it('names the missing key and the route in the message', () => {
+    withStore(() => {
+      const ctx = new RequestContext(
+        mockReq({ method: 'GET', url: '/projects/42' }),
+        ...mockResNext(),
+      )
+      let caught: MissingContextValueError | undefined
+      try {
+        ctx.require('tenantPerm')
+      } catch (e) {
+        caught = e as MissingContextValueError
+      }
+      expect(caught?.key).toBe('tenantPerm')
+      expect(caught?.route).toBe('GET /projects/42')
+      expect(caught?.message).toContain('tenantPerm')
+      expect(caught?.message).toContain('GET /projects/42')
+    })
+  })
+
+  it('treats null as a real value — only undefined throws', () => {
+    // A contributor resolving to null is saying "looked, found nothing",
+    // which is a decision. undefined means nothing ran at all.
+    withStore((store) => {
+      store.values.set('lookup', null)
+      const ctx = new RequestContext(mockReq(), ...mockResNext())
+      expect(ctx.require('lookup')).toBeNull()
+    })
+  })
+
+  it('throws for a key explicitly set to undefined', () => {
+    withStore((store) => {
+      store.values.set('maybe', undefined)
+      const ctx = new RequestContext(mockReq(), ...mockResNext())
+      expect(() => ctx.require('maybe')).toThrow(MissingContextValueError)
+    })
+  })
+
+  it('still throws (does not crash differently) with no ALS frame active', () => {
+    // Outside a request store there is no metadata map at all. require()
+    // should report the missing key, not a TypeError on undefined.
+    const ctx = new RequestContext(mockReq(), ...mockResNext())
+    expect(() => ctx.require('tenant')).toThrow(MissingContextValueError)
+  })
+
+  it('omits the route suffix when the request exposes no method/url', () => {
+    withStore(() => {
+      const ctx = new RequestContext(mockReq(), ...mockResNext())
+      const err = (() => {
+        try {
+          ctx.require('x')
+        } catch (e) {
+          return e as MissingContextValueError
+        }
+      })()
+      expect(err?.route).toBeUndefined()
+      expect(err?.message).toContain("No context value for 'x'")
+    })
+  })
+})

--- a/packages/kickjs/__tests__/context-required-params.test.ts
+++ b/packages/kickjs/__tests__/context-required-params.test.ts
@@ -1,0 +1,160 @@
+import 'reflect-metadata'
+import { describe, it, expect } from 'vitest'
+import { defineContextDecorator } from '../src/index'
+
+// Before this, `paramDefaults` was the only way to satisfy a required
+// field of `P`, so contributors that genuinely need a per-call-site
+// value ended up with invented defaults — `action: 'settings:read'` on a
+// permission contributor every call site overrides. A route that then
+// forgot the argument silently gated on the placeholder instead of
+// failing to compile. Now: undefaulted required fields are mandatory at
+// each call site, and `requiredParams` enforces the same thing at
+// runtime for JS / `as any` call sites.
+
+type PermParams = { action: string; scope?: string }
+
+const NoParams = defineContextDecorator({
+  key: 'noParams',
+  resolve: () => 'ok',
+})
+
+const AllOptional = defineContextDecorator.withParams<{ scope?: string }>()({
+  key: 'allOptional',
+  resolve: (_ctx, _deps, p) => p.scope ?? 'default',
+})
+
+const RequiresAction = defineContextDecorator.withParams<PermParams>()({
+  key: 'requiresAction',
+  resolve: (_ctx, _deps, p) => p.action,
+})
+
+const DefaultedAction = defineContextDecorator.withParams<PermParams>()({
+  key: 'defaultedAction',
+  paramDefaults: { action: 'read' },
+  resolve: (_ctx, _deps, p) => p.action,
+})
+
+const PartiallyDefaulted = defineContextDecorator.withParams<{
+  action: string
+  tenant: string
+}>()({
+  key: 'partiallyDefaulted',
+  paramDefaults: { tenant: 'default' },
+  resolve: (_ctx, _deps, p) => `${p.tenant}:${p.action}`,
+})
+
+describe('required params — compile-time', () => {
+  it('keeps the bare + .registration forms for zero-param contributors', () => {
+    // Back-compat: the overwhelmingly common case must be untouched.
+    NoParams(class Bare {})
+    expect(NoParams.registration.key).toBe('noParams')
+  })
+
+  it('keeps the bare form when every param is optional', () => {
+    AllOptional(class Bare {})
+    expect(AllOptional.registration.key).toBe('allOptional')
+  })
+
+  it('keeps the bare form when paramDefaults covers the required field', () => {
+    DefaultedAction(class Bare {})
+    expect(DefaultedAction.registration.key).toBe('defaultedAction')
+  })
+
+  it('rejects every param-less form when a required field is undefaulted', () => {
+    // @ts-expect-error — bare class-decorator application can't supply `action`
+    RequiresAction(class Bare {})
+    // @ts-expect-error — bare method-decorator application can't supply `action`
+    RequiresAction({}, 'someMethod')
+    // @ts-expect-error — `{}` is missing `action`
+    RequiresAction({})
+    // @ts-expect-error — `.registration` has no way to supply `action`
+    void RequiresAction.registration
+    // @ts-expect-error — `.with({})` is missing `action`
+    RequiresAction.with({})
+
+    // The supported forms still type-check.
+    RequiresAction({ action: 'audit:read' })
+    RequiresAction({ action: 'audit:read', scope: 'org' })
+    expect(RequiresAction.with({ action: 'audit:read' }).registration.key).toBe('requiresAction')
+  })
+
+  it('requires only the fields paramDefaults did not cover', () => {
+    // @ts-expect-error — `action` is still undefaulted
+    PartiallyDefaulted({ tenant: 'acme' })
+
+    PartiallyDefaulted({ action: 'read' })
+    PartiallyDefaulted({ action: 'read', tenant: 'acme' })
+  })
+})
+
+describe('required params — runtime (requiredParams)', () => {
+  const Runtime = defineContextDecorator.withParams<{ action: string }>()({
+    key: 'runtimeGuard',
+    requiredParams: ['action'],
+    resolve: (_ctx, _deps, p) => p.action,
+  })
+
+  // Every call below goes through `as any` on purpose — these are the
+  // paths the type system can't see (plain JS, dynamic params).
+  const untyped = Runtime as any
+
+  it('throws on a factory call missing the param', () => {
+    expect(() => untyped({})).toThrow(TypeError)
+    expect(() => untyped({})).toThrow(/missing required param\(s\) 'action'/)
+  })
+
+  it('throws on bare decorator application', () => {
+    expect(() => untyped(class Bare {})).toThrow(/bare `@decorator` usage/)
+  })
+
+  it('throws on .registration access', () => {
+    expect(() => untyped.registration).toThrow(/`\.registration`/)
+  })
+
+  it('throws on .with() missing the param', () => {
+    expect(() => untyped.with({})).toThrow(/`\.with\(\)`/)
+  })
+
+  it('names the decorator and suggests the fix', () => {
+    expect(() => untyped({})).toThrow(/defineContextDecorator\(runtimeGuard\)/)
+    expect(() => untyped({})).toThrow(/paramDefaults/)
+  })
+
+  it('accepts the call once the param is supplied', () => {
+    expect(() => Runtime({ action: 'read' })).not.toThrow()
+    expect(Runtime.with({ action: 'read' }).registration.key).toBe('runtimeGuard')
+  })
+
+  it('treats a defaulted required param as satisfied', () => {
+    const Defaulted = defineContextDecorator.withParams<{ action: string }>()({
+      key: 'runtimeDefaulted',
+      requiredParams: ['action'],
+      paramDefaults: { action: 'read' },
+      resolve: (_ctx, _deps, p) => p.action,
+    })
+    expect(() => Defaulted(class Bare {})).not.toThrow()
+    expect(Defaulted.registration.key).toBe('runtimeDefaulted')
+  })
+
+  it('rejects a malformed requiredParams at definition time', () => {
+    expect(() =>
+      defineContextDecorator({
+        key: 'bad',
+        // @ts-expect-error — deliberately malformed
+        requiredParams: 'action',
+        resolve: () => 1,
+      }),
+    ).toThrow(/requiredParams must be an array/)
+
+    expect(() =>
+      // `['']` is a well-typed `string[]`, so only the runtime guard
+      // catches it — which is exactly the class of call site this
+      // validation exists for.
+      defineContextDecorator({
+        key: 'bad2',
+        requiredParams: [''],
+        resolve: () => 1,
+      }),
+    ).toThrow(/requiredParams entries must be non-empty strings/)
+  })
+})

--- a/packages/kickjs/src/core/context-decorator.ts
+++ b/packages/kickjs/src/core/context-decorator.ts
@@ -406,9 +406,15 @@ export interface ContextDecoratorWithDefaults<
  *   resolve: (ctx, _deps, { action }) => check(ctx, action),
  * })
  *
- * @OperatorPerm                       // ✗ compile error — `action` missing
- * @OperatorPerm({})                   // ✗ compile error — `action` missing
- * @OperatorPerm({ action: 'read' })   // ✓
+ * class Ops {
+ *   @OperatorPerm                     // ✗ compile error — `action` missing
+ *   @Get('/a')
+ *   a(ctx: RequestContext) {}
+ *
+ *   @OperatorPerm({ action: 'read' }) // ✓
+ *   @Get('/b')
+ *   b(ctx: RequestContext) {}
+ * }
  * ```
  *
  * If you want the bare form back, give `action` a default in

--- a/packages/kickjs/src/core/context-decorator.ts
+++ b/packages/kickjs/src/core/context-decorator.ts
@@ -54,6 +54,40 @@ export type ResolvedDeps<D extends Record<string, DepValue>> = {
 }
 
 /**
+ * Keys of `T` that are declared required (i.e. not `?`-optional).
+ */
+type RequiredParamKeys<T> = {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  [K in keyof T]-?: {} extends Pick<T, K> ? never : K
+}[keyof T]
+
+/**
+ * Params a call site MUST supply: the required keys of `P` that
+ * `paramDefaults` (type `PD`) doesn't already provide.
+ *
+ * The `string extends keyof P` guard short-circuits the index-signature
+ * case — `P` defaults to `Record<string, never>` for the overwhelmingly
+ * common zero-params contributor, and a mapped type over `string` would
+ * otherwise report "every key is required" and break `@Foo` for every
+ * existing decorator in the wild.
+ */
+export type MissingParamKeys<P, PD> = string extends keyof P
+  ? never
+  : Exclude<RequiredParamKeys<P>, keyof PD>
+
+/**
+ * The argument type for a call site (`@Foo({...})`, `.with({...})`).
+ *
+ * `Partial<P>` when every required field has a default, so adopters keep
+ * overriding just the fields they care about. Otherwise `Partial<P>`
+ * intersected with the undefaulted required fields, making those
+ * mandatory at each call site.
+ */
+export type CallSiteParams<P, PD> = [MissingParamKeys<P, PD>] extends [never]
+  ? Partial<P>
+  : Partial<P> & Pick<P, MissingParamKeys<P, PD> & keyof P>
+
+/**
  * Spec passed to {@link defineContextDecorator}. Describes one entry in
  * the per-request contributor pipeline.
  *
@@ -62,12 +96,16 @@ export type ResolvedDeps<D extends Record<string, DepValue>> = {
  * @typeParam Ctx - Concrete execution-context type. Defaults to the abstract
  *                  {@link ExecutionContext}; HTTP contributors typically
  *                  default to `RequestContext` at the call site.
+ * @typeParam PD  - Inferred from `paramDefaults`. Drives which params each
+ *                  call site is required to supply — see {@link CallSiteParams}.
+ *                  Never spell this by hand.
  */
 export interface ContextDecoratorSpec<
   K extends string = string,
   D extends Record<string, DepValue> = Record<string, never>,
   P extends Record<string, unknown> = Record<string, never>,
   Ctx extends ExecutionContext = ExecutionContext,
+  PD extends Partial<P> = Partial<P>,
 > {
   /** ContextMeta key the resolved value is written to. */
   key: K
@@ -107,23 +145,36 @@ export interface ContextDecoratorSpec<
    * validator-agnostic so projects can plug Zod / Valibot / hand-rolled
    * checks without the framework caring.
    *
-   * **Required-field caveat.** The factory call signature accepts
-   * `Partial<P>` so adopters can override only the fields they care
-   * about. If your `P` declares a *required* field that isn't in
-   * `paramDefaults`, the merged runtime value can be missing that
-   * field even though TypeScript types `params` as `P` inside
-   * `resolve()`. Mitigate by either:
+   * **Required fields are enforced at the call site.** A required field
+   * of `P` that has no entry here must be supplied wherever the
+   * decorator is applied — `@Foo({ action: 'audit:read' })`. The bare
+   * `@Foo` form and `.registration` stop type-checking for such a
+   * decorator, because neither can supply the value.
    *
-   * 1. Marking the field optional in `P` and `if`-checking inside
-   *    `resolve()`, or
-   * 2. Providing a default for every required field in
-   *    `paramDefaults`.
+   * This exists so nobody has to invent a meaningless default just to
+   * satisfy the type (`action: 'settings:read'` on a permission
+   * contributor every call site overrides anyway). A default that is
+   * never correct is worse than no default: forget the argument at one
+   * call site and the route silently gates on the placeholder instead
+   * of failing to compile.
    *
-   * The framework can't enforce option 2 at compile time without
-   * giving up the back-compat that lets `paramDefaults` be omitted
-   * entirely for `P = Record<string, never>`.
+   * Omit this entirely for the common zero-params case — `P` defaults
+   * to `Record<string, never>`, which requires nothing.
    */
-  paramDefaults?: Partial<P>
+  paramDefaults?: PD
+  /**
+   * Runtime mirror of the compile-time requirement above: param names
+   * that must be present after merging call-site params over
+   * `paramDefaults`. A missing one throws `TypeError` at the point of
+   * use (decoration time for `@Foo`, call time for `@Foo({...})` /
+   * `.with({...})`), naming the decorator and the field.
+   *
+   * The type-level check already covers TypeScript call sites, so this
+   * is for the paths types can't reach: plain-JS adopters, `as any`
+   * escapes, and params assembled dynamically. Optional — list only
+   * fields whose absence is a correctness bug rather than a default.
+   */
+  requiredParams?: readonly (keyof P & string)[]
   /**
    * Hook invoked when `resolve()` throws and `optional` is `false`.
    * Returning a value writes it to `ctx.set(key, …)`; returning
@@ -242,15 +293,41 @@ export interface ContextDecoratorTarget {
 }
 
 /**
- * The value returned by {@link defineContextDecorator}. Callable as
- * either a class or method decorator (with `paramDefaults` applied),
- * as a factory (`@Foo({...})` returning a per-site decorator), or
- * via `.with(params)` for non-decorator registration sites (module
- * hooks, adapter hooks, bootstrap option). `.registration` exposes
- * the underlying frozen {@link ContributorRegistration} for the
- * default-params case.
+ * The value returned by {@link defineContextDecorator}.
+ *
+ * Resolves to one of two shapes depending on whether every required
+ * field of `P` has a `paramDefaults` entry:
+ *
+ * - {@link ContextDecoratorWithDefaults} — the classic shape. Usable
+ *   bare (`@Foo`), as a factory (`@Foo({...})`), via `.with(params)`,
+ *   and via `.registration`.
+ * - {@link ContextDecoratorRequiringParams} — when `P` has required
+ *   fields `paramDefaults` doesn't cover. Only the factory and
+ *   `.with(params)` forms exist, because the others have no way to
+ *   supply the missing values. Applying such a decorator bare is a
+ *   compile error rather than a silent `undefined` at request time.
+ *
+ * `PD` is inferred from the spec's `paramDefaults`; the default here
+ * (`Partial<P>`) keeps hand-written `ContextDecorator<K, D, P>`
+ * annotations resolving to the permissive shape as before.
  */
-export interface ContextDecorator<
+export type ContextDecorator<
+  K extends string = string,
+  D extends Record<string, DepValue> = Record<string, never>,
+  P extends Record<string, unknown> = Record<string, never>,
+  Ctx extends ExecutionContext = ExecutionContext,
+  PD = Partial<P>,
+> = [MissingParamKeys<P, PD>] extends [never]
+  ? ContextDecoratorWithDefaults<K, D, P, Ctx>
+  : ContextDecoratorRequiringParams<K, D, P, Ctx, PD>
+
+/**
+ * Decorator whose params are fully defaulted (or which takes none).
+ * Callable as a class or method decorator directly, as a factory, or
+ * via `.with(params)` / `.registration` at non-decorator registration
+ * sites.
+ */
+export interface ContextDecoratorWithDefaults<
   K extends string = string,
   D extends Record<string, DepValue> = Record<string, never>,
   P extends Record<string, unknown> = Record<string, never>,
@@ -317,6 +394,50 @@ export interface ContextDecorator<
 }
 
 /**
+ * Decorator with at least one required param that `paramDefaults`
+ * doesn't cover. Deliberately narrower than
+ * {@link ContextDecoratorWithDefaults}: the bare `@Foo` form, the
+ * zero-arg `@Foo()` form, and the `.registration` accessor are all
+ * absent, because none of them can supply the missing value.
+ *
+ * ```ts
+ * const OperatorPerm = defineContextDecorator.withParams<{ action: string }>()({
+ *   key: 'operatorPerm',
+ *   resolve: (ctx, _deps, { action }) => check(ctx, action),
+ * })
+ *
+ * @OperatorPerm                       // ✗ compile error — `action` missing
+ * @OperatorPerm({})                   // ✗ compile error — `action` missing
+ * @OperatorPerm({ action: 'read' })   // ✓
+ * ```
+ *
+ * If you want the bare form back, give `action` a default in
+ * `paramDefaults` — but only when the default is genuinely correct for
+ * an undecorated route, which for a permission string it usually isn't.
+ */
+export interface ContextDecoratorRequiringParams<
+  K extends string = string,
+  D extends Record<string, DepValue> = Record<string, never>,
+  P extends Record<string, unknown> = Record<string, never>,
+  Ctx extends ExecutionContext = ExecutionContext,
+  PD = Partial<P>,
+> {
+  /**
+   * Factory usage — the only decorator form available here. The
+   * argument type carries every required field `paramDefaults` didn't
+   * provide, so omitting one is a compile error at this call site.
+   */
+  (params: CallSiteParams<P, PD>): ContextDecoratorTarget
+  /**
+   * Build a registration for non-decorator registration sites. Same
+   * required-field rule as the factory form.
+   */
+  with(params: CallSiteParams<P, PD>): {
+    readonly registration: ContributorRegistration<K, D, Ctx>
+  }
+}
+
+/**
  * Curried params-first helper for {@link defineContextDecorator}.
  *
  * Solves the partial-inference problem: TS generics are positional, so
@@ -350,9 +471,15 @@ export interface DefineContextDecoratorWithParams<P extends Record<string, unkno
     K extends string,
     D extends Record<string, DepValue> = Record<string, never>,
     Ctx extends ExecutionContext = ExecutionContext,
+    // Inferred from `spec.paramDefaults`. The `Record<never, never>`
+    // default (NOT `Partial<P>`) is what makes an omitted `paramDefaults`
+    // mean "nothing is defaulted" — so every required field of `P` lands
+    // on the call site. `Partial<P>` here would make `keyof PD` cover all
+    // of `P` and silently defeat the whole check.
+    PD extends Partial<P> = Record<never, never>,
   >(
-    spec: ContextDecoratorSpec<K, D, P, Ctx>,
-  ): ContextDecorator<K, D, P, Ctx>
+    spec: ContextDecoratorSpec<K, D, P, Ctx, PD>,
+  ): ContextDecorator<K, D, P, Ctx, PD>
 }
 
 /**
@@ -367,9 +494,10 @@ export interface DefineContextDecoratorFn {
     D extends Record<string, DepValue> = Record<string, never>,
     P extends Record<string, unknown> = Record<string, never>,
     Ctx extends ExecutionContext = ExecutionContext,
+    PD extends Partial<P> = Record<never, never>,
   >(
-    spec: ContextDecoratorSpec<K, D, P, Ctx>,
-  ): ContextDecorator<K, D, P, Ctx>
+    spec: ContextDecoratorSpec<K, D, P, Ctx, PD>,
+  ): ContextDecorator<K, D, P, Ctx, PD>
 
   /**
    * Curried entry point. Spell only the per-call params shape `P`;
@@ -418,7 +546,8 @@ function defineContextDecoratorImpl<
   D extends Record<string, DepValue> = Record<string, never>,
   P extends Record<string, unknown> = Record<string, never>,
   Ctx extends ExecutionContext = ExecutionContext,
->(spec: ContextDecoratorSpec<K, D, P, Ctx>): ContextDecorator<K, D, P, Ctx> {
+  PD extends Partial<P> = Record<never, never>,
+>(spec: ContextDecoratorSpec<K, D, P, Ctx, PD>): ContextDecorator<K, D, P, Ctx, PD> {
   // ---- Boot-time validation --------------------------------------
   // Surface mistakes the moment `defineContextDecorator` is called
   // (typically module-load time) instead of letting them ride to
@@ -454,6 +583,20 @@ function defineContextDecoratorImpl<
     throw new TypeError(
       `defineContextDecorator(${spec.key}): spec.dependsOn must be an array when provided ` +
         `(got ${typeof spec.dependsOn}).`,
+    )
+  }
+  if (spec.requiredParams !== undefined && !Array.isArray(spec.requiredParams)) {
+    throw new TypeError(
+      `defineContextDecorator(${spec.key}): spec.requiredParams must be an array when provided ` +
+        `(got ${typeof spec.requiredParams}).`,
+    )
+  }
+  if (
+    Array.isArray(spec.requiredParams) &&
+    spec.requiredParams.some((p) => typeof p !== 'string' || p.length === 0)
+  ) {
+    throw new TypeError(
+      `defineContextDecorator(${spec.key}): spec.requiredParams entries must be non-empty strings.`,
     )
   }
   if (
@@ -636,6 +779,33 @@ function defineContextDecoratorImpl<
     return { ...defaults, ...(override as Partial<P>) } as P
   }
 
+  const sharedRequiredParams = Object.freeze([...(spec.requiredParams ?? [])])
+
+  /**
+   * Runtime half of the required-params guarantee. The type system
+   * already stops TS call sites from omitting a required field, so this
+   * catches what types can't see: plain-JS adopters, `as any`, and
+   * params built dynamically.
+   *
+   * `usage` names the form that failed so the message points at the fix
+   * — a bare `@Foo` on a decorator with required params needs to become
+   * `@Foo({ ... })`, which is a different edit from a factory call that
+   * merely forgot one field.
+   */
+  const assertRequiredParams = (params: P, usage: string): void => {
+    if (sharedRequiredParams.length === 0) return
+    const missing = sharedRequiredParams.filter(
+      (name) => (params as Record<string, unknown>)[name] === undefined,
+    )
+    if (missing.length === 0) return
+    throw new TypeError(
+      `defineContextDecorator(${spec.key}): ${usage} is missing required param(s) ` +
+        `${missing.map((m) => `'${m}'`).join(', ')}. ` +
+        `Supply them at the call site — e.g. \`@${spec.key}({ ${missing[0]}: … })\` — or ` +
+        `add a default in \`paramDefaults\` if one is genuinely correct for every route.`,
+    )
+  }
+
   // Overloaded function signatures so `decoratorOrFactory`'s type
   // matches `ContextDecorator`'s call shapes directly — no
   // `as unknown as` double-cast needed. The implementation signature
@@ -657,11 +827,16 @@ function defineContextDecoratorImpl<
         string | symbol | undefined,
         PropertyDescriptor?,
       ]
+      // Bare `@Foo` — nothing can supply params here, so a required one
+      // that isn't defaulted is a decoration-time (module-load) failure
+      // rather than an undefined riding into the resolver.
+      assertRequiredParams({ ...defaults } as P, 'bare `@decorator` usage')
       applyAsDecorator(defaultRegistration, target, propertyKey)
       return undefined
     }
     // Factory call — capture merged params and return a decorator.
     const params = mergeParams(args[0])
+    assertRequiredParams(params, 'factory call')
     const registration = buildRegistration(params)
     return (target: object, propertyKey?: string | symbol) => {
       applyAsDecorator(registration, target, propertyKey)
@@ -686,13 +861,33 @@ function defineContextDecoratorImpl<
   // then `Object.freeze` locks the shape so adopters can't mutate
   // `decorator.registration = …` post-construction.
   const decorator = Object.assign(decoratorOrFactory, {
-    registration: defaultRegistration,
-    with: (params: Partial<P>) => ({
-      registration: buildRegistration(mergeParams(params)),
-    }),
+    with: (params: Partial<P>) => {
+      const merged = mergeParams(params)
+      assertRequiredParams(merged, '`.with()`')
+      return { registration: buildRegistration(merged) }
+    },
   })
 
-  return Object.freeze(decorator)
+  // `.registration` is a getter, not a plain property, so that reading it
+  // on a decorator with undefaulted required params throws instead of
+  // handing back a registration whose resolver will see `undefined`.
+  // (`Object.assign` would have copied the value and lost the check.)
+  Object.defineProperty(decorator, 'registration', {
+    get() {
+      assertRequiredParams({ ...defaults } as P, '`.registration`')
+      return defaultRegistration
+    },
+    enumerable: true,
+    configurable: false,
+  })
+
+  // `ContextDecorator` is a conditional type (permissive vs required-params
+  // shape), and TS can't evaluate a conditional whose input generics are
+  // still unresolved — so the assignment can't be checked structurally
+  // here regardless of how `decorator` is built. The cast is the price of
+  // the call-site guarantee; the two branches differ only in which call
+  // forms they expose, and every one of them is implemented above.
+  return Object.freeze(decorator) as unknown as ContextDecorator<K, D, P, Ctx, PD>
 }
 
 /**
@@ -715,9 +910,10 @@ export const defineContextDecorator: DefineContextDecoratorFn = Object.freeze(
         K extends string,
         D extends Record<string, DepValue> = Record<string, never>,
         Ctx extends ExecutionContext = ExecutionContext,
+        PD extends Partial<P> = Record<never, never>,
       >(
-        spec: ContextDecoratorSpec<K, D, P, Ctx>,
-      ): ContextDecorator<K, D, P, Ctx> => defineContextDecoratorImpl<K, D, P, Ctx>(spec)
+        spec: ContextDecoratorSpec<K, D, P, Ctx, PD>,
+      ): ContextDecorator<K, D, P, Ctx, PD> => defineContextDecoratorImpl<K, D, P, Ctx, PD>(spec)
     },
   }),
 ) as DefineContextDecoratorFn

--- a/packages/kickjs/src/core/context-errors.ts
+++ b/packages/kickjs/src/core/context-errors.ts
@@ -1,11 +1,18 @@
 /**
  * Errors thrown by the Context Contributor pipeline.
  *
- * All three are startup-time errors raised during pipeline build (topo-sort
- * + validation), not per-request — a misconfigured app fails to boot rather
- * than fails a request. Per the locked design in `architecture.md` §20.4,
- * the pipeline is validated once when each route is mounted and the
- * resolved order is cached on the route.
+ * `MissingContributorError`, `ContributorCycleError`, and
+ * `DuplicateContributorError` are startup-time errors raised during
+ * pipeline build (topo-sort + validation), not per-request — a
+ * misconfigured app fails to boot rather than fails a request. Per the
+ * locked design in `architecture.md` §20.4, the pipeline is validated
+ * once when each route is mounted and the resolved order is cached on
+ * the route.
+ *
+ * `MissingContextValueError` is the one request-time error here: it is
+ * raised by `ctx.require(key)` when a value a handler declared it needs
+ * is absent. See its doc comment for why that case can't be caught at
+ * startup today.
  */
 
 /**
@@ -33,6 +40,49 @@ export class MissingContributorError extends Error {
     this.dependent = dependent
     this.route = route
     this.dependentDefinedAt = dependentDefinedAt
+  }
+}
+
+/**
+ * `ctx.require(key)` found no value under `key` in the per-request
+ * metadata store.
+ *
+ * Thrown at request time, by design. `ctx.get(key)` returns
+ * `T | undefined` for every key, so the usual workaround is a
+ * non-null assertion — `ctx.get('tenant')!` — which compiles whether or
+ * not the route actually carries the contributor that produces it. On
+ * an authorization value that is the worst possible thing to leave
+ * untypeable: dropping the decorator produces no diagnostic anywhere,
+ * and the handler reads `undefined` as though it were a real value.
+ *
+ * `ctx.require()` converts that silent hole into a loud, named failure
+ * that points at the missing contributor. Compile-time narrowing (so a
+ * dropped decorator fails `tsc` instead) needs per-route context-key
+ * unions out of typegen — tracked in `architecture.md` §20.14.
+ *
+ * @example
+ * ```text
+ * MissingContextValueError: No context value for 'tenantPerm' on GET /projects/:id
+ *     Nothing wrote this key before the handler ran. Either the contributor
+ *     that produces it isn't applied to this route, or it ran and resolved
+ *     to undefined (check `optional: true` contributors).
+ * ```
+ */
+export class MissingContextValueError extends Error {
+  readonly key: string
+  readonly route?: string
+
+  constructor(key: string, route?: string) {
+    const where = route ? ` on ${route}` : ''
+    super(
+      `No context value for '${key}'${where}\n` +
+        `    Nothing wrote this key before the handler ran. Either the contributor\n` +
+        `    that produces it isn't applied to this route, or it ran and resolved\n` +
+        `    to undefined (check \`optional: true\` contributors).`,
+    )
+    this.name = 'MissingContextValueError'
+    this.key = key
+    this.route = route
   }
 }
 

--- a/packages/kickjs/src/core/execution-context.ts
+++ b/packages/kickjs/src/core/execution-context.ts
@@ -94,6 +94,13 @@ export type MetaValue<K extends string, Fallback = unknown> = K extends keyof Co
 export interface ExecutionContext {
   /** Read a typed value from per-request metadata. */
   get<K extends string>(key: K): MetaValue<K> | undefined
+  /**
+   * Read a value that must be present, throwing `MissingContextValueError`
+   * when it isn't. Use for preconditions (permissions, tenant, resolved
+   * subject) where `get(key)!` would silently paper over a contributor
+   * that never ran. Only `undefined` throws — `null` is a real value.
+   */
+  require<K extends string>(key: K): NonNullable<MetaValue<K>>
   /** Write a typed value into per-request metadata. */
   set<K extends string>(key: K, value: MetaValue<K>): void
   /** Unique per-request identifier (HTTP: x-request-id; WS/queue/cron: transport-defined). */

--- a/packages/kickjs/src/core/execution-context.ts
+++ b/packages/kickjs/src/core/execution-context.ts
@@ -98,9 +98,10 @@ export interface ExecutionContext {
    * Read a value that must be present, throwing `MissingContextValueError`
    * when it isn't. Use for preconditions (permissions, tenant, resolved
    * subject) where `get(key)!` would silently paper over a contributor
-   * that never ran. Only `undefined` throws — `null` is a real value.
+   * that never ran. Only `undefined` throws — `null` is a real value,
+   * hence `Exclude<…, undefined>` rather than `NonNullable<…>`.
    */
-  require<K extends string>(key: K): NonNullable<MetaValue<K>>
+  require<K extends string>(key: K): Exclude<MetaValue<K>, undefined>
   /** Write a typed value into per-request metadata. */
   set<K extends string>(key: K, value: MetaValue<K>): void
   /** Unique per-request identifier (HTTP: x-request-id; WS/queue/cron: transport-defined). */

--- a/packages/kickjs/src/core/index.ts
+++ b/packages/kickjs/src/core/index.ts
@@ -205,6 +205,7 @@ export {
   MissingContributorError,
   ContributorCycleError,
   DuplicateContributorError,
+  MissingContextValueError,
 } from './context-errors'
 
 // Phase 2 — pipeline builder + topo-sort + validation.

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -3,6 +3,7 @@ import type { Request, NextFunction } from 'express'
 import type { ActiveRuntime, RuntimeResponse } from './runtime'
 import { type ExecutionContext, type MetaValue } from '../core/execution-context'
 import { normalizeProblem, type ProblemDetails, type ValidationError } from '../core/errors'
+import { MissingContextValueError } from '../core/context-errors'
 import { requestStore } from './request-store'
 import {
   parseQuery,
@@ -561,6 +562,57 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
    */
   get<K extends string>(key: K): MetaValue<K> | undefined {
     return this.metadataReadOnly()?.get(key) as MetaValue<K> | undefined
+  }
+
+  /**
+   * Read a value that a contributor is expected to have produced, and
+   * throw {@link MissingContextValueError} when it hasn't.
+   *
+   * Use this instead of `ctx.get(key)!` anywhere the value is a
+   * precondition rather than an optional extra — permissions, tenants,
+   * the resolved subject of the route. The non-null assertion compiles
+   * whether or not the producing contributor is actually applied to the
+   * route, so a dropped `@LoadTenant` turns into `undefined` flowing
+   * silently into an auth check. `require()` fails loudly at that point
+   * instead, naming the key.
+   *
+   * ```ts
+   * // before — compiles even if @OperatorPerm was never applied
+   * const perm = ctx.get('operatorPerm')!
+   *
+   * // after — throws MissingContextValueError naming the key + route
+   * const perm = ctx.require('operatorPerm')
+   * ```
+   *
+   * This is a runtime guarantee, not a compile-time one: it narrows the
+   * return type but cannot prove the decorator is present. Making a
+   * missing contributor a `tsc` error needs per-route key unions from
+   * typegen — see `architecture.md` §20.14.
+   *
+   * `null` counts as present; only `undefined` (or a missing entry)
+   * throws. A contributor that deliberately resolves to `null` is
+   * expressing "looked, found nothing", which is a real value.
+   */
+  require<K extends string>(key: K): NonNullable<MetaValue<K>> {
+    const value = this.metadataReadOnly()?.get(key)
+    if (value === undefined) {
+      throw new MissingContextValueError(key, this.routeLabel())
+    }
+    return value as NonNullable<MetaValue<K>>
+  }
+
+  /**
+   * Best-effort `"GET /path"` label for error messages. Runtime-agnostic:
+   * express/fastify requests and web-standard `Request` all expose
+   * `method` + `url`, but none of them are guaranteed here, so every
+   * access is defensive and the whole thing is optional.
+   */
+  private routeLabel(): string | undefined {
+    const req = this.req as { method?: unknown; url?: unknown } | undefined
+    const method = typeof req?.method === 'string' ? req.method : undefined
+    const url = typeof req?.url === 'string' ? req.url : undefined
+    if (method && url) return `${method} ${url}`
+    return method ?? url
   }
 
   /**

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -591,14 +591,18 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
    *
    * `null` counts as present; only `undefined` (or a missing entry)
    * throws. A contributor that deliberately resolves to `null` is
-   * expressing "looked, found nothing", which is a real value.
+   * expressing "looked, found nothing", which is a real value — which
+   * is why the return type is `Exclude<…, undefined>` and NOT
+   * `NonNullable<…>`. The latter would strip `null` from the type while
+   * the runtime still hands it back, so a caller would be told a value
+   * is non-null and then get `null`.
    */
-  require<K extends string>(key: K): NonNullable<MetaValue<K>> {
+  require<K extends string>(key: K): Exclude<MetaValue<K>, undefined> {
     const value = this.metadataReadOnly()?.get(key)
     if (value === undefined) {
       throw new MissingContextValueError(key, this.routeLabel())
     }
-    return value as NonNullable<MetaValue<K>>
+    return value as Exclude<MetaValue<K>, undefined>
   }
 
   /**

--- a/packages/kickjs/vitest.config.ts
+++ b/packages/kickjs/vitest.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
       tsconfig: './tsconfig.test.json',
       // Default include only matches *.test-d.ts — without this the
       // expectTypeOf suite below was never actually type-checked.
-      include: ['**/infer-handler-response.test.ts'],
+      include: ['**/infer-handler-response.test.ts', '**/context-required-params.test.ts'],
     },
     environment: 'node',
     include: ['__tests__/**/*.test.ts', '**/__tests__/**/*.test.ts','**/*.test.ts'],

--- a/packages/kickjs/vitest.config.ts
+++ b/packages/kickjs/vitest.config.ts
@@ -22,7 +22,11 @@ export default defineConfig({
       tsconfig: './tsconfig.test.json',
       // Default include only matches *.test-d.ts — without this the
       // expectTypeOf suite below was never actually type-checked.
-      include: ['**/infer-handler-response.test.ts', '**/context-required-params.test.ts'],
+      include: [
+        '**/infer-handler-response.test.ts',
+        '**/context-required-params.test.ts',
+        '**/context-require.test.ts',
+      ],
     },
     environment: 'node',
     include: ['__tests__/**/*.test.ts', '**/__tests__/**/*.test.ts','**/*.test.ts'],

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -12,6 +12,7 @@ import {
   type ContextDecorator,
   type ContributorRegistration,
   type ExecutionContext,
+  MissingContextValueError,
   type KickPlugin,
   type MetaValue,
   type ModuleRoutes,
@@ -256,6 +257,14 @@ export async function runContributor<
     get(key) {
       return meta.get(key) as never
     },
+    require(key) {
+      // Same contract as RequestContext.require — a resolver under test
+      // that depends on an upstream key should fail here exactly the way
+      // it would in production, not read `undefined`.
+      const value = meta.get(key)
+      if (value === undefined) throw new MissingContextValueError(key)
+      return value as never
+    },
     set(key, value) {
       meta.set(key, value)
     },
@@ -419,6 +428,11 @@ export async function createTestPlugin(
       const ctx: ExecutionContext = {
         get(key) {
           return meta.get(key) as never
+        },
+        require(key) {
+          const value = meta.get(key)
+          if (value === undefined) throw new MissingContextValueError(key)
+          return value as never
         },
         set(key, value) {
           meta.set(key, value)


### PR DESCRIPTION
## Why

An adopter review of the context-decorator surface surfaced four issues. Two are the same root cause — the type system knowing less than the decorator does — and two are checks that report something other than what they claim.

I verified each against the source before changing anything. Three reproduced; the reported `engines: >=24` warning did not (every `package.json` here is `>=20.0`, and no CLI template emits `>=24` — that warning comes from the consuming project or a transitive dep).

## What changed

### 1. `ctx.require(key)` — reading guaranteed values

`ctx.get(key)` returns `T | undefined` for every key, so consuming a value a contributor guarantees meant `ctx.get(key)!`. That assertion compiles **whether or not the producing decorator is applied to the route**. Drop the decorator in a refactor and there is no diagnostic anywhere — `tsc` is satisfied, the pipeline runs, and the handler reads `undefined`. On an authorization gate that fails open, silently.

```ts
const perm = ctx.get('operatorPerm')!   // before — compiles either way
const perm = ctx.require('operatorPerm') // after — throws MissingContextValueError
```

Returns `NonNullable<MetaValue<K>>`, so the `!` goes away too. `null` counts as present; only `undefined` throws.

This is a **runtime** guarantee. Compile-time narrowing needs per-route context-key unions out of typegen; the design (and why it's deferred — soundness depends on typegen seeing all five registration sites) is written up in `architecture.md` §20.14.

### 2. Required params are enforced at the call site

`paramDefaults` was the only way to satisfy a required field of `P`, which pushed adopters into inventing defaults that are never correct — `action: 'settings:read'` on a permission contributor every call site overrides. A route that then forgot the argument silently gated on the placeholder.

```ts
const OperatorPerm = defineHttpContextDecorator.withParams<{ action: string }>()({
  key: 'operatorPerm',
  resolve: (ctx, _d, { action }) => check(ctx, action),
})

@OperatorPerm                            // ✗ compile error
@OperatorPerm({})                        // ✗ compile error
@OperatorPerm({ action: 'audit:read' })  // ✓
```

For such a decorator the bare form, `@Foo()`, and `.registration` don't exist — none can supply the value. New optional `requiredParams: ['action']` enforces the same at runtime for plain-JS and `as any` call sites.

Back-compat: `PD` is inferred from `paramDefaults` and defaults to "nothing defaulted" only at the definition site; hand-written `ContextDecorator<K, D, P>` annotations still resolve to the permissive shape. Every existing zero-param decorator is untouched — covered by type tests.

### 3. `kick typegen --check` never failed a build

Reported as "`--check` doesn't check". The mechanism is worse than that: the runner threw correctly all along, but `runAllPluginTypegens` wraps the pass in a catch that shields `kick dev` from a transiently-broken plugin — and it swallowed the drift error too, warning `"… skipped"` and returning `[]`. The command then asked `results.some(r => r.status === 'written')`, got `false` from an empty array, and exited 0. **For every plugin, since the flag was introduced.**

`typegen-runner.test.ts` covered the runner, which is why this stayed green.

Drift now propagates as `TypegenDriftError` listing every stale file in one pass, and a plugin that fails to generate under `--check` fails the gate rather than passing on "keeping previous output".

### 4. `kick doctor` false-alarmed on extended tsconfigs

The loader followed exactly one level of `extends`, only when it was a string, resolved relative paths against the project root rather than the extending file, looked for bare specifiers only in the project's own `node_modules`, and parsed parents with a bare `JSON.parse`. Any one of them told a project that sets `experimentalDecorators` / `emitDecoratorMetadata` in a shared base config that it was missing them. Lean per-package configs in a monorepo hit all five.

Now: chains of any depth, array `extends` (TS 5.0+), `node_modules` lookup walking up the tree (pnpm hoisting), directory specifiers resolving to `tsconfig.json`, and JSONC (comments **and** trailing commas) throughout. A tsconfig that exists but can't be parsed reports as unreadable rather than as missing — a trailing comma used to become a phantom "no tsconfig.json".

### 5. Agent docs + contributor scaffold carry the full call-site surface

Agents were missing the registration forms. Both the `AGENTS.md` section and the `kickjs-context-contributor` skill now carry all five call sites, the `.registration` / `.with({...}).registration` distinction (passing the decorator itself is the most common wiring bug), when to use `.withParams<P>()`, the read-back table, and `ctx.get(key)!` / `contributors: [Decorator]` as named red flags.

`kick g contributor --params` no longer scaffolds placeholder `paramDefaults` — it emits `requiredParams`. The scaffold was teaching the exact pattern that made forgotten arguments silent.

## Verification

- Every new test was confirmed to **fail against the unfixed code**, not just pass against the fixed code:
  - `--check`: 4 of 6 gate tests fail without the rethrow
  - doctor: 10 of the new tests fail against the old loader
- Type-level assertions run under `vitest --typecheck` (added to the typecheck `include`), so the `@ts-expect-error` directives are actually verified rather than decorative.
- One vacuous assertion caught and tightened during review: `bothPass` returned `true` for an empty result list, which would have passed against the very bug it tests.
- `pnpm test` — 48/48 tasks green. `pnpm typecheck` — 29/29. `pnpm lint` + `format:check` clean.

Note: `h3-v2` (`npm:h3@2.0.1-rc.22`) was declared but missing from `node_modules`, failing 6 test files across `kickjs` and `client`. `pnpm install` fixed it; the lockfile was already correct and is unchanged.

## Breaking

`ExecutionContext` gains a required `require` member. Hand-written implementations need to add it; `RequestContext` and both `@forinda/kickjs-testing` fake contexts are updated here.

Changeset: `@forinda/kickjs` minor, `@forinda/kickjs-cli` + `@forinda/kickjs-testing` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ctx.require()` for safely accessing required request context values, with clear errors when values are missing.
  * Added required-parameter enforcement for context decorators at compile time and runtime.
  * Enhanced type generation checks to report all outdated outputs and fail appropriately in check mode.

* **Bug Fixes**
  * Improved `kick doctor` detection across extended, monorepo, and JSONC TypeScript configurations.

* **Documentation**
  * Expanded guidance and generated contributor documentation for context access, registration, and required parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->