### PR TITLE
feat: resolve module-level contributors() for context-key narrowing

### DIFF
--- a/.changeset/module-contributor-narrowing.md
+++ b/.changeset/module-contributor-narrowing.md
@@ -1,0 +1,25 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+Resolve module-level `contributors()` for per-route context-key narrowing.
+
+A module's `contributors()` hook previously degraded the **entire project**: the scanner detected the word `contributors` anywhere and disabled narrowing everywhere, so any project using module-scoped contributors got no benefit from the feature at all. The hook is now attributed to the controllers that module mounts — it and the mounts live on the same module object, so they share a file — and its keys union into those routes exactly as a class-level decorator's would.
+
+```ts
+export const AuditModule = defineModule({
+  name: 'Audit',
+  build: () => ({
+    routes: () => ({ path: '/audit', controller: AuditController }),
+    contributors: () => [LoadTenant.registration],
+  }),
+})
+```
+
+Routes on `AuditController` now narrow to `'tenant'` with no decorator on the controller at all — and `ctx.require('somethingElse')` on them is a compile error.
+
+Both registration forms are resolved (`X.registration` and `X.with({…}).registration`), in both the `defineModule` object form and the `class X implements AppModule` form.
+
+**Adapter and bootstrap registrations still degrade the project.** They apply app-wide and can't be attributed to any particular route. The classifier isn't a heuristic: `AppModule` declares `contributors?()` and `routes()` as siblings, so a `contributors` member alongside a `routes` member is the module hook, and `bootstrap({ contributors })` / `defineAdapter({ contributors })` / `definePlugin({ contributors })` — which have no sibling `routes` — are not.
+
+Module resolution itself degrades rather than reporting a partial set when the hook isn't a literal array of registration entries (a spread, a helper call, a variable holding the array), or when a controller is mounted by two modules — there, which contributor set applied depends on which mount served the request.

--- a/architecture.md
+++ b/architecture.md
@@ -3440,13 +3440,30 @@ false errors across whole projects.
 **Escape hatch:** type the handler as plain `RequestContext` instead of
 `Ctx<KickRoutes…>`. `TKeys` defaults to `string` and no narrowing applies.
 
-**Still not covered (unchanged from the prerequisites below):** module,
-adapter, and bootstrap registration sites are detected but not resolved —
-their presence degrades the whole project. Resolving them is the next
-increment. A third-party adapter shipping a contributor from inside
-`node_modules` remains invisible; under the fail-closed direction that
-surfaces as a false compile error on `require()`, which the escape hatch
-covers.
+**Module-level `contributors()` is resolved.** A module hook is attributed
+to the controllers that module mounts (the hook and the mounts live on the
+same module object, so they share a file), and its keys union into those
+routes exactly as a class-level decorator's would. Precedence
+(method > class > module) decides which registration wins for a duplicate
+key, not whether the key is present, so a union is the correct operation.
+
+The classifier is `AppModule`'s own shape rather than a heuristic:
+`contributors?()` and `routes()` are declared as siblings, so a
+`contributors` member alongside a `routes` member IS the module hook, and
+anything else — `bootstrap({ contributors })`, `defineAdapter({
+contributors })`, `definePlugin({ contributors })` — is app-wide.
+
+Module resolution degrades (rather than reporting a partial set) when the
+hook isn't a literal array of `X.registration` / `X.with(…).registration`
+entries — a spread, a helper call, a variable — or when a controller is
+mounted by two modules, where which set applied depends on which mount
+served the request.
+
+**Still not covered:** adapter and bootstrap registration sites are
+detected but not resolved — their presence degrades the whole project. A
+third-party adapter shipping a contributor from inside `node_modules`
+remains invisible; under the fail-closed direction that surfaces as a
+false compile error on `require()`, which the escape hatch covers.
 
 The original design follows, retained for the reasoning.
 
@@ -3551,13 +3568,16 @@ Sketch:
 
 #### Next increment
 
-- Resolve module-level `contributors()` and map modules to their mounted
-  controllers, so a module-scoped contributor narrows instead of degrading
-  the project.
+- ~~Resolve module-level `contributors()` and map modules to their mounted
+  controllers~~ — done; see above.
 - Resolve simple `bootstrap({ contributors: [X.registration] })` identifier
-  forms — these union into every route rather than degrading.
-- Adapter-level stays out of reach for third-party packages; the escape
-  hatch is the answer there.
+  forms — these union into every route rather than degrading. Same
+  `collectContributorRefs` machinery the module hook uses; the difference
+  is the attribution (every route, not a module's mounts).
+- Adapter-level stays out of reach for third-party packages, whose
+  `contributors()` bodies live in `node_modules`. A first-party
+  `defineAdapter` in the adopter's own `src/` could be resolved the same
+  way as bootstrap; the escape hatch is the answer for the rest.
 
 ---
 

--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -303,7 +303,9 @@ That's the refactor that used to be invisible: `ctx.get('operatorPerm')!` compil
 
 ::: tip When typegen can't prove it, it doesn't narrow
 
-Narrowing applies only to routes whose full contributor set is provable from method- and class-level decorators. Typegen emits no narrowing (today's behaviour) when it sees an unrecognised decorator, an unresolvable import, an ambiguous name, or **any** contributor registered at module / adapter / bootstrap level — a global registration adds keys to routes that carry no decorator for them, so nothing in the project can be proven complete while one exists.
+Narrowing applies only to routes whose full contributor set is provable. Typegen resolves method decorators, class decorators, and a module's `contributors()` hook — the last is attributed to the controllers that module mounts, so a module-scoped contributor narrows just like a class-level one.
+
+It emits no narrowing (today's behaviour) when it sees an unrecognised decorator, an unresolvable import, an ambiguous name, a module hook it can't enumerate (a spread, a helper call), a controller mounted by two modules, or **any** contributor registered at **adapter or bootstrap** level — those apply app-wide and can't be tied to a particular route, so nothing in the project is provable while one exists.
 
 If narrowing is ever wrong for a route, type the handler as plain `RequestContext` instead of `Ctx<KickRoutes…>` — that opts out entirely.
 

--- a/packages/cli/__tests__/context-narrowing-e2e.test.ts
+++ b/packages/cli/__tests__/context-narrowing-e2e.test.ts
@@ -144,6 +144,85 @@ export class EscapeController {
     if (tsc.exitCode !== 0) throw new Error(`tsc should pass:\n${tsc.stdout}\n${tsc.stderr}`)
   })
 
+  it('narrows from a module-level contributors() hook', () => {
+    // This case used to degrade the ENTIRE project — the scanner saw the
+    // word `contributors` and gave up everywhere. It's now attributed to
+    // the controllers the module mounts.
+    write('src/contributors/perm.ts', CONTRIBUTORS)
+    write(
+      'src/audit/audit.controller.ts',
+      `import { Controller, Get, type Ctx } from '@forinda/kickjs'
+${META}
+@Controller()
+export class AuditController {
+  @Get('/audit')
+  audit(ctx: Ctx<KickRoutes.AuditController['audit']>) {
+    return ctx.json({ tenant: ctx.require('tenant') })
+  }
+}
+`,
+    )
+    write(
+      'src/audit/audit.module.ts',
+      `import { defineModule } from '@forinda/kickjs'
+import { AuditController } from './audit.controller'
+import { LoadTenant } from '../contributors/perm'
+
+export const AuditModule = defineModule({
+  name: 'Audit',
+  build: () => ({
+    routes: () => ({ path: '/audit', controller: AuditController }),
+    contributors: () => [LoadTenant.registration],
+  }),
+})
+`,
+    )
+    typegen()
+
+    // The module hook supplies 'tenant' even though no decorator does.
+    expect(emittedRoutes()).toContain('contextKeys: "tenant"')
+
+    const tsc = runTsc(fixture)
+    if (tsc.exitCode !== 0) throw new Error(`tsc should pass:\n${tsc.stdout}\n${tsc.stderr}`)
+  })
+
+  it('still rejects a key the module hook does not supply', () => {
+    write('src/contributors/perm.ts', CONTRIBUTORS)
+    write(
+      'src/audit/audit.controller.ts',
+      `import { Controller, Get, type Ctx } from '@forinda/kickjs'
+${META}
+@Controller()
+export class AuditController {
+  @Get('/audit')
+  audit(ctx: Ctx<KickRoutes.AuditController['audit']>) {
+    return ctx.json({ perm: ctx.require('operatorPerm') })
+  }
+}
+`,
+    )
+    write(
+      'src/audit/audit.module.ts',
+      `import { defineModule } from '@forinda/kickjs'
+import { AuditController } from './audit.controller'
+import { LoadTenant } from '../contributors/perm'
+
+export const AuditModule = defineModule({
+  name: 'Audit',
+  build: () => ({
+    routes: () => ({ path: '/audit', controller: AuditController }),
+    contributors: () => [LoadTenant.registration],
+  }),
+})
+`,
+    )
+    typegen()
+
+    const tsc = runTsc(fixture)
+    expect(tsc.exitCode).not.toBe(0)
+    expect(`${tsc.stdout}${tsc.stderr}`).toContain('operatorPerm')
+  })
+
   it('degrades every route to `string` once contributors are registered globally', () => {
     // A bootstrap-level contributor populates keys on routes that carry
     // no decorator for them. Narrowing anything after that would produce

--- a/packages/cli/__tests__/extract-ast.test.ts
+++ b/packages/cli/__tests__/extract-ast.test.ts
@@ -20,11 +20,23 @@ const MODULE_FILE = resolve('/proj/src/modules/users/user.module.ts')
  * parity here would mean either faking the data or dropping the signal.
  */
 function stripAstOnly(extract: unknown): unknown {
-  const e = extract as { routes?: Array<Record<string, unknown>> } | null
-  if (!e?.routes) return e
+  const e = extract as Record<string, unknown> | null
+  if (!e) return e
+  const {
+    // Both are classification the regex path structurally cannot do: it
+    // can't tell a module `contributors()` hook (attributable to the
+    // controllers that module mounts) from an adapter/bootstrap one
+    // (app-wide). The regex path therefore assumes the app-wide case,
+    // which is the safe answer, not a parity violation.
+    moduleContributors: _moduleContributors,
+    hasNonDecoratorContributors: _hasNonDecoratorContributors,
+    ...rest
+  } = e
+  const routes = rest.routes as Array<Record<string, unknown>> | undefined
+  if (!routes) return rest
   return {
-    ...e,
-    routes: e.routes.map(({ appliedDecorators: _ignored, ...rest }) => rest),
+    ...rest,
+    routes: routes.map(({ appliedDecorators: _ignored, ...route }) => route),
   }
 }
 

--- a/packages/cli/__tests__/module-contributor-resolution.test.ts
+++ b/packages/cli/__tests__/module-contributor-resolution.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect } from 'vitest'
+import { resolve } from 'node:path'
+
+import {
+  buildModuleContributorMap,
+  extractFile,
+  resolveRouteContextKeys,
+} from '../src/typegen/scanner'
+import type { DiscoveredContextKey, FileExtract } from '../src/typegen/scanner'
+
+const CWD = resolve('/proj')
+const CONTROLLER = resolve('/proj/src/users/user.controller.ts')
+const MODULE = resolve('/proj/src/users/user.module.ts')
+
+// Module-level `contributors()` used to degrade the ENTIRE project: the
+// scanner detected the word `contributors` and gave up everywhere. It's
+// now attributed to the controllers that module mounts, so a module-scoped
+// contributor narrows like a class-level decorator does.
+//
+// Adapter / plugin / bootstrap registrations still degrade — they apply
+// app-wide and can't be tied to any particular route. The classifier that
+// separates the two is `AppModule`'s own shape: `contributors()` and
+// `routes()` are declared as siblings, so a `contributors` member next to
+// a `routes` member is the module hook and nothing else is.
+
+const CONTRIBUTORS: DiscoveredContextKey[] = [
+  {
+    key: 'tenant',
+    exportName: 'LoadTenant',
+    filePath: resolve('/proj/src/contributors/tenant.ts'),
+    relativePath: 'src/contributors/tenant.ts',
+  },
+  {
+    key: 'audit',
+    exportName: 'Audit',
+    filePath: resolve('/proj/src/contributors/audit.ts'),
+    relativePath: 'src/contributors/audit.ts',
+  },
+]
+
+const CONTROLLER_SRC = `
+import { Controller, Get } from '@forinda/kickjs'
+@Controller()
+export class UserController {
+  @Get('/')
+  list(ctx) {}
+}
+`
+
+/** Extract a controller + module pair and resolve the routes' keys. */
+function resolveWith(moduleSrc: string, controllerSrc = CONTROLLER_SRC) {
+  const controllerExtract = extractFile(controllerSrc, CONTROLLER, CWD)
+  const moduleExtract = extractFile(moduleSrc, MODULE, CWD)
+  const extracts: (FileExtract | null)[] = [controllerExtract, moduleExtract]
+  const routes = controllerExtract.routes
+  resolveRouteContextKeys(
+    routes,
+    CONTRIBUTORS,
+    extracts.some((e) => e?.hasNonDecoratorContributors === true),
+    buildModuleContributorMap(extracts),
+  )
+  return routes.map((r) => r.contextKeys)
+}
+
+describe('module-level contributors() — defineModule object form', () => {
+  it('attributes the module hook to the controllers it mounts', () => {
+    expect(
+      resolveWith(`
+        import { defineModule } from '@forinda/kickjs'
+        import { UserController } from './user.controller'
+        import { LoadTenant } from '../contributors/tenant'
+        export const UserModule = defineModule({
+          name: 'Users',
+          build: () => ({
+            routes: () => ({ path: '/users', controller: UserController }),
+            contributors: () => [LoadTenant.registration],
+          }),
+        })`),
+    ).toEqual([['tenant']])
+  })
+
+  it('resolves the .with({...}).registration form', () => {
+    expect(
+      resolveWith(`
+        import { defineModule } from '@forinda/kickjs'
+        import { UserController } from './user.controller'
+        import { LoadTenant } from '../contributors/tenant'
+        export const UserModule = defineModule({
+          name: 'Users',
+          build: () => ({
+            routes: () => ({ path: '/users', controller: UserController }),
+            contributors: () => [LoadTenant.with({ source: 'subdomain' }).registration],
+          }),
+        })`),
+    ).toEqual([['tenant']])
+  })
+
+  it('unions several module contributors', () => {
+    expect(
+      resolveWith(`
+        import { defineModule } from '@forinda/kickjs'
+        import { UserController } from './user.controller'
+        import { LoadTenant } from '../contributors/tenant'
+        import { Audit } from '../contributors/audit'
+        export const UserModule = defineModule({
+          name: 'Users',
+          build: () => ({
+            routes: () => ({ path: '/users', controller: UserController }),
+            contributors: () => [LoadTenant.registration, Audit.registration],
+          }),
+        })`),
+    ).toEqual([['audit', 'tenant']])
+  })
+
+  it('unions module contributors with method-level decorators', () => {
+    // Precedence (method > class > module) decides which registration wins
+    // for a duplicate key, not whether the key is present — so the route's
+    // provable set is the union.
+    expect(
+      resolveWith(
+        `
+        import { defineModule } from '@forinda/kickjs'
+        import { UserController } from './user.controller'
+        import { LoadTenant } from '../contributors/tenant'
+        export const UserModule = defineModule({
+          name: 'Users',
+          build: () => ({
+            routes: () => ({ path: '/users', controller: UserController }),
+            contributors: () => [LoadTenant.registration],
+          }),
+        })`,
+        `
+        import { Controller, Get } from '@forinda/kickjs'
+        import { Audit } from '../contributors/audit'
+        @Controller()
+        export class UserController {
+          @Audit
+          @Get('/')
+          list(ctx) {}
+        }`,
+      ),
+    ).toEqual([['audit', 'tenant']])
+  })
+
+  it('resolves module imports against the MODULE file, not the controller', () => {
+    // The module and the controllers it mounts routinely live in different
+    // directories; resolving the hook's relative specifiers against the
+    // controller would silently fail to match.
+    expect(
+      resolveWith(`
+        import { defineModule } from '@forinda/kickjs'
+        import { UserController } from './user.controller'
+        import { LoadTenant } from '@/contributors/tenant'
+        export const UserModule = defineModule({
+          name: 'Users',
+          build: () => ({
+            routes: () => ({ path: '/users', controller: UserController }),
+            contributors: () => [LoadTenant.registration],
+          }),
+        })`),
+    ).toEqual([['tenant']])
+  })
+})
+
+describe('module-level contributors() — class form', () => {
+  it('attributes an AppModule class hook to its mounted controllers', () => {
+    expect(
+      resolveWith(`
+        import type { AppModule } from '@forinda/kickjs'
+        import { UserController } from './user.controller'
+        import { LoadTenant } from '../contributors/tenant'
+        export class UserModule implements AppModule {
+          routes() {
+            return [{ path: '/users', controller: UserController }]
+          }
+          contributors() {
+            return [LoadTenant.registration]
+          }
+        }`),
+    ).toEqual([['tenant']])
+  })
+})
+
+describe('module contributors — degradation', () => {
+  it('degrades when the hook contains something it cannot enumerate', () => {
+    expect(
+      resolveWith(`
+        import { defineModule } from '@forinda/kickjs'
+        import { UserController } from './user.controller'
+        import { buildContributors } from './helpers'
+        export const UserModule = defineModule({
+          name: 'Users',
+          build: () => ({
+            routes: () => ({ path: '/users', controller: UserController }),
+            contributors: () => buildContributors(),
+          }),
+        })`),
+    ).toEqual([null])
+  })
+
+  it('degrades on a spread inside the hook', () => {
+    expect(
+      resolveWith(`
+        import { defineModule } from '@forinda/kickjs'
+        import { UserController } from './user.controller'
+        import { LoadTenant } from '../contributors/tenant'
+        import { shared } from './shared'
+        export const UserModule = defineModule({
+          name: 'Users',
+          build: () => ({
+            routes: () => ({ path: '/users', controller: UserController }),
+            contributors: () => [LoadTenant.registration, ...shared],
+          }),
+        })`),
+    ).toEqual([null])
+  })
+
+  it('degrades when the hook references an unresolvable binding', () => {
+    expect(
+      resolveWith(`
+        import { defineModule } from '@forinda/kickjs'
+        import { UserController } from './user.controller'
+        export const UserModule = defineModule({
+          name: 'Users',
+          build: () => ({
+            routes: () => ({ path: '/users', controller: UserController }),
+            contributors: () => [Mystery.registration],
+          }),
+        })`),
+    ).toEqual([null])
+  })
+
+  it('still degrades the whole project for a bootstrap-level registration', () => {
+    // `bootstrap({ contributors })` has no sibling `routes`, so it is not
+    // classified as a module hook and keeps forcing degradation.
+    const controllerExtract = extractFile(CONTROLLER_SRC, CONTROLLER, CWD)
+    const bootstrapExtract = extractFile(
+      `import { bootstrap } from '@forinda/kickjs'
+       import { LoadTenant } from './contributors/tenant'
+       export const app = bootstrap({ modules: [], contributors: [LoadTenant.registration] })`,
+      resolve('/proj/src/index.ts'),
+      CWD,
+    )
+    expect(bootstrapExtract.hasNonDecoratorContributors).toBe(true)
+
+    const extracts: (FileExtract | null)[] = [controllerExtract, bootstrapExtract]
+    const routes = controllerExtract.routes
+    resolveRouteContextKeys(routes, CONTRIBUTORS, true, buildModuleContributorMap(extracts))
+    expect(routes.map((r) => r.contextKeys)).toEqual([null])
+  })
+
+  it('classifies an adapter contributors() hook as app-wide', () => {
+    // `defineAdapter({ contributors })` — no sibling `routes`.
+    const extract = extractFile(
+      `import { defineAdapter } from '@forinda/kickjs'
+       import { LoadTenant } from './contributors/tenant'
+       export const a = defineAdapter({
+         name: 'x',
+         contributors: () => [LoadTenant.registration],
+       })`,
+      resolve('/proj/src/adapters/a.ts'),
+      CWD,
+    )
+    expect(extract.hasNonDecoratorContributors).toBe(true)
+    expect(extract.moduleContributors).toBeNull()
+  })
+
+  it('does not flag a module file that has no contributors hook', () => {
+    const extract = extractFile(
+      `import { defineModule } from '@forinda/kickjs'
+       import { UserController } from './user.controller'
+       export const UserModule = defineModule({
+         name: 'Users',
+         build: () => ({ routes: () => ({ path: '/users', controller: UserController }) }),
+       })`,
+      MODULE,
+      CWD,
+    )
+    expect(extract.hasNonDecoratorContributors).toBe(false)
+    expect(extract.moduleContributors).toBeNull()
+  })
+
+  it('degrades a controller mounted by two modules', () => {
+    // Which module's contributors applied depends on which mount served
+    // the request, so neither set can be asserted.
+    const controllerExtract = extractFile(CONTROLLER_SRC, CONTROLLER, CWD)
+    const moduleSrc = (name: string) => `
+      import { defineModule } from '@forinda/kickjs'
+      import { UserController } from './user.controller'
+      import { LoadTenant } from '../contributors/tenant'
+      export const ${name} = defineModule({
+        name: '${name}',
+        build: () => ({
+          routes: () => ({ path: '/${name}', controller: UserController }),
+          contributors: () => [LoadTenant.registration],
+        }),
+      })`
+    const extracts: (FileExtract | null)[] = [
+      controllerExtract,
+      extractFile(moduleSrc('A'), resolve('/proj/src/users/a.module.ts'), CWD),
+      extractFile(moduleSrc('B'), resolve('/proj/src/users/b.module.ts'), CWD),
+    ]
+    const routes = controllerExtract.routes
+    resolveRouteContextKeys(routes, CONTRIBUTORS, false, buildModuleContributorMap(extracts))
+    expect(routes.map((r) => r.contextKeys)).toEqual([null])
+  })
+})

--- a/packages/cli/src/typegen/extract-ast.ts
+++ b/packages/cli/src/typegen/extract-ast.ts
@@ -34,6 +34,7 @@ import {
   type DiscoveredRoute,
   type DiscoveredToken,
   type DecoratorRef,
+  type ModuleContributorSet,
   type FileExtract,
   type ModuleMount,
   type SchemaRef,
@@ -258,6 +259,91 @@ function appliedDecoratorRefs(decorators: Node[], ctx: FileContext): DecoratorRe
     })
   }
   return out
+}
+
+/**
+ * Collect the contributor bindings referenced inside a module's
+ * `contributors()` hook.
+ *
+ * The two supported forms are the two the guide documents:
+ *
+ * ```ts
+ * contributors: () => [LoadTenant.registration]
+ * contributors: () => [LoadTenant.with({ source: 'subdomain' }).registration]
+ * ```
+ *
+ * `resolved` is false when the hook contains anything else — a spread, a
+ * helper call, a variable holding the array. Narrowing then degrades for
+ * that module's routes rather than reporting a partial set, since a
+ * missing key produces a false compile error on `ctx.require()`.
+ */
+function collectContributorRefs(
+  hook: Node,
+  ctx: FileContext,
+): { refs: DecoratorRef[]; resolved: boolean } {
+  const unresolved = { refs: [] as DecoratorRef[], resolved: false }
+
+  // Structural, not a free walk. A walk that merely collects every
+  // `.registration` it can see reports `resolved: true` for a hook like
+  // `contributors: () => buildContributors()` — nothing to collect, so
+  // nothing looks wrong — and the route is then narrowed to a set that
+  // omits whatever the helper returns.
+  const returned = returnedExpression(hook)
+  if (!returned || returned.type !== 'ArrayExpression') return unresolved
+
+  const refs: DecoratorRef[] = []
+  for (const element of (returned.elements as unknown[] | undefined) ?? []) {
+    // A hole, a spread, or anything that isn't a plain member expression
+    // means we can't enumerate the list.
+    if (!isNode(element) || element.type !== 'MemberExpression') return unresolved
+    if (identifierName(element.property) !== 'registration') return unresolved
+
+    const object = element.object as Node
+    // `LoadTenant.registration`
+    let name = identifierName(object)
+    // `LoadTenant.with({...}).registration`
+    if (!name && isNode(object) && object.type === 'CallExpression') {
+      const callee = object.callee as Node
+      if (
+        isNode(callee) &&
+        callee.type === 'MemberExpression' &&
+        identifierName(callee.property) === 'with'
+      ) {
+        name = identifierName(callee.object)
+      }
+    }
+    if (!name) return unresolved
+
+    const imported = ctx.imports.get(name)
+    refs.push({
+      identifier: name,
+      source: imported ? imported.source : ctx.topLevelConsts.has(name) ? '' : null,
+    })
+  }
+
+  return { refs, resolved: true }
+}
+
+/**
+ * The expression a hook returns: the body of a concise arrow, or the
+ * argument of the single top-level `return` in a block body. Returns null
+ * for anything less obvious (multiple returns, conditional returns),
+ * which callers treat as unresolvable.
+ */
+function returnedExpression(hook: Node): Node | null {
+  const fn = (hook.value ?? hook) as Node
+  if (!isNode(fn)) return null
+  const body = fn.body as Node | undefined
+  if (!isNode(body)) return null
+
+  if (body.type !== 'BlockStatement') return body // concise arrow body
+
+  const statements = ((body.body as Node[] | undefined) ?? []).filter(
+    (s) => s.type === 'ReturnStatement',
+  )
+  if (statements.length !== 1) return null
+  const argument = statements[0].argument as Node | undefined
+  return isNode(argument) ? argument : null
 }
 
 /** Schema field (`body:` / `query:` / `params:`) — bare identifiers only. */
@@ -674,6 +760,52 @@ export function extractFileAst(source: string, filePath: string, cwd: string): F
     }
   })
 
+  // ── Module-level `contributors()` ──────────────────────────────────
+  //
+  // `AppModule` declares `contributors?()` and `routes()` as siblings, so
+  // a `contributors` member sitting next to a `routes` member IS the
+  // module hook. That distinction matters: `bootstrap({ contributors })`
+  // and `definePlugin({ contributors })` apply app-wide and can't be
+  // attributed to any particular route, so they still force degradation.
+  // Anything not positively classified as module-level is treated as one
+  // of those.
+  const moduleContributorNodes = new Set<Node>()
+  const allContributorNodes = new Set<Node>()
+
+  walk(program, (node) => {
+    const isProp = node.type === 'Property' && identifierName(node.key) === 'contributors'
+    const isMethod = node.type === 'MethodDefinition' && identifierName(node.key) === 'contributors'
+    if (isProp || isMethod) allContributorNodes.add(node)
+  })
+
+  /** Members of an object literal or class body, whichever this is. */
+  const membersOf = (container: Node): Node[] =>
+    ((container.properties ?? (container.body as Node | undefined)?.body) as Node[] | undefined) ??
+    []
+
+  walk(program, (node) => {
+    if (node.type !== 'ObjectExpression' && node.type !== 'ClassDeclaration') return
+    const members = membersOf(node)
+    const names = members.map((m) => identifierName(m.key))
+    if (!names.includes('routes')) return
+    for (const member of members) {
+      if (identifierName(member.key) === 'contributors') moduleContributorNodes.add(member)
+    }
+  })
+
+  let moduleContributors: ModuleContributorSet | null = null
+  if (moduleContributorNodes.size > 0) {
+    const refs: DecoratorRef[] = []
+    let resolved = true
+    for (const node of moduleContributorNodes) {
+      const body = (node.value ?? node) as Node
+      const collected = collectContributorRefs(body, ctx)
+      if (!collected.resolved) resolved = false
+      refs.push(...collected.refs)
+    }
+    moduleContributors = { refs, resolved, filePath }
+  }
+
   return {
     classes,
     tokens,
@@ -684,8 +816,10 @@ export function extractFileAst(source: string, filePath: string, cwd: string): F
     routes,
     moduleMounts,
     globPatterns: /\.module\.[mc]?[tj]sx?$/.test(filePath) ? globPatterns : [],
-    // Overwritten by `extractFile` — see the note on the regex path.
-    hasNonDecoratorContributors: false,
+    moduleContributors,
+    // Every `contributors` we could NOT tie to a module is app-wide
+    // (bootstrap / adapter / plugin) and still forces degradation.
+    hasNonDecoratorContributors: allContributorNodes.size > moduleContributorNodes.size,
   }
 }
 

--- a/packages/cli/src/typegen/scanner.ts
+++ b/packages/cli/src/typegen/scanner.ts
@@ -130,6 +130,20 @@ export interface DiscoveredRoute {
   contextKeys?: string[] | null
 }
 
+/** Contributor bindings a module registers via its `contributors()` hook. */
+export interface ModuleContributorSet {
+  refs: DecoratorRef[]
+  /** False when the hook contained an entry the extractor couldn't name. */
+  resolved: boolean
+  /**
+   * The module file the hook lives in. Relative import specifiers inside
+   * the hook resolve against THIS file, not against the controller's —
+   * a module and the controllers it mounts routinely sit in different
+   * directories.
+   */
+  filePath: string
+}
+
 /** A decorator as written at a call site, with its import resolved. */
 export interface DecoratorRef {
   /** The decorator's local binding name, e.g. `LoadTenant`. */
@@ -1501,15 +1515,60 @@ function declarationMatchesImport(
   return decl === normalizedTail || decl.endsWith(`/${normalizedTail}`)
 }
 
+/**
+ * Module `contributors()` resolved per controller. `'ambiguous'` marks a
+ * controller mounted by more than one module where contributors are in
+ * play — which set applies depends on which mount served the request, so
+ * neither can be asserted.
+ */
+export type ModuleContributorsByController = Map<string, ModuleContributorSet | 'ambiguous'>
+
+/**
+ * Attribute each module file's `contributors()` to the controllers that
+ * same file mounts. Mirrors how `moduleMounts` already ties a mount path
+ * to a controller — the hook and the mounts live on the same module
+ * object, so they share a file.
+ */
+export function buildModuleContributorMap(
+  extracts: (FileExtract | null)[],
+): ModuleContributorsByController {
+  const out: ModuleContributorsByController = new Map()
+  const mountedBy = new Map<string, number>()
+
+  for (const extract of extracts) {
+    if (!extract) continue
+    for (const { controller } of extract.moduleMounts) {
+      mountedBy.set(controller, (mountedBy.get(controller) ?? 0) + 1)
+    }
+  }
+
+  for (const extract of extracts) {
+    if (!extract?.moduleContributors) continue
+    for (const { controller } of extract.moduleMounts) {
+      // Mounted twice AND contributors are involved — can't attribute.
+      if ((mountedBy.get(controller) ?? 0) > 1) {
+        out.set(controller, 'ambiguous')
+        continue
+      }
+      const existing = out.get(controller)
+      out.set(controller, existing === undefined ? extract.moduleContributors : 'ambiguous')
+    }
+  }
+
+  return out
+}
+
 export function resolveRouteContextKeys(
   routes: DiscoveredRoute[],
   contextKeys: DiscoveredContextKey[],
   hasNonDecoratorContributors: boolean,
+  moduleContributors: ModuleContributorsByController = new Map(),
 ): void {
   if (hasNonDecoratorContributors) {
-    // A contributor registered at module / adapter / bootstrap level adds
-    // keys to routes that carry no decorator for them. Until those sites
-    // are resolved, no route in the project can be proven complete.
+    // An ADAPTER, PLUGIN, or BOOTSTRAP contributor applies to every route
+    // in the app and can't be attributed to any of them in particular, so
+    // nothing is provable while one exists. Module-level hooks no longer
+    // land here — they're tied to the controllers their module mounts.
     for (const route of routes) route.contextKeys = null
     return
   }
@@ -1538,31 +1597,54 @@ export function resolveRouteContextKeys(
     const keys = new Set<string>()
     let provable = true
 
+    /**
+     * Resolve one binding reference to the key it writes, or `null` when
+     * it can't be pinned down. Name AND declaration file must both match:
+     * matching on the name alone would credit a route that imports
+     * `@LoadTenant` from an unrelated package with the project's own
+     * `LoadTenant` key.
+     */
+    const resolveRef = (importerFile: string, ref: DecoratorRef): string | null => {
+      if (ref.source === null) return null
+      const matches = (byExportName.get(ref.identifier) ?? []).filter((ck) =>
+        declarationMatchesImport(importerFile, ref.source as string, ck.filePath),
+      )
+      return matches.length === 1 ? matches[0].key : null
+    }
+
     for (const dec of applied) {
       if (CONTRIBUTOR_FREE_DECORATORS.has(dec.identifier)) continue
-
-      if (dec.source === null) {
-        // The binding didn't resolve to an import or a same-file const.
+      const key = resolveRef(route.filePath, dec)
+      if (key === null) {
         provable = false
         break
       }
+      keys.add(key)
+    }
 
-      // Name AND declaration file must both match. Matching on the name
-      // alone was wrong: a route importing `@LoadTenant` from some other
-      // module (a third-party decorator that happens to share the name)
-      // would be credited with the project's unique local `LoadTenant`
-      // key, narrowing the route to a key it never actually carries.
-      const matches = (byExportName.get(dec.identifier) ?? []).filter((ck) =>
-        declarationMatchesImport(route.filePath, dec.source as string, ck.filePath),
-      )
-      if (matches.length !== 1) {
-        // Zero: not one of our context decorators (or imported from
-        // somewhere we can't resolve). More than one: ambiguous. Either
-        // way the route's key set can't be enumerated.
+    // Module-level `contributors()` — applies to every route the module
+    // mounts, so it unions into the route's key set the same way a
+    // class-level decorator does. Precedence (method > class > module)
+    // decides which registration wins for a duplicate key, not whether
+    // the key is present, so a union is the right operation here.
+    if (provable) {
+      const fromModule = moduleContributors.get(route.controller)
+      if (fromModule === 'ambiguous') {
         provable = false
-        break
+      } else if (fromModule) {
+        if (!fromModule.resolved) {
+          provable = false
+        } else {
+          for (const ref of fromModule.refs) {
+            const key = resolveRef(fromModule.filePath, ref)
+            if (key === null) {
+              provable = false
+              break
+            }
+            keys.add(key)
+          }
+        }
       }
-      keys.add(matches[0].key)
     }
 
     // Sorted so the emitted union is stable across runs — an unstable
@@ -1597,6 +1679,16 @@ export interface FileExtract {
   /** `import.meta.glob([...])` patterns (only non-empty for `*.module.ts`). */
   globPatterns: string[]
   /**
+   * Contributor bindings referenced by this file's module `contributors()`
+   * hook, or `null` when the file has no module hook. These apply to every
+   * controller the same file mounts (see `moduleMounts`).
+   *
+   * `resolved: false` means the hook exists but contains something the
+   * extractor couldn't enumerate — the mounted controllers' routes then
+   * degrade rather than narrowing to a partial set.
+   */
+  moduleContributors?: ModuleContributorSet | null
+  /**
    * This file registers context contributors somewhere other than a
    * method/class decorator — a `contributors()` module/adapter/plugin hook
    * or `bootstrap({ contributors: [...] })`.
@@ -1628,13 +1720,19 @@ const CONTRIBUTOR_REGISTRATION = /\bcontributors\s*(?::|\()/
  * the dev loop alive.
  */
 export function extractFile(source: string, filePath: string, cwd: string): FileExtract {
-  // Computed here rather than in either extractor so the AST and regex
-  // paths can't disagree about it — a false `false` would silently enable
-  // narrowing on a project that registers contributors globally.
-  const hasNonDecoratorContributors = CONTRIBUTOR_REGISTRATION.test(source)
   const ast = extractFileAst(source, filePath, cwd)
-  if (ast) return { ...ast, hasNonDecoratorContributors }
-  return { ...extractFileRegex(source, filePath, cwd), hasNonDecoratorContributors }
+  // The AST path classifies each `contributors` occurrence — module hook
+  // (attributable to the controllers that module mounts) vs adapter /
+  // plugin / bootstrap (app-wide, forces degradation) — so its own value
+  // is authoritative and must not be overwritten here.
+  if (ast) return ast
+  // The regex path can't tell the two apart, so it assumes the worse one.
+  // Erring the other way would silently enable narrowing on a project
+  // that registers contributors app-wide.
+  return {
+    ...extractFileRegex(source, filePath, cwd),
+    hasNonDecoratorContributors: CONTRIBUTOR_REGISTRATION.test(source),
+  }
 }
 
 /**
@@ -1898,6 +1996,7 @@ function joinExtracts(files: string[], extracts: (FileExtract | null)[]): Omit<S
     routes,
     contextKeys,
     extracts.some((e) => e?.hasNonDecoratorContributors === true),
+    buildModuleContributorMap(extracts),
   )
 
   // forinda/kick-js#235 §4 — for every module file, extract its


### PR DESCRIPTION
## Why

Follow-up to #481. Module-level `contributors()` degraded the **entire project** — the scanner detected the word `contributors` anywhere and disabled narrowing everywhere. Any project using module-scoped contributors got zero benefit from #481. That was the gap I flagged when it merged.

```ts
export const AuditModule = defineModule({
  name: 'Audit',
  build: () => ({
    routes: () => ({ path: '/audit', controller: AuditController }),
    contributors: () => [LoadTenant.registration],
  }),
})
```

Routes on `AuditController` now narrow to `'tenant'` with no decorator on the controller at all, and `ctx.require('operatorPerm')` on them is a compile error.

## How the hook is attributed

A module's `contributors()` and its `routes()` live on the same object, so they share a file — the same fact `moduleMounts` already relies on to tie a mount path to a controller. The hook's keys union into the routes of the controllers that file mounts.

Union, not override: precedence (method > class > module) decides which *registration* wins for a duplicate key, not whether the key is *present*. Presence is what narrowing cares about.

## Classifying module vs app-wide

Not a heuristic — it's `AppModule`'s own shape. The interface declares:

```ts
contributors?(): ContributorRegistrations
routes(): ModuleRoutes | ModuleRoutes[] | null
```

They're siblings. So a `contributors` member alongside a `routes` member **is** the module hook, and `bootstrap({ contributors })`, `defineAdapter({ contributors })`, `definePlugin({ contributors })` — none of which have a sibling `routes` — are not. Anything not positively classified as module-level is treated as app-wide, which is the degrading answer.

Both registration forms resolve (`X.registration`, `X.with({…}).registration`), in both the `defineModule` object form and the `class X implements AppModule` form.

## One bug my own first implementation had

I first wrote the hook extraction as a walk collecting every `.registration` it could see. A test caught the problem:

```ts
contributors: () => buildContributors()
```

Nothing to collect, so nothing looks wrong — it reported success with an empty set, and the route got narrowed to a union missing everything the helper returns. That's a false-narrow, which under `require()` gating means a legitimate call stops compiling.

Rewritten structurally: the hook must return a literal array, and **every** element must be a nameable registration expression. Anything else — a spread, a helper call, a variable, multiple returns — is unresolvable and degrades.

## Degradation cases

- hook isn't a literal array of registration entries
- a binding inside the hook doesn't resolve
- a controller mounted by **two** modules — which set applied depends on which mount served the request
- adapter / bootstrap registrations anywhere (unchanged)

## Verification

End to end against real `tsc`, not just unit level:

| scenario | emitted | `tsc` |
| --- | --- | --- |
| module hook supplies `tenant`, no decorator on controller | `contextKeys: "tenant"` | passes |
| requiring a key the hook doesn't supply | `contextKeys: "tenant"` | fails, names `operatorPerm` |

Plus 13 unit tests on attribution and the degradation paths. CLI suite 557 tests; full monorepo 48/48 tasks, typecheck 29/29, lint + format clean.

## Still not covered

Adapter and bootstrap sites. Bootstrap is the natural next one — same `collectContributorRefs` machinery, different attribution (every route rather than a module's mounts). Third-party adapters stay out of reach since their `contributors()` bodies live in `node_modules`; the escape hatch covers that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
