### PR TITLE
feat: per-route context-key narrowing — dropped decorators fail tsc

### DIFF
--- a/.changeset/per-route-context-key-narrowing.md
+++ b/.changeset/per-route-context-key-narrowing.md
@@ -1,0 +1,24 @@
+---
+'@forinda/kickjs': minor
+'@forinda/kickjs-cli': minor
+---
+
+Per-route context-key narrowing — a dropped contributor decorator is now a compile error.
+
+`kick typegen` emits a `contextKeys` union per route from the context decorators applied at method and class level, and `ctx.require()` is narrowed to it. Removing a decorator removes the key:
+
+```
+error TS2345: Argument of type '"operatorPerm"' is not assignable to parameter of type '"tenant"'.
+```
+
+That refactor was previously invisible to `tsc` — `ctx.get('operatorPerm')!` compiled whether or not the decorator was applied, and the handler read `undefined` into an authorization check.
+
+**`ctx.get()` is deliberately not narrowed.** The original design (`architecture.md` §20.14) proposed dropping `| undefined` from `get()` for keys typegen believes are present. That was not built, because the two options fail in opposite directions: narrowing `get()` wrongly produces a value the types promise and the runtime doesn't deliver — silent, fails open, the exact failure this line of work removed. Narrowing `require()` wrongly produces a compile error — loud, fails closed, and covered by an escape hatch.
+
+**Narrowing applies only where completeness is provable.** A route gets a key union only when every decorator on it is either a known contributor-free framework decorator or a resolvable context decorator. Typegen emits `string` (no narrowing, today's behaviour) for an unrecognised decorator — adopter decorators can bundle contributors of their own — an unresolvable import, an ambiguous binding name, a route recovered by the regex fallback, or the presence of **any** contributor registered at module / adapter / bootstrap level, since a global registration adds keys to routes that carry no decorator for them. `never` is distinct from `string`: it means the scanner proved the route carries no contributors, so `require()` on it really is a mistake.
+
+**Escape hatch:** type the handler as plain `RequestContext` rather than `Ctx<KickRoutes…>` — `TKeys` defaults to `string` and no narrowing applies.
+
+API changes, both source-compatible: `RequestContext` gains a fourth type parameter `TKeys extends string = string`, and `ExecutionContext` becomes `ExecutionContext<TKeys extends string = string>`. Existing annotations keep working — the defaults reproduce today's behaviour exactly. `RouteShape` gains an optional `contextKeys` member.
+
+Module, adapter, and bootstrap registration sites are detected but not yet resolved; resolving them (so a module-scoped contributor narrows instead of degrading the project) is the next increment.

--- a/.changeset/per-route-context-key-narrowing.md
+++ b/.changeset/per-route-context-key-narrowing.md
@@ -7,7 +7,7 @@ Per-route context-key narrowing — a dropped contributor decorator is now a com
 
 `kick typegen` emits a `contextKeys` union per route from the context decorators applied at method and class level, and `ctx.require()` is narrowed to it. Removing a decorator removes the key:
 
-```
+```text
 error TS2345: Argument of type '"operatorPerm"' is not assignable to parameter of type '"tenant"'.
 ```
 

--- a/architecture.md
+++ b/architecture.md
@@ -3396,10 +3396,59 @@ Audit results from grepping `__ctxMeta`, `requestStore`, `tenantStorage`, `getCu
 | `examples/task-drizzle-api` (or new example)          | Add `LoadTenant` contributor showing class-level + method-level + adapter-level use in one app          |
 | `examples/multi-tenant-{drizzle,prisma,mongoose}-api` | Optional: convert hand-written tenant resolution middleware to a contributor (showcases migration path) |
 
-### 20.14 Compile-time context narrowing (deferred — RFC)
+### 20.14 Compile-time context narrowing (SHIPPED — with one deliberate deviation)
 
-**Status:** deferred. `ctx.require()` ships as the runtime half; this section
-records the design for the compile-time half so it isn't relitigated.
+**Status:** shipped. `ctx.require()` is the runtime half; per-route
+`contextKeys` from `kick/routes` typegen is the compile-time half.
+
+**Deviation from the design below, made during implementation:** this
+section originally proposed narrowing `ctx.get()` — dropping `| undefined`
+for keys typegen believes are present. That was the wrong direction and
+was NOT built.
+
+The two options fail in opposite ways when typegen's view is incomplete:
+
+|                            | if typegen is wrong                    | failure mode                                               |
+| -------------------------- | -------------------------------------- | ---------------------------------------------------------- |
+| Narrow `get()` (proposed)  | a key it thinks is present isn't       | typed `T`, actually `undefined` — **fails open, silently** |
+| Narrow `require()` (built) | a key that is present isn't in the set | false compile error — **fails closed, loudly**             |
+
+Narrowing `get()` would have reintroduced the exact failure this whole line
+of work set out to remove: a value the type system promises and the runtime
+doesn't deliver. `get()` is therefore untouched and still returns
+`| undefined` for every key. `require()`'s key parameter is narrowed to the
+route's proven set, which is what makes a dropped decorator a `tsc` error.
+
+**What that buys:** dropping `@OperatorPerm` from a route turns
+`ctx.require('operatorPerm')` into
+`TS2345: Argument of type '"operatorPerm"' is not assignable to parameter of type '"tenant"'`.
+
+**Soundness rule — prove completeness or degrade.** A route gets a key
+union only when every decorator on it (method + class) is either a known
+contributor-free framework decorator or a resolvable context decorator.
+Anything else — an unrecognised decorator (adopter decorators can bundle
+contributors of their own), an unresolvable import, an ambiguous binding
+name, a route recovered by the regex fallback, or the presence of ANY
+non-decorator contributor registration in the project — emits `string`,
+which means "not proven" and disables narrowing for that route.
+
+Note `never` vs `string`: `never` is emitted when the scanner proved a
+route carries no contributors (so any `require()` on it is a real
+mistake); `string` means it couldn't tell. Conflating them would produce
+false errors across whole projects.
+
+**Escape hatch:** type the handler as plain `RequestContext` instead of
+`Ctx<KickRoutes…>`. `TKeys` defaults to `string` and no narrowing applies.
+
+**Still not covered (unchanged from the prerequisites below):** module,
+adapter, and bootstrap registration sites are detected but not resolved —
+their presence degrades the whole project. Resolving them is the next
+increment. A third-party adapter shipping a contributor from inside
+`node_modules` remains invisible; under the fail-closed direction that
+surfaces as a false compile error on `require()`, which the escape hatch
+covers.
+
+The original design follows, retained for the reasoning.
 
 #### The gap
 
@@ -3494,10 +3543,21 @@ Sketch:
 #### Prerequisites
 
 - [x] `--check` genuinely fails on stale generated types
-- [ ] Typegen can enumerate adapter- and bootstrap-level contributors, or the
-      design explicitly degrades to `string` when it can't prove completeness
-- [ ] `contextKeys` emitted per route by the `kick/routes` plugin
-- [ ] `RequestContext` carries `TKeys` end to end
+- [x] The design explicitly degrades to `string` when it can't prove
+      completeness (typegen still does not _enumerate_ adapter/bootstrap
+      contributors — it detects them and degrades)
+- [x] `contextKeys` emitted per route by the `kick/routes` plugin
+- [x] `RequestContext` carries `TKeys` end to end
+
+#### Next increment
+
+- Resolve module-level `contributors()` and map modules to their mounted
+  controllers, so a module-scoped contributor narrows instead of degrading
+  the project.
+- Resolve simple `bootstrap({ contributors: [X.registration] })` identifier
+  forms — these union into every route rather than degrading.
+- Adapter-level stays out of reach for third-party packages; the escape
+  hatch is the answer there.
 
 ---
 

--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -280,11 +280,34 @@ It returns `Exclude<MetaValue<K>, undefined>` — no `!`, no `| undefined` — a
 
 `null` counts as present — only `undefined` throws. A contributor that deliberately resolves to `null` is saying "looked, found nothing", which is a real answer.
 
-::: warning This is a runtime guarantee, not a compile-time one
+### A dropped decorator is a compile error
 
-`ctx.require()` turns a silent `undefined` into a loud, named failure on the first request. It **cannot** make a missing decorator a compile error — proving that needs per-route context-key unions out of typegen. The design is written up in `architecture.md` §20.14; until it lands, a dropped decorator fails fast at runtime rather than at build time.
+When your handler is typed with a generated route type — `Ctx<KickRoutes.AuditController['audit']>` — `kick typegen` narrows `require()` to the keys it proved that route actually carries. Removing the decorator removes the key:
 
-Integration tests that exercise each route are still the thing that catches a dropped decorator before production.
+```ts
+@LoadTenant
+@OperatorPerm({ action: 'audit:read' })   // ← delete this line
+@Get('/audit')
+audit(ctx: Ctx<KickRoutes.AuditController['audit']>) {
+  return ctx.json({ perm: ctx.require('operatorPerm') })
+}
+```
+
+```text
+error TS2345: Argument of type '"operatorPerm"' is not assignable to parameter of type '"tenant"'.
+```
+
+That's the refactor that used to be invisible: `ctx.get('operatorPerm')!` compiled either way, and the handler read `undefined` into an authorization check.
+
+`ctx.get()` is deliberately **not** narrowed. Narrowing it would mean claiming a key is present, and if typegen were ever wrong about that you'd have a value the types promise and the runtime doesn't deliver — the exact failure `require()` exists to prevent. `require()` narrows in the safe direction: if typegen's view is incomplete you get a compile error, not a false guarantee.
+
+::: tip When typegen can't prove it, it doesn't narrow
+
+Narrowing applies only to routes whose full contributor set is provable from method- and class-level decorators. Typegen emits no narrowing (today's behaviour) when it sees an unrecognised decorator, an unresolvable import, an ambiguous name, or **any** contributor registered at module / adapter / bootstrap level — a global registration adds keys to routes that carry no decorator for them, so nothing in the project can be proven complete while one exists.
+
+If narrowing is ever wrong for a route, type the handler as plain `RequestContext` instead of `Ctx<KickRoutes…>` — that opts out entirely.
+
+Integration tests that exercise each route are still worth having; narrowing covers the dropped-decorator case, not a contributor that throws or resolves to `undefined`.
 :::
 
 ## Error handling

--- a/packages/cli/__tests__/context-key-narrowing.test.ts
+++ b/packages/cli/__tests__/context-key-narrowing.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect } from 'vitest'
+import { resolve } from 'node:path'
+
+import { extractFile, resolveRouteContextKeys } from '../src/typegen/scanner'
+import type { DiscoveredContextKey, DiscoveredRoute } from '../src/typegen/scanner'
+
+const CWD = resolve('/proj')
+const CONTROLLER = resolve('/proj/src/users/user.controller.ts')
+
+// Per-route context-key narrowing exists so a dropped `@LoadTenant`
+// becomes a tsc error instead of an undefined riding into an auth check.
+// Its correctness rests entirely on one rule: prove the route's full
+// contributor set, or emit nothing and let it stay unnarrowed. These
+// tests are mostly about the "or emit nothing" half — an over-narrow
+// union turns a legitimate `ctx.require()` into a false compile error.
+
+function routesFrom(source: string, filePath = CONTROLLER): DiscoveredRoute[] {
+  return extractFile(source, filePath, CWD).routes
+}
+
+const CONTRIBUTOR: DiscoveredContextKey[] = [
+  {
+    key: 'tenant',
+    exportName: 'LoadTenant',
+    filePath: resolve('/proj/src/contributors/tenant.ts'),
+    relativePath: 'src/contributors/tenant.ts',
+  },
+  {
+    key: 'operatorPerm',
+    exportName: 'OperatorPerm',
+    filePath: resolve('/proj/src/contributors/perm.ts'),
+    relativePath: 'src/contributors/perm.ts',
+  },
+]
+
+function keysFor(source: string, contextKeys = CONTRIBUTOR, hasGlobal = false) {
+  const routes = routesFrom(source)
+  resolveRouteContextKeys(routes, contextKeys, hasGlobal)
+  return routes.map((r) => r.contextKeys)
+}
+
+describe('context-key extraction', () => {
+  it('captures the binding a contributor is assigned to', () => {
+    const extract = extractFile(
+      `import { defineHttpContextDecorator } from '@forinda/kickjs'
+       export const LoadTenant = defineHttpContextDecorator({
+         key: 'tenant',
+         resolve: (ctx) => ctx.req.headers['x-tenant-id'],
+       })`,
+      resolve('/proj/src/contributors/tenant.ts'),
+      CWD,
+    )
+    expect(extract.contextKeys).toEqual([
+      expect.objectContaining({ key: 'tenant', exportName: 'LoadTenant' }),
+    ])
+  })
+
+  it('captures the binding through the curried withParams form', () => {
+    const extract = extractFile(
+      `import { defineHttpContextDecorator } from '@forinda/kickjs'
+       export const OperatorPerm = defineHttpContextDecorator.withParams<{ action: string }>()({
+         key: 'operatorPerm',
+         resolve: (ctx, _d, p) => p.action,
+       })`,
+      resolve('/proj/src/contributors/perm.ts'),
+      CWD,
+    )
+    expect(extract.contextKeys[0]).toMatchObject({
+      key: 'operatorPerm',
+      exportName: 'OperatorPerm',
+    })
+  })
+
+  it('records a null binding for a non-const-initialiser call', () => {
+    const extract = extractFile(
+      `import { defineContextDecorator } from '@forinda/kickjs'
+       export const list = [defineContextDecorator({ key: 'inline', resolve: () => 1 })]`,
+      resolve('/proj/src/contributors/inline.ts'),
+      CWD,
+    )
+    expect(extract.contextKeys[0]).toMatchObject({ key: 'inline', exportName: null })
+  })
+})
+
+describe('resolveRouteContextKeys — narrows only what it can prove', () => {
+  it('resolves method-level decorators to their keys', () => {
+    expect(
+      keysFor(`
+        import { Controller, Get } from '@forinda/kickjs'
+        import { LoadTenant } from '../contributors/tenant'
+        @Controller()
+        export class UserController {
+          @LoadTenant
+          @Get('/')
+          list(ctx) {}
+        }`),
+    ).toEqual([['tenant']])
+  })
+
+  it('includes class-level decorators on every method', () => {
+    expect(
+      keysFor(`
+        import { Controller, Get } from '@forinda/kickjs'
+        import { LoadTenant } from '../contributors/tenant'
+        import { OperatorPerm } from '../contributors/perm'
+        @LoadTenant
+        @Controller()
+        export class UserController {
+          @OperatorPerm({ action: 'read' })
+          @Get('/')
+          list(ctx) {}
+          @Get('/:id')
+          one(ctx) {}
+        }`),
+    ).toEqual([['operatorPerm', 'tenant'], ['tenant']])
+  })
+
+  it('resolves the factory-call form as well as the bare form', () => {
+    expect(
+      keysFor(`
+        import { Controller, Get } from '@forinda/kickjs'
+        import { OperatorPerm } from '../contributors/perm'
+        @Controller()
+        export class UserController {
+          @OperatorPerm({ action: 'audit:read' })
+          @Get('/')
+          list(ctx) {}
+        }`),
+    ).toEqual([['operatorPerm']])
+  })
+
+  it('proves the empty set for a route with no contributors', () => {
+    // `[]` (not null) — the scanner is asserting this route carries none,
+    // so `ctx.require()` on it should be a compile error.
+    expect(
+      keysFor(`
+        import { Controller, Get } from '@forinda/kickjs'
+        @Controller()
+        export class UserController {
+          @Get('/')
+          list(ctx) {}
+        }`),
+    ).toEqual([[]])
+  })
+
+  it('ignores known contributor-free framework decorators', () => {
+    expect(
+      keysFor(`
+        import { Controller, Get, Middleware, Public } from '@forinda/kickjs'
+        import { LoadTenant } from '../contributors/tenant'
+        @Controller()
+        export class UserController {
+          @Public()
+          @Middleware(someFn)
+          @LoadTenant
+          @Get('/')
+          list(ctx) {}
+        }`),
+    ).toEqual([['tenant']])
+  })
+
+  // ── the degradation cases — where correctness actually lives ────────
+
+  it('degrades on an unrecognised decorator', () => {
+    // An adopter decorator can bundle contributors of its own (the
+    // composition recipe does exactly that), so "unknown" cannot be
+    // treated as "harmless".
+    expect(
+      keysFor(`
+        import { Controller, Get } from '@forinda/kickjs'
+        import { WithAudit } from '../decorators/audit'
+        @Controller()
+        export class UserController {
+          @WithAudit
+          @Get('/')
+          list(ctx) {}
+        }`),
+    ).toEqual([null])
+  })
+
+  it('degrades every route when contributors are registered outside decorators', () => {
+    const src = `
+      import { Controller, Get } from '@forinda/kickjs'
+      import { LoadTenant } from '../contributors/tenant'
+      @Controller()
+      export class UserController {
+        @LoadTenant
+        @Get('/')
+        list(ctx) {}
+      }`
+    // Provable on its own...
+    expect(keysFor(src)).toEqual([['tenant']])
+    // ...but a module/adapter/bootstrap registration anywhere in the
+    // project adds keys to routes that carry no decorator for them.
+    expect(keysFor(src, CONTRIBUTOR, true)).toEqual([null])
+  })
+
+  it('degrades on an ambiguous binding name', () => {
+    const ambiguous: DiscoveredContextKey[] = [
+      ...CONTRIBUTOR,
+      {
+        key: 'otherTenant',
+        exportName: 'LoadTenant',
+        filePath: resolve('/proj/src/other/tenant.ts'),
+        relativePath: 'src/other/tenant.ts',
+      },
+    ]
+    expect(
+      keysFor(
+        `
+        import { Controller, Get } from '@forinda/kickjs'
+        import { LoadTenant } from '../contributors/tenant'
+        @Controller()
+        export class UserController {
+          @LoadTenant
+          @Get('/')
+          list(ctx) {}
+        }`,
+        ambiguous,
+      ),
+    ).toEqual([null])
+  })
+
+  it('degrades when the decorator binding cannot be resolved to an import', () => {
+    // No import statement and no same-file const — we matched the name
+    // but can't be confident it's that contributor.
+    expect(
+      keysFor(`
+        import { Controller, Get } from '@forinda/kickjs'
+        @Controller()
+        export class UserController {
+          @LoadTenant
+          @Get('/')
+          list(ctx) {}
+        }`),
+    ).toEqual([null])
+  })
+
+  it('degrades a route with no decorator list at all (regex fallback)', () => {
+    const routes: DiscoveredRoute[] = [{ appliedDecorators: undefined } as DiscoveredRoute]
+    resolveRouteContextKeys(routes, CONTRIBUTOR, false)
+    expect(routes[0].contextKeys).toBeNull()
+  })
+
+  it('degrades — rather than partially narrowing — when one of several is unknown', () => {
+    // The dangerous shape: two resolvable decorators and one unknown.
+    // Emitting just the two would look like a complete set.
+    expect(
+      keysFor(`
+        import { Controller, Get } from '@forinda/kickjs'
+        import { LoadTenant } from '../contributors/tenant'
+        import { OperatorPerm } from '../contributors/perm'
+        import { Mystery } from '../decorators/mystery'
+        @Controller()
+        export class UserController {
+          @LoadTenant
+          @OperatorPerm({ action: 'x' })
+          @Mystery
+          @Get('/')
+          list(ctx) {}
+        }`),
+    ).toEqual([null])
+  })
+})

--- a/packages/cli/__tests__/context-key-narrowing.test.ts
+++ b/packages/cli/__tests__/context-key-narrowing.test.ts
@@ -195,7 +195,9 @@ describe('resolveRouteContextKeys — narrows only what it can prove', () => {
     expect(keysFor(src, CONTRIBUTOR, true)).toEqual([null])
   })
 
-  it('degrades on an ambiguous binding name', () => {
+  it('disambiguates two same-named contributors via the import specifier', () => {
+    // Two `LoadTenant` exports in different files. The name alone is
+    // ambiguous, but the import says which one, so this still narrows.
     const ambiguous: DiscoveredContextKey[] = [
       ...CONTRIBUTOR,
       {
@@ -218,7 +220,136 @@ describe('resolveRouteContextKeys — narrows only what it can prove', () => {
         }`,
         ambiguous,
       ),
+    ).toEqual([['tenant']])
+
+    // ...and pointing at the other file picks up the other key.
+    expect(
+      keysFor(
+        `
+        import { Controller, Get } from '@forinda/kickjs'
+        import { LoadTenant } from '../other/tenant'
+        @Controller()
+        export class UserController {
+          @LoadTenant
+          @Get('/')
+          list(ctx) {}
+        }`,
+        ambiguous,
+      ),
+    ).toEqual([['otherTenant']])
+  })
+
+  it('degrades when an alias specifier suffix-matches more than one file', () => {
+    // `@/contributors/tenant` is matched by path suffix (tsconfig paths
+    // aren't parsed), so two files whose paths both end that way are
+    // genuinely ambiguous — refuse rather than pick one.
+    const ambiguous: DiscoveredContextKey[] = [
+      CONTRIBUTOR[0],
+      {
+        key: 'nestedTenant',
+        exportName: 'LoadTenant',
+        filePath: resolve('/proj/src/features/contributors/tenant.ts'),
+        relativePath: 'src/features/contributors/tenant.ts',
+      },
+    ]
+    expect(
+      keysFor(
+        `
+        import { Controller, Get } from '@forinda/kickjs'
+        import { LoadTenant } from '@/contributors/tenant'
+        @Controller()
+        export class UserController {
+          @LoadTenant
+          @Get('/')
+          list(ctx) {}
+        }`,
+        ambiguous,
+      ),
     ).toEqual([null])
+  })
+
+  it('does not credit a same-named decorator imported from elsewhere', () => {
+    // The route imports `LoadTenant` from a third-party package that has
+    // nothing to do with the project's own contributor of that name.
+    // Matching on the identifier alone would narrow this route to
+    // 'tenant' — a key it never actually carries.
+    expect(
+      keysFor(`
+        import { Controller, Get } from '@forinda/kickjs'
+        import { LoadTenant } from '@acme/auth'
+        @Controller()
+        export class UserController {
+          @LoadTenant
+          @Get('/')
+          list(ctx) {}
+        }`),
+    ).toEqual([null])
+  })
+
+  it('resolves a relative import to the declaring file', () => {
+    // Same identifier, and the specifier really does point at the file
+    // that declares it.
+    expect(
+      keysFor(`
+        import { Controller, Get } from '@forinda/kickjs'
+        import { LoadTenant } from '../contributors/tenant'
+        @Controller()
+        export class UserController {
+          @LoadTenant
+          @Get('/')
+          list(ctx) {}
+        }`),
+    ).toEqual([['tenant']])
+  })
+
+  it('degrades when a relative import points at a different file', () => {
+    expect(
+      keysFor(`
+        import { Controller, Get } from '@forinda/kickjs'
+        import { LoadTenant } from '../elsewhere/tenant'
+        @Controller()
+        export class UserController {
+          @LoadTenant
+          @Get('/')
+          list(ctx) {}
+        }`),
+    ).toEqual([null])
+  })
+
+  it('resolves the `@/` path alias that `kick new` scaffolds', () => {
+    // tsconfig `paths: { '@/*': ['./src/*'] }` is what the CLI emits, so
+    // alias imports are the norm in adopter projects; degrading on them
+    // would switch the feature off for most codebases.
+    expect(
+      keysFor(`
+        import { Controller, Get } from '@forinda/kickjs'
+        import { LoadTenant } from '@/contributors/tenant'
+        @Controller()
+        export class UserController {
+          @LoadTenant
+          @Get('/')
+          list(ctx) {}
+        }`),
+    ).toEqual([['tenant']])
+  })
+
+  it('resolves a same-file contributor', () => {
+    const routes = routesFrom(
+      `import { Controller, Get, defineHttpContextDecorator } from '@forinda/kickjs'
+       const LoadTenant = defineHttpContextDecorator({ key: 'tenant', resolve: () => 1 })
+       @Controller()
+       export class UserController {
+         @LoadTenant
+         @Get('/')
+         list(ctx) {}
+       }`,
+    )
+    resolveRouteContextKeys(
+      routes,
+      [{ key: 'tenant', exportName: 'LoadTenant', filePath: CONTROLLER, relativePath: 'x' }],
+      false,
+    )
+    expect(routes[0].contextKeys).toEqual(['tenant'])
   })
 
   it('degrades when the decorator binding cannot be resolved to an import', () => {

--- a/packages/cli/__tests__/context-narrowing-e2e.test.ts
+++ b/packages/cli/__tests__/context-narrowing-e2e.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { assertCliOk, cleanupFixture, createFixtureProject, runCli, runTsc } from './helpers'
+
+// End-to-end proof for per-route context-key narrowing: scaffold a real
+// project, run `kick typegen`, and put the result through tsc.
+//
+// The unit tests in context-key-narrowing.test.ts pin the resolution
+// policy. This file pins the thing that actually matters to an adopter —
+// that dropping a contributor decorator turns into a compile error, and
+// that the safety valves genuinely stop it from firing when typegen
+// can't see the whole picture.
+
+let fixture: string
+
+beforeEach(() => {
+  fixture = createFixtureProject('narrowing')
+})
+
+afterEach(() => {
+  cleanupFixture(fixture)
+})
+
+function write(relPath: string, contents: string): void {
+  const full = join(fixture, relPath)
+  mkdirSync(dirname(full), { recursive: true })
+  writeFileSync(full, contents)
+}
+
+const CONTRIBUTORS = `import { defineHttpContextDecorator } from '@forinda/kickjs'
+
+export const OperatorPerm = defineHttpContextDecorator.withParams<{ action: string }>()({
+  key: 'operatorPerm',
+  resolve: (_ctx, _deps, p) => p.action,
+})
+
+export const LoadTenant = defineHttpContextDecorator({
+  key: 'tenant',
+  resolve: (ctx) => ({ id: String(ctx.req.headers['x-tenant-id']) }),
+})
+`
+
+const META = `declare module '@forinda/kickjs' {
+  interface ContextMeta {
+    tenant: { id: string }
+    operatorPerm: string
+  }
+}
+`
+
+/** Controller whose handler requires 'operatorPerm'. */
+function controller(opts: { withPermDecorator: boolean }): string {
+  return `import { Controller, Get, type Ctx } from '@forinda/kickjs'
+import { LoadTenant, OperatorPerm } from '../contributors/perm'
+
+${META}
+@Controller()
+export class AuditController {
+  @LoadTenant
+  ${opts.withPermDecorator ? "@OperatorPerm({ action: 'audit:read' })" : ''}
+  @Get('/audit')
+  audit(ctx: Ctx<KickRoutes.AuditController['audit']>) {
+    return ctx.json({ perm: ctx.require('operatorPerm') })
+  }
+}
+`
+}
+
+function typegen(): void {
+  assertCliOk(runCli(fixture, ['typegen']), 'kick typegen')
+}
+
+function emittedRoutes(): string {
+  return readFileSync(join(fixture, '.kickjs/types/kick__routes.ts'), 'utf-8')
+}
+
+describe('per-route context-key narrowing (end to end)', () => {
+  it('compiles when the contributor decorator is applied', () => {
+    write('src/contributors/perm.ts', CONTRIBUTORS)
+    write('src/audit/audit.controller.ts', controller({ withPermDecorator: true }))
+    typegen()
+
+    expect(emittedRoutes()).toContain('contextKeys: "operatorPerm" | "tenant"')
+
+    const tsc = runTsc(fixture)
+    if (tsc.exitCode !== 0) throw new Error(`tsc should pass:\n${tsc.stdout}\n${tsc.stderr}`)
+  })
+
+  it('fails to compile when the decorator is dropped — the whole point', () => {
+    write('src/contributors/perm.ts', CONTRIBUTORS)
+    write('src/audit/audit.controller.ts', controller({ withPermDecorator: false }))
+    typegen()
+
+    // The key is gone from the route's proven set...
+    expect(emittedRoutes()).toContain('contextKeys: "tenant"')
+
+    // ...so requiring it no longer type-checks. Before narrowing this was
+    // invisible: `ctx.get('operatorPerm')!` compiled either way and the
+    // handler read undefined at request time.
+    const tsc = runTsc(fixture)
+    expect(tsc.exitCode).not.toBe(0)
+    expect(`${tsc.stdout}${tsc.stderr}`).toContain('operatorPerm')
+  })
+
+  it('emits `never` for a route proven to carry no contributors', () => {
+    write('src/contributors/perm.ts', CONTRIBUTORS)
+    write(
+      'src/plain/plain.controller.ts',
+      `import { Controller, Get, type Ctx } from '@forinda/kickjs'
+@Controller()
+export class PlainController {
+  @Get('/plain')
+  plain(ctx: Ctx<KickRoutes.PlainController['plain']>) {
+    return ctx.json({ ok: true })
+  }
+}
+`,
+    )
+    typegen()
+    expect(emittedRoutes()).toContain('contextKeys: never')
+  })
+
+  it('does not narrow a handler typed as plain RequestContext (escape hatch)', () => {
+    // The documented way out when typegen's view is wrong: drop the
+    // generated route type and TKeys falls back to `string`.
+    write('src/contributors/perm.ts', CONTRIBUTORS)
+    write(
+      'src/escape/escape.controller.ts',
+      `import { Controller, Get, type RequestContext } from '@forinda/kickjs'
+${META}
+@Controller()
+export class EscapeController {
+  @Get('/escape')
+  escape(ctx: RequestContext) {
+    return ctx.json({ perm: ctx.require('operatorPerm') })
+  }
+}
+`,
+    )
+    typegen()
+
+    const tsc = runTsc(fixture)
+    if (tsc.exitCode !== 0) throw new Error(`tsc should pass:\n${tsc.stdout}\n${tsc.stderr}`)
+  })
+
+  it('degrades every route to `string` once contributors are registered globally', () => {
+    // A bootstrap-level contributor populates keys on routes that carry
+    // no decorator for them. Narrowing anything after that would produce
+    // false compile errors, so typegen stops narrowing entirely.
+    write('src/contributors/perm.ts', CONTRIBUTORS)
+    write('src/audit/audit.controller.ts', controller({ withPermDecorator: false }))
+    write(
+      'src/index.ts',
+      `import { bootstrap } from '@forinda/kickjs'
+import { LoadTenant } from './contributors/perm'
+export const app = bootstrap({ modules: [], contributors: [LoadTenant.registration] })
+`,
+    )
+    typegen()
+
+    expect(emittedRoutes()).toContain('contextKeys: string')
+    expect(emittedRoutes()).not.toContain('contextKeys: "')
+
+    // The dropped decorator no longer errors — correctly, because the key
+    // could legitimately be arriving from the global registration.
+    const tsc = runTsc(fixture)
+    if (tsc.exitCode !== 0) throw new Error(`tsc should pass:\n${tsc.stdout}\n${tsc.stderr}`)
+  })
+})

--- a/packages/cli/__tests__/extract-ast.test.ts
+++ b/packages/cli/__tests__/extract-ast.test.ts
@@ -9,12 +9,30 @@ const CWD = resolve('/proj')
 const FILE = resolve('/proj/src/modules/users/user.controller.ts')
 const MODULE_FILE = resolve('/proj/src/modules/users/user.module.ts')
 
-/** Run both extractors and assert deep equality (parity harness). */
+/**
+ * Run both extractors and assert deep equality (parity harness).
+ *
+ * `appliedDecorators` is excluded: it is AST-only by design. Recording
+ * which decorators a route carries needs real parsing, and a route from
+ * the regex fallback deliberately has no list at all — the absence is the
+ * signal that its context-key set can't be proven, which is what makes
+ * per-route narrowing degrade safely on an unparseable file. Demanding
+ * parity here would mean either faking the data or dropping the signal.
+ */
+function stripAstOnly(extract: unknown): unknown {
+  const e = extract as { routes?: Array<Record<string, unknown>> } | null
+  if (!e?.routes) return e
+  return {
+    ...e,
+    routes: e.routes.map(({ appliedDecorators: _ignored, ...rest }) => rest),
+  }
+}
+
 function expectParity(source: string, filePath = FILE): void {
   const ast = extractFileAst(source, filePath, CWD)
   const regex = extractFileRegex(source, filePath, CWD)
   expect(ast).not.toBeNull()
-  expect(ast).toEqual(regex)
+  expect(stripAstOnly(ast)).toEqual(stripAstOnly(regex))
 }
 
 describe('extractFileAst — parity with the regex extractors', () => {

--- a/packages/cli/src/typegen/extract-ast.ts
+++ b/packages/cli/src/typegen/extract-ast.ts
@@ -33,6 +33,7 @@ import {
   type DiscoveredPluginOrAdapter,
   type DiscoveredRoute,
   type DiscoveredToken,
+  type DecoratorRef,
   type FileExtract,
   type ModuleMount,
   type SchemaRef,
@@ -231,6 +232,34 @@ function resolveSchemaRef(identifier: string, ctx: FileContext): SchemaRef {
   return { identifier, source: null }
 }
 
+/**
+ * Every decorator applied at a site, as `{ identifier, source }`, with the
+ * HTTP verb decorators (which *are* the route) filtered out.
+ *
+ * Deliberately unclassified here: the extractor sees one file at a time
+ * and can't know whether `@LoadTenant` resolves to a context contributor,
+ * a framework decorator, or an adopter's own wrapper. The scanner's join
+ * phase makes that call with the whole project in view — see
+ * `resolveRouteContextKeys`. Keeping the policy in one place is what
+ * makes "degrade when unprovable" auditable.
+ */
+function appliedDecoratorRefs(decorators: Node[], ctx: FileContext): DecoratorRef[] {
+  const out: DecoratorRef[] = []
+  for (const dec of decorators) {
+    // `@Foo(...)` → callee identifier; `@Foo` → the expression itself.
+    const call = decoratorCall(dec)
+    const name = call ? call.name : identifierName((dec as { expression?: Node }).expression)
+    if (!name || HTTP_DECORATORS.has(name)) continue
+    const imported = ctx.imports.get(name)
+    out.push({
+      identifier: name,
+      // '' = declared in this same file, null = couldn't be resolved.
+      source: imported ? imported.source : ctx.topLevelConsts.has(name) ? '' : null,
+    })
+  }
+  return out
+}
+
 /** Schema field (`body:` / `query:` / `params:`) — bare identifiers only. */
 function schemaFieldRef(options: Node | null, field: string, ctx: FileContext): SchemaRef | null {
   const value = getProp(options, field)
@@ -308,6 +337,19 @@ export function extractFileAst(source: string, filePath: string, cwd: string): F
 
   const seenHelperNames = new Set<string>()
   const seenContextKeys = new Set<string>()
+
+  // `const LoadTenant = defineHttpContextDecorator({...})` — map the init
+  // CallExpression back to the binding it's assigned to, so an applied
+  // `@LoadTenant` decorator can later be resolved to the key it writes.
+  // The walk below visits call expressions without their parent, hence
+  // the pre-pass.
+  const bindingByInit = new Map<Node, string>()
+  walk(program, (node) => {
+    if (node.type !== 'VariableDeclarator') return
+    const name = identifierName(node.id)
+    const init = node.init
+    if (name && isNode(init)) bindingByInit.set(init, name)
+  })
   const seenTokenNodes = new Set<Node>()
   /** Top-level `const X = <init>` map for @ApiQueryParams const refs. */
   const topLevelConstInits = new Map<string, Node>()
@@ -470,7 +512,12 @@ export function extractFileAst(source: string, filePath: string, cwd: string): F
       const key = stringValue(getProp(firstObjectArg(node), 'key'))
       if (key !== null && !seenContextKeys.has(key)) {
         seenContextKeys.add(key)
-        contextKeys.push({ key, filePath, relativePath: relPath })
+        contextKeys.push({
+          key,
+          exportName: bindingByInit.get(node) ?? null,
+          filePath,
+          relativePath: relPath,
+        })
       }
       return
     }
@@ -489,7 +536,12 @@ export function extractFileAst(source: string, filePath: string, cwd: string): F
           const key = stringValue(getProp(firstObjectArg(node), 'key'))
           if (key !== null && !seenContextKeys.has(key)) {
             seenContextKeys.add(key)
-            contextKeys.push({ key, filePath, relativePath: relPath })
+            contextKeys.push({
+              key,
+              exportName: bindingByInit.get(node) ?? null,
+              filePath,
+              relativePath: relPath,
+            })
           }
         }
       }
@@ -568,6 +620,12 @@ export function extractFileAst(source: string, filePath: string, cwd: string): F
       if (!discovered) continue
       const decs = decoratorsOf(member)
       const apiQp = extractApiQueryParams(decs, topLevelConstInits)
+      // Method- AND class-level decorators both contribute to the route's
+      // context keys (class-level applies to every method on it).
+      const appliedDecorators = [
+        ...appliedDecoratorRefs(decoratorsOf(cls), ctx),
+        ...appliedDecoratorRefs(decs, ctx),
+      ]
       for (const dec of decs) {
         const dc = decoratorCall(dec)
         if (!dc || !HTTP_DECORATORS.has(dc.name)) continue
@@ -594,6 +652,7 @@ export function extractFileAst(source: string, filePath: string, cwd: string): F
           filePath,
           relativePath: relPath,
           controllerIsDefaultExport: discovered.isDefault,
+          appliedDecorators,
           // Per-file contract: own path only (parity with the regex
           // extractor's empty-mount default); joinExtracts overwrites with
           // the cross-file mount-joined path.
@@ -625,6 +684,8 @@ export function extractFileAst(source: string, filePath: string, cwd: string): F
     routes,
     moduleMounts,
     globPatterns: /\.module\.[mc]?[tj]sx?$/.test(filePath) ? globPatterns : [],
+    // Overwritten by `extractFile` — see the note on the regex path.
+    hasNonDecoratorContributors: false,
   }
 }
 

--- a/packages/cli/src/typegen/render/routes.ts
+++ b/packages/cli/src/typegen/render/routes.ts
@@ -167,6 +167,7 @@ export const kickRpc = {} as const
         `        body: ${bodyType}`,
         `        query: ${queryType}`,
         `        response: ${responseType}`,
+        `        contextKeys: ${renderContextKeys(m)}`,
         `      }`,
       )
     }
@@ -286,6 +287,23 @@ ${rpcManifest}
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────
+
+/**
+ * The route's `contextKeys` member: a union of proven context keys, or
+ * `string` when the scanner couldn't prove the set is complete.
+ *
+ * `string` means "unknown", which reads as "don't narrow" downstream and
+ * preserves today's behaviour. The empty-array case is deliberately
+ * `never`: the scanner proved this route carries NO contributors, so
+ * every `ctx.require()` on it genuinely is a mistake and should not
+ * compile.
+ */
+function renderContextKeys(m: DiscoveredRoute): string {
+  const keys = m.contextKeys
+  if (keys == null) return 'string'
+  if (keys.length === 0) return 'never'
+  return keys.map((k) => JSON.stringify(k)).join(' | ')
+}
 
 function renderQueryShape(m: DiscoveredRoute): string {
   if (m.queryFilterable === null) return 'unknown'

--- a/packages/cli/src/typegen/scanner.ts
+++ b/packages/cli/src/typegen/scanner.ts
@@ -27,7 +27,7 @@
 
 import type { Dirent } from 'node:fs'
 import { readdir, readFile } from 'node:fs/promises'
-import { join, relative, resolve, sep } from 'node:path'
+import { dirname, join, relative, resolve, sep } from 'node:path'
 import { ScanCache } from './scanner-cache'
 import { extractFileAst } from './extract-ast'
 
@@ -1452,6 +1452,55 @@ const CONTRIBUTOR_FREE_DECORATORS = new Set([
  * it is still a false alarm, and false alarms are how a feature like this
  * gets switched off.
  */
+/** Strip a `.ts` / `.tsx` / `.js` / `.mjs` … extension and normalise slashes. */
+function normalizeModulePath(p: string): string {
+  return p
+    .split(sep)
+    .join('/')
+    .replace(/\.[mc]?[tj]sx?$/, '')
+}
+
+/**
+ * Does `specifier`, as written in `importerFile`, refer to `declFile`?
+ *
+ * Three forms, deliberately conservative — a `false` costs a route its
+ * narrowing (safe), a wrong `true` credits a route with a key it doesn't
+ * carry (not safe):
+ *
+ * - `''` — the decorator is declared in the importing file itself.
+ * - relative (`./x`, `../contributors/x`) — resolved against the
+ *   importer's directory, extension-insensitive, `/index` tolerated.
+ * - anything else — a bare package specifier or a path alias. tsconfig
+ *   `paths` aren't parsed here, but `@/*` → `./src/*` is what `kick new`
+ *   scaffolds and is near-universal in adopter projects, so an alias-ish
+ *   specifier is matched by path suffix. A real package specifier
+ *   (`@acme/auth`) won't suffix-match any local file and so degrades,
+ *   which is the outcome we want for a third-party decorator.
+ */
+function declarationMatchesImport(
+  importerFile: string,
+  specifier: string,
+  declFile: string,
+): boolean {
+  const decl = normalizeModulePath(declFile)
+
+  if (specifier === '') return decl === normalizeModulePath(importerFile)
+
+  if (specifier.startsWith('.')) {
+    const resolved = normalizeModulePath(resolve(dirname(importerFile), specifier))
+    return decl === resolved || decl === `${resolved}/index`
+  }
+
+  // Alias or bare specifier. Drop a leading alias marker, then require the
+  // remainder to be a path suffix of the declaration file.
+  const tail = specifier.replace(/^[@~#]\//, '')
+  // A scoped package (`@acme/auth`) keeps its `@`, so it can't suffix-match
+  // a real file path and correctly falls through to `false`.
+  if (tail === specifier && specifier.startsWith('@')) return false
+  const normalizedTail = normalizeModulePath(tail)
+  return decl === normalizedTail || decl.endsWith(`/${normalizedTail}`)
+}
+
 export function resolveRouteContextKeys(
   routes: DiscoveredRoute[],
   contextKeys: DiscoveredContextKey[],
@@ -1492,16 +1541,24 @@ export function resolveRouteContextKeys(
     for (const dec of applied) {
       if (CONTRIBUTOR_FREE_DECORATORS.has(dec.identifier)) continue
 
-      const matches = byExportName.get(dec.identifier)
-      if (!matches || matches.length !== 1) {
-        // Unknown decorator, or an ambiguous binding name. Either way we
-        // cannot enumerate this route's keys.
+      if (dec.source === null) {
+        // The binding didn't resolve to an import or a same-file const.
         provable = false
         break
       }
-      if (dec.source === null) {
-        // The binding didn't resolve to an import or a same-file const —
-        // we can't be confident it's the contributor we matched by name.
+
+      // Name AND declaration file must both match. Matching on the name
+      // alone was wrong: a route importing `@LoadTenant` from some other
+      // module (a third-party decorator that happens to share the name)
+      // would be credited with the project's unique local `LoadTenant`
+      // key, narrowing the route to a key it never actually carries.
+      const matches = (byExportName.get(dec.identifier) ?? []).filter((ck) =>
+        declarationMatchesImport(route.filePath, dec.source as string, ck.filePath),
+      )
+      if (matches.length !== 1) {
+        // Zero: not one of our context decorators (or imported from
+        // somewhere we can't resolve). More than one: ambiguous. Either
+        // way the route's key set can't be enumerated.
         provable = false
         break
       }

--- a/packages/cli/src/typegen/scanner.ts
+++ b/packages/cli/src/typegen/scanner.ts
@@ -113,6 +113,32 @@ export interface DiscoveredRoute {
    * against real URLs. Optional for old fixtures; falls back to `path`.
    */
   mountedPath?: string
+  /**
+   * Every decorator applied to this route's method or its controller
+   * class, minus the HTTP verb decorators. Unclassified on purpose — the
+   * join phase decides which are context contributors, which are known
+   * framework decorators, and which are unrecognised (and therefore make
+   * the route's key set unprovable).
+   */
+  appliedDecorators?: DecoratorRef[]
+  /**
+   * Union of context keys proven populated for this route, or `null` when
+   * completeness could not be established. `null` is emitted as `string`
+   * (no narrowing) — never as an empty union, which would wrongly reject
+   * every `ctx.require()` call on the route.
+   */
+  contextKeys?: string[] | null
+}
+
+/** A decorator as written at a call site, with its import resolved. */
+export interface DecoratorRef {
+  /** The decorator's local binding name, e.g. `LoadTenant`. */
+  identifier: string
+  /**
+   * Module specifier it was imported from; `''` when declared in the same
+   * file, `null` when the binding could not be resolved at all.
+   */
+  source: string | null
 }
 
 /** A statically-resolved schema identifier reference */
@@ -201,6 +227,18 @@ export interface DiscoveredPluginOrAdapter {
 export interface DiscoveredContextKey {
   /** The literal `key:` value the contributor writes. */
   key: string
+  /**
+   * The binding the decorator was assigned to — `LoadTenant` for
+   * `export const LoadTenant = defineHttpContextDecorator({ key: 'tenant' })`.
+   *
+   * `null` when the call isn't a simple `const X = …` initialiser (inline
+   * in an array, returned from a factory, …). Needed to map an applied
+   * `@LoadTenant` decorator back to the key it populates, which is what
+   * lets per-route context-key narrowing work at all; a `null` binding
+   * simply can't be resolved from a decorator site, so routes using it
+   * degrade to unnarrowed rather than guessing.
+   */
+  exportName: string | null
   /** Absolute file path. */
   filePath: string
   /** Path relative to scan root, with forward slashes. */
@@ -373,7 +411,7 @@ const DEFINE_HELPER_START = /\b(defineAdapter|definePlugin)\s*(?:<[^>]*>)?\s*\(/
 // (e.g. `defineHttpContextDecorator<'tenant', Record<string, never>>`),
 // which a flat `<[^>]*>` would truncate at the inner `>`.
 const CONTEXT_DECORATOR_START =
-  /\b(?:defineContextDecorator|defineHttpContextDecorator)\s*(?:\.withParams\s*<(?:[^<>]|<[^<>]*>)*>\s*\(\s*\))?\s*(?:<(?:[^<>]|<[^<>]*>)*>)?\s*\(/g
+  /(?:(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::[^=]+)?=\s*)?\b(?:defineContextDecorator|defineHttpContextDecorator)\s*(?:\.withParams\s*<(?:[^<>]|<[^<>]*>)*>\s*\(\s*\))?\s*(?:<(?:[^<>]|<[^<>]*>)*>)?\s*\(/g
 
 /**
  * Match a class declaration whose `implements` clause includes `AppAdapter`.
@@ -1154,9 +1192,10 @@ export function extractContextKeysFromSource(
   const seen = new Set<string>()
 
   CONTEXT_DECORATOR_START.lastIndex = 0
-  // The match value itself is unused — we only need the loop to advance
-  // and `lastIndex` to point just past the spec's opening paren.
-  while (CONTEXT_DECORATOR_START.exec(source) !== null) {
+  // Capture group 1 is the optional `const <Name> =` binding; `lastIndex`
+  // points just past the spec's opening paren either way.
+  let match: RegExpExecArray | null
+  while ((match = CONTEXT_DECORATOR_START.exec(source)) !== null) {
     const openParen = CONTEXT_DECORATOR_START.lastIndex - 1
     const closeParen = findBalancedClose(source, openParen)
     if (closeParen < 0) continue
@@ -1166,7 +1205,7 @@ export function extractContextKeysFromSource(
     const key = keyMatch[1]
     if (seen.has(key)) continue
     seen.add(key)
-    out.push({ key, filePath, relativePath: relPath })
+    out.push({ key, exportName: match[1] ?? null, filePath, relativePath: relPath })
   }
 
   return out
@@ -1364,6 +1403,118 @@ export function findCollisions(classes: DiscoveredClass[]): ClassCollision[] {
 }
 
 /**
+ * Framework decorators that are known NOT to register context
+ * contributors. Anything applied to a route that isn't one of these and
+ * isn't a resolvable context decorator makes the route's key set
+ * unprovable — an adopter's own decorator can wrap contributors of its
+ * own (the composition recipe in the context-decorators guide does
+ * exactly that), so "unrecognised" cannot be treated as "harmless".
+ */
+const CONTRIBUTOR_FREE_DECORATORS = new Set([
+  'Controller',
+  'Service',
+  'Repository',
+  'Injectable',
+  'Component',
+  'Module',
+  'Middleware',
+  'ApiQueryParams',
+  'Public',
+  'Roles',
+  'Cron',
+  'Cacheable',
+  'CacheEvict',
+  'FileUpload',
+  'Asset',
+  'Builder',
+  'PostConstruct',
+  'PreDestroy',
+  'Value',
+  'Inject',
+  'Autowired',
+])
+
+/**
+ * Resolve each route's provable context-key union, mutating `routes` in
+ * place.
+ *
+ * The rule is "prove completeness or degrade". A route gets a key union
+ * only when EVERY decorator applied to it (method and class) is either a
+ * known contributor-free framework decorator or a context decorator whose
+ * key we resolved. Anything unaccounted for — an unresolvable import, an
+ * unrecognised decorator, an ambiguous binding name, or the presence of
+ * non-decorator contributor registration anywhere in the project — yields
+ * `null`, which downstream emits as `string` (today's behaviour).
+ *
+ * Degrading is always safe; narrowing wrongly is not. Because `require()`
+ * narrowing rejects unknown keys, an over-narrow union turns a legitimate
+ * call into a compile error. That fails loudly rather than silently, but
+ * it is still a false alarm, and false alarms are how a feature like this
+ * gets switched off.
+ */
+export function resolveRouteContextKeys(
+  routes: DiscoveredRoute[],
+  contextKeys: DiscoveredContextKey[],
+  hasNonDecoratorContributors: boolean,
+): void {
+  if (hasNonDecoratorContributors) {
+    // A contributor registered at module / adapter / bootstrap level adds
+    // keys to routes that carry no decorator for them. Until those sites
+    // are resolved, no route in the project can be proven complete.
+    for (const route of routes) route.contextKeys = null
+    return
+  }
+
+  // Binding name → the context decorators exporting it. More than one
+  // entry means the name is ambiguous project-wide and we refuse to guess.
+  const byExportName = new Map<string, DiscoveredContextKey[]>()
+  for (const ck of contextKeys) {
+    if (!ck.exportName) continue
+    const list = byExportName.get(ck.exportName)
+    if (list) list.push(ck)
+    else byExportName.set(ck.exportName, [ck])
+  }
+
+  for (const route of routes) {
+    const applied = route.appliedDecorators
+    if (!applied) {
+      // Only the AST extractor records applied decorators. A route that
+      // came from the regex fallback (unparseable file, mid-edit in watch
+      // mode) has no decorator list, so nothing about it is provable.
+      // Note the distinction from `[]`, which means "parsed fine, carries
+      // no decorators" and IS provable.
+      route.contextKeys = null
+      continue
+    }
+    const keys = new Set<string>()
+    let provable = true
+
+    for (const dec of applied) {
+      if (CONTRIBUTOR_FREE_DECORATORS.has(dec.identifier)) continue
+
+      const matches = byExportName.get(dec.identifier)
+      if (!matches || matches.length !== 1) {
+        // Unknown decorator, or an ambiguous binding name. Either way we
+        // cannot enumerate this route's keys.
+        provable = false
+        break
+      }
+      if (dec.source === null) {
+        // The binding didn't resolve to an import or a same-file const —
+        // we can't be confident it's the contributor we matched by name.
+        provable = false
+        break
+      }
+      keys.add(matches[0].key)
+    }
+
+    // Sorted so the emitted union is stable across runs — an unstable
+    // order would show up as spurious drift under `kick typegen --check`.
+    route.contextKeys = provable ? [...keys].toSorted() : null
+  }
+}
+
+/**
  * The complete per-file extraction result. Every field here is a pure
  * function of a single file's source text — no cross-file context — so
  * the whole object is cacheable keyed by the file's signature.
@@ -1388,7 +1539,25 @@ export interface FileExtract {
   moduleMounts: ModuleMount[]
   /** `import.meta.glob([...])` patterns (only non-empty for `*.module.ts`). */
   globPatterns: string[]
+  /**
+   * This file registers context contributors somewhere other than a
+   * method/class decorator — a `contributors()` module/adapter/plugin hook
+   * or `bootstrap({ contributors: [...] })`.
+   *
+   * Presence, not resolution: those sites add keys to routes that carry no
+   * corresponding decorator, so per-route narrowing can't be proven
+   * complete anywhere in the project once one exists. Detecting them is
+   * enough to degrade; resolving them is a later increment.
+   */
+  hasNonDecoratorContributors: boolean
 }
+
+/**
+ * `contributors` used as an object property (`contributors: [...]`) or a
+ * method (`contributors() {}` / `contributors: () =>`). Matches the
+ * module, adapter, plugin, and bootstrap registration sites in one shot.
+ */
+const CONTRIBUTOR_REGISTRATION = /\bcontributors\s*(?::|\()/
 
 /**
  * Run per-file extraction over one source string. Pure: depends only
@@ -1402,9 +1571,13 @@ export interface FileExtract {
  * the dev loop alive.
  */
 export function extractFile(source: string, filePath: string, cwd: string): FileExtract {
+  // Computed here rather than in either extractor so the AST and regex
+  // paths can't disagree about it — a false `false` would silently enable
+  // narrowing on a project that registers contributors globally.
+  const hasNonDecoratorContributors = CONTRIBUTOR_REGISTRATION.test(source)
   const ast = extractFileAst(source, filePath, cwd)
-  if (ast) return ast
-  return extractFileRegex(source, filePath, cwd)
+  if (ast) return { ...ast, hasNonDecoratorContributors }
+  return { ...extractFileRegex(source, filePath, cwd), hasNonDecoratorContributors }
 }
 
 /**
@@ -1424,6 +1597,9 @@ export function extractFileRegex(source: string, filePath: string, cwd: string):
     routes: extractRoutesFromSource(source, filePath, cwd, classes, new Map()),
     moduleMounts: extractModuleMounts(source),
     globPatterns: /\.module\.[mc]?[tj]sx?$/.test(filePath) ? extractGlobPatterns(source) : [],
+    // Overwritten by `extractFile`, which computes it once for both the
+    // AST and regex paths so they can't disagree.
+    hasNonDecoratorContributors: false,
   }
 }
 
@@ -1657,6 +1833,15 @@ function joinExtracts(files: string[], extracts: (FileExtract | null)[]): Omit<S
       }
     }
   }
+
+  // Per-route context-key resolution. Runs after the route list is
+  // complete because the decision is project-wide: one non-decorator
+  // registration site anywhere degrades every route.
+  resolveRouteContextKeys(
+    routes,
+    contextKeys,
+    extracts.some((e) => e?.hasNonDecoratorContributors === true),
+  )
 
   // forinda/kick-js#235 §4 — for every module file, extract its
   // `import.meta.glob([...])` patterns and flag any decorated class

--- a/packages/kickjs/src/core/context-errors.ts
+++ b/packages/kickjs/src/core/context-errors.ts
@@ -56,9 +56,14 @@ export class MissingContributorError extends Error {
  * and the handler reads `undefined` as though it were a real value.
  *
  * `ctx.require()` converts that silent hole into a loud, named failure
- * that points at the missing contributor. Compile-time narrowing (so a
- * dropped decorator fails `tsc` instead) needs per-route context-key
- * unions out of typegen — tracked in `architecture.md` §20.14.
+ * that points at the missing contributor.
+ *
+ * A handler typed with a generated route type (`Ctx<KickRoutes…>`) also
+ * gets compile-time narrowing, so a dropped decorator fails `tsc` rather
+ * than reaching this error at all. This error remains the backstop for
+ * routes typegen couldn't prove (module/adapter/bootstrap registrations),
+ * handlers typed as plain `RequestContext`, and contributors that ran but
+ * resolved to `undefined`. See `architecture.md` §20.14.
  *
  * @example
  * ```text

--- a/packages/kickjs/src/core/execution-context.ts
+++ b/packages/kickjs/src/core/execution-context.ts
@@ -91,8 +91,15 @@ export type MetaValue<K extends string, Fallback = unknown> = K extends keyof Co
  * pipeline only depends on this interface — contributors authored against
  * `ExecutionContext` work across every transport that adopts it.
  */
-export interface ExecutionContext {
-  /** Read a typed value from per-request metadata. */
+export interface ExecutionContext<TKeys extends string = string> {
+  /**
+   * Read a typed value from per-request metadata.
+   *
+   * Deliberately NOT narrowed by `TKeys`: `get` accepts any key and
+   * always returns `| undefined`. Narrowing it would mean claiming a key
+   * is present, and a wrong claim there fails open — exactly the silent
+   * failure `require` exists to prevent.
+   */
   get<K extends string>(key: K): MetaValue<K> | undefined
   /**
    * Read a value that must be present, throwing `MissingContextValueError`
@@ -100,8 +107,14 @@ export interface ExecutionContext {
    * subject) where `get(key)!` would silently paper over a contributor
    * that never ran. Only `undefined` throws — `null` is a real value,
    * hence `Exclude<…, undefined>` rather than `NonNullable<…>`.
+   *
+   * When `TKeys` is narrowed (via a typegen'd `Ctx<KickRoutes…>`), asking
+   * for a key the route doesn't carry is a compile error — which is how a
+   * dropped decorator stops being invisible. The narrowing direction is
+   * deliberate: an incomplete typegen view produces a false *error*, not
+   * a false guarantee.
    */
-  require<K extends string>(key: K): Exclude<MetaValue<K>, undefined>
+  require<K extends TKeys>(key: K): Exclude<MetaValue<K>, undefined>
   /** Write a typed value into per-request metadata. */
   set<K extends string>(key: K, value: MetaValue<K>): void
   /** Unique per-request identifier (HTTP: x-request-id; WS/queue/cron: transport-defined). */

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -246,6 +246,21 @@ export interface RouteShape {
   body?: unknown
   query?: unknown
   response?: unknown
+  /**
+   * Union of context keys `kick typegen` proved are populated for this
+   * route — the keys of every context contributor applied at method or
+   * class level. Drives {@link RequestContext.require} narrowing, so
+   * calling `ctx.require()` for a key this route doesn't carry is a
+   * compile error instead of a request-time throw.
+   *
+   * `string` (the default) means "not proven", not "no keys". Typegen
+   * emits `string` whenever it cannot see the full picture — a
+   * contributor registered at module / adapter / bootstrap level, or an
+   * unrecognised decorator that might bundle contributors of its own.
+   * Narrowing an unprovable route would produce compile errors for keys
+   * that really are present.
+   */
+  contextKeys?: string
 }
 
 /**
@@ -256,7 +271,18 @@ export interface RouteShape {
  * Contributor pipeline (#107) can run against this concrete HTTP context
  * the same way it will run against future WS / queue / cron contexts.
  */
-export class RequestContext<TBody = any, TParams = any, TQuery = any> implements ExecutionContext {
+export class RequestContext<
+  TBody = any,
+  TParams = any,
+  TQuery = any,
+  /**
+   * Context keys proven present for this route. Defaults to `string`, so
+   * a handler typed as plain `RequestContext` keeps today's unnarrowed
+   * behaviour — which is also the deliberate escape hatch when typegen's
+   * view is incomplete.
+   */
+  TKeys extends string = string,
+> implements ExecutionContext<TKeys> {
   /**
    * Engine-agnostic response driver the response helpers write through. Under
    * the Express runtime it IS `res` (Express's Response satisfies
@@ -584,10 +610,13 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
    * const perm = ctx.require('operatorPerm')
    * ```
    *
-   * This is a runtime guarantee, not a compile-time one: it narrows the
-   * return type but cannot prove the decorator is present. Making a
-   * missing contributor a `tsc` error needs per-route key unions from
-   * typegen — see `architecture.md` §20.14.
+   * When `TKeys` is narrowed — which it is for a handler typed as
+   * `Ctx<KickRoutes…>`, from typegen's per-route `contextKeys` — asking
+   * for a key the route doesn't carry is a compile error, so a dropped
+   * decorator fails the build. `TKeys` stays `string` (no narrowing) for
+   * a plain `RequestContext` and for any route typegen couldn't prove
+   * complete; there this is a runtime guarantee only.
+   * See `architecture.md` §20.14.
    *
    * `null` counts as present; only `undefined` (or a missing entry)
    * throws. A contributor that deliberately resolves to `null` is
@@ -597,7 +626,7 @@ export class RequestContext<TBody = any, TParams = any, TQuery = any> implements
    * the runtime still hands it back, so a caller would be told a value
    * is non-null and then get `null`.
    */
-  require<K extends string>(key: K): Exclude<MetaValue<K>, undefined> {
+  require<K extends TKeys>(key: K): Exclude<MetaValue<K>, undefined> {
     const value = this.metadataReadOnly()?.get(key)
     if (value === undefined) {
       throw new MissingContextValueError(key, this.routeLabel())
@@ -930,7 +959,10 @@ export interface SseHandler<T = unknown> {
 export type Ctx<TRoute extends RouteShape = RouteShape> = RequestContext<
   TRoute extends { body: infer B } ? B : any,
   TRoute extends { params: infer P } ? P : any,
-  TRoute extends { query: infer Q } ? Q : any
+  TRoute extends { query: infer Q } ? Q : any,
+  // Falls back to `string` (no narrowing) whenever typegen couldn't prove
+  // the route's full contributor set — see `RouteShape.contextKeys`.
+  TRoute extends { contextKeys: infer K } ? (K extends string ? K : string) : string
 >
 
 /**


### PR DESCRIPTION
## Why

Closes the compile-time half of `architecture.md` §20.14 — the last item from the original adopter review:

> a dropped decorator is invisible to `tsc`, because `ctx.get('tenantPerm')!` compiles whether or not the route is decorated. On an auth gate that's the worst possible thing to be untypeable.

It isn't invisible any more:

```ts
@LoadTenant
@OperatorPerm({ action: 'audit:read' })   // ← delete this line
@Get('/audit')
audit(ctx: Ctx<KickRoutes.AuditController['audit']>) {
  return ctx.json({ perm: ctx.require('operatorPerm') })
}
```

```text
error TS2345: Argument of type '"operatorPerm"' is not assignable to parameter of type '"tenant"'.
```

## I did not build what the RFC specified

§20.14 (which I wrote) proposed narrowing `ctx.get()` — dropping `| undefined` for keys typegen believes are present. **That was the wrong direction and is not in this PR.** Tracing what typegen can actually see made the problem clear: it currently scans *zero* contributor registration sites, and adapter-level registrations ship from inside `node_modules` where a static scan can't follow them.

So typegen's view is *structurally* incomplete, and the two options fail in opposite directions:

| | if typegen is wrong | failure mode |
| --- | --- | --- |
| Narrow `get()` (specified) | thinks a key is present, it isn't | typed `T`, actually `undefined` — **silent, fails open** |
| Narrow `require()` (built) | a present key isn't in the set | false compile error — **loud, fails closed** |

Narrowing `get()` would have reintroduced the exact failure the whole PR series set out to remove: a value the types promise and the runtime doesn't deliver. `get()` is untouched and still returns `| undefined` for every key.

## Soundness: prove completeness or degrade

A route gets a key union only when **every** decorator on it is either a known contributor-free framework decorator or a resolvable context decorator. Everything else emits `string` — no narrowing, today's behaviour:

- an unrecognised decorator — adopter decorators can bundle contributors of their own (the composition recipe in the guide does exactly that), so "unknown" can't be treated as "harmless"
- an unresolvable import, or an ambiguous binding name across the project
- a route recovered by the regex fallback, which can't see decorators at all
- the presence of **any** contributor registered at module / adapter / bootstrap level — a global registration adds keys to routes carrying no decorator for them, so nothing in the project is provable while one exists

`never` is deliberately distinct from `string`: `never` means the scanner *proved* the route carries no contributors, so `require()` on it is a real mistake. Conflating the two would produce false errors across whole projects.

**Escape hatch:** type the handler as plain `RequestContext` instead of `Ctx<KickRoutes…>`; `TKeys` falls back to `string`.

## Verified end to end, not just at unit level

Scaffolded a real project, ran `kick typegen`, put the output through `tsc`:

| scenario | emitted | `tsc` |
| --- | --- | --- |
| decorator applied | `contextKeys: "operatorPerm" \| "tenant"` | passes |
| **decorator dropped** | `contextKeys: "tenant"` | **TS2345 naming the key** |
| no contributors on route | `contextKeys: never` | — |
| plain `RequestContext` handler | — | passes (escape hatch) |
| global `bootstrap({ contributors })` | `contextKeys: string` everywhere | passes (degraded) |

All five are in `context-narrowing-e2e.test.ts` against real `tsc`, plus 14 unit tests on the resolution policy — most of them on the degradation paths, since that's where correctness actually lives.

## API changes — source-compatible

- `RequestContext` gains a 4th type param `TKeys extends string = string`
- `ExecutionContext` → `ExecutionContext<TKeys extends string = string>`
- `RouteShape` gains optional `contextKeys`

Defaults reproduce today's behaviour exactly; existing annotations are unchanged. Full monorepo: 48/48 test tasks, 29/29 typecheck, lint + format clean.

## Not covered

Module, adapter, and bootstrap sites are *detected* but not *resolved* — they degrade the project rather than narrowing. Resolving module-level `contributors()` is the natural next increment (noted in §20.14). A third-party adapter shipping a contributor stays invisible; under the fail-closed direction that surfaces as a false `require()` error, which the escape hatch covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated route types now narrow `ctx.require()` to context keys proven for each route.
  * Dropped context decorators can trigger TypeScript compile-time errors.
  * Routes with unknown contributor configuration safely fall back to unrestricted keys.
  * Plain `RequestContext` remains available as an escape hatch.

* **Documentation**
  * Updated architecture and guides to explain narrowing behavior, limitations, and runtime safeguards.

* **Tests**
  * Added coverage for decorator detection, route narrowing, fallback behavior, and end-to-end type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->