### PR TITLE
fix: make an unexpected 500 diagnosable

### DIFF
--- a/.changeset/diagnosable-unexpected-errors.md
+++ b/.changeset/diagnosable-unexpected-errors.md
@@ -1,0 +1,17 @@
+---
+'@forinda/kickjs': minor
+---
+
+Make an unexpected 500 diagnosable. Previously it told you nothing on either side at once — an adopter hitting a missing-table error had to go to the database to find out what happened.
+
+**`Logger.error(err, msg)` discarded the error object.** The error-first form is the framework's own idiom at ~16 call sites (`error-handler`, `application`, `bootstrap`, `request-scope`, plus the `ai` and `mcp` adapters), and every one of them was logging a bare sentence: the implementation called `provider.error(msg)` with the error appearing nowhere in the call, so **no stack, no error name, no `cause` chain** ever reached the log. The error is now forwarded to the provider as a trailing argument — `console` renders the full stack, and pino/winston adapters receive it as structured extra. The message-first form (`log.error('save failed', { id })`) was dropping its trailing args for the same reason; also fixed.
+
+**Unexpected 500 responses carry a correlation id and, outside production, real detail.** The body was a bare `{ message: 'Internal Server Error' }` in every environment. It now always includes `requestId` (from the request-scoped id, falling back to the inbound `x-request-id` header, omitted when neither exists) — without it an opaque 500 can't be tied to its own log line. Outside production the body also carries `error` (an error summary that walks the `cause` chain, which is where ORM and driver errors hide the reason that matters) and `stack`. Production bodies stay opaque: no message, no stack.
+
+**The web/edge error fallbacks were completely silent.** `web/handler.ts` and the h3 v2 runtime emitted `{ error: 'Internal Server Error' }` with no log call at all, so a failure reaching those last-resort branches left no trace anywhere. Both now log the error and include the summary outside production.
+
+**New `describeError(err)` export** — one-line error summary including the error name and `cause` chain, depth-capped and cycle-guarded. Used by the error paths above; exported because adopters writing a custom `onError` want the same thing.
+
+**Edge-safety fix:** `logger.ts` read `process.env.LOG_LEVEL` unguarded, so importing it from a strict edge runtime with no `process` global threw. The colour probe next to it was already guarded; this one wasn't. It matters now that the edge-safe web pipeline imports the logger.
+
+The cross-runtime conformance test for thrown errors now asserts the shared invariant (500 + opaque message + a `requestId`) rather than deep-equalling the old bare body, and passes on express, fastify, and h3 alike.

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -71,7 +71,33 @@ The handler reads `err.status` and returns the appropriate status code. If valid
 
 ### 3. Unexpected Errors
 
-Anything else falls through to a generic handler that reads `err.status` or `err.statusCode`, defaulting to **500**. For 500 errors, the original message is hidden from the client and replaced with `"Internal Server Error"`. All unexpected errors are logged with the request method and URL.
+Anything else falls through to a generic handler that reads `err.status` or `err.statusCode`, defaulting to **500**. For 500 errors the original message is hidden from the client and replaced with `"Internal Server Error"`, because it can carry table names, SQL, connection strings, or user data.
+
+The body is not bare, though. Every unexpected error response carries a **`requestId`** — the correlation handle back to the log line — and outside production it also carries the error summary and stack:
+
+::: code-group
+
+```json [development]
+{
+  "message": "Internal Server Error",
+  "requestId": "3e1fe4d4-ca15-4201-b536-c97dc7738ee4",
+  "error": "Error: findMany failed ← caused by Error: relation \"users\" does not exist",
+  "stack": ["Error: findMany failed", "    at UserRepo.list (src/users/user.repo.ts:24:11)", "..."]
+}
+```
+
+```json [production]
+{
+  "message": "Internal Server Error",
+  "requestId": "3e1fe4d4-ca15-4201-b536-c97dc7738ee4"
+}
+```
+
+:::
+
+The `error` field walks the **`cause` chain**, which is where ORM and database drivers put the reason that actually matters — a Prisma or Drizzle failure typically reports "query failed" at the top and names the missing relation three levels down.
+
+`requestId` comes from the request-scoped id, falling back to the inbound `x-request-id` header; it is omitted when neither is present. It is included in production on purpose: without it an opaque 500 can't be tied to its own log entry.
 
 ### Headers-Sent Guard
 
@@ -84,6 +110,8 @@ Errors are logged using the `@forinda/kickjs` `Logger` tagged with `ErrorHandler
 - **500+ HttpException** and **unexpected errors** are logged at `error` level with full stack traces.
 - **Headers-already-sent** conditions are logged at `warn` level.
 - **Client errors** (4xx) are not logged by default to reduce noise.
+
+The error object is passed through to the logger provider, so `console` renders the complete stack and a pino/winston adapter receives it as structured extra. If you swap in your own `LoggerProvider`, its `error(msg, ...args)` receives the error as the first vararg — forward it rather than dropping it, or you lose the stack.
 
 ## Not-Found Handler
 

--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -13,9 +13,12 @@ const log = Logger.for('UserService')
 
 log.info('User created', { id: 'usr_123' })
 log.warn('Quota approaching')
-log.error('DB unreachable', err)
+log.error('DB unreachable', err) // message-first
+log.error(err, 'DB unreachable') // error-first (pino style) — also supported
 log.debug('Cache miss for key=%s', key)
 ```
+
+`log.error` accepts both orders. The error object is always forwarded to the provider, so the stack survives either way — `console` prints it in full, and a pino/winston adapter receives it as the first vararg. When you write a custom provider, forward `...args`; dropping them drops your stack traces.
 
 The default provider respects the `LOG_LEVEL` env var (default `info`): messages below the threshold are dropped, ordered `trace < debug < info < warn < error < fatal` (plus `silent`). So `debug`/`trace` calls — including the framework's verbose startup detail like the route table and DI wiring — stay quiet unless you run with `LOG_LEVEL=debug`. Custom providers (Pino, Winston, …) manage their own levels.
 

--- a/packages/kickjs/__tests__/error-diagnostics.test.ts
+++ b/packages/kickjs/__tests__/error-diagnostics.test.ts
@@ -1,0 +1,207 @@
+import 'reflect-metadata'
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { Logger, describeError, type LoggerProvider } from '../src/index'
+import { errorHandler } from '../src/http/middleware/error-handler'
+
+// An unexpected 500 used to be undiagnosable from both sides at once:
+//
+//   response: {"message":"Internal Server Error"}          ← nothing
+//   log line: ERROR [ErrorHandler] GET /x — <message>      ← no stack
+//
+// because `Logger.error(err, msg)` discarded the error object outright
+// (`provider.error(msg)` — the error appeared nowhere in the call), and
+// the 500 body carried no detail and no correlation id even in dev.
+
+/** Capture what actually reaches the provider. */
+function captureProvider() {
+  const calls: Array<{ msg: string; args: any[] }> = []
+  const provider: LoggerProvider = {
+    info: () => {},
+    warn: () => {},
+    error: (msg, ...args) => calls.push({ msg, args }),
+    debug: () => {},
+    child: () => provider,
+  }
+  Logger.setProvider(provider)
+  return calls
+}
+
+/** Minimal express-ish req/res doubles. */
+function mockReq(over: Record<string, unknown> = {}) {
+  return { method: 'GET', originalUrl: '/projects/42', headers: {}, ...over } as any
+}
+
+function mockRes() {
+  const res: any = {
+    headersSent: false,
+    statusCode: 0,
+    body: undefined,
+    headers: {} as Record<string, unknown>,
+    status(code: number) {
+      res.statusCode = code
+      return res
+    },
+    json(payload: unknown) {
+      res.body = payload
+      return res
+    },
+    setHeader(k: string, v: unknown) {
+      res.headers[k] = v
+    },
+  }
+  return res
+}
+
+const ORIGINAL_ENV = process.env.NODE_ENV
+
+afterEach(() => {
+  Logger.resetProvider()
+  process.env.NODE_ENV = ORIGINAL_ENV
+})
+
+describe('Logger.error — error-first form', () => {
+  let calls: ReturnType<typeof captureProvider>
+  beforeEach(() => {
+    calls = captureProvider()
+  })
+
+  it('forwards the error object so the stack survives', () => {
+    const err = new Error('relation "users" does not exist')
+    Logger.for('T').error(err, 'GET /users failed')
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].msg).toBe('GET /users failed')
+    // The regression: the error used to appear nowhere in the call.
+    expect(calls[0].args).toContain(err)
+    expect((calls[0].args[0] as Error).stack).toBeDefined()
+  })
+
+  it('uses the error summary as the line when no message is given', () => {
+    const err = new Error('boom')
+    Logger.for('T').error(err)
+    expect(calls[0].msg).toContain('boom')
+    expect(calls[0].args).toContain(err)
+  })
+
+  it('no longer drops trailing args on the message-first form', () => {
+    Logger.for('T').error('save failed', { id: 7 })
+    expect(calls[0]).toEqual({ msg: 'save failed', args: [{ id: 7 }] })
+  })
+})
+
+describe('describeError', () => {
+  it('includes the error name', () => {
+    expect(describeError(new TypeError('bad'))).toBe('TypeError: bad')
+  })
+
+  it('walks the cause chain — where ORM drivers hide the real reason', () => {
+    const root = new Error('relation "users" does not exist')
+    const wrapped = new Error('Query failed', { cause: root })
+    const outer = new Error('findMany failed', { cause: wrapped })
+    const out = describeError(outer)
+    expect(out).toContain('findMany failed')
+    expect(out).toContain('Query failed')
+    expect(out).toContain('relation "users" does not exist')
+  })
+
+  it('survives a circular cause chain', () => {
+    const a = new Error('a')
+    const b = new Error('b', { cause: a })
+    ;(a as any).cause = b
+    expect(() => describeError(a)).not.toThrow()
+    expect(describeError(a)).toContain('[circular cause]')
+  })
+
+  it('handles non-Error throws', () => {
+    expect(describeError('just a string')).toBe('just a string')
+    expect(describeError({ code: 42 })).toContain('42')
+    expect(describeError(undefined)).toBe('Unknown error')
+  })
+})
+
+describe('errorHandler — unexpected 500s', () => {
+  beforeEach(() => {
+    captureProvider()
+  })
+
+  it('carries the error summary and stack outside production', () => {
+    process.env.NODE_ENV = 'development'
+    const res = mockRes()
+    const err = new Error('relation "users" does not exist')
+    errorHandler()(err, mockReq(), res, () => {})
+
+    expect(res.statusCode).toBe(500)
+    expect(res.body.message).toBe('Internal Server Error')
+    expect(res.body.error).toContain('relation "users" does not exist')
+    expect(Array.isArray(res.body.stack)).toBe(true)
+  })
+
+  it('stays opaque in production', () => {
+    process.env.NODE_ENV = 'production'
+    const res = mockRes()
+    errorHandler()(new Error('connection string leaked here'), mockReq(), res, () => {})
+
+    expect(res.statusCode).toBe(500)
+    expect(res.body.message).toBe('Internal Server Error')
+    expect(res.body.error).toBeUndefined()
+    expect(res.body.stack).toBeUndefined()
+    expect(JSON.stringify(res.body)).not.toContain('connection string')
+  })
+
+  it('includes requestId in production so the 500 ties to its log line', () => {
+    process.env.NODE_ENV = 'production'
+    const res = mockRes()
+    const req = mockReq({ headers: { 'x-request-id': 'req-abc' } })
+    errorHandler()(new Error('boom'), req, res, () => {})
+
+    expect(res.body.requestId).toBe('req-abc')
+  })
+
+  it('prefers the request-scoped requestId over the raw header', () => {
+    process.env.NODE_ENV = 'production'
+    const res = mockRes()
+    const req = mockReq({ requestId: 'scoped-1', headers: { 'x-request-id': 'header-1' } })
+    errorHandler()(new Error('boom'), req, res, () => {})
+
+    expect(res.body.requestId).toBe('scoped-1')
+  })
+
+  it('omits requestId entirely when none is available', () => {
+    process.env.NODE_ENV = 'production'
+    const res = mockRes()
+    errorHandler()(new Error('boom'), mockReq(), res, () => {})
+    expect('requestId' in res.body).toBe(false)
+  })
+
+  it('surfaces the cause chain in the dev body', () => {
+    process.env.NODE_ENV = 'development'
+    const res = mockRes()
+    const err = new Error('findMany failed', {
+      cause: new Error('relation "users" does not exist'),
+    })
+    errorHandler()(err, mockReq(), res, () => {})
+    expect(res.body.error).toContain('relation "users" does not exist')
+  })
+
+  it('still passes non-500 statuses through with their own message', () => {
+    process.env.NODE_ENV = 'production'
+    const res = mockRes()
+    const err: any = new Error('teapot')
+    err.status = 418
+    errorHandler()(err, mockReq(), res, () => {})
+
+    expect(res.statusCode).toBe(418)
+    expect(res.body.message).toBe('teapot')
+  })
+
+  it('logs the error object, not just a sentence', () => {
+    const calls = captureProvider()
+    process.env.NODE_ENV = 'production'
+    const err = new Error('relation "users" does not exist')
+    errorHandler()(err, mockReq(), mockRes(), () => {})
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].args).toContain(err)
+    expect(calls[0].msg).toContain('GET /projects/42')
+  })
+})

--- a/packages/kickjs/__tests__/fastify-conformance.test.ts
+++ b/packages/kickjs/__tests__/fastify-conformance.test.ts
@@ -151,7 +151,13 @@ for (const rt of RUNTIMES) {
       await app.setup()
 
       const res = await request(app.handle.bind(app)).get('/api/v1/e/boom').expect(500)
-      expect(res.body).toEqual({ message: 'Internal Server Error' })
+      // The cross-runtime invariant is the status + the opaque client-facing
+      // message. Outside production the body also carries `error`, `stack`,
+      // and `requestId` — asserted in error-diagnostics.test.ts rather than
+      // pinned here, so this stays a conformance check and not a snapshot of
+      // the dev payload.
+      expect(res.body).toMatchObject({ message: 'Internal Server Error' })
+      expect(res.body.requestId).toBeTruthy()
     })
 
     it('returns 404 for an unmatched route', async () => {

--- a/packages/kickjs/src/core/index.ts
+++ b/packages/kickjs/src/core/index.ts
@@ -109,7 +109,13 @@ export {
 } from './cache'
 
 // Logger
-export { Logger, createLogger, ConsoleLoggerProvider, type LoggerProvider } from './logger'
+export {
+  Logger,
+  createLogger,
+  describeError,
+  ConsoleLoggerProvider,
+  type LoggerProvider,
+} from './logger'
 
 // Disposables — framework-owned resource teardown drained by Application.shutdown()
 export { registerDisposable, disposeAll, type Disposable } from './disposables'

--- a/packages/kickjs/src/core/logger.ts
+++ b/packages/kickjs/src/core/logger.ts
@@ -59,7 +59,14 @@ const LEVEL_RANK: Record<string, number> = {
  * takes effect. An unrecognised value falls back to `info`.
  */
 function thresholdRank(): number {
-  const level = (process.env.LOG_LEVEL ?? 'info').toLowerCase()
+  // `process` is guarded because this module is reachable from the
+  // edge-safe web pipeline (`@forinda/kickjs/web`), where strict runtimes
+  // expose no `process` global at all. The colour probe below already
+  // guarded; this one did not, so merely importing the logger could throw
+  // on such a runtime.
+  const level = (
+    (typeof process !== 'undefined' ? process.env?.LOG_LEVEL : undefined) ?? 'info'
+  ).toLowerCase()
   return LEVEL_RANK[level] ?? LEVEL_RANK.info
 }
 
@@ -233,13 +240,38 @@ export class Logger {
     this.provider.warn(msg, ...args)
   }
 
-  error(msgOrObj: any, msg?: string, ...args: any[]) {
-    if (typeof msgOrObj === 'string') {
-      this.provider.error(msgOrObj)
-    } else if (msg) {
-      this.provider.error(msg, ...args)
+  /** Pino-style error-first form — `log.error(err, 'what failed')`. */
+  error(err: unknown, msg: string, ...args: any[]): void
+  /** Message-first form — `log.error('what failed', detail)`. */
+  error(msg: string, ...args: any[]): void
+  /** Error alone — `log.error(err)`. */
+  error(err: unknown): void
+  error(msgOrErr: any, ...rest: any[]): void {
+    if (typeof msgOrErr === 'string') {
+      // Message-first. `rest` used to be dropped on the floor, so
+      // `log.error('save failed', { id })` logged only the string.
+      this.provider.error(msgOrErr, ...rest)
+      return
+    }
+
+    // Error-first (the framework's own idiom at ~16 call sites). The
+    // error object used to be discarded entirely — `provider.error(msg)`
+    // with the error nowhere in the call — so every `log.error(err, msg)`
+    // in the codebase logged a bare sentence with NO stack, no error
+    // name, and no `cause` chain. That is what made an unexpected 500
+    // undiagnosable from the logs: you got the message and nothing else.
+    //
+    // The error is now forwarded as a trailing argument, which is what
+    // the msg-first `LoggerProvider` contract can carry. `console.error`
+    // renders the full stack from it; a pino/winston adapter receives it
+    // as structured extra.
+    const [maybeMsg, ...extra] = rest
+    if (typeof maybeMsg === 'string') {
+      this.provider.error(maybeMsg, msgOrErr, ...extra)
     } else {
-      this.provider.error(String(msgOrObj))
+      // No message supplied — use the error's own summary as the line so
+      // the log stays readable, and still pass the object for the stack.
+      this.provider.error(describeError(msgOrErr), msgOrErr, ...rest)
     }
   }
 
@@ -255,6 +287,45 @@ export class Logger {
   fatal(msg: string, ...args: any[]) {
     if (this.provider.fatal) this.provider.fatal(msg, ...args)
     else this.provider.error(msg, ...args)
+  }
+}
+
+/**
+ * One-line summary of an unknown thrown value, including the error name
+ * and — when present — the `cause` chain. ORM and driver errors routinely
+ * wrap the useful detail in `cause`, so dropping it is how a 500 ends up
+ * saying nothing actionable.
+ *
+ * Depth-capped and cycle-guarded: `cause` is attacker-influenced in some
+ * stacks and self-referential chains do occur.
+ */
+export function describeError(err: unknown, maxDepth = 4): string {
+  const parts: string[] = []
+  const seen = new Set<unknown>()
+  let current: unknown = err
+  for (let depth = 0; current !== undefined && current !== null && depth < maxDepth; depth++) {
+    if (seen.has(current)) {
+      parts.push('[circular cause]')
+      break
+    }
+    seen.add(current)
+    if (current instanceof Error) {
+      parts.push(current.name ? `${current.name}: ${current.message}` : current.message)
+      current = (current as { cause?: unknown }).cause
+    } else {
+      parts.push(typeof current === 'string' ? current : safeStringify(current))
+      break
+    }
+  }
+  return parts.length > 0 ? parts.join(' ← caused by ') : 'Unknown error'
+}
+
+/** `JSON.stringify` that never throws on circular / exotic values. */
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value)
+  } catch {
+    return String(value)
   }
 }
 

--- a/packages/kickjs/src/http/middleware/error-handler.ts
+++ b/packages/kickjs/src/http/middleware/error-handler.ts
@@ -1,5 +1,11 @@
 import type { Request, Response, NextFunction } from 'express'
-import { HttpException, ProblemException, normalizeProblem, createLogger } from '../../core'
+import {
+  HttpException,
+  ProblemException,
+  normalizeProblem,
+  createLogger,
+  describeError,
+} from '../../core'
 
 const log = createLogger('ErrorHandler')
 
@@ -19,6 +25,10 @@ export function notFoundHandler() {
  * expose details in production — for client-facing field-level validation,
  * for example — should pass their own `onError` to `bootstrap()` and decide
  * the policy explicitly.
+ *
+ * Unexpected 500s carry `requestId` in every environment (the correlation
+ * handle back to the log line) and, outside production, the error summary
+ * plus stack. Production bodies stay opaque.
  *
  * {@link ProblemException} is dispatched first and emits an
  * `application/problem+json` response per RFC 9457. Plain
@@ -79,8 +89,40 @@ export function errorHandler() {
 
     // Unexpected errors — always log
     const status = err.status || err.statusCode || 500
-    log.error(err, `${req.method} ${req.originalUrl} — ${err.message || 'Unhandled error'}`)
-    const message = status === 500 ? 'Internal Server Error' : err.message || 'Error'
-    res.status(status).json({ message })
+    const requestId = (req as any).requestId ?? req.headers['x-request-id']
+    log.error(
+      err,
+      `${req.method} ${req.originalUrl} — ${describeError(err)}${
+        requestId ? ` [${requestId}]` : ''
+      }`,
+    )
+
+    if (status !== 500) {
+      return res.status(status).json({
+        message: err.message || 'Error',
+        ...(requestId ? { requestId } : {}),
+      })
+    }
+
+    // A 500 body must never carry the raw error in production — it can
+    // contain table names, SQL, connection strings, or user data. But
+    // returning a bare `{ message: 'Internal Server Error' }` in
+    // development means the one place a developer is looking tells them
+    // nothing, and the failure has to be re-diagnosed from the database.
+    //
+    // Development gets the full picture. Production gets the requestId,
+    // which is the correlation handle back to the (now stack-carrying)
+    // log line — without it an opaque 500 can't even be tied to its own
+    // log entry.
+    res.status(500).json({
+      message: 'Internal Server Error',
+      ...(requestId ? { requestId } : {}),
+      ...(isProduction
+        ? {}
+        : {
+            error: describeError(err),
+            ...(typeof err?.stack === 'string' ? { stack: err.stack.split('\n') } : {}),
+          }),
+    })
   }
 }

--- a/packages/kickjs/src/http/runtimes/h3-web.ts
+++ b/packages/kickjs/src/http/runtimes/h3-web.ts
@@ -28,6 +28,9 @@ import type {
 } from '../runtime'
 import { compileWebRoute, type WebRouteHooks } from '../web/handler'
 import { WebRequestShim, WebResponseDriver } from '../web/driver'
+import { createLogger, describeError } from '../../core/logger'
+
+const log = createLogger('H3WebRuntime')
 
 const peerRequire = createRequire(import.meta.url)
 
@@ -110,8 +113,21 @@ async function runConnectTerminal(
     }
   }
   if (!driver.settled) {
-    if (err !== undefined) driver.status(500).json({ error: 'Internal Server Error' })
-    else driver.status(404).json({ error: 'Not Found' })
+    if (err !== undefined) {
+      // The configured error handler ran but didn't settle the response
+      // (or there wasn't one). Emitting a bare 500 with no log entry
+      // makes this failure invisible on both sides — log it here, since
+      // by definition nothing downstream will.
+      log.error(err, `h3-web: error handler did not settle the response — ${describeError(err)}`)
+      driver.status(500).json({
+        error: 'Internal Server Error',
+        ...(typeof process !== 'undefined' && process.env?.NODE_ENV === 'production'
+          ? {}
+          : { message: describeError(err) }),
+      })
+    } else {
+      driver.status(404).json({ error: 'Not Found' })
+    }
   }
   return driver.ready
 }

--- a/packages/kickjs/src/http/web/handler.ts
+++ b/packages/kickjs/src/http/web/handler.ts
@@ -11,7 +11,9 @@ import { validate } from '../middleware/validate'
 import { applyUploadConfig, type RawUploadPart } from '../middleware/upload-config'
 import type { RouteEntry, RuntimeResponse } from '../runtime'
 import { WebRequestShim, WebResponseDriver } from './driver'
+import { createLogger, describeError } from '../../core/logger'
 
+const log = createLogger('WebPipeline')
 const NOOP_NEXT = (): void => {}
 const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 
@@ -32,7 +34,14 @@ export interface WebRouteHooks {
   onError?: (err: unknown, req: WebRequestShim, res: WebResponseDriver) => void | Promise<void>
 }
 
-/** Fallback error shape when no engine error handler settles the response. */
+/**
+ * Fallback error shape when no engine error handler settles the response.
+ *
+ * This path used to be completely silent: a bare
+ * `{ error: 'Internal Server Error' }` with no log line anywhere, so a
+ * failure that reached here left no trace on either side. It is a
+ * last-resort branch, which is exactly when diagnostics matter most.
+ */
 function defaultErrorResponse(err: unknown, driver: WebResponseDriver): void {
   const status =
     typeof (err as { status?: number })?.status === 'number'
@@ -40,9 +49,31 @@ function defaultErrorResponse(err: unknown, driver: WebResponseDriver): void {
       : typeof (err as { statusCode?: number })?.statusCode === 'number'
         ? (err as { statusCode: number }).statusCode
         : 500
-  const message =
-    status >= 500 ? 'Internal Server Error' : ((err as Error)?.message ?? 'Request failed')
-  driver.status(status).json({ error: message })
+
+  if (status >= 500) {
+    log.error(err, `Unhandled error in web pipeline — ${describeError(err)}`)
+    const stack = (err as Error)?.stack
+    driver.status(status).json({
+      error: 'Internal Server Error',
+      ...(isProduction()
+        ? {}
+        : {
+            message: describeError(err),
+            ...(typeof stack === 'string' ? { stack: stack.split('\n') } : {}),
+          }),
+    })
+    return
+  }
+
+  driver.status(status).json({ error: (err as Error)?.message ?? 'Request failed' })
+}
+
+/**
+ * Read per-call, not at module scope: the web entry is imported once and
+ * reused across invocations, and edge runtimes may not expose `process`.
+ */
+function isProduction(): boolean {
+  return typeof process !== 'undefined' && process.env?.NODE_ENV === 'production'
 }
 
 /**


### PR DESCRIPTION
## Why

Follow-up to #478 — the one item from the adopter review I left untraced:

> framework-level errors surfacing as bare `Internal Server Error` — the missing-table 500 told me nothing without going to the DB.

It told them nothing on **both** sides at once, for two independent reasons. I reproduced each before changing anything.

## What was actually broken

### 1. `Logger.error(err, msg)` discarded the error object

The pino-style error-first form is the framework's own idiom — ~16 call sites across `error-handler`, `application`, `bootstrap`, `request-scope`, plus the `ai` and `mcp` adapters. The implementation:

```ts
error(msgOrObj: any, msg?: string, ...args: any[]) {
  if (typeof msgOrObj === 'string') this.provider.error(msgOrObj)   // drops ...args too
  else if (msg) this.provider.error(msg, ...args)                   // ← error appears NOWHERE
  else this.provider.error(String(msgOrObj))                        // ← stack lost
}
```

Every `log.error(err, 'something failed')` in the codebase logged a bare sentence. Verified before the fix:

```
ERROR [Probe] GET /users — relation "users" does not exist
```

No stack, no error name, no `cause` chain. After:

```
ERROR [Probe] GET /users — relation "users" does not exist Error: relation "users" does not exist
    at boom (src/users/user.repo.ts:24:11)
    ...
```

The message-first form was dropping its trailing args for the same reason (`log.error('save failed', { id })` logged only the string) — also fixed.

### 2. The 500 body carried nothing, in every environment

`{ message: 'Internal Server Error' }` and that was it. Not even a correlation id, so the opaque response couldn't be tied to its own log line.

Now:

| | development | production |
|---|---|---|
| `message` | `Internal Server Error` | `Internal Server Error` |
| `requestId` | ✅ | ✅ |
| `error` (summary + cause chain) | ✅ | — |
| `stack` | ✅ | — |

Production stays opaque on purpose — a 500 message can carry table names, SQL, connection strings, or user data. `requestId` is included **in** production because without it an opaque 500 can't be correlated with anything.

### 3. The web/edge fallbacks were completely silent

`web/handler.ts` and the h3 v2 runtime emitted `{ error: 'Internal Server Error' }` with **no log call at all** — a failure reaching those branches left no trace anywhere. That's the last-resort path, which is exactly when diagnostics matter. Both now log and, outside production, include the summary.

## Also in here

- **`describeError(err)`** (new export) — one-line summary including error name and the **`cause` chain**, depth-capped and cycle-guarded. ORM and driver errors put the reason that matters three levels down: Prisma/Drizzle report "query failed" at the top and name the missing relation underneath. Exported because adopters writing a custom `onError` want the same thing.
- **Edge-safety fix** — `logger.ts` read `process.env.LOG_LEVEL` unguarded, so importing it from a strict edge runtime with no `process` global threw. The colour probe two lines below was already guarded; this one wasn't. It matters now that the edge-safe web pipeline imports the logger.

## Behaviour change

`fastify-conformance.test.ts` deep-equalled the old bare body. It now asserts the cross-runtime invariant — 500 + opaque message + a `requestId` — which as a side effect proves all three engines produce a correlation id. The dev-only fields are asserted in `error-diagnostics.test.ts` rather than pinned into a conformance snapshot.

Adopters asserting `toEqual({ message: 'Internal Server Error' })` on a 500 in their own tests will need `toMatchObject`. Called out in the changeset.

## Verification

- 12 of the 15 new tests fail against the unfixed code. The 3 that pass are the already-correct behaviours (production opacity, requestId omission, non-500 passthrough) — those are regression guards, not new claims.
- Production-leak test asserts the response body does not contain the error text at all, not merely that the field is absent.
- `pnpm test` 48/48 tasks, 703/703 in `kickjs`. `typecheck` 29/29. Lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
