### PR TITLE
feat(db): PostgreSQL named schemas via pgSchema()

### DIFF
--- a/.changeset/lucky-donkeys-shake.md
+++ b/.changeset/lucky-donkeys-shake.md
@@ -1,0 +1,34 @@
+---
+'@forinda/kickjs-db': minor
+---
+
+feat: PostgreSQL named schemas via `pgSchema()`
+
+Tables can now live in a named PG schema:
+
+```ts
+import { pgSchema } from '@forinda/kickjs-db/pg'
+
+const billing = pgSchema('billing')
+const invoices = billing.table('invoices', {
+  id: serial().primaryKey(),
+  ref: varchar(32).notNull(),
+})
+```
+
+- Emits `CREATE SCHEMA IF NOT EXISTS "billing"` ahead of the tables that need it.
+- Qualifies every generated statement — `CREATE`/`DROP`/`ALTER TABLE`, `CREATE INDEX`, `DROP INDEX` (whose name resolves through `search_path`), and any `REFERENCES` pointing at the table.
+- Keys the row type as `KickDbSchema['billing.invoices']`, which Kysely reads as schema-qualified, so `db.selectFrom('billing.invoices')` resolves with no `withSchema()` call.
+- Two schemas may hold same-named tables: snapshot keys are qualified, so `billing.events` and `audit.events` no longer collide.
+
+`pgSchema('public')` collapses to "no schema" in both the runtime value and the type key — PG puts `public` on the default `search_path`, so treating it as a distinct key would make the diff emit `DROP TABLE users` + `CREATE TABLE public.users` for what is the same physical table.
+
+Schemas are never dropped. There is no `dropSchema` change: a schema can hold objects this app never declared, so a `DROP SCHEMA` inferred from "nothing references it any more" could destroy data the diff never saw. Down migrations leave the emptied schema for an operator to remove.
+
+PostgreSQL only — on MySQL a schema is a database and SQLite has none, so declaring one and diffing against those dialects throws at snapshot time, before any DDL is written.
+
+Unqualified tables are completely unaffected: no `schema` field is written, no `schemas` array is added, and snapshots serialize byte-identically, so existing migration hashes stay valid.
+
+Introspection is unchanged and still single-schema (`pgAdapter({ schema })`, default `public`) — tables in other schemas are created and migrated correctly but are not yet compared during drift detection.
+
+Also fixes a latent bug this surfaced: `diffTable` stamped the bare table name onto every column/index/FK change instead of the snapshot key.

--- a/docs/api/db.md
+++ b/docs/api/db.md
@@ -263,6 +263,76 @@ See [`docs/guide/db-extensions.md`](../guide/db-extensions.md) for the full mapp
 
 PostgreSQL-only ENUM type. See [Schema Types guide](../guide/db-schema-types.md#postgresql-enums).
 
+### `pgSchema(name)`
+
+Declare a PostgreSQL named schema and hang tables off it. Imported from the
+`/pg` subpath.
+
+```ts
+import { pgSchema } from '@forinda/kickjs-db/pg'
+import { table, serial, varchar } from '@forinda/kickjs-db'
+
+const billing = pgSchema('billing')
+
+const invoices = billing.table('invoices', {
+  id: serial().primaryKey(),
+  ref: varchar(32).notNull(),
+})
+
+const users = table('users', { id: serial().primaryKey() }) // default search_path
+```
+
+Generates:
+
+```sql
+CREATE SCHEMA IF NOT EXISTS "billing";
+CREATE TABLE "billing"."invoices" ( ... );
+CREATE TABLE "users" ( ... );
+```
+
+and keys the row type by the qualified name, which Kysely reads as
+schema-qualified:
+
+```ts
+type DB = KickDbSchema // { 'billing.invoices': {...}, users: {...} }
+
+await db.selectFrom('billing.invoices').selectAll().execute()
+```
+
+Every generated statement for the table is qualified — `CREATE`/`DROP`/`ALTER
+TABLE`, `CREATE INDEX`, `DROP INDEX` (whose name resolves through
+`search_path`, so it needs the qualifier), and any `REFERENCES` pointing at it.
+
+**Two schemas may hold same-named tables.** Snapshot keys are the qualified
+name, so `billing.events` and `audit.events` never collide.
+
+**`pgSchema('public')` collapses to no schema.** PG puts `public` on the
+default `search_path`, so `pgSchema('public').table('users', …)` and
+`table('users', …)` name the same physical table. Treating them as different
+snapshot keys would make the diff emit `DROP TABLE users` + `CREATE TABLE
+public.users`, so `public` is normalised away in both the runtime value and
+the row-type key.
+
+**Schemas are never dropped.** There is no `dropSchema` change. A schema can
+hold objects this app never declared — another service's tables, extensions,
+views — so a `DROP SCHEMA` inferred from "no table references it any more"
+could destroy data the diff never saw. Down migrations leave the emptied
+schema in place for an operator to remove deliberately.
+
+::: warning PostgreSQL only
+On MySQL a "schema" _is_ a database and SQLite has none (only `ATTACH`
+aliases), so the qualified identifiers would mean something different.
+Declaring a schema and then diffing against either dialect throws at snapshot
+time, before any DDL is written.
+:::
+
+::: tip Introspection scope
+`kick db pull` / drift detection still read a single schema — the one set via
+`pgAdapter({ schema })`, default `public`. Tables you declare in another schema
+are created and migrated correctly, but will not be compared against the live
+database. Multi-schema introspection is not implemented yet.
+:::
+
 ## Query API
 
 Three layers, all mix freely on the same `KickDbClient`.

--- a/packages/db/__tests__/fuzz/apply-changeset.ts
+++ b/packages/db/__tests__/fuzz/apply-changeset.ts
@@ -134,6 +134,15 @@ function applyOne(snapshot: SchemaSnapshot, change: ChangeSet[number]): void {
       }
       return
     }
+    case 'createSchema': {
+      // Mirrors extractSnapshot: `schemas` is sorted and only present when
+      // non-empty, so the fuzz round-trip stays an exact comparison. There is
+      // no dropSchema variant to mirror — schemas are never removed.
+      const schemas = new Set(snapshot.schemas ?? [])
+      schemas.add(change.schema)
+      snapshot.schemas = [...schemas].toSorted()
+      return
+    }
     default: {
       // Exhaustiveness guard: a new Change variant added without
       // an applier case here would silently no-op and make the

--- a/packages/db/__tests__/unit/columns-array-brands.test-d.ts
+++ b/packages/db/__tests__/unit/columns-array-brands.test-d.ts
@@ -2,7 +2,7 @@
 // `.test-d.ts` file because vitest only enforces expectTypeOf assertions
 // under `--typecheck`, whose include list is `**/*.test-d.ts`.
 //
-// Run: vitest run --typecheck --typecheck.ignoreSourceErrors \
+// Run: pnpm exec vitest run --typecheck --typecheck.ignoreSourceErrors \
 //        __tests__/unit/columns-array-brands.test-d.ts
 import { describe, it, expectTypeOf } from 'vitest'
 import type { Generated } from 'kysely'

--- a/packages/db/__tests__/unit/pg-schema.test-d.ts
+++ b/packages/db/__tests__/unit/pg-schema.test-d.ts
@@ -1,0 +1,65 @@
+// Type-level companion to pg-schema.test.ts. Lives in a `.test-d.ts` file
+// because vitest only enforces expectTypeOf assertions under `--typecheck`,
+// whose include list is `**/*.test-d.ts` — and because the package tsconfig
+// only includes `src`, so `tsc --noEmit` would never see these.
+//
+// Run: vitest run --typecheck --typecheck.ignoreSourceErrors \
+//        __tests__/unit/pg-schema.test-d.ts
+import { describe, it, expectTypeOf } from 'vitest'
+import type { Generated } from 'kysely'
+
+import { serial, varchar, table } from '../../src/index'
+import type { SchemaToTypes } from '../../src/index'
+import { pgSchema } from '../../src/pg'
+
+describe('pgSchema() row-type keys (type-level)', () => {
+  it('keys a schema-qualified table by "<schema>.<table>"', () => {
+    const billing = pgSchema('billing')
+    const invoices = billing.table('invoices', {
+      id: serial().primaryKey(),
+      ref: varchar(32).notNull(),
+    })
+    const schema = { invoices }
+    type DB = SchemaToTypes<typeof schema>
+
+    // Kysely reads a dotted table name as schema-qualified, so this key is
+    // what makes `db.selectFrom('billing.invoices')` resolve without a
+    // withSchema() call.
+    expectTypeOf<keyof DB>().toEqualTypeOf<'billing.invoices'>()
+    expectTypeOf<DB['billing.invoices']>().toEqualTypeOf<{
+      id: Generated<number>
+      ref: string
+    }>()
+  })
+
+  it('leaves an unqualified table keyed by its bare name', () => {
+    const users = table('users', { id: serial().primaryKey() })
+    type DB = SchemaToTypes<{ users: typeof users }>
+    expectTypeOf<keyof DB>().toEqualTypeOf<'users'>()
+  })
+
+  it("keys pgSchema('public') tables bare, matching the runtime collapse", () => {
+    // The runtime drops `public` so `pgSchema('public').table('users')` and
+    // `table('users')` share a snapshot key. If the TYPE said
+    // 'public.users' while the runtime said 'users', every query built off
+    // KickDbSchema would name a table the migration never created.
+    const pub = pgSchema('public')
+    const users = pub.table('users', { id: serial().primaryKey() })
+    type DB = SchemaToTypes<{ users: typeof users }>
+    expectTypeOf<keyof DB>().toEqualTypeOf<'users'>()
+  })
+
+  it('keeps two schemas with same-named tables as distinct keys', () => {
+    const events = pgSchema('billing').table('events', { id: serial().primaryKey() })
+    const auditEvents = pgSchema('audit').table('events', { id: serial().primaryKey() })
+    type DB = SchemaToTypes<{ events: typeof events; auditEvents: typeof auditEvents }>
+    expectTypeOf<keyof DB>().toEqualTypeOf<'billing.events' | 'audit.events'>()
+  })
+
+  it('mixes qualified and unqualified tables in one map', () => {
+    const users = table('users', { id: serial().primaryKey() })
+    const invoices = pgSchema('billing').table('invoices', { id: serial().primaryKey() })
+    type DB = SchemaToTypes<{ users: typeof users; invoices: typeof invoices }>
+    expectTypeOf<keyof DB>().toEqualTypeOf<'users' | 'billing.invoices'>()
+  })
+})

--- a/packages/db/__tests__/unit/pg-schema.test-d.ts
+++ b/packages/db/__tests__/unit/pg-schema.test-d.ts
@@ -3,7 +3,7 @@
 // whose include list is `**/*.test-d.ts` — and because the package tsconfig
 // only includes `src`, so `tsc --noEmit` would never see these.
 //
-// Run: vitest run --typecheck --typecheck.ignoreSourceErrors \
+// Run: pnpm exec vitest run --typecheck --typecheck.ignoreSourceErrors \
 //        __tests__/unit/pg-schema.test-d.ts
 import { describe, it, expectTypeOf } from 'vitest'
 import type { Generated } from 'kysely'

--- a/packages/db/__tests__/unit/pg-schema.test.ts
+++ b/packages/db/__tests__/unit/pg-schema.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest'
+import { table, serial, varchar, integer, index, extractSnapshot, diff } from '@forinda/kickjs-db'
+import { pgSchema } from '@forinda/kickjs-db/pg'
+import { invertChanges } from '../../src/diff/invert'
+import { emitPg } from '../../src/emit/pg'
+import type { SchemaSnapshot } from '../../src/snapshot/types'
+
+const empty: SchemaSnapshot = { version: 1, dialect: 'postgres', tables: {} }
+
+describe('pgSchema()', () => {
+  describe('declaration', () => {
+    it('keys the snapshot by qualified name and records the schema', () => {
+      const billing = pgSchema('billing')
+      const invoices = billing.table('invoices', { id: serial().primaryKey() })
+
+      const snap = extractSnapshot({ invoices }, 'postgres')
+
+      expect(Object.keys(snap.tables)).toEqual(['billing.invoices'])
+      expect(snap.tables['billing.invoices'].name).toBe('invoices')
+      expect(snap.tables['billing.invoices'].schema).toBe('billing')
+      expect(snap.schemas).toEqual(['billing'])
+    })
+
+    it('leaves unqualified tables byte-identical to before schemas existed', () => {
+      const users = table('users', { id: serial().primaryKey() })
+      const snap = extractSnapshot({ users }, 'postgres')
+
+      expect(Object.keys(snap.tables)).toEqual(['users'])
+      // No `schema` key at all, and no `schemas` array — an added-but-undefined
+      // field would change the serialized JSON and break migration hashes.
+      expect('schema' in snap.tables.users).toBe(false)
+      expect('schemas' in snap).toBe(false)
+    })
+
+    it("collapses pgSchema('public') to no schema", () => {
+      // Otherwise `public.users` and `users` would be different snapshot keys
+      // for the same physical table, and the diff would emit DROP + CREATE.
+      const pub = pgSchema('public')
+      const users = pub.table('users', { id: serial().primaryKey() })
+      const snap = extractSnapshot({ users }, 'postgres')
+
+      expect(Object.keys(snap.tables)).toEqual(['users'])
+      expect('schema' in snap.tables.users).toBe(false)
+      expect(snap.schemas).toBeUndefined()
+    })
+
+    it('lets two schemas hold same-named tables without collision', () => {
+      const billing = pgSchema('billing')
+      const audit = pgSchema('audit')
+      const a = billing.table('events', { id: serial().primaryKey() })
+      const b = audit.table('events', { id: serial().primaryKey() })
+
+      const snap = extractSnapshot({ a, b }, 'postgres')
+
+      expect(Object.keys(snap.tables).toSorted()).toEqual(['audit.events', 'billing.events'])
+      expect(snap.schemas).toEqual(['audit', 'billing'])
+    })
+
+    it('sorts the schema list so the snapshot hash is order-independent', () => {
+      const z = pgSchema('zeta').table('t', { id: serial().primaryKey() })
+      const a = pgSchema('alpha').table('t', { id: serial().primaryKey() })
+      expect(extractSnapshot({ z, a }, 'postgres').schemas).toEqual(['alpha', 'zeta'])
+    })
+
+    it('rejects a schema name that is not a bare identifier', () => {
+      expect(() => pgSchema('bad-name')).toThrow(/invalid schema name/)
+      expect(() => pgSchema('drop";--')).toThrow(/invalid schema name/)
+      expect(() => pgSchema('')).toThrow(/invalid schema name/)
+    })
+  })
+
+  describe('dialect guard', () => {
+    it.each(['mysql', 'sqlite'] as const)('rejects a declared schema on %s', (dialect) => {
+      const invoices = pgSchema('billing').table('invoices', { id: serial().primaryKey() })
+      expect(() => extractSnapshot({ invoices }, dialect)).toThrow(/PostgreSQL-only/)
+    })
+
+    it('leaves unqualified tables working on every dialect', () => {
+      const users = table('users', { id: serial().primaryKey() })
+      for (const dialect of ['postgres', 'mysql', 'sqlite'] as const) {
+        expect(() => extractSnapshot({ users }, dialect)).not.toThrow()
+      }
+    })
+  })
+
+  describe('DDL', () => {
+    it('creates the schema before the tables inside it', () => {
+      const invoices = pgSchema('billing').table('invoices', { id: serial().primaryKey() })
+      const next = extractSnapshot({ invoices }, 'postgres')
+      const changes = diff(empty, next)
+
+      expect(changes[0]).toEqual({ kind: 'createSchema', schema: 'billing' })
+      expect(changes[1].kind).toBe('createTable')
+
+      const sql = emitPg(changes)
+      expect(sql).toContain('CREATE SCHEMA IF NOT EXISTS "billing";')
+      expect(sql).toContain('CREATE TABLE "billing"."invoices"')
+      // The schema statement must precede the table that needs it.
+      expect(sql.indexOf('CREATE SCHEMA')).toBeLessThan(sql.indexOf('CREATE TABLE'))
+    })
+
+    it('does not re-create a schema that already existed', () => {
+      const invoices = pgSchema('billing').table('invoices', { id: serial().primaryKey() })
+      const prev = extractSnapshot({ invoices }, 'postgres')
+      const withMore = pgSchema('billing').table('notes', { id: serial().primaryKey() })
+      const next = extractSnapshot({ invoices, withMore }, 'postgres')
+
+      const changes = diff(prev, next)
+      expect(changes.some((c) => c.kind === 'createSchema')).toBe(false)
+    })
+
+    it('qualifies DROP TABLE', () => {
+      const invoices = pgSchema('billing').table('invoices', { id: serial().primaryKey() })
+      const prev = extractSnapshot({ invoices }, 'postgres')
+      const sql = emitPg(diff(prev, empty))
+      expect(sql).toContain('DROP TABLE "billing"."invoices";')
+    })
+
+    it('qualifies a foreign key that targets a schema-qualified table', () => {
+      const billing = pgSchema('billing')
+      const invoices = billing.table('invoices', { id: serial().primaryKey() })
+      const lines = table('lines', {
+        id: serial().primaryKey(),
+        invoiceId: integer().references(() => invoices.id),
+      })
+
+      const sql = emitPg(diff(empty, extractSnapshot({ invoices, lines }, 'postgres')))
+      expect(sql).toContain('REFERENCES "billing"."invoices" ("id")')
+    })
+
+    it('qualifies DROP INDEX with the table schema', () => {
+      // CREATE INDEX takes its schema from the qualified table it targets, but
+      // DROP INDEX resolves the index name through search_path — a bare name
+      // would miss, or hit a same-named index in public.
+      const withIdx = pgSchema('billing').table(
+        'invoices',
+        { id: serial().primaryKey(), ref: varchar(32) },
+        (t) => ({ refIdx: index('invoices_ref_idx').on(t.ref) }),
+      )
+      const withoutIdx = pgSchema('billing').table('invoices', {
+        id: serial().primaryKey(),
+        ref: varchar(32),
+      })
+
+      const prev = extractSnapshot({ withIdx }, 'postgres')
+      const next = extractSnapshot({ withoutIdx }, 'postgres')
+      const sql = emitPg(diff(prev, next))
+
+      expect(sql).toContain('DROP INDEX "billing"."invoices_ref_idx";')
+    })
+
+    it('creates an index on the qualified table', () => {
+      const withIdx = pgSchema('billing').table(
+        'invoices',
+        { id: serial().primaryKey(), ref: varchar(32) },
+        (t) => ({ refIdx: index('invoices_ref_idx').on(t.ref) }),
+      )
+      const sql = emitPg(diff(empty, extractSnapshot({ withIdx }, 'postgres')))
+      expect(sql).toContain('ON "billing"."invoices"')
+    })
+
+    it('qualifies ALTER TABLE for column changes', () => {
+      const before = pgSchema('billing').table('invoices', { id: serial().primaryKey() })
+      const after = pgSchema('billing').table('invoices', {
+        id: serial().primaryKey(),
+        note: varchar(64),
+      })
+      const sql = emitPg(
+        diff(extractSnapshot({ before }, 'postgres'), extractSnapshot({ after }, 'postgres')),
+      )
+      expect(sql).toContain('ALTER TABLE "billing"."invoices" ADD COLUMN')
+    })
+  })
+
+  describe('inversion', () => {
+    it('never drops a schema in the down migration', () => {
+      // A schema can hold objects this app never declared, so an inferred
+      // DROP SCHEMA could destroy data the diff never saw.
+      const invoices = pgSchema('billing').table('invoices', { id: serial().primaryKey() })
+      const forward = diff(empty, extractSnapshot({ invoices }, 'postgres'))
+
+      const down = invertChanges(forward)
+      expect(down.some((c) => c.kind === 'createSchema')).toBe(false)
+      expect(down.map((c) => c.kind)).toContain('dropTable')
+      expect(emitPg(down)).not.toContain('DROP SCHEMA')
+    })
+
+    it('still prunes redundant teardown for a qualified table', () => {
+      // dropTable carries a bare name + schema while dropIndex carries the
+      // qualified key; comparing them raw would stop the prune from firing.
+      const withIdx = pgSchema('billing').table(
+        'invoices',
+        { id: serial().primaryKey(), ref: varchar(32) },
+        (t) => ({ refIdx: index('invoices_ref_idx').on(t.ref) }),
+      )
+      const forward = diff(empty, extractSnapshot({ withIdx }, 'postgres'))
+      const down = invertChanges(forward)
+
+      expect(down.some((c) => c.kind === 'dropIndex')).toBe(false)
+      expect(down.some((c) => c.kind === 'dropTable')).toBe(true)
+    })
+  })
+
+  describe('end to end', () => {
+    it('qualifies every identifier in the up and down SQL', () => {
+      const billing = pgSchema('billing')
+      const invoices = billing.table(
+        'invoices',
+        { id: serial().primaryKey(), ref: varchar(32) },
+        (t) => ({ refIdx: index('invoices_ref_idx').on(t.ref) }),
+      )
+      const lines = table('lines', {
+        id: serial().primaryKey(),
+        invoiceId: integer().references(() => invoices.id),
+      })
+
+      const next = extractSnapshot({ invoices, lines }, 'postgres')
+      const forward = diff(empty, next)
+      const up = emitPg(forward)
+      const down = emitPg(invertChanges(forward))
+
+      expect(up).toContain('CREATE SCHEMA IF NOT EXISTS "billing";')
+      expect(up).toContain('CREATE TABLE "billing"."invoices"')
+      expect(up).toContain('REFERENCES "billing"."invoices" ("id")')
+      // `lines` is unqualified and must stay that way.
+      expect(up).toContain('CREATE TABLE "lines"')
+
+      expect(down).toContain('DROP TABLE "billing"."invoices";')
+      expect(down).toContain('DROP TABLE "lines";')
+      expect(down).not.toContain('DROP SCHEMA')
+
+      // Nothing may reference the qualified table by its bare name — that
+      // would resolve through search_path to the wrong object.
+      expect(up).not.toMatch(/(CREATE|ALTER|DROP) TABLE "invoices"/)
+      expect(down).not.toMatch(/(CREATE|ALTER|DROP) TABLE "invoices"/)
+    })
+  })
+})

--- a/packages/db/__tests__/unit/pg-schema.test.ts
+++ b/packages/db/__tests__/unit/pg-schema.test.ts
@@ -67,6 +67,22 @@ describe('pgSchema()', () => {
       expect(() => pgSchema('drop";--')).toThrow(/invalid schema name/)
       expect(() => pgSchema('')).toThrow(/invalid schema name/)
     })
+
+    it('rejects a non-string schema name', () => {
+      // `RegExp.test(x)` stringifies its argument, so a bare regex guard lets
+      // `undefined` ('undefined'), `null` ('null'), `true` ('true') and
+      // `['a']` ('a') through — each with a different downstream failure:
+      //   undefined → silently unqualified table
+      //   null      → `"schema": null` serialized into the snapshot
+      //   true/['a']→ a table keyed "true.x" / "a.x" and DDL creating a
+      //               schema by that name
+      // The types forbid all of these, but JS callers and `any` do not.
+      for (const bad of [undefined, null, 123, true, {}, ['a']]) {
+        expect(() => pgSchema(bad as unknown as string), `pgSchema(${String(bad)})`).toThrow(
+          /invalid schema name/,
+        )
+      }
+    })
   })
 
   describe('dialect guard', () => {

--- a/packages/db/src/client/schema-types.ts
+++ b/packages/db/src/client/schema-types.ts
@@ -31,10 +31,35 @@ type ColumnTSType<C> =
         : T
     : never
 
+/**
+ * Table key Kysely sees. A table declared via `pgSchema('billing').table(...)`
+ * keys as `'billing.invoices'` — Kysely treats a dotted table name as
+ * schema-qualified, so `db.selectFrom('billing.invoices')` resolves without a
+ * `withSchema()` call. Unqualified tables keep their bare key, so existing
+ * `KickDbSchema['users']` lookups are unchanged.
+ *
+ * Matched on `__isTable` rather than on `TableDecl<...>` assignability: the
+ * schema generic makes a qualified table structurally incompatible with the
+ * unqualified default, which would silently drop it from the map.
+ */
+type TableKey<T> = T extends { __name: infer N extends string }
+  ? // `__schema` is OPTIONAL, so its property type is `'billing' | undefined`.
+    // Matching it against `infer S extends string` therefore fails and every
+    // table silently falls back to its bare key — extract the string member
+    // instead, which leaves `never` (→ bare key) for unqualified tables.
+    Extract<T extends { __schema?: infer S } ? S : never, string> extends infer Schema
+    ? [Schema] extends [never]
+      ? N
+      : Schema extends string
+        ? `${Schema}.${N}`
+        : N
+    : never
+  : never
+
 export type SchemaToTypes<S> = {
-  [K in keyof S as S[K] extends TableDecl<string, Record<string, ColumnBuilder>>
-    ? S[K]['__name']
-    : never]: S[K] extends TableDecl<string, infer C>
+  [K in keyof S as S[K] extends { __isTable: true }
+    ? TableKey<S[K]>
+    : never]: S[K] extends TableDecl<string, infer C, string | undefined>
     ? { [Col in keyof C]: ColumnTSType<C[Col]> }
     : never
 }

--- a/packages/db/src/diff/engine.ts
+++ b/packages/db/src/diff/engine.ts
@@ -1,4 +1,5 @@
 import { RemovedValueAsDefaultError } from '../errors'
+import { snapshotTableName } from '../snapshot/name'
 import type { SchemaSnapshot, TableSnapshot } from '../snapshot/types'
 import type { Change, ChangeSet } from './types'
 
@@ -7,6 +8,15 @@ export function diff(prev: SchemaSnapshot, next: SchemaSnapshot): ChangeSet {
 
   const prevTables = new Set(Object.keys(prev.tables))
   const nextTables = new Set(Object.keys(next.tables))
+
+  // Schemas come first of all: a new enum or table inside `billing` needs
+  // `CREATE SCHEMA billing` to have run. `IF NOT EXISTS` makes re-emission
+  // harmless, so we only need "is it new to this diff", not exact tracking.
+  // Never dropped — see the CreateSchema doc comment.
+  const prevSchemas = new Set(prev.schemas ?? [])
+  for (const schema of next.schemas ?? []) {
+    if (!prevSchemas.has(schema)) changes.push({ kind: 'createSchema', schema })
+  }
 
   // Enum diffs run BEFORE table operations on the create side (so a new
   // table referencing a new enum sees the type already exist) and AFTER
@@ -197,6 +207,12 @@ function diffEnumsDropPhase(prev: SchemaSnapshot, next: SchemaSnapshot, changes:
 }
 
 function diffTable(prev: TableSnapshot, next: TableSnapshot, changes: Change[]) {
+  // Every `table:` field on a Change carries the QUALIFIED name — that is what
+  // the emitters quote and what `invertChanges` matches dropTable against.
+  // Using the bare `next.name` here emitted `ALTER TABLE "invoices"` for a
+  // table that actually lives in `billing`, which resolves through search_path
+  // to a different table (or nothing).
+  const tableRef = snapshotTableName(next)
   const prevCols = new Map(Object.entries(prev.columns))
   const nextCols = new Map(Object.entries(next.columns))
 
@@ -210,17 +226,17 @@ function diffTable(prev: TableSnapshot, next: TableSnapshot, changes: Change[]) 
     const before = prevCols.get(drops[0])!
     const after = nextCols.get(adds[0])!
     if (columnAttrsEqual(before, after)) {
-      changes.push({ kind: 'renameColumn', table: next.name, from: drops[0], to: adds[0] })
+      changes.push({ kind: 'renameColumn', table: tableRef, from: drops[0], to: adds[0] })
       drops.length = 0
       adds.length = 0
     }
   }
 
   for (const c of drops) {
-    changes.push({ kind: 'dropColumn', table: next.name, column: prevCols.get(c)! })
+    changes.push({ kind: 'dropColumn', table: tableRef, column: prevCols.get(c)! })
   }
   for (const c of adds) {
-    changes.push({ kind: 'addColumn', table: next.name, column: nextCols.get(c)! })
+    changes.push({ kind: 'addColumn', table: tableRef, column: nextCols.get(c)! })
   }
 
   // Common columns — alter detection
@@ -229,22 +245,22 @@ function diffTable(prev: TableSnapshot, next: TableSnapshot, changes: Change[]) 
     const before = prevCols.get(c)!
     const after = nextCols.get(c)!
     if (!columnsEqual(before, after)) {
-      changes.push({ kind: 'alterColumn', table: next.name, column: c, before, after })
+      changes.push({ kind: 'alterColumn', table: tableRef, column: c, before, after })
     }
   }
 
   diffByName(
     prev.indexes,
     next.indexes,
-    (i) => changes.push({ kind: 'dropIndex', table: next.name, index: i }),
-    (i) => changes.push({ kind: 'addIndex', table: next.name, index: i }),
+    (i) => changes.push({ kind: 'dropIndex', table: tableRef, index: i }),
+    (i) => changes.push({ kind: 'addIndex', table: tableRef, index: i }),
   )
 
   diffByName(
     prev.foreignKeys,
     next.foreignKeys,
-    (f) => changes.push({ kind: 'dropForeignKey', table: next.name, fk: f }),
-    (f) => changes.push({ kind: 'addForeignKey', table: next.name, fk: f }),
+    (f) => changes.push({ kind: 'dropForeignKey', table: tableRef, fk: f }),
+    (f) => changes.push({ kind: 'addForeignKey', table: tableRef, fk: f }),
   )
 }
 

--- a/packages/db/src/diff/invert.ts
+++ b/packages/db/src/diff/invert.ts
@@ -1,4 +1,5 @@
-import type { Change, ChangeSet } from './types'
+import { snapshotTableName } from '../snapshot/name'
+import type { Change, ChangeSet, CreateSchema } from './types'
 
 /**
  * Reverse a forward ChangeSet so emitting it produces the SQL that undoes
@@ -18,6 +19,11 @@ import type { Change, ChangeSet } from './types'
 export function invertChanges(forward: ChangeSet): ChangeSet {
   const reversed: Change[] = []
   for (const change of forward) {
+    // `createSchema` has no inverse by design. A schema can hold objects this
+    // app never declared, so a generated DROP SCHEMA could destroy data the
+    // diff never saw; the down migration leaves the (now empty) schema behind
+    // for an operator to remove deliberately. See CreateSchema in ./types.
+    if (change.kind === 'createSchema') continue
     reversed.push(invert(change))
   }
   const ordered = reversed.toReversed()
@@ -29,8 +35,12 @@ export function invertChanges(forward: ChangeSet): ChangeSet {
   // which no longer contains the table when the inversion of a
   // createTable is in the same set (every first migration of an
   // FK-bearing schema hit `SqliteRebuildRequiredError`).
+  // Qualified on both sides: `dropTable` carries a TableSnapshot (bare name +
+  // schema) while `dropForeignKey`/`dropIndex` carry the qualified snapshot
+  // key, so comparing raw `.name` would never match a schema-qualified table
+  // and the prune below would silently stop firing for it.
   const droppedTables = new Set(
-    ordered.filter((c) => c.kind === 'dropTable').map((c) => c.table.name),
+    ordered.filter((c) => c.kind === 'dropTable').map((c) => snapshotTableName(c.table)),
   )
   return ordered.filter((c) => {
     if (c.kind === 'dropForeignKey' || c.kind === 'dropIndex') {
@@ -40,7 +50,9 @@ export function invertChanges(forward: ChangeSet): ChangeSet {
   })
 }
 
-function invert(change: Change): Change {
+// `CreateSchema` is filtered out above rather than inverted, so excluding it
+// here keeps the switch exhaustive without a dead default branch.
+function invert(change: Exclude<Change, CreateSchema>): Change {
   switch (change.kind) {
     case 'createTable':
       return { kind: 'dropTable', table: change.table }

--- a/packages/db/src/diff/types.ts
+++ b/packages/db/src/diff/types.ts
@@ -6,6 +6,20 @@ import type {
   TableSnapshot,
 } from '../snapshot/types'
 
+/**
+ * `CREATE SCHEMA IF NOT EXISTS "x"` — emitted ahead of every table change so
+ * a new schema exists before anything is created inside it.
+ *
+ * There is deliberately no `dropSchema` counterpart. A schema can hold objects
+ * this app never declared (another service's tables, extensions, views), so a
+ * `DROP SCHEMA` inferred from "no table references it any more" could destroy
+ * data the diff never saw. Removing a schema stays a manual operation.
+ */
+export interface CreateSchema {
+  kind: 'createSchema'
+  schema: string
+}
+
 export interface CreateTable {
   kind: 'createTable'
   table: TableSnapshot
@@ -136,6 +150,7 @@ export interface RemoveEnumValue {
 }
 
 export type Change =
+  | CreateSchema
   | CreateTable
   | DropTable
   | RenameTable

--- a/packages/db/src/dsl/pg-schema.ts
+++ b/packages/db/src/dsl/pg-schema.ts
@@ -64,7 +64,14 @@ const SCHEMA_NAME = /^[A-Za-z_][A-Za-z0-9_$]*$/
  * {@link EffectiveSchema} for why that matters.
  */
 export function pgSchema<TName extends string>(name: TName): PgSchema<EffectiveSchema<TName>> {
-  if (!SCHEMA_NAME.test(name)) {
+  // The typeof check is load-bearing, not belt-and-braces: `RegExp.test(x)`
+  // stringifies its argument, so the regex alone accepts `undefined`
+  // ('undefined'), `null` ('null'), `true` ('true') and `['a']` ('a'). Each
+  // fails differently downstream — `undefined` yields a silently unqualified
+  // table, `null` serializes `"schema": null` into the snapshot, and the
+  // others key a table `"true.x"` / `"a.x"` and emit DDL creating a schema by
+  // that name. TS forbids all of them; JS callers and `any` do not.
+  if (typeof name !== 'string' || !SCHEMA_NAME.test(name)) {
     throw new Error(
       `pgSchema: invalid schema name ${JSON.stringify(name)}. ` +
         `Expected an unquoted PostgreSQL identifier matching ${SCHEMA_NAME.source}.`,

--- a/packages/db/src/dsl/pg-schema.ts
+++ b/packages/db/src/dsl/pg-schema.ts
@@ -1,0 +1,94 @@
+import type { ColumnBuilder, ColumnRef } from './columns/types'
+import type { IndexDecl } from './constraints'
+import { buildTable, type TableDecl } from './table'
+
+/**
+ * PostgreSQL named-schema namespace.
+ *
+ * ```ts
+ * const billing = pgSchema('billing')
+ *
+ * const invoices = billing.table('invoices', {
+ *   id: uuid().primaryKey().defaultRandom(),
+ *   total: numeric().notNull(),
+ * })
+ * ```
+ *
+ * Emits `CREATE SCHEMA IF NOT EXISTS "billing"` ahead of the tables that need
+ * it, qualifies every generated statement (`"billing"."invoices"`), and keys
+ * the row type as `KickDbSchema['billing.invoices']` so Kysely resolves the
+ * qualified table without a `withSchema()` call.
+ *
+ * Tables declared through the bare `table()` factory are untouched: no schema
+ * field, bare identifiers, same snapshot bytes and migration hashes as before.
+ *
+ * PostgreSQL only. A schema is a true namespace only on PG — on MySQL the
+ * word means "database" and on SQLite it means an `ATTACH` alias, both of
+ * which have different lifecycles than `CREATE SCHEMA`. Declaring one and
+ * then diffing against MySQL/SQLite throws rather than emitting DDL that
+ * looks right and means something else.
+ */
+export interface PgSchema<TSchema extends string | undefined = string | undefined> {
+  readonly __isPgSchema: true
+  /** The schema name as declared, e.g. `billing`. */
+  readonly name: string
+
+  table<TName extends string, C extends Record<string, ColumnBuilder>>(
+    name: TName,
+    columns: C,
+    constraints?: (refs: { [K in keyof C]: ColumnRef }) => Record<string, IndexDecl>,
+  ): TableDecl<TName, C, TSchema> & { [K in keyof C]: ColumnRef }
+}
+
+/**
+ * `public` resolves to "no schema" rather than to itself.
+ *
+ * PG creates `public` for every database and puts it on the default
+ * search_path, so `pgSchema('public').table('users', …)` and
+ * `table('users', …)` name the same physical table. If the former stamped
+ * `schema: 'public'`, its snapshot key would be `public.users` while the
+ * latter's is `users` — the diff engine would read that as "drop `users`,
+ * create `public.users`" and emit a DROP TABLE. Collapsing to `undefined`
+ * keeps the two spellings interchangeable, and the conditional return type
+ * below keeps the static key in step with the runtime one.
+ */
+type EffectiveSchema<TName extends string> = TName extends 'public' ? undefined : TName
+
+/** Reject names that would need quoting gymnastics or inject into DDL. */
+const SCHEMA_NAME = /^[A-Za-z_][A-Za-z0-9_$]*$/
+
+/**
+ * Declare a PostgreSQL schema namespace. See {@link PgSchema}.
+ *
+ * `pgSchema('public')` is accepted and collapses to "no schema" — see
+ * {@link EffectiveSchema} for why that matters.
+ */
+export function pgSchema<TName extends string>(name: TName): PgSchema<EffectiveSchema<TName>> {
+  if (!SCHEMA_NAME.test(name)) {
+    throw new Error(
+      `pgSchema: invalid schema name ${JSON.stringify(name)}. ` +
+        `Expected an unquoted PostgreSQL identifier matching ${SCHEMA_NAME.source}.`,
+    )
+  }
+  const effective = (name === 'public' ? undefined : name) as EffectiveSchema<TName>
+
+  return {
+    __isPgSchema: true,
+    name,
+    table<TName2 extends string, C extends Record<string, ColumnBuilder>>(
+      tableName: TName2,
+      columns: C,
+      constraints?: (refs: { [K in keyof C]: ColumnRef }) => Record<string, IndexDecl>,
+    ) {
+      return buildTable(tableName, columns, constraints, effective)
+    },
+  }
+}
+
+export function isPgSchema(value: unknown): value is PgSchema<string> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { __isPgSchema?: unknown }).__isPgSchema === true
+  )
+}

--- a/packages/db/src/dsl/table.ts
+++ b/packages/db/src/dsl/table.ts
@@ -6,17 +6,49 @@ export type { ColumnRef }
 export interface TableDecl<
   TName extends string = string,
   C extends Record<string, ColumnBuilder> = Record<string, ColumnBuilder>,
+  TSchema extends string | undefined = string | undefined,
 > {
   __isTable: true
   __name: TName
   __columns: C
   __indexes: IndexDecl[]
+  /**
+   * Named SQL schema this table lives in, from `pgSchema('x').table(...)`.
+   * `undefined` means the connection's default search_path (`public` on PG),
+   * which is every table declared through the bare `table()` factory.
+   *
+   * PostgreSQL only — `assertSchemasSupported()` rejects a declared schema
+   * on MySQL/SQLite at snapshot time rather than emitting subtly wrong DDL.
+   */
+  __schema?: TSchema
 }
 
-type TableRefs<TName extends string, C extends Record<string, ColumnBuilder>> = TableDecl<
-  TName,
-  C
-> & {
+/**
+ * Fully-qualified name used as the snapshot key, the Kysely table key, and
+ * the emitted identifier. `quoteIdent` splits on `.`, so `billing.invoices`
+ * renders as `"billing"."invoices"` with no further work.
+ *
+ * Unqualified tables keep their bare name, so every pre-schema snapshot,
+ * migration hash, and `KickDbSchema` key is byte-identical to before.
+ */
+export type QualifiedName<
+  TName extends string,
+  TSchema extends string | undefined,
+> = TSchema extends string ? `${TSchema}.${TName}` : TName
+
+/** Runtime counterpart of {@link QualifiedName}. */
+export function qualifiedTableName(decl: {
+  __name: string
+  __schema?: string | undefined
+}): string {
+  return decl.__schema ? `${decl.__schema}.${decl.__name}` : decl.__name
+}
+
+type TableRefs<
+  TName extends string,
+  C extends Record<string, ColumnBuilder>,
+  TSchema extends string | undefined = undefined,
+> = TableDecl<TName, C, TSchema> & {
   [K in keyof C]: ColumnRef
 }
 
@@ -35,17 +67,43 @@ export function table<TName extends string, C extends Record<string, ColumnBuild
   columns: C,
   constraints?: ConstraintBuilder<C>,
 ): TableRefs<TName, C> {
-  const decl: TableDecl<TName, C> = {
+  return buildTable(name, columns, constraints, undefined)
+}
+
+/**
+ * Shared table constructor. `table()` passes `schema: undefined`;
+ * `pgSchema('x').table()` passes the schema name through.
+ */
+export function buildTable<
+  TName extends string,
+  C extends Record<string, ColumnBuilder>,
+  TSchema extends string | undefined,
+>(
+  name: TName,
+  columns: C,
+  constraints: ConstraintBuilder<C> | undefined,
+  schema: TSchema,
+): TableRefs<TName, C, TSchema> {
+  const decl: TableDecl<TName, C, TSchema> = {
     __isTable: true,
     __name: name,
     __columns: columns,
     __indexes: [],
   }
+  // Only stamp the field when a schema was declared, so unqualified tables
+  // serialize identically to before this feature existed.
+  if (schema !== undefined) decl.__schema = schema
+
+  // Column refs carry the QUALIFIED owner name. `extractSnapshot` reads it
+  // straight into `ForeignKeySnapshot.refTable`, so a foreign key pointing
+  // at a schema-qualified table emits `REFERENCES "billing"."invoices"`
+  // without the FK path needing to know schemas exist.
+  const owner = schema !== undefined ? `${schema}.${name}` : name
 
   const refs = {} as { [K in keyof C]: ColumnRef }
   for (const [key, builder] of Object.entries(columns) as [keyof C, ColumnBuilder][]) {
     refs[key] = {
-      __tableName: name,
+      __tableName: owner,
       __name: key as string,
       __builder: builder,
       __state: () => builder.__state(),

--- a/packages/db/src/emit/mysql.ts
+++ b/packages/db/src/emit/mysql.ts
@@ -40,6 +40,14 @@ export function emitMysql(changes: ChangeSet): string {
 
 function emitChange(change: Change): string {
   switch (change.kind) {
+    case 'createSchema':
+      // Unreachable through `generate()` — extractSnapshot rejects a declared
+      // schema on non-PG dialects first. Kept explicit rather than silently
+      // emitting `CREATE SCHEMA`, which on MySQL means CREATE DATABASE.
+      throw new Error(
+        `kickjs-db: pgSchema() is PostgreSQL-only — cannot emit schema ` +
+          `"${change.schema}" for MySQL, where a schema is a database.`,
+      )
     case 'createTable':
       return emitCreateTable(change.table)
     case 'dropTable':

--- a/packages/db/src/emit/pg.ts
+++ b/packages/db/src/emit/pg.ts
@@ -1,5 +1,6 @@
 import type { Change, ChangeSet } from '../diff/types'
 import type { ColumnSnapshot, TableSnapshot } from '../snapshot/types'
+import { snapshotTableName } from '../snapshot/name'
 import { quoteIdent, quoteLiteral } from './identifiers'
 import { alterTypeAddValue, alterTypeRenameTo, renderAlterType } from './alter-type'
 
@@ -7,14 +8,37 @@ export function emitPg(changes: ChangeSet): string {
   return changes.map(emitChange).join('\n')
 }
 
+/**
+ * Qualified identifier for a table snapshot. `quoteIdent` splits on `.`, so
+ * `billing.invoices` renders `"billing"."invoices"`.
+ *
+ * Changes that carry `table: string` already hold the qualified snapshot key
+ * and need no help; only the two that carry a whole `TableSnapshot` do.
+ */
+function tableIdent(t: TableSnapshot): string {
+  return quoteIdent(snapshotTableName(t))
+}
+
+/** Schema portion of a qualified snapshot key, or undefined when bare. */
+function schemaOf(qualified: string): string | undefined {
+  const dot = qualified.indexOf('.')
+  return dot === -1 ? undefined : qualified.slice(0, dot)
+}
+
 function emitChange(change: Change): string {
   switch (change.kind) {
+    case 'createSchema':
+      // IF NOT EXISTS: the schema may predate this app, and re-running a
+      // migration against a partially-applied database must not fail.
+      return `CREATE SCHEMA IF NOT EXISTS ${quoteIdent(change.schema)};`
     case 'createTable':
       return emitCreateTable(change.table)
     case 'dropTable':
-      return `DROP TABLE ${quoteIdent(change.table.name)};`
+      return `DROP TABLE ${tableIdent(change.table)};`
     case 'renameTable':
-      return `ALTER TABLE ${quoteIdent(change.from)} RENAME TO ${quoteIdent(change.to)};`
+      // PG requires the target of RENAME TO to be unqualified — the table
+      // cannot change schema this way (that is ALTER TABLE … SET SCHEMA).
+      return `ALTER TABLE ${quoteIdent(change.from)} RENAME TO ${quoteIdent(bareName(change.to))};`
     case 'addColumn':
       return emitAddColumn(change.table, change.column)
     case 'dropColumn':
@@ -25,8 +49,15 @@ function emitChange(change: Change): string {
       return emitAlterColumn(change.table, change.before, change.after)
     case 'addIndex':
       return emitAddIndex(change.table, change.index)
-    case 'dropIndex':
-      return `DROP INDEX ${quoteIdent(change.index.name)};`
+    case 'dropIndex': {
+      // An index lives in its table's schema, and DROP INDEX resolves through
+      // search_path — so a bare name would miss (or worse, hit a same-named
+      // index in public). CREATE INDEX needs no such qualification: it takes
+      // the schema from the qualified table it targets.
+      const schema = schemaOf(change.table)
+      const name = schema ? `${schema}.${change.index.name}` : change.index.name
+      return `DROP INDEX ${quoteIdent(name)};`
+    }
     case 'addForeignKey':
       return emitAddFk(change.table, change.fk)
     case 'dropForeignKey':
@@ -293,7 +324,13 @@ function emitCreateTable(t: TableSnapshot): string {
     .map((c) => quoteIdent(c.name))
   const lines = [...cols]
   if (pk.length > 0) lines.push(`PRIMARY KEY (${pk.join(', ')})`)
-  return `CREATE TABLE ${quoteIdent(t.name)} (\n  ${lines.join(',\n  ')}\n);`
+  return `CREATE TABLE ${tableIdent(t)} (\n  ${lines.join(',\n  ')}\n);`
+}
+
+/** Strip any schema qualifier: `billing.invoices` → `invoices`. */
+function bareName(qualified: string): string {
+  const dot = qualified.indexOf('.')
+  return dot === -1 ? qualified : qualified.slice(dot + 1)
 }
 
 function emitColumnDecl(c: ColumnSnapshot): string {

--- a/packages/db/src/emit/sqlite.ts
+++ b/packages/db/src/emit/sqlite.ts
@@ -101,6 +101,14 @@ function perTableName(change: Change): string | null {
 
 function emitChange(change: Change): string {
   switch (change.kind) {
+    case 'createSchema':
+      // Unreachable through `generate()` — extractSnapshot rejects a declared
+      // schema on non-PG dialects first. SQLite has no CREATE SCHEMA at all;
+      // the nearest thing is an ATTACH alias, a connection-time concern.
+      throw new Error(
+        `kickjs-db: pgSchema() is PostgreSQL-only — cannot emit schema ` +
+          `"${change.schema}" for SQLite, which has no schemas (only ATTACH).`,
+      )
     case 'createTable':
       return emitCreateTable(change.table.name, change.table)
     case 'dropTable':

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -3,5 +3,8 @@
 // and Kysely dialect. `pg` is an optional peer dependency of
 // `@forinda/kickjs-db` — install it alongside to use this subpath.
 export * from './dsl/columns/pg'
+// Named-schema namespaces (`pgSchema('billing').table(...)`). PG-only, so it
+// lives on this subpath rather than the dialect-neutral root barrel.
+export * from './dsl/pg-schema'
 export * from './adapters/pg/adapter'
 export * from './adapters/pg/dialect'

--- a/packages/db/src/snapshot/extract.ts
+++ b/packages/db/src/snapshot/extract.ts
@@ -1,5 +1,5 @@
 import type { ColumnBuilder } from '../dsl/columns/types'
-import type { TableDecl } from '../dsl/table'
+import { qualifiedTableName, type TableDecl } from '../dsl/table'
 import { extractRelations } from '../query/extract-relations'
 import type {
   Dialect,
@@ -19,6 +19,30 @@ interface MaybeTable {
 
 function isTable(v: unknown): v is TableDecl<string, Record<string, ColumnBuilder>> {
   return Boolean(v && typeof v === 'object' && (v as MaybeTable).__isTable === true)
+}
+
+/**
+ * Named schemas are a PostgreSQL-only feature here.
+ *
+ * The word means something different on every engine: on MySQL a "schema" IS
+ * a database (different lifecycle, different privileges, no `CREATE SCHEMA
+ * IF NOT EXISTS` semantics we could honour), and SQLite has no schemas at all
+ * — only `ATTACH`ed database aliases, which are a connection-time concern the
+ * adapter would have to own. Emitting `"billing"."invoices"` on those engines
+ * would produce SQL that parses and means the wrong thing.
+ *
+ * So fail loudly at snapshot time, which is before any DDL is written or
+ * applied.
+ */
+function assertSchemasSupported(dialect: Dialect, schemaNames: ReadonlySet<string>): void {
+  if (dialect === 'postgres' || schemaNames.size === 0) return
+  const names = [...schemaNames].toSorted().join(', ')
+  throw new Error(
+    `pgSchema() is PostgreSQL-only, but the ${dialect} schema declares: ${names}. ` +
+      `On MySQL a schema is a database and SQLite has none, so the qualified ` +
+      `identifiers would mean something different than on PG. ` +
+      `Drop the pgSchema() wrapper, or move these tables to a PG dialect.`,
+  )
 }
 
 /**
@@ -42,13 +66,20 @@ export function extractSnapshot(schema: Record<string, unknown>, dialect: Dialec
   const tables: Record<string, TableSnapshot> = {}
   const enums: Record<string, EnumSnapshot> = {}
 
+  const schemaNames = new Set<string>()
+
   for (const value of Object.values(schema)) {
     if (isTable(value)) {
-      tables[value.__name] = extractTable(value)
+      // Key by qualified name so two schemas can hold same-named tables
+      // without the later one silently overwriting the earlier.
+      tables[qualifiedTableName(value)] = extractTable(value)
+      if (value.__schema !== undefined) schemaNames.add(value.__schema)
     } else if (isPgEnum(value)) {
       enums[value.enumName] = { name: value.enumName, values: [...value.values] }
     }
   }
+
+  assertSchemasSupported(dialect, schemaNames)
 
   const relations = extractRelations(schema, tables)
 
@@ -58,6 +89,11 @@ export function extractSnapshot(schema: Record<string, unknown>, dialect: Dialec
   // omit it when absent to keep snapshots minimal for adopters who
   // don't use the relational query layer.
   const snapshot: SchemaSnapshot = { version: 1, dialect, tables }
+  if (schemaNames.size > 0) {
+    // Sorted so snapshot JSON — and therefore the migration hash — does not
+    // depend on ESM namespace iteration order.
+    snapshot.schemas = [...schemaNames].toSorted()
+  }
   if (dialect === 'postgres' && Object.keys(enums).length > 0) {
     snapshot.enums = enums
   }
@@ -97,5 +133,10 @@ function extractTable(t: TableDecl<string, Record<string, ColumnBuilder>>): Tabl
     }
   }
 
-  return { name: t.__name, columns, indexes, foreignKeys, checks: [] }
+  const snapshot: TableSnapshot = { name: t.__name, columns, indexes, foreignKeys, checks: [] }
+  // Only present the key when a schema was declared — an explicit
+  // `schema: undefined` would change the serialized JSON and invalidate
+  // every existing migration hash.
+  if (t.__schema !== undefined) snapshot.schema = t.__schema
+  return snapshot
 }

--- a/packages/db/src/snapshot/name.ts
+++ b/packages/db/src/snapshot/name.ts
@@ -1,0 +1,13 @@
+/**
+ * Qualified name for a table snapshot — `billing.invoices` when the table
+ * declares a schema, the bare name otherwise.
+ *
+ * This is the form used as the `SchemaSnapshot.tables` key and as every
+ * `table: string` field on a diff `Change`, so anything holding a whole
+ * `TableSnapshot` must run it through here before comparing against one of
+ * those. `quoteIdent` splits on `.`, so the result also renders correctly as
+ * an identifier without further work.
+ */
+export function snapshotTableName(t: { name: string; schema?: string }): string {
+  return t.schema ? `${t.schema}.${t.name}` : t.name
+}

--- a/packages/db/src/snapshot/types.ts
+++ b/packages/db/src/snapshot/types.ts
@@ -31,7 +31,18 @@ export interface CheckSnapshot {
 }
 
 export interface TableSnapshot {
+  /**
+   * Bare table name, unqualified. The schema (when any) lives in
+   * {@link TableSnapshot.schema}; the map key on `SchemaSnapshot.tables` is
+   * the qualified form (`billing.invoices`).
+   */
   name: string
+  /**
+   * Named SQL schema, from `pgSchema('x').table(...)`. Absent for tables in
+   * the connection's default search_path, which keeps pre-schema snapshots
+   * byte-identical (and their migration hashes valid).
+   */
+  schema?: string
   columns: Record<string, ColumnSnapshot>
   indexes: IndexSnapshot[]
   foreignKeys: ForeignKeySnapshot[]
@@ -80,7 +91,20 @@ export interface RelationSnapshot {
 export interface SchemaSnapshot {
   version: 1
   dialect: Dialect
+  /**
+   * Keyed by QUALIFIED name — `billing.invoices` for a table declared through
+   * `pgSchema('billing')`, the bare name otherwise. Qualifying the key is what
+   * lets two schemas hold same-named tables without colliding, and it makes
+   * every `table: string` field on a diff `Change` already schema-correct:
+   * `quoteIdent` splits on `.`, rendering `"billing"."invoices"`.
+   */
   tables: Record<string, TableSnapshot>
+  /**
+   * Named schemas the tables in this snapshot live in, sorted. Drives
+   * `CREATE SCHEMA IF NOT EXISTS` emission. PG-only; absent when no table
+   * declares a schema, so existing snapshots keep their exact shape.
+   */
+  schemas?: readonly string[]
   /** ENUM types declared via `pgEnum()`. PG-only; absent on other dialects. */
   enums?: Record<string, EnumSnapshot>
   /**

--- a/packages/db/tsconfig.test.json
+++ b/packages/db/tsconfig.test.json
@@ -7,7 +7,7 @@
       "@forinda/kickjs": ["../kickjs/src/index.ts"],
       "@forinda/kickjs/*": ["../kickjs/src/*"],
       "@forinda/kickjs-db": ["./src/index.ts"],
-      "@forinda/kickjs-db/pg": ["./src/dsl/columns/pg.ts"],
+      "@forinda/kickjs-db/pg": ["./src/pg.ts"],
       "@forinda/kickjs-db/*": ["./src/*"]
     }
   },

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -28,8 +28,12 @@ export default defineConfig({
         replacement: path.resolve(__dirname, 'src/devtools-events.ts'),
       },
       {
+        // The real subpath barrel, matching `exports['./pg']` — not just the
+        // column types. Pointing this at src/dsl/columns/pg.ts made the alias
+        // narrower than the published surface, so anything else exported from
+        // ./pg (pgSchema, the adapter, the dialect) was invisible to tests.
         find: '@forinda/kickjs-db/pg',
-        replacement: path.resolve(__dirname, 'src/dsl/columns/pg.ts'),
+        replacement: path.resolve(__dirname, 'src/pg.ts'),
       },
       // M5.B — internal-only aliases so tests can reach helpers that
       // aren't part of the public `package.json` exports.


### PR DESCRIPTION
Adds PostgreSQL named-schema support to `@forinda/kickjs-db`. Previously a table could not declare a schema at all: `TableDecl` had no field for it, the emitters never qualified an identifier, and there was no `withSchema` anywhere in the package.

## API

```ts
import { pgSchema } from '@forinda/kickjs-db/pg'
import { table, serial, varchar } from '@forinda/kickjs-db'

const billing = pgSchema('billing')

const invoices = billing.table('invoices', {
  id: serial().primaryKey(),
  ref: varchar(32).notNull(),
})

const users = table('users', { id: serial().primaryKey() }) // default search_path
```

```sql
CREATE SCHEMA IF NOT EXISTS "billing";
CREATE TABLE "billing"."invoices" ( ... );
CREATE TABLE "users" ( ... );
```

```ts
type DB = KickDbSchema // { 'billing.invoices': {...}, users: {...} }
await db.selectFrom('billing.invoices').selectAll().execute()
```

Kysely reads a dotted table name as schema-qualified, so the qualified key is what makes the query resolve with no `withSchema()` call.

## What is qualified

Everything that names the table: `CREATE` / `DROP` / `ALTER TABLE`, `CREATE INDEX`, and any `REFERENCES` pointing at it. `DROP INDEX` too — an index lives in its table's schema but `DROP INDEX` resolves the *name* through `search_path`, so a bare name would miss, or hit a same-named index in `public`. `CREATE INDEX` needs no qualifier because it takes the schema from the qualified table it targets.

Snapshot keys are qualified, so two schemas may hold same-named tables: `billing.events` and `audit.events` no longer collide.

## Three decisions worth reviewing

**`pgSchema('public')` collapses to "no schema"** — in the runtime value *and* the type key. PG puts `public` on the default `search_path`, so `pgSchema('public').table('users', …)` and `table('users', …)` name the same physical table. Keeping them as distinct snapshot keys would make the diff emit `DROP TABLE users` + `CREATE TABLE public.users` — data loss for anyone switching spellings. The conditional return type keeps the static key in step with the runtime one; a mismatch there would have every query name a table the migration never created.

**No `dropSchema` change exists.** A schema can hold objects this app never declared — another service's tables, extensions, views — so a `DROP SCHEMA` inferred from "nothing references it any more" could destroy data the diff never saw. Down migrations leave the emptied schema for an operator to remove deliberately.

**PostgreSQL only.** On MySQL a schema *is* a database and SQLite has none (only `ATTACH` aliases), so the same qualified identifiers would parse and mean something different. `extractSnapshot` throws before any DDL is written, and both emitters carry an explicit unreachable-case guard rather than silently emitting `CREATE SCHEMA` (which on MySQL means `CREATE DATABASE`).

## Backward compatibility

Unqualified tables are untouched. No `schema` field is written, no `schemas` array is added — an added-but-`undefined` key would change the serialized JSON and invalidate every existing migration hash. There is a test asserting exactly that.

## Two latent bugs this surfaced

Both were pre-existing and are fixed here, each caught by a test written for the feature rather than by inspection:

- **`diffTable` stamped the bare table name** onto every column / index / FK change instead of the snapshot key, so a qualified table emitted `ALTER TABLE "invoices"` — which resolves through `search_path` to a different table, or to nothing.
- **`invertChanges` compared `dropTable`'s bare `.name` against `dropIndex`'s qualified key**, so the redundant-teardown prune silently stopped firing for schema-qualified tables. On SQLite that prune is load-bearing, not tidiness — without it, FK/index drops compile to a table rebuild against a snapshot that no longer holds the table.

Also corrects the vitest alias for `@forinda/kickjs-db/pg`, which pointed at `src/dsl/columns/pg.ts` — narrower than the published `exports['./pg']`, so anything else on that subpath (the adapter, the dialect, and now `pgSchema`) was invisible to tests.

## Testing

- 19 behavioural tests — snapshot keying, the `public` collapse, cross-schema collision, sorted `schemas` (hash stability), name validation, the dialect guard, DDL for every statement kind, FK targets, and a full up/down round trip asserting nothing references the qualified table by its bare name.
- 5 type-level tests via `vitest --typecheck`, in a `.test-d.ts` because the package `tsconfig.json` only includes `src` — `tsc --noEmit` would never have seen them.
- **478 passed, no type errors.** The 4 failures in `introspect-sqlite.test.ts` are pre-existing and environmental: a stale `better-sqlite3` native binary (`NODE_MODULE_VERSION 127`, built for Node 22, running Node 24). They fail identically on `main`.

## Out of scope

Introspection stays single-schema — `pgAdapter({ schema })`, default `public`, which today only scopes drift-detection queries. Tables in another schema are created and migrated correctly but are **not** compared against the live database yet. Documented with a warning in `docs/api/db.md`. The runtime `withSchema()` that the parked schema-per-tenant design (`docs/db/architecture.md:536`) needs is likewise not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQ4PPKDTxDSxBGLLYHU9Up


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL named-schema support through `pgSchema()`.
  * Generated migrations now create schemas when needed and correctly qualify tables, indexes, constraints, and references.
  * Tables with identical names in different schemas are handled independently, with schema-aware Kysely row-type keys.
  * The default `public` schema remains equivalent to an unqualified table.

* **Bug Fixes**
  * Corrected schema-qualified table references in column, index, and foreign-key changes.
  * Down migrations never drop schemas.

* **Documentation**
  * Added API documentation and PostgreSQL-only usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->