### PR TITLE
fix(cli): resolve sibling package versions on Windows instead of falling back to the CLI version

### DIFF
--- a/.changeset/stale-donuts-repeat.md
+++ b/.changeset/stale-donuts-repeat.md
@@ -1,0 +1,9 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+fix: scaffolded projects no longer pin every `@forinda/kickjs*` dependency to the CLI's own version
+
+`kick new` resolves each sibling package's published version with `npm view <pkg> version`, falling back to the CLI's version when the query fails. On Windows that query always failed: `npm` is a `.cmd` batch shim, so `execFileSync('npm', …)` raised `ENOENT` (there is no `npm.exe`) and `npm.cmd` raised `EINVAL` (Node >= 18.20 refuses to spawn batch files without a shell — CVE-2024-27980). The error was swallowed, so every generated `package.json` silently collapsed onto the CLI version — `@forinda/kickjs`, `-schema`, `-vite`, `-swagger` and friends all stamped `^<cli version>` even though per-package independent versioning means they diverge.
+
+Version resolution now goes through a cross-platform `captureCommand` helper that routes `.cmd` shims via `cmd.exe` on Windows, so each dependency gets its real published range. The same helper fixes `kick new --template fullstack`, whose root `<pm> install` step failed on Windows for the same reason.

--- a/packages/cli/__tests__/shell-capture.test.ts
+++ b/packages/cli/__tests__/shell-capture.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { captureCommand } from '../src/utils/shell'
+
+/**
+ * Regression guard for the "scaffolded projects pin every sibling to the
+ * CLI's own version" bug.
+ *
+ * `resolveSiblingVersions()` shells out to `npm view <pkg> version` and
+ * falls back to the CLI's version whenever the query fails. On Windows
+ * that query ALWAYS failed — `npm` is a `.cmd` batch shim, so
+ * `execFileSync('npm', …)` raised ENOENT (no `npm.exe`) and
+ * `execFileSync('npm.cmd', …)` raised EINVAL (Node >= 18.20 refuses to
+ * spawn batch files without a shell — CVE-2024-27980). Because the
+ * caller swallowed the error, every generated `package.json` silently
+ * collapsed onto the CLI version instead of each package's real one.
+ *
+ * These tests exercise the real `npm` binary on whatever platform they
+ * run on, which is exactly the case that used to break.
+ */
+describe('captureCommand', () => {
+  it('runs a package-manager shim and captures its stdout', () => {
+    // `npm --version` is offline, fast, and — critically — is the `.cmd`
+    // shim on Windows that plain execFileSync cannot launch.
+    const out = captureCommand('npm', ['--version'], { timeout: 30_000 })
+    expect(out).toMatch(/^\d+\.\d+\.\d+/)
+  })
+
+  it('captures multi-token arguments without a shell rewriting them', () => {
+    const out = captureCommand('npm', ['config', 'get', 'registry'], { timeout: 30_000 })
+    expect(out).toMatch(/^https?:\/\//)
+  })
+
+  it('returns null for a command that does not exist', () => {
+    expect(captureCommand('kick-definitely-not-a-real-binary', ['--version'])).toBeNull()
+  })
+
+  it('refuses arguments carrying shell metacharacters', () => {
+    // Must not reach a shell that would treat `&&` as a command separator.
+    expect(captureCommand('npm', ['view', 'foo && echo pwned', 'version'])).toBeNull()
+    expect(captureCommand('npm', ['view', 'foo | echo pwned', 'version'])).toBeNull()
+    expect(captureCommand('npm', ['view', 'foo`whoami`', 'version'])).toBeNull()
+  })
+
+  it('returns null when the command exits non-zero', () => {
+    expect(captureCommand('npm', ['run', 'no-such-script-here'], { timeout: 30_000 })).toBeNull()
+  })
+})

--- a/packages/cli/__tests__/shell-capture.test.ts
+++ b/packages/cli/__tests__/shell-capture.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { captureCommand } from '../src/utils/shell'
+import { captureCommand, shellSafeInvocation } from '../src/utils/shell'
 
 /**
  * Regression guard for the "scaffolded projects pin every sibling to the
@@ -34,14 +34,87 @@ describe('captureCommand', () => {
     expect(captureCommand('kick-definitely-not-a-real-binary', ['--version'])).toBeNull()
   })
 
-  it('refuses arguments carrying shell metacharacters', () => {
-    // Must not reach a shell that would treat `&&` as a command separator.
-    expect(captureCommand('npm', ['view', 'foo && echo pwned', 'version'])).toBeNull()
-    expect(captureCommand('npm', ['view', 'foo | echo pwned', 'version'])).toBeNull()
-    expect(captureCommand('npm', ['view', 'foo`whoami`', 'version'])).toBeNull()
-  })
-
   it('returns null when the command exits non-zero', () => {
     expect(captureCommand('npm', ['run', 'no-such-script-here'], { timeout: 30_000 })).toBeNull()
+  })
+})
+
+/**
+ * The argument guard only engages on the Windows branch, so asserting it via
+ * `captureCommand` would prove nothing on a Linux/macOS runner: there the
+ * invocation is passed through untouched and the call fails for an unrelated
+ * reason (npm rejecting a bogus package spec), which looks identical to the
+ * guard firing. `shellSafeInvocation` therefore takes the platform as an
+ * argument so both branches are exercised on every host.
+ */
+describe('shellSafeInvocation', () => {
+  const WIN = 'win32' as NodeJS.Platform
+  const NIX = 'linux' as NodeJS.Platform
+
+  it('passes the command through untouched off Windows', () => {
+    expect(shellSafeInvocation('npm', ['view', 'pkg', 'version'], NIX)).toEqual([
+      'npm',
+      ['view', 'pkg', 'version'],
+    ])
+  })
+
+  it('routes through cmd.exe on Windows', () => {
+    const invocation = shellSafeInvocation('npm', ['view', 'pkg', 'version'], WIN)
+    expect(invocation).not.toBeNull()
+    const [file, args] = invocation!
+    expect(file.toLowerCase()).toContain('cmd')
+    expect(args.slice(0, 3)).toEqual(['/d', '/s', '/c'])
+    expect(args[3]).toBe('npm view pkg version')
+  })
+
+  it('quotes arguments containing spaces', () => {
+    expect(shellSafeInvocation('npm', ['run', 'my script'], WIN)![1][3]).toBe('npm run "my script"')
+  })
+
+  it('rejects arguments carrying shell metacharacters', () => {
+    // Each of these would be command syntax, not data, if it reached cmd.exe.
+    for (const evil of [
+      'foo && echo pwned',
+      'foo | echo pwned',
+      'foo & calc',
+      'foo > out.txt',
+      'foo < in.txt',
+      'foo ^ bar',
+      'foo`whoami`',
+      'foo%PATH%',
+      '(foo)',
+      'foo;bar',
+      'foo\nbar',
+      'foo"bar',
+    ]) {
+      expect(shellSafeInvocation('npm', ['view', evil, 'version'], WIN)).toBeNull()
+    }
+  })
+
+  it('rejects a metacharacter in the command name itself', () => {
+    expect(shellSafeInvocation('npm && calc', ['--version'], WIN)).toBeNull()
+  })
+
+  /**
+   * A backslash is not shell syntax, but Windows argv quoting corrupts it:
+   * `['C:\some path\']` reaches the child as `['"C:\some', 'path\"']` — one
+   * argument silently becomes two. Rejecting beats corrupting.
+   */
+  it('rejects backslashes, which Windows quoting would mangle', () => {
+    expect(shellSafeInvocation('npm', ['view', 'C:\\some path\\', 'version'], WIN)).toBeNull()
+    expect(shellSafeInvocation('npm', ['view', 'no-space\\', 'version'], WIN)).toBeNull()
+  })
+
+  it('still accepts the argument shapes the CLI actually passes', () => {
+    // Scoped names, dist-tag specs, flags — none may trip the guard.
+    for (const args of [
+      ['view', '@forinda/kickjs', 'version'],
+      ['view', '@forinda/kickjs@alpha', 'exports', '--json'],
+      ['view', '@forinda/kickjs-cli@latest', 'version'],
+      ['install'],
+      ['--version'],
+    ]) {
+      expect(shellSafeInvocation('npm', args, WIN)).not.toBeNull()
+    }
   })
 })

--- a/packages/cli/src/generators/fullstack.ts
+++ b/packages/cli/src/generators/fullstack.ts
@@ -15,6 +15,7 @@ import { join } from 'node:path'
 import { execFileSync } from 'node:child_process'
 
 import { writeFileSafe } from '../utils/fs'
+import { runCommand } from '../utils/shell'
 import { initProject, resolveSiblingVersions } from './project'
 
 export interface InitFullstackOptions {
@@ -96,7 +97,9 @@ export async function initFullstackProject(options: InitFullstackOptions): Promi
   if (options.installDeps) {
     console.log(`\n  Installing workspace dependencies with ${packageManager}...\n`)
     try {
-      execFileSync(packageManager, ['install'], { cwd: dir, stdio: 'inherit' })
+      // `runCommand`, not bare execFileSync — on Windows every package
+      // manager is a `.cmd` shim that execFileSync cannot spawn.
+      runCommand(packageManager, ['install'], { cwd: dir })
     } catch {
       console.log(`\n  Warning: ${packageManager} install failed. Run it manually.`)
     }

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -1,8 +1,9 @@
 import { join, dirname } from 'node:path'
-import { execFileSync, execSync } from 'node:child_process'
+import { execSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { writeFileSafe } from '../utils/fs'
+import { captureCommand } from '../utils/shell'
 import {
   generatePackageJson,
   generateViteConfig,
@@ -58,28 +59,19 @@ const SIBLING_PACKAGES = [
 
 /**
  * Resolve the latest published version of every sibling package via
- * `npm view <name> version` (via execFileSync — no shell, no
- * injection vector). Each query has a short timeout; failures fall
- * back to the CLI's own version with a `^` prefix so the scaffold
- * stays usable offline.
+ * `npm view <name> version` (through `captureCommand`, which routes
+ * around Windows' `.cmd` shims — see utils/shell.ts). Each query has a
+ * short timeout; failures fall back to the CLI's own version with a `^`
+ * prefix so the scaffold stays usable offline.
  */
 export async function resolveSiblingVersions(): Promise<Record<string, string>> {
   const results = await Promise.all(
     SIBLING_PACKAGES.map(async (name) => {
-      try {
-        const out = execFileSync('npm', ['view', name, 'version'], {
-          encoding: 'utf-8',
-          timeout: 5000,
-          stdio: ['ignore', 'pipe', 'ignore'],
-        })
-          .toString()
-          .trim()
-        if (out && /^\d+\.\d+\.\d+/.test(out)) {
-          return [name, `^${out}`] as const
-        }
-      } catch {
-        // Network failure / package not yet published / npm
-        // unavailable. Fall back to CLI version below.
+      // Network failure / package not yet published / npm unavailable
+      // all surface as null → fall back to the CLI's own version.
+      const out = captureCommand('npm', ['view', name, 'version'])
+      if (out && /^\d+\.\d+\.\d+/.test(out)) {
+        return [name, `^${out}`] as const
       }
       return [name, CLI_VERSION_FALLBACK] as const
     }),
@@ -101,18 +93,8 @@ export async function resolveSiblingVersions(): Promise<Record<string, string>> 
  * major`).
  */
 function resolveVersionAtTag(name: string, tag: string): string | null {
-  try {
-    const out = execFileSync('npm', ['view', `${name}@${tag}`, 'version'], {
-      encoding: 'utf-8',
-      timeout: 5000,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    })
-      .toString()
-      .trim()
-    return out && /^\d+\.\d+\.\d+/.test(out) ? out : null
-  } catch {
-    return null
-  }
+  const out = captureCommand('npm', ['view', `${name}@${tag}`, 'version'])
+  return out && /^\d+\.\d+\.\d+/.test(out) ? out : null
 }
 
 /**
@@ -149,15 +131,9 @@ function baseVersionGte(a: string, b: string): boolean {
 }
 
 function tagExportsSubpath(name: string, tag: string, subpath: string): boolean {
+  const out = captureCommand('npm', ['view', `${name}@${tag}`, 'exports', '--json'])
+  if (!out) return false
   try {
-    const out = execFileSync('npm', ['view', `${name}@${tag}`, 'exports', '--json'], {
-      encoding: 'utf-8',
-      timeout: 5000,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    })
-      .toString()
-      .trim()
-    if (!out) return false
     const exportsMap = JSON.parse(out) as Record<string, unknown>
     return Object.prototype.hasOwnProperty.call(exportsMap, subpath)
   } catch {

--- a/packages/cli/src/utils/shell.ts
+++ b/packages/cli/src/utils/shell.ts
@@ -1,4 +1,88 @@
-import { execSync, spawnSync } from 'node:child_process'
+import { execFileSync, execSync, spawnSync } from 'node:child_process'
+
+/**
+ * Whether a command needs to be routed through `cmd.exe` to run.
+ *
+ * On Windows, `npm` / `pnpm` / `yarn` / `bun` are `.cmd` batch shims, not
+ * `.exe`s, and `execFileSync` cannot launch either spelling:
+ *
+ *   - `execFileSync('npm', …)`     → ENOENT  (there is no `npm.exe` on PATH)
+ *   - `execFileSync('npm.cmd', …)` → EINVAL  (Node >= 18.20 / 20.12 refuses to
+ *                                             spawn batch files without a
+ *                                             shell — CVE-2024-27980)
+ *
+ * Both failures are silent wherever the caller swallows the error, so the
+ * command looks like it "returned nothing" rather than "never ran".
+ */
+const NEEDS_SHELL = process.platform === 'win32'
+
+/**
+ * Characters that `cmd.exe` would interpret rather than pass through. Every
+ * argument we route through the shell is checked against this: callers pass
+ * package names, dist-tags and allowlisted binary names, none of which
+ * legitimately contain these.
+ */
+const CMD_METACHARACTERS = /[&|<>^"'`(){}[\];!%\r\n]/
+
+/**
+ * Build the `[file, args]` pair to hand to `execFileSync`, routing through
+ * `cmd.exe` on Windows so `.cmd` shims are launchable.
+ *
+ * `/d` skips AutoRun registry commands, `/s` makes cmd treat everything after
+ * `/c` as one verbatim string (it strips only the outer quote pair Node adds).
+ * Returns `null` when an argument contains shell metacharacters — refusing to
+ * run beats running something the shell rewrote.
+ */
+function shellSafeInvocation(file: string, args: string[]): [string, string[]] | null {
+  if (!NEEDS_SHELL) return [file, args]
+  if (CMD_METACHARACTERS.test(file) || args.some((a) => CMD_METACHARACTERS.test(a))) return null
+  const command = [file, ...args].map((a) => (a.includes(' ') ? `"${a}"` : a)).join(' ')
+  return [process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', command]]
+}
+
+/**
+ * Run a command and capture its trimmed stdout, cross-platform.
+ *
+ * Returns `null` if the command is missing, exits non-zero, times out, or
+ * carries arguments unsafe to pass through `cmd.exe`. Callers treat `null` as
+ * "unknown" and fall back — the point of this helper is that a Windows `.cmd`
+ * shim no longer masquerades as a failed command.
+ */
+export function captureCommand(
+  file: string,
+  args: string[],
+  opts: { timeout?: number; cwd?: string } = {},
+): string | null {
+  const invocation = shellSafeInvocation(file, args)
+  if (!invocation) return null
+  try {
+    const out = execFileSync(invocation[0], invocation[1], {
+      encoding: 'utf-8',
+      timeout: opts.timeout ?? 5000,
+      cwd: opts.cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
+    })
+    const trimmed = out.toString().trim()
+    return trimmed || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Run a command with inherited stdio, cross-platform. Throws on failure so
+ * callers can decide whether a missing package manager is fatal.
+ */
+export function runCommand(file: string, args: string[], opts: { cwd?: string } = {}): void {
+  const invocation = shellSafeInvocation(file, args)
+  if (!invocation) throw new Error(`Refusing to run '${file}': unsafe arguments`)
+  execFileSync(invocation[0], invocation[1], {
+    cwd: opts.cwd,
+    stdio: 'inherit',
+    windowsHide: true,
+  })
+}
 
 /**
  * Run a shell command synchronously, printing output.

--- a/packages/cli/src/utils/shell.ts
+++ b/packages/cli/src/utils/shell.ts
@@ -1,7 +1,31 @@
 import { execFileSync, execSync, spawnSync } from 'node:child_process'
 
 /**
- * Whether a command needs to be routed through `cmd.exe` to run.
+ * Characters an argument may not contain when it has to travel through
+ * `cmd.exe`.
+ *
+ * The first group is shell syntax — `cmd.exe` would interpret these rather
+ * than pass them through. The trailing `\\` is different in kind: a backslash
+ * is not shell syntax, but Windows command-line quoting mangles it. Node's
+ * argv encoder doubles trailing backslashes, and a backslash immediately
+ * before a closing quote escapes that quote, so a single argument silently
+ * splits in two:
+ *
+ *   ['C:\\some path\\']  →  cmd receives  ['"C:\\some', 'path\\"']
+ *   ['no-space\\']       →  cmd receives  ['no-space\\\\']
+ *
+ * Correct escaping is possible but fiddly, and no caller in this CLI needs it
+ * — arguments here are package names, dist-tags, subcommands and flags, and
+ * working directories travel via the `cwd` option rather than as arguments.
+ * So a backslash is rejected outright: a loud `null` beats a silently
+ * corrupted argument, which is the exact failure mode this module exists to
+ * eliminate.
+ */
+const CMD_UNSAFE = /[&|<>^"'`(){}[\];!%\r\n\\]/
+
+/**
+ * Build the `[file, args]` pair to hand to `execFileSync`, routing through
+ * `cmd.exe` on Windows so `.cmd` shims are launchable.
  *
  * On Windows, `npm` / `pnpm` / `yarn` / `bun` are `.cmd` batch shims, not
  * `.exe`s, and `execFileSync` cannot launch either spelling:
@@ -13,29 +37,23 @@ import { execFileSync, execSync, spawnSync } from 'node:child_process'
  *
  * Both failures are silent wherever the caller swallows the error, so the
  * command looks like it "returned nothing" rather than "never ran".
- */
-const NEEDS_SHELL = process.platform === 'win32'
-
-/**
- * Characters that `cmd.exe` would interpret rather than pass through. Every
- * argument we route through the shell is checked against this: callers pass
- * package names, dist-tags and allowlisted binary names, none of which
- * legitimately contain these.
- */
-const CMD_METACHARACTERS = /[&|<>^"'`(){}[\];!%\r\n]/
-
-/**
- * Build the `[file, args]` pair to hand to `execFileSync`, routing through
- * `cmd.exe` on Windows so `.cmd` shims are launchable.
  *
  * `/d` skips AutoRun registry commands, `/s` makes cmd treat everything after
  * `/c` as one verbatim string (it strips only the outer quote pair Node adds).
- * Returns `null` when an argument contains shell metacharacters — refusing to
- * run beats running something the shell rewrote.
+ * Returns `null` when an argument is unsafe to pass through — refusing to run
+ * beats running something the shell rewrote.
+ *
+ * `platform` is injectable so both branches are unit-testable from any host
+ * OS; production callers use the default. It is read per call rather than
+ * captured at import time for the same reason.
  */
-function shellSafeInvocation(file: string, args: string[]): [string, string[]] | null {
-  if (!NEEDS_SHELL) return [file, args]
-  if (CMD_METACHARACTERS.test(file) || args.some((a) => CMD_METACHARACTERS.test(a))) return null
+export function shellSafeInvocation(
+  file: string,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+): [string, string[]] | null {
+  if (platform !== 'win32') return [file, args]
+  if (CMD_UNSAFE.test(file) || args.some((a) => CMD_UNSAFE.test(a))) return null
   const command = [file, ...args].map((a) => (a.includes(' ') ? `"${a}"` : a)).join(' ')
   return [process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', command]]
 }


### PR DESCRIPTION
## The bug

Projects created by `kick new` pin every `@forinda/kickjs*` dependency to the **CLI's** version rather than each package's own published version.

A scaffold with `--packages swagger,ws,queue,devtools` produced:

```jsonc
"@forinda/kickjs":          "^6.9.1",  // actually published: 6.5.1
"@forinda/kickjs-schema":   "^6.9.1",  // actually published: 0.1.3
"@forinda/kickjs-swagger":  "^6.9.1",  // actually published: 7.1.0
"@forinda/kickjs-ws":       "^6.9.1",  // actually published: 7.0.1
"@forinda/kickjs-queue":    "^6.9.1",  // actually published: 7.0.1
"@forinda/kickjs-devtools": "^6.9.1",  // actually published: 7.1.1
"@forinda/kickjs-cli":      "^6.9.1",  // correct by coincidence
"@forinda/kickjs-vite":     "^6.9.1",  // actually published: 8.0.0
```

`@forinda/kickjs-schema@^6.9.1` doesn't exist at all, so `install` fails outright; the rest silently under- or over-install.

## Root cause

`resolveSiblingVersions()` shells out to `npm view <pkg> version` and falls back to the CLI's own version when the query fails. On Windows the query **always** failed:

```
execFileSync('npm', …)      → ENOENT   // there is no npm.exe — npm is a .cmd shim
execFileSync('npm.cmd', …)  → EINVAL   // Node >=18.20 refuses to spawn batch files
                                       // without a shell (CVE-2024-27980 hardening)
```

The error was swallowed in a bare `catch`, so a command that **never ran** was indistinguishable from a package that **isn't published** — and every dependency took the fallback path at once. The fallback itself is correct and worth keeping (it makes the scaffold work offline); it was just firing 100% of the time on Windows.

Two adjacent helpers had the same defect and were failing silently for the same reason:

- `resolveVersionAtTag()` / `tagExportsSubpath()` — mis-gated the alpha runtime pin, so a `--runtime fastify` / `--runtime h3` scaffold couldn't tell whether the engine subpath had graduated to stable.
- `initFullstackProject()` — the workspace root `<pm> install` used `execFileSync(packageManager, …)`, which fails on Windows for **every** package manager, since `pnpm` / `npm` / `yarn` / `bun` are all `.cmd` shims.

## The fix

Adds cross-platform `captureCommand` / `runCommand` helpers to `packages/cli/src/utils/shell.ts`, routing `.cmd` shims through `cmd.exe /d /s /c` on Windows and calling `execFileSync` directly elsewhere.

`shell: true` would also have worked, but it's rejected here on two counts: it concatenates rather than escapes arguments (Node 24 now emits `DEP0190` warning about exactly this), and that warning would surface as noise in the CLI's own output. Instead the invocation is built explicitly and every argument is checked against a shell-metacharacter guard — package names and dist-tags can never be reinterpreted as `cmd.exe` syntax, and an argument that looks like it might be is refused rather than run.

## After

```jsonc
"@forinda/kickjs":          "^6.5.1",
"@forinda/kickjs-schema":   "^0.1.3",
"@forinda/kickjs-swagger":  "^7.1.0",
"@forinda/kickjs-ws":       "^7.0.1",
"@forinda/kickjs-queue":    "^7.0.1",
"@forinda/kickjs-devtools": "^7.1.1",
"@forinda/kickjs-cli":      "^6.9.1",
"@forinda/kickjs-vite":     "^8.0.0"
```

## Testing

- New `packages/cli/__tests__/shell-capture.test.ts` (5 tests) — exercises the real `npm` binary, which on Windows *is* the `.cmd` shim that used to fail, plus the metacharacter guard, missing binaries, and non-zero exits. Meaningful on POSIX runners too, just not as a platform regression guard.
- Existing scaffold / package-manager / info suites: 31 passing.
- `tsc --noEmit` and `oxlint` clean.
- End-to-end: scaffolded both a default and a `--packages swagger,ws,queue,devtools` project and diffed the generated `package.json` (output above).

## Notes

- Unix behaviour is unchanged — `shellSafeInvocation` returns `[file, args]` untouched off Windows.
- The offline fallback to the CLI version is deliberately retained; it now fires only when `npm` genuinely can't answer.
- Unrelated: `pnpm format` currently rewrites 18 markdown files that `format:check` flags (oxfmt drift predating this branch). Left out of this diff to keep it scoped — worth a separate `style:` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQ4PPKDTxDSxBGLLYHU9Up


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `kick new` so generated projects resolve each sibling package to its published version instead of always using the CLI version.
  - Fixed Windows failures when installing dependencies or running package-manager commands, including `kick new --template fullstack`.
  - Improved command safety by rejecting unsafe shell arguments and handling failed or unavailable commands consistently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->