### PR TITLE
chore: move pnpm settings from package.json to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,22 +78,6 @@
   "url": "https://github.com/forinda/kick-js/issues"
  },
  "homepage": "https://kickjs.app/",
- "pnpm": {
-  "onlyBuiltDependencies": [
-   "@swc/core",
-   "better-sqlite3",
-   "esbuild"
-  ],
-  "ignoredBuiltDependencies": [
-   "lefthook"
-  ],
-  "overrides": {
-   "esbuild@<0.25.0": ">=0.25.0",
-   "uuid@<14.0.0": ">=14.0.0",
-   "@hono/node-server@<1.19.13": ">=1.19.13",
-   "undici@<6.24.0": "^6.24.0"
-  }
- },
  "dependencies": {
   "picocolors": "^1.1.1"
  }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,17 @@ packages:
   - 'packages/*/spa'
   - 'docs'
   - '!examples'
+
+onlyBuiltDependencies:
+  - '@swc/core'
+  - better-sqlite3
+  - esbuild
+
+ignoredBuiltDependencies:
+  - lefthook
+
+overrides:
+  esbuild@<0.25.0: '>=0.25.0'
+  uuid@<14.0.0: '>=14.0.0'
+  '@hono/node-server@<1.19.13': '>=1.19.13'
+  undici@<6.24.0: ^6.24.0


### PR DESCRIPTION
## Why

Running any pnpm command with a pnpm 11 CLI on this repo prints:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm.
The following keys were ignored: "pnpm.onlyBuiltDependencies", "pnpm.overrides".
```

pnpm 11 dropped support for the `pnpm` field in `package.json` — those
settings now live in `pnpm-workspace.yaml`.

Today this is only noise: the repo pins `packageManager: pnpm@10.12.1`, so a
v11 CLI delegates to 10.12.1, which still honours the field. But the moment
`packageManager` is bumped to 11, the `overrides` block stops applying
**silently** — and that block pins security fixes:

```json
"esbuild@<0.25.0": ">=0.25.0",
"uuid@<14.0.0": ">=14.0.0",
"@hono/node-server@<1.19.13": ">=1.19.13",
"undici@<6.24.0": "^6.24.0"
```

Losing those without a build failure is the bad outcome. Move them now,
before the bump.

## What

Moved `onlyBuiltDependencies`, `ignoredBuiltDependencies`, and `overrides`
from the `pnpm` block in `package.json` into `pnpm-workspace.yaml`, and
deleted the now-empty `pnpm` block.

pnpm 10 already reads all three keys from `pnpm-workspace.yaml`, so this is
compatible with the currently pinned `packageManager` and forward-compatible
with pnpm 11.

## Verification

```
$ pnpm install --lockfile-only
Scope: all 27 workspace projects
Done in 431ms using pnpm v10.12.1
```

No warning, and `pnpm-lock.yaml` is unchanged — the `overrides:` section at
the top of the lockfile still resolves to the same four pins, confirming the
settings are being read from their new home.

## Not in scope

Bumping `packageManager` to pnpm 11. That changes lockfile format and needs
its own CI pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated package manager configuration into the workspace settings.
  * Preserved approved build dependencies, ignored dependencies, and version overrides for a more consistent install/setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->