### PR TITLE
feat(config): read .env.test under test runs so dev env stops leaking in

### DIFF
--- a/.changeset/lucky-pugs-search.md
+++ b/.changeset/lucky-pugs-search.md
@@ -1,0 +1,25 @@
+---
+'@forinda/kickjs': minor
+---
+
+Read `.env.test` instead of `.env` under a test run, so development env stops leaking into tests
+
+KickJS loads dotenv as an import-time side effect with `override: false`. That
+protects vars the test runner already pinned, but every var it _didn't_ pin was
+silently backfilled from the developer's `.env` — so a suite could pin its
+database URL and still reach live development services through the vars it
+forgot, with nothing in the output saying so.
+
+Now, when `NODE_ENV=test` (or Vitest's `VITEST` is set) and a `.env.test` exists
+in `process.cwd()`, that file is read and `.env` is **not**. No cascade — falling
+through to `.env` is the leak. Set `KICKJS_ENV_FILE` to a comma-separated file
+list, or `off`, to override the choice.
+
+Apps with no `.env.test` keep their exact current behaviour, plus a one-time
+stderr warning naming what got backfilled.
+
+Also fixed: `reloadEnv()` used an inline `dotenv.config()` that always read
+`.env`, so an HMR reload could clobber pinned `.env.test` values; it now routes
+through the same resolver as boot. And `resetEnvCache()` left
+`Container._envResolver` installed over a null cache, making `@Value()` reads
+indistinguishable from an unset key — it is now cleared.

--- a/.changeset/lucky-pugs-search.md
+++ b/.changeset/lucky-pugs-search.md
@@ -10,13 +10,27 @@ silently backfilled from the developer's `.env` — so a suite could pin its
 database URL and still reach live development services through the vars it
 forgot, with nothing in the output saying so.
 
-Now, when `NODE_ENV=test` (or Vitest's `VITEST` is set) and a `.env.test` exists
-in `process.cwd()`, that file is read and `.env` is **not**. No cascade — falling
-through to `.env` is the leak. Set `KICKJS_ENV_FILE` to a comma-separated file
-list, or `off`, to override the choice.
+Env files now follow the cascade Vite popularised, where a mode-specific file
+outranks every generic one (`[mode]` is `NODE_ENV`):
 
-Apps with no `.env.test` keep their exact current behaviour, plus a one-time
-stderr warning naming what got backfilled.
+```
+.env.[mode].local  >  .env.[mode]  >  .env.local  >  .env
+```
+
+Vars already in `process.env` still outrank all four, as before.
+
+**Test mode is the deliberate exception.** When the mode is `test` and a
+`.env.test` / `.env.test.local` exists, those are read and the generic `.env` /
+`.env.local` are **not** — no layering, no fallback. Falling through is the
+leak, and `.env.local` is excluded for the same reason: it holds one
+developer's machine setup. `development` and `production` cascade normally,
+where layering is expected and there is no dev-resource-in-a-test failure mode.
+
+`KICKJS_ENV_FILE` replaces the cascade entirely — a comma-separated file list,
+highest precedence first (`.env.ci,.env.shared`), or `off` to skip dotenv.
+
+Apps with no mode files keep their exact current behaviour, plus a one-time
+stderr warning under a test run naming what got backfilled.
 
 Also fixed: `reloadEnv()` used an inline `dotenv.config()` that always read
 `.env`, so an HMR reload could clobber pinned `.env.test` values; it now routes

--- a/.changeset/lucky-pugs-search.md
+++ b/.changeset/lucky-pugs-search.md
@@ -13,7 +13,7 @@ forgot, with nothing in the output saying so.
 Env files now follow the cascade Vite popularised, where a mode-specific file
 outranks every generic one (`[mode]` is `NODE_ENV`):
 
-```
+```text
 .env.[mode].local  >  .env.[mode]  >  .env.local  >  .env
 ```
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -319,7 +319,7 @@ KickJS uses the same env-file cascade Vite popularised (see its "Env Variables
 and Modes" guide): a mode-specific file outranks every generic one, and keys
 found only in a generic file are still available.
 
-```
+```text
 .env.[mode].local  >  .env.[mode]  >  .env.local  >  .env
 ```
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -300,14 +300,65 @@ it('rejects files exceeding size limit', async () => {
 
 ## Environment Isolation
 
-Use `vi.stubEnv()` to set env vars without leaking to other tests:
+Load order decides this, so start there. Two things happen **before any
+`beforeAll` runs**:
+
+1. Importing `@forinda/kickjs` reads your env file into `process.env` as an
+   import-time side effect.
+2. Your `loadEnv(envSchema)` call parses `process.env` **once** and caches the
+   result. `ConfigService.get()` and `@Value()` read that cached snapshot, not
+   `process.env`.
+
+So a var must be set before the module graph is imported. The reliable
+placements are a `.env.test` file, your runner's `env` config, or a
+`setupFiles` entry that runs first.
+
+### `.env.test` — the default
+
+Under a test run (`NODE_ENV=test`, or Vitest's `VITEST`), KickJS reads
+`.env.test` if the file exists — and **only** `.env.test`. It does not fall
+back to `.env`.
+
+That short-circuit is deliberate. With a fallback, every var your test config
+forgets to pin gets silently backfilled from your development `.env`: you can
+pin your database URL and still reach live development services through the
+vars you forgot, and nothing in the run tells you. One file wins outright
+instead.
+
+```bash
+# .env.test — checked in; the whole environment your suite runs against
+NODE_ENV=test
+DATABASE_URL=postgresql://test@localhost/myapp_test
+LOG_LEVEL=silent
+```
+
+With no `.env.test` present, `.env` is read as before and KickJS prints a
+one-time warning naming what it backfilled.
+
+Override the choice with `KICKJS_ENV_FILE` — a comma-separated list of files,
+or `off` to skip dotenv entirely (for env injected via the shell, Docker, or a
+secret manager):
+
+```bash
+KICKJS_ENV_FILE=off vitest run
+KICKJS_ENV_FILE=.env.ci vitest run
+```
+
+### `vi.stubEnv()` mid-suite
+
+`vi.stubEnv()` mutates `process.env`, which is already too late for anything
+read through `ConfigService` / `@Value()` — the parse happened at import. To
+make a stub take effect, drop the cache and re-parse:
 
 ```ts
 import { vi, beforeAll, afterAll } from 'vitest'
+import { loadEnv, resetEnvCache } from '@forinda/kickjs'
+import { envSchema } from '../src/env'
 
 beforeAll(() => {
   vi.stubEnv('JWT_SECRET', 'test-secret-32-chars-minimum!!')
-  vi.stubEnv('DATABASE_URL', 'postgresql://test@localhost/test')
+  resetEnvCache()
+  loadEnv(envSchema)
 })
 
 afterAll(() => {
@@ -315,9 +366,8 @@ afterAll(() => {
 })
 ```
 
-::: warning
-Never use `process.env.X = 'value'` directly — it leaks across tests. Always use `vi.stubEnv()`.
-:::
+`vi.stubEnv()` alone is still correct for code that reads `process.env`
+directly.
 
 ## Container Isolation
 
@@ -359,7 +409,8 @@ The generated tests are scaffolds with real assertions. Customize them for your 
 - Use `beforeEach(() => Container.reset())` for serial test isolation
 - Use `isolated: true` for concurrent tests
 - Test controllers without auth by creating test-only controllers
-- Use `vi.stubEnv()` for env vars, never raw `process.env`
+- Put test env in `.env.test` — it wins outright and never falls back to `.env`
+- `vi.stubEnv()` after import needs `resetEnvCache()` + `loadEnv()` to reach `ConfigService`
 - The `expressApp` works directly with supertest — no server needed
 - Adapter lifecycle hooks (`beforeMount`, `beforeStart`) still run during setup
 - Generated tests work out of the box — `kick g module user && npx vitest run`

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -435,15 +435,23 @@ import { loadEnv, resetEnvCache } from '@forinda/kickjs'
 import { envSchema } from '../src/env'
 
 beforeAll(() => {
-  vi.stubEnv('JWT_SECRET', 'test-secret-32-chars-minimum!!')
+  vi.stubEnv('JWT_SECRET', 'test-secret-with-at-least-32-chars')
   resetEnvCache()
   loadEnv(envSchema)
 })
 
 afterAll(() => {
   vi.unstubAllEnvs()
+  // `unstubAllEnvs()` restores process.env, but the cached parse still
+  // holds the stub — drop it too, or a later test in the same worker
+  // reads your stubbed value through ConfigService / @Value().
+  resetEnvCache()
+  loadEnv(envSchema)
 })
 ```
+
+Your stub has to satisfy the schema: `loadEnv(envSchema)` re-validates, so a
+`JWT_SECRET` declared `z.string().min(32)` rejects a 30-character placeholder.
 
 `vi.stubEnv()` alone is still correct for code that reads `process.env`
 directly.

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -315,15 +315,32 @@ placements are a `.env.test` file, your runner's `env` config, or a
 
 ### `.env.test` — the default
 
-Under a test run (`NODE_ENV=test`, or Vitest's `VITEST`), KickJS reads
-`.env.test` if the file exists — and **only** `.env.test`. It does not fall
-back to `.env`.
+KickJS uses the same env-file cascade Vite popularised (see its "Env Variables
+and Modes" guide): a mode-specific file outranks every generic one, and keys
+found only in a generic file are still available.
+
+```
+.env.[mode].local  >  .env.[mode]  >  .env.local  >  .env
+```
+
+`[mode]` is your `NODE_ENV`. Vars already in `process.env` outrank all four, so
+what your shell or CI exports always wins. `*.local` files are for personal
+machine overrides — add `*.local` to `.gitignore`.
+
+**Test mode is the one exception.** Under a test run (`NODE_ENV=test`, or
+Vitest's `VITEST`), if a `.env.test` or `.env.test.local` exists, those are read
+and the generic `.env` / `.env.local` are **not**. No layering, no fallback.
 
 That short-circuit is deliberate. With a fallback, every var your test config
 forgets to pin gets silently backfilled from your development `.env`: you can
 pin your database URL and still reach live development services through the
-vars you forgot, and nothing in the run tells you. One file wins outright
-instead.
+vars you forgot, and nothing in the run tells you. `.env.local` is excluded for
+the same reason — it is precisely the file holding one developer's machine
+setup.
+
+For `development` and `production` the layering is what you want (shared base
+plus per-mode overrides) and there is no dev-resource-in-a-test failure mode to
+guard against, so those cascade normally.
 
 ```bash
 # .env.test — checked in; the whole environment your suite runs against
@@ -335,14 +352,76 @@ LOG_LEVEL=silent
 With no `.env.test` present, `.env` is read as before and KickJS prints a
 one-time warning naming what it backfilled.
 
-Override the choice with `KICKJS_ENV_FILE` — a comma-separated list of files,
-or `off` to skip dotenv entirely (for env injected via the shell, Docker, or a
-secret manager):
+### `KICKJS_ENV_FILE` — taking manual control
+
+`KICKJS_ENV_FILE` replaces the whole cascade with a list you choose. It accepts
+a comma-separated list of paths, **highest precedence first**, or `off` to skip
+dotenv entirely:
 
 ```bash
+# Skip env files completely — env comes from the shell, Docker, or a
+# secret manager. Nothing on disk can leak in.
 KICKJS_ENV_FILE=off vitest run
+
+# One file, nothing else. Not even .env is consulted.
 KICKJS_ENV_FILE=.env.ci vitest run
 ```
+
+Order is precedence, so put the file that should win **first**. This is the
+manual equivalent of the built-in cascade — a base file plus overrides layered
+on top:
+
+```bash
+# .env.ci wins on conflicts; .env.shared supplies everything it omits.
+KICKJS_ENV_FILE=.env.ci,.env.shared vitest run
+```
+
+```bash
+# Three layers: a per-developer file beats the team's test defaults,
+# which beat the shared base.
+KICKJS_ENV_FILE=.env.test.local,.env.test,.env.shared vitest run
+```
+
+Reversing the list reverses the outcome — `.env.shared,.env.ci` lets
+`.env.shared` win, which is usually not what you meant:
+
+```bash
+# ✗ Wrong way round — the base overrides your CI values.
+KICKJS_ENV_FILE=.env.shared,.env.ci vitest run
+```
+
+Paths resolve relative to `process.cwd()`, so a monorepo can reach a file the
+cascade would never find on its own — note that cwd is the **package** dir when
+run through a workspace filter, not the repo root:
+
+```bash
+# Layer a repo-root file under the package's own.
+KICKJS_ENV_FILE=.env.test,../../.env.shared pnpm --filter api test
+```
+
+Missing files in the list are skipped silently, so an optional local override
+costs nothing:
+
+```bash
+# Works whether or not .env.test.local exists.
+KICKJS_ENV_FILE=.env.test.local,.env.test vitest run
+```
+
+Set it per command as above, or pin it for a whole suite from the runner —
+which also keeps it out of individual developers' shells:
+
+```ts
+// vitest.config.ts
+export default defineConfig({
+  test: {
+    env: { KICKJS_ENV_FILE: '.env.ci,.env.shared' },
+  },
+})
+```
+
+One caveat: vars already present in `process.env` still outrank every file in
+the list, `KICKJS_ENV_FILE` included. It picks which files are read, not whether
+files beat the environment.
 
 ### `vi.stubEnv()` mid-suite
 

--- a/packages/cli/__tests__/doctor.test.ts
+++ b/packages/cli/__tests__/doctor.test.ts
@@ -11,6 +11,7 @@ import {
   checkKickJsInstalled,
   checkReflectMetadata,
   checkRuntimeEngine,
+  checkTestEnvIsolation,
   checkUploadDriver,
   defineDoctorCheck,
   defineDoctorExtension,
@@ -648,5 +649,66 @@ describe('defineDoctorCheck', () => {
     }))
     const results = await runChecks(dir, { extraChecks: [myCheck] })
     expect(results.find((r) => r.name === 'Bound check')?.status).toBe('pass')
+  })
+})
+
+describe('checkTestEnvIsolation', () => {
+  const VITEST_CFG = 'export default {}\n'
+
+  it('skips a project with no test runner config', () => {
+    const dir = tempProject({ '.env': 'DATABASE_URL=postgres://localhost/dev\n' })
+    expect(checkTestEnvIsolation(ctx(dir))).toBeNull()
+  })
+
+  it('skips a project with no .env — nothing can be inherited', () => {
+    const dir = tempProject({ 'vitest.config.ts': VITEST_CFG })
+    expect(checkTestEnvIsolation(ctx(dir))).toBeNull()
+  })
+
+  it('warns on the vulnerable shape: .env + a suite, no .env.test', () => {
+    const dir = tempProject({
+      'vitest.config.ts': VITEST_CFG,
+      '.env': 'DATABASE_URL=postgres://localhost/myapp_dev\n',
+    })
+    const r = checkTestEnvIsolation(ctx(dir))
+    expect(r?.status).toBe('warn')
+    expect(r?.fix).toContain('.env.test')
+    expect(r?.fix).toContain('KICKJS_ENV_FILE=off')
+  })
+
+  it('passes once .env.test exists', () => {
+    const dir = tempProject({
+      'vitest.config.ts': VITEST_CFG,
+      '.env': 'DATABASE_URL=postgres://localhost/myapp_dev\n',
+      '.env.test': 'DATABASE_URL=postgres://localhost/myapp_test\n',
+    })
+    expect(checkTestEnvIsolation(ctx(dir))?.status).toBe('pass')
+  })
+
+  it('passes when only .env.test.local provides the isolation', () => {
+    const dir = tempProject({
+      'vitest.config.ts': VITEST_CFG,
+      '.env': 'DATABASE_URL=postgres://localhost/myapp_dev\n',
+      '.env.test.local': 'DATABASE_URL=postgres://localhost/myapp_test\n',
+    })
+    expect(checkTestEnvIsolation(ctx(dir))?.status).toBe('pass')
+  })
+
+  it('warns on a bare .env.local with no .env — it leaks the same way', () => {
+    const dir = tempProject({
+      'vitest.config.ts': VITEST_CFG,
+      '.env.local': 'DATABASE_URL=postgres://localhost/myapp_dev\n',
+    })
+    const r = checkTestEnvIsolation(ctx(dir))
+    expect(r?.status).toBe('warn')
+    expect(r?.message).toContain('.env.local')
+  })
+
+  it('recognises a jest project too', () => {
+    const dir = tempProject({
+      'jest.config.js': 'module.exports = {}\n',
+      '.env': 'DATABASE_URL=postgres://localhost/myapp_dev\n',
+    })
+    expect(checkTestEnvIsolation(ctx(dir))?.status).toBe('warn')
   })
 })

--- a/packages/cli/__tests__/doctor.test.ts
+++ b/packages/cli/__tests__/doctor.test.ts
@@ -704,6 +704,37 @@ describe('checkTestEnvIsolation', () => {
     expect(r?.message).toContain('.env.local')
   })
 
+  it('warns when a test script pins KICKJS_ENV_FILE past the isolation', () => {
+    // KICKJS_ENV_FILE is consulted before the test-mode short-circuit, so a
+    // complete .env.test sitting right there is simply not read.
+    const dir = tempProject({
+      'vitest.config.ts': VITEST_CFG,
+      '.env': 'DATABASE_URL=postgres://localhost/myapp_dev\n',
+      '.env.test': 'DATABASE_URL=postgres://localhost/myapp_test\n',
+      'package.json': JSON.stringify({
+        name: 'x',
+        scripts: { test: 'KICKJS_ENV_FILE=.env vitest run' },
+      }),
+    })
+    const r = checkTestEnvIsolation(ctx(dir))
+    expect(r?.status).toBe('warn')
+    expect(r?.message).toContain('KICKJS_ENV_FILE=.env')
+  })
+
+  it('still passes when the override is KICKJS_ENV_FILE=off', () => {
+    // `off` means env comes from the runner — isolation is not defeated.
+    const dir = tempProject({
+      'vitest.config.ts': VITEST_CFG,
+      '.env': 'DATABASE_URL=postgres://localhost/myapp_dev\n',
+      '.env.test': 'DATABASE_URL=postgres://localhost/myapp_test\n',
+      'package.json': JSON.stringify({
+        name: 'x',
+        scripts: { test: 'KICKJS_ENV_FILE=off vitest run' },
+      }),
+    })
+    expect(checkTestEnvIsolation(ctx(dir))?.status).toBe('pass')
+  })
+
   it('recognises a jest project too', () => {
     const dir = tempProject({
       'jest.config.js': 'module.exports = {}\n',

--- a/packages/cli/__tests__/explain.test.ts
+++ b/packages/cli/__tests__/explain.test.ts
@@ -132,6 +132,16 @@ describe('known-issues registry', () => {
     expect(withShape!.confidence).toBeGreaterThan(bare!.confidence)
   })
 
+  it('treats .env.test.local as isolation, matching kick doctor', () => {
+    const input = 'vitest run wiped the dev database — tests connected to the wrong db'
+    const bare = findBestMatch(input)
+    const isolated = findBestMatch(input, {
+      hasFile: (p: string) => p === '.env' || p === '.env.test.local',
+    })
+    // Already isolated — no confidence bump for a vulnerable shape.
+    expect(isolated!.confidence).toBe(bare!.confidence)
+  })
+
   it('does not match a resource complaint with no test context', () => {
     const m = findBestMatch('the production database was wiped during a migration')
     expect(m?.diagnosis.id).not.toBe('test-env-leaked-from-dotenv')

--- a/packages/cli/__tests__/explain.test.ts
+++ b/packages/cli/__tests__/explain.test.ts
@@ -111,6 +111,32 @@ describe('known-issues registry', () => {
     expect(m!.diagnosis.id).toBe('cluster-in-vite-dev')
   })
 
+  it('matches test-env-leaked-from-dotenv when a suite hits a real resource', () => {
+    const m = findBestMatch('vitest run wiped the dev database — tests connected to the wrong db')
+    expect(m).not.toBeNull()
+    expect(m!.diagnosis.id).toBe('test-env-leaked-from-dotenv')
+  })
+
+  it('matches test-env-leaked-from-dotenv when vi.stubEnv appears to do nothing', () => {
+    const m = findBestMatch('in my vitest suite vi.stubEnv has no effect on ConfigService.get')
+    expect(m).not.toBeNull()
+    expect(m!.diagnosis.id).toBe('test-env-leaked-from-dotenv')
+  })
+
+  it('raises confidence when .env exists without .env.test', () => {
+    const input = 'vitest run wiped the dev database — tests connected to the wrong db'
+    const bare = findBestMatch(input)
+    const withShape = findBestMatch(input, {
+      hasFile: (p: string) => p === '.env',
+    })
+    expect(withShape!.confidence).toBeGreaterThan(bare!.confidence)
+  })
+
+  it('does not match a resource complaint with no test context', () => {
+    const m = findBestMatch('the production database was wiped during a migration')
+    expect(m?.diagnosis.id).not.toBe('test-env-leaked-from-dotenv')
+  })
+
   it('returns null for completely unrelated errors', () => {
     const m = findBestMatch('the rocket motor failed to ignite at T-minus 3')
     expect(m).toBeNull()

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -698,6 +698,27 @@ const TEST_RUNNER_CONFIGS = [
 const TEST_ENV_FILES = ['.env.test', '.env.test.local'] as const
 const GENERIC_ENV_FILES = ['.env', '.env.local'] as const
 
+/**
+ * The value a `KICKJS_ENV_FILE` override would carry into a test run, or
+ * `null` if nothing sets it. Checks the package's test scripts first (an
+ * override pinned there applies to everyone), then doctor's own env.
+ *
+ * Deliberately a shallow scan of `scripts.test*`: a var exported from a
+ * developer's shell profile or a CI job definition is not visible from
+ * here, so this catches the common committed case rather than every case.
+ */
+function findTestEnvFileOverride(ctx: DoctorContext): string | null {
+  const scripts = ctx.pkg?.scripts
+  if (scripts && typeof scripts === 'object') {
+    for (const [name, value] of Object.entries(scripts)) {
+      if (!name.startsWith('test') || typeof value !== 'string') continue
+      const hit = /KICKJS_ENV_FILE=(\S+)/.exec(value)
+      if (hit?.[1]) return hit[1]
+    }
+  }
+  return process.env['KICKJS_ENV_FILE'] ?? null
+}
+
 export function checkTestEnvIsolation(ctx: DoctorContext): DoctorResult | null {
   const hasTestRunner = TEST_RUNNER_CONFIGS.some((f) => existsSync(join(ctx.cwd, f)))
   if (!hasTestRunner) return null
@@ -707,6 +728,24 @@ export function checkTestEnvIsolation(ctx: DoctorContext): DoctorResult | null {
 
   const isolating = TEST_ENV_FILES.filter((f) => existsSync(join(ctx.cwd, f)))
   if (isolating.length > 0) {
+    // `KICKJS_ENV_FILE` is consulted BEFORE the test-mode short-circuit, so
+    // it wins outright: a script running `KICKJS_ENV_FILE=.env vitest` reads
+    // `.env` no matter how complete the `.env.test` sitting next to it is.
+    // Reporting a plain pass there would certify isolation that is not in
+    // effect. Look for the override in the test scripts (where it would be
+    // pinned for everyone) and in doctor's own environment.
+    const override = findTestEnvFileOverride(ctx)
+    if (override && override !== 'off' && override !== 'none') {
+      return {
+        name: 'test env isolation',
+        status: 'warn',
+        message: `${isolating.join(', ')} present, but KICKJS_ENV_FILE=${override} overrides it`,
+        fix:
+          `KICKJS_ENV_FILE is checked before test-mode isolation, so ${isolating[0]} is\n` +
+          `ignored and "${override}" is read instead. Drop the override to use the\n` +
+          'test files, or set KICKJS_ENV_FILE=off if env comes from the runner.',
+      }
+    }
     return {
       name: 'test env isolation',
       status: 'pass',

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -670,6 +670,66 @@ export function checkTypegenFreshness(ctx: DoctorContext): DoctorResult | null {
   }
 }
 
+/** Test-runner configs that mean "this project has a suite". */
+const TEST_RUNNER_CONFIGS = [
+  'vitest.config.ts',
+  'vitest.config.js',
+  'vitest.config.mts',
+  'vite.config.ts',
+  'jest.config.ts',
+  'jest.config.js',
+]
+
+/**
+ * Warn when a project has a `.env` and a test suite but no `.env.test`.
+ *
+ * KickJS loads dotenv at import time with `override: false`, so vars the
+ * test runner pins are safe but everything it *doesn't* pin is backfilled
+ * from the developer's `.env`. That makes the runner's `env` block a
+ * hand-maintained allow-list, and the failure is silent: a suite can pin
+ * its database URL and still reach live development services through the
+ * vars it forgot.
+ *
+ * Under a test run, a `.env.test` / `.env.test.local` is read INSTEAD of the
+ * generic `.env` and `.env.local` — no layering, no fallback — which closes
+ * that hole, but only if one of those files exists. It is opt-in, and an
+ * opt-in nobody discovers is worth nothing, hence this check.
+ */
+const TEST_ENV_FILES = ['.env.test', '.env.test.local'] as const
+const GENERIC_ENV_FILES = ['.env', '.env.local'] as const
+
+export function checkTestEnvIsolation(ctx: DoctorContext): DoctorResult | null {
+  const hasTestRunner = TEST_RUNNER_CONFIGS.some((f) => existsSync(join(ctx.cwd, f)))
+  if (!hasTestRunner) return null
+
+  const generic = GENERIC_ENV_FILES.filter((f) => existsSync(join(ctx.cwd, f)))
+  if (generic.length === 0) return null
+
+  const isolating = TEST_ENV_FILES.filter((f) => existsSync(join(ctx.cwd, f)))
+  if (isolating.length > 0) {
+    return {
+      name: 'test env isolation',
+      status: 'pass',
+      message: `${isolating.join(', ')} present`,
+    }
+  }
+
+  return {
+    name: 'test env isolation',
+    status: 'warn',
+    message: `${generic.join(', ')} present, no .env.test`,
+    fix:
+      "Under NODE_ENV=test (or vitest's VITEST) KickJS reads .env.test / .env.test.local\n" +
+      `INSTEAD of ${generic.join(' and ')} — no layering, no fallback. Without one of\n` +
+      'those files, every var your test config does not pin resolves from your\n' +
+      'development env — including DATABASE_URL and any third-party credentials.\n' +
+      '\n' +
+      'Create .env.test holding the whole environment the suite should run against\n' +
+      '(a var you leave out is then missing, not inherited), or set KICKJS_ENV_FILE=off\n' +
+      'and supply env from the test runner.',
+  }
+}
+
 // ── Runner ────────────────────────────────────────────────────────────
 
 const BUILT_IN_CHECKS: DoctorCheck[] = [
@@ -681,6 +741,7 @@ const BUILT_IN_CHECKS: DoctorCheck[] = [
   checkReflectMetadata,
   checkDecoratorTsConfig,
   checkEnvWiring,
+  checkTestEnvIsolation,
   checkTypegenFreshness,
 ]
 

--- a/packages/cli/src/explain/known-issues.ts
+++ b/packages/cli/src/explain/known-issues.ts
@@ -336,6 +336,111 @@ const moduleNotRegistered: KnownIssue = {
   },
 }
 
+// ── Issue 8: test run inherited the developer's .env ─────────────────────
+
+const testEnvLeakedFromDotenv: KnownIssue = {
+  match(input, ctx) {
+    const hasTestContext = includesAny(input, [
+      'vitest',
+      'test',
+      'spec',
+      '__tests__',
+      '.test.',
+      'jest',
+    ])
+    if (!hasTestContext) return null
+
+    // Two distinct symptoms of the same cause.
+    //   a) the suite reached a real resource it should never have touched
+    //   b) a stub/override "did nothing" to ConfigService / @Value
+    const hitRealResource = includesAny(input, [
+      'wrong database',
+      'dev database',
+      'development database',
+      'production database',
+      'wrong db',
+      'dev db',
+      'connected to the wrong',
+      'wiped',
+      'truncated',
+      'deleted rows',
+      'sent a real email',
+      'real email',
+      'live api',
+    ])
+    const stubDidNothing =
+      includesAny(input, ['stubenv', 'process.env', 'setupfiles', 'test.env', 'env override']) &&
+      includesAny(input, [
+        'no effect',
+        'not applied',
+        'ignored',
+        'still',
+        'undefined',
+        'does nothing',
+        "doesn't work",
+        'not working',
+      ])
+
+    if (!hitRealResource && !stubDidNothing) return null
+
+    // A project with a `.env` but no `.env.test` is the exact vulnerable
+    // shape, so seeing it on disk is a strong corroborating signal.
+    const vulnerableShape = ctx?.hasFile?.('.env') === true && ctx?.hasFile?.('.env.test') === false
+
+    let confidence = hitRealResource && stubDidNothing ? 85 : hitRealResource ? 75 : 65
+    if (vulnerableShape) confidence = Math.min(95, confidence + 10)
+
+    return {
+      confidence,
+      diagnosis: {
+        id: 'test-env-leaked-from-dotenv',
+        title: 'Test run inherited env vars from your development .env',
+        explanation:
+          'KickJS loads dotenv as an import-time side effect, with `override: false`.\n' +
+          'That protects the vars your test runner pinned — but every var it did NOT\n' +
+          'pin is silently backfilled from your `.env`. So a suite can pin its database\n' +
+          'URL and still reach live development services through the vars it forgot,\n' +
+          'and nothing in the run reports it.\n' +
+          '\n' +
+          'The second symptom has the same root: `loadEnv()` parses process.env ONCE\n' +
+          'into a module-level cache, and ConfigService.get() / @Value() read that\n' +
+          'snapshot. A vi.stubEnv() in beforeAll runs long after the parse, so it is a\n' +
+          'silent no-op for them (it still works for code reading process.env directly).\n' +
+          '\n' +
+          "Under a test run (NODE_ENV=test, or vitest's VITEST), KickJS reads `.env.test`\n" +
+          'if it exists — and only `.env.test`, with no fallback to `.env`. Falling\n' +
+          'through is the leak, so one file wins outright.',
+        fix:
+          'Create a .env.test next to your .env holding the WHOLE environment the suite\n' +
+          'should run against. A var you leave out will be missing rather than\n' +
+          'inherited, which is the point — the run fails loudly instead of quietly\n' +
+          'reaching your dev stack.\n' +
+          '\n' +
+          'To stub a var mid-suite, drop the cache and re-parse. To opt out of dotenv\n' +
+          'entirely, set KICKJS_ENV_FILE=off (it also takes a comma-separated file list).',
+        codeBefore:
+          '# .env  ← read by your tests today, including every var you forgot to pin\n' +
+          'DATABASE_URL=postgres://localhost:5432/myapp_dev\n',
+        codeAfter:
+          '# .env.test  ← read INSTEAD of .env under NODE_ENV=test / VITEST\n' +
+          'NODE_ENV=test\n' +
+          'DATABASE_URL=postgres://localhost:5432/myapp_test\n' +
+          'LOG_LEVEL=silent\n' +
+          '\n' +
+          '// mid-suite stubs need the cache dropped:\n' +
+          "import { loadEnv, resetEnvCache } from '@forinda/kickjs'\n" +
+          "import { envSchema } from '../src/env'\n\n" +
+          'beforeAll(() => {\n' +
+          "  vi.stubEnv('JWT_SECRET', 'x'.repeat(32))\n" +
+          '  resetEnvCache()\n' +
+          '  loadEnv(envSchema)\n' +
+          '})',
+        docs: 'https://kickjs.app/guide/testing.html#environment-isolation',
+      },
+    }
+  },
+}
+
 // ── Registry ──────────────────────────────────────────────────────────────
 
 export const KNOWN_ISSUES: KnownIssue[] = [
@@ -346,6 +451,7 @@ export const KNOWN_ISSUES: KnownIssue[] = [
   clusterInDevMode,
   reflectMetadataMissing,
   moduleNotRegistered,
+  testEnvLeakedFromDotenv,
 ]
 
 /**

--- a/packages/cli/src/explain/known-issues.ts
+++ b/packages/cli/src/explain/known-issues.ts
@@ -383,9 +383,15 @@ const testEnvLeakedFromDotenv: KnownIssue = {
 
     if (!hitRealResource && !stubDidNothing) return null
 
-    // A project with a `.env` but no `.env.test` is the exact vulnerable
-    // shape, so seeing it on disk is a strong corroborating signal.
-    const vulnerableShape = ctx?.hasFile?.('.env') === true && ctx?.hasFile?.('.env.test') === false
+    // A project with a generic env file but no test-scoped one is the exact
+    // vulnerable shape, so seeing it on disk is a strong corroborating signal.
+    // Both `.env.test` and `.env.test.local` isolate — checking only the
+    // former would flag an already-isolated project, and it would disagree
+    // with `kick doctor`'s check, which counts both.
+    const hasGeneric = ctx?.hasFile?.('.env') === true || ctx?.hasFile?.('.env.local') === true
+    const hasTestScoped =
+      ctx?.hasFile?.('.env.test') === true || ctx?.hasFile?.('.env.test.local') === true
+    const vulnerableShape = hasGeneric && !hasTestScoped
 
     let confidence = hitRealResource && stubDidNothing ? 85 : hitRealResource ? 75 : 65
     if (vulnerableShape) confidence = Math.min(95, confidence + 10)

--- a/packages/kickjs/__tests__/env-file-resolution.test.ts
+++ b/packages/kickjs/__tests__/env-file-resolution.test.ts
@@ -218,9 +218,11 @@ describe('backfill warning accounting', () => {
     expect(appliedKeys(before, { KICK_TEST_X: 'from-file' })).toEqual([])
   })
 
-  it('warns naming only the leaked var, not the pinned one', () => {
-    // End-to-end through reloadEnv. KICK_TEST_X is pinned by the "runner"
-    // AND present in .env; KICK_TEST_DEV_ONLY exists only in .env.
+  it('names every var the reload actually changed', () => {
+    // End-to-end through reloadEnv, which is the `override: true` path — so
+    // the file wins over the pre-set value and BOTH keys genuinely change.
+    // Both must therefore be named; the runner-pinned exclusion is an
+    // `override: false` behaviour, covered by the unit cases above.
     process.env.KICK_TEST_X = 'from-runner'
     writeFileSync('.env', 'KICK_TEST_X=from-file\nKICK_TEST_DEV_ONLY=leaked\n')
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -228,11 +230,10 @@ describe('backfill warning accounting', () => {
     try {
       reloadEnv()
       const message = warn.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(message).toContain('KICK_TEST_X')
       expect(message).toContain('KICK_TEST_DEV_ONLY')
-      // reloadEnv uses override:true, so the file DOES win here — the
-      // point is the count and list come from what changed, not from
-      // everything the file happened to contain.
-      expect(message).toContain('env var(s) from')
+      expect(message).toContain('2 env var(s) from')
+      expect(process.env.KICK_TEST_X).toBe('from-file')
     } finally {
       warn.mockRestore()
     }

--- a/packages/kickjs/__tests__/env-file-resolution.test.ts
+++ b/packages/kickjs/__tests__/env-file-resolution.test.ts
@@ -15,11 +15,12 @@
  * through `reloadEnv()`, which routes to the same resolver.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { Container, reloadEnv, resetEnvCache } from '../src'
+import { appliedKeys } from '../src/config/env'
 
 const KEYS = ['KICK_TEST_X', 'KICK_TEST_DEV_ONLY'] as const
 
@@ -182,5 +183,76 @@ describe('env file cascade for non-test modes', () => {
     // Neither generic file contributes — `.env.local` is a developer's
     // personal machine config, which is precisely what must not leak in.
     expect(process.env.KICK_TEST_DEV_ONLY).toBeUndefined()
+  })
+})
+
+/**
+ * The backfill warning must name only the vars dotenv ACTUALLY applied.
+ *
+ * `result.parsed` is everything read out of the files, not everything
+ * applied: under `override: false` a key the test runner already pinned
+ * keeps the runner's value and the file's copy is discarded. Reporting
+ * those would name vars the user got right, which inverts the message —
+ * it exists to say what leaked IN.
+ */
+describe('backfill warning accounting', () => {
+  it('excludes keys whose value the runner already pinned', () => {
+    // Models the override:false boot path: PINNED is already in
+    // process.env, so dotenv leaves it and only NEW_KEY is applied.
+    process.env.KICK_TEST_X = 'from-runner'
+    const before = { ...process.env }
+    process.env.KICK_TEST_DEV_ONLY = 'from-file'
+
+    const applied = appliedKeys(before, {
+      KICK_TEST_X: 'from-file',
+      KICK_TEST_DEV_ONLY: 'from-file',
+    })
+
+    expect(applied).toEqual(['KICK_TEST_DEV_ONLY'])
+  })
+
+  it('reports nothing when every parsed key was already pinned', () => {
+    process.env.KICK_TEST_X = 'from-runner'
+    const before = { ...process.env }
+
+    expect(appliedKeys(before, { KICK_TEST_X: 'from-file' })).toEqual([])
+  })
+
+  it('warns naming only the leaked var, not the pinned one', () => {
+    // End-to-end through reloadEnv. KICK_TEST_X is pinned by the "runner"
+    // AND present in .env; KICK_TEST_DEV_ONLY exists only in .env.
+    process.env.KICK_TEST_X = 'from-runner'
+    writeFileSync('.env', 'KICK_TEST_X=from-file\nKICK_TEST_DEV_ONLY=leaked\n')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      reloadEnv()
+      const message = warn.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(message).toContain('KICK_TEST_DEV_ONLY')
+      // reloadEnv uses override:true, so the file DOES win here — the
+      // point is the count and list come from what changed, not from
+      // everything the file happened to contain.
+      expect(message).toContain('env var(s) from')
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('stays silent when the generic files change nothing', () => {
+    // Every key in .env already matches process.env — nothing was taken,
+    // so there is nothing to warn about.
+    process.env.KICK_TEST_X = 'same'
+    writeFileSync('.env', 'KICK_TEST_X=same\n')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      reloadEnv()
+      const kickjsWarnings = warn.mock.calls
+        .map((c) => String(c[0]))
+        .filter((m) => m.includes('[kickjs]'))
+      expect(kickjsWarnings).toEqual([])
+    } finally {
+      warn.mockRestore()
+    }
   })
 })

--- a/packages/kickjs/__tests__/env-file-resolution.test.ts
+++ b/packages/kickjs/__tests__/env-file-resolution.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Proves the test-isolation contract of the dotenv boot step: under a
+ * test run, a `.env.test` on disk wins outright and the developer's
+ * `.env` is not read at all.
+ *
+ * The bug this locks down: `dotenv.config({ override: false })` runs as
+ * an import-time side effect of `@forinda/kickjs`, so every key a test
+ * runner forgets to pin gets silently backfilled from `.env`. A suite
+ * can pin its database URL and still reach live development services
+ * through the keys it forgot — and nothing in the run says so. The
+ * short-circuit (rather than a `.env.test` → `.env` cascade) is what
+ * closes that hole: falling through IS the leak.
+ *
+ * `tryLoadDotenv()` only runs at module load, so these cases drive it
+ * through `reloadEnv()`, which routes to the same resolver.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { Container, reloadEnv, resetEnvCache } from '../src'
+
+const KEYS = ['KICK_TEST_X', 'KICK_TEST_DEV_ONLY'] as const
+
+let dir: string
+let cwd: string
+
+function clearKeys(): void {
+  for (const k of KEYS) delete process.env[k]
+  delete process.env.KICKJS_ENV_FILE
+}
+
+beforeEach(() => {
+  Container.reset()
+  resetEnvCache()
+  clearKeys()
+  cwd = process.cwd()
+  dir = mkdtempSync(path.join(tmpdir(), 'kick-envres-'))
+  process.chdir(dir)
+})
+
+afterEach(() => {
+  process.chdir(cwd)
+  rmSync(dir, { recursive: true, force: true })
+  clearKeys()
+})
+
+/** Both files present — the shape a leaking project actually has. */
+function writeBothEnvFiles(): void {
+  writeFileSync('.env', 'KICK_TEST_X=dev\nKICK_TEST_DEV_ONLY=leaked\n')
+  writeFileSync('.env.test', 'KICK_TEST_X=test\n')
+}
+
+describe('env file resolution under a test run', () => {
+  it('reads .env.test and does NOT fall through to .env', () => {
+    expect(process.env.NODE_ENV === 'test' || !!process.env.VITEST).toBe(true)
+    writeBothEnvFiles()
+
+    reloadEnv()
+
+    expect(process.env.KICK_TEST_X).toBe('test')
+    // The regression: a key present only in `.env` must not appear.
+    // Before the fix this was 'leaked'.
+    expect(process.env.KICK_TEST_DEV_ONLY).toBeUndefined()
+  })
+
+  it('KICKJS_ENV_FILE=off skips dotenv entirely', () => {
+    writeBothEnvFiles()
+    process.env.KICKJS_ENV_FILE = 'off'
+
+    reloadEnv()
+
+    expect(process.env.KICK_TEST_X).toBeUndefined()
+    expect(process.env.KICK_TEST_DEV_ONLY).toBeUndefined()
+  })
+
+  it('KICKJS_ENV_FILE names the file(s) to read, overriding the test default', () => {
+    writeBothEnvFiles()
+    process.env.KICKJS_ENV_FILE = '.env'
+
+    reloadEnv()
+
+    // Explicit opt-back-in to the old behaviour — the compat escape hatch.
+    expect(process.env.KICK_TEST_X).toBe('dev')
+    expect(process.env.KICK_TEST_DEV_ONLY).toBe('leaked')
+  })
+
+  it('falls back to .env when no .env.test exists (unchanged for existing apps)', () => {
+    writeFileSync('.env', 'KICK_TEST_X=dev\nKICK_TEST_DEV_ONLY=leaked\n')
+
+    reloadEnv()
+
+    expect(process.env.KICK_TEST_X).toBe('dev')
+    expect(process.env.KICK_TEST_DEV_ONLY).toBe('leaked')
+  })
+})

--- a/packages/kickjs/__tests__/env-file-resolution.test.ts
+++ b/packages/kickjs/__tests__/env-file-resolution.test.ts
@@ -25,6 +25,8 @@ const KEYS = ['KICK_TEST_X', 'KICK_TEST_DEV_ONLY'] as const
 
 let dir: string
 let cwd: string
+let nodeEnv: string | undefined
+let vitestFlag: string | undefined
 
 function clearKeys(): void {
   for (const k of KEYS) delete process.env[k]
@@ -35,6 +37,8 @@ beforeEach(() => {
   Container.reset()
   resetEnvCache()
   clearKeys()
+  nodeEnv = process.env.NODE_ENV
+  vitestFlag = process.env.VITEST
   cwd = process.cwd()
   dir = mkdtempSync(path.join(tmpdir(), 'kick-envres-'))
   process.chdir(dir)
@@ -44,6 +48,12 @@ afterEach(() => {
   process.chdir(cwd)
   rmSync(dir, { recursive: true, force: true })
   clearKeys()
+  // The mode cases below drive NODE_ENV directly; restore it so a stray
+  // value can't leak into the next file's expectations.
+  if (nodeEnv === undefined) delete process.env.NODE_ENV
+  else process.env.NODE_ENV = nodeEnv
+  if (vitestFlag === undefined) delete process.env.VITEST
+  else process.env.VITEST = vitestFlag
 })
 
 /** Both files present — the shape a leaking project actually has. */
@@ -93,5 +103,84 @@ describe('env file resolution under a test run', () => {
 
     expect(process.env.KICK_TEST_X).toBe('dev')
     expect(process.env.KICK_TEST_DEV_ONLY).toBe('leaked')
+  })
+})
+
+/**
+ * Non-test modes follow the cascade Vite popularised: mode-specific files
+ * outrank every generic one, and keys that appear only in a generic file
+ * are still available. Test mode is the deliberate exception, covered above.
+ */
+describe('env file cascade for non-test modes', () => {
+  /** Drive the resolver as `production` rather than the ambient test run. */
+  function asProduction(): void {
+    process.env.NODE_ENV = 'production'
+    delete process.env.VITEST
+  }
+
+  it('layers .env.production over .env instead of replacing it', () => {
+    asProduction()
+    writeFileSync('.env', 'KICK_TEST_X=base\nKICK_TEST_DEV_ONLY=from-base\n')
+    writeFileSync('.env.production', 'KICK_TEST_X=prod\n')
+
+    reloadEnv()
+
+    expect(process.env.KICK_TEST_X).toBe('prod')
+    // The whole point of layering: base-only keys survive.
+    expect(process.env.KICK_TEST_DEV_ONLY).toBe('from-base')
+  })
+
+  it('ranks .env.[mode] above .env.local, per Vite', () => {
+    asProduction()
+    writeFileSync('.env.local', 'KICK_TEST_X=local\n')
+    writeFileSync('.env.production', 'KICK_TEST_X=prod\n')
+
+    reloadEnv()
+
+    // Mode beats generic — including generic `.local`.
+    expect(process.env.KICK_TEST_X).toBe('prod')
+  })
+
+  it('ranks .env.[mode].local highest of the four', () => {
+    asProduction()
+    writeFileSync('.env', 'KICK_TEST_X=base\n')
+    writeFileSync('.env.local', 'KICK_TEST_X=local\n')
+    writeFileSync('.env.production', 'KICK_TEST_X=prod\n')
+    writeFileSync('.env.production.local', 'KICK_TEST_X=prod-local\n')
+
+    reloadEnv()
+
+    expect(process.env.KICK_TEST_X).toBe('prod-local')
+  })
+
+  it('keeps precedence under reloadEnv (override:true reverses dotenv order)', () => {
+    // Regression guard: dotenv resolves array precedence positionally and
+    // flips direction with `override: true`. Without reversing the array,
+    // a reload lets `.env` beat `.env.production` — the cascade silently
+    // inverts on the HMR path only.
+    asProduction()
+    writeFileSync('.env', 'KICK_TEST_X=base\n')
+    writeFileSync('.env.production', 'KICK_TEST_X=prod\n')
+
+    reloadEnv()
+    expect(process.env.KICK_TEST_X).toBe('prod')
+
+    // Second reload — the override path runs again over already-set vars.
+    writeFileSync('.env.production', 'KICK_TEST_X=prod-v2\n')
+    reloadEnv()
+    expect(process.env.KICK_TEST_X).toBe('prod-v2')
+  })
+
+  it('still isolates under test mode, .local included', () => {
+    writeFileSync('.env', 'KICK_TEST_X=dev\nKICK_TEST_DEV_ONLY=leaked\n')
+    writeFileSync('.env.local', 'KICK_TEST_DEV_ONLY=leaked-local\n')
+    writeFileSync('.env.test.local', 'KICK_TEST_X=test-local\n')
+
+    reloadEnv()
+
+    expect(process.env.KICK_TEST_X).toBe('test-local')
+    // Neither generic file contributes — `.env.local` is a developer's
+    // personal machine config, which is precisely what must not leak in.
+    expect(process.env.KICK_TEST_DEV_ONLY).toBeUndefined()
   })
 })

--- a/packages/kickjs/src/config/env.ts
+++ b/packages/kickjs/src/config/env.ts
@@ -128,6 +128,26 @@ function resolveEnvFiles(): string[] | null {
 /** One-shot guard so the test-backfill warning cannot spam a suite. */
 let warnedTestBackfill = false
 
+/**
+ * Of the keys dotenv parsed out of the files, the ones whose value in
+ * `process.env` actually differs from `before` — i.e. the ones dotenv
+ * really applied.
+ *
+ * This distinction is the whole point of the warning. `result.parsed`
+ * is everything READ from the files, not everything APPLIED: under
+ * `override: false` a key already set by the test runner keeps the
+ * runner's value and the file's copy is discarded. Warning about those
+ * would name vars the user correctly pinned, which is exactly backwards
+ * — the message exists to say which vars leaked IN, and listing pinned
+ * ones alongside them makes it untrustworthy noise.
+ *
+ * Exported for tests only; not re-exported from the package index, so
+ * it is not public API.
+ */
+export function appliedKeys(before: NodeJS.ProcessEnv, parsed: Record<string, string>): string[] {
+  return Object.keys(parsed).filter((k) => process.env[k] !== before[k])
+}
+
 function tryLoadDotenv(override = false): void {
   const files = resolveEnvFiles()
   if (!files) return
@@ -145,19 +165,29 @@ function tryLoadDotenv(override = false): void {
     // override path has to reverse it — otherwise a `reloadEnv()` would
     // silently invert the cascade and let `.env` beat `.env.production`.
     const path = override ? files.toReversed() : files
-    const result = dotenv.config({ path, override, quiet: true })
 
     // Isolation is opt-in, and nobody discovers an opt-in. A test run that
-    // read the generic files says so once, on stderr.
+    // read the generic files says so once, on stderr — but only about the
+    // vars it actually pulled in, so snapshot process.env first. Skipped
+    // entirely when no warning could fire, to keep the copy off the boot
+    // path of a normal run.
     const usedGeneric = files.some((f) => (GENERIC_ENV_FILES as readonly string[]).includes(f))
-    if (!warnedTestBackfill && isTestRun() && usedGeneric && result.parsed) {
-      warnedTestBackfill = true
-      const keys = Object.keys(result.parsed)
-      if (keys.length > 0) {
+    const mayWarn = !warnedTestBackfill && isTestRun() && usedGeneric
+    const before = mayWarn ? { ...process.env } : undefined
+
+    const result = dotenv.config({ path, override, quiet: true })
+
+    if (mayWarn && result.parsed) {
+      const applied = appliedKeys(before!, result.parsed)
+      // Only latch the one-shot guard once something is actually reported;
+      // latching on a run that had nothing to say would swallow the real
+      // warning from a later reload.
+      if (applied.length > 0) {
+        warnedTestBackfill = true
         console.warn(
-          `[kickjs] test run backfilled ${keys.length} env var(s) from ` +
-            `${files.join(', ')} (${keys.slice(0, 5).join(', ')}` +
-            `${keys.length > 5 ? ', …' : ''}). Create a .env.test to isolate the ` +
+          `[kickjs] test run took ${applied.length} env var(s) from ` +
+            `${files.join(', ')} (${applied.slice(0, 5).join(', ')}` +
+            `${applied.length > 5 ? ', …' : ''}). Create a .env.test to isolate the ` +
             'suite, or set KICKJS_ENV_FILE=off.',
         )
       }
@@ -391,6 +421,10 @@ export function reloadEnv(): void {
 export function resetEnvCache(): void {
   cachedEnv = null
   cachedSchema = null
+  // Also re-arm the one-shot backfill warning. This is the "start fresh"
+  // hook, and a suite that swaps env between cases should get told each
+  // time it picks up the generic files, not only the first.
+  warnedTestBackfill = false
   // Drop the resolver too. It closes over `cachedEnv`, so leaving it
   // installed left `@Value()` reading through a live closure over a
   // null cache — indistinguishable from "key not set" but with no

--- a/packages/kickjs/src/config/env.ts
+++ b/packages/kickjs/src/config/env.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
 import type { z } from 'zod'
 import { detectSchema, type InferSchemaOutput } from '@forinda/kickjs-schema'
 import { Container } from '../core/container'
@@ -49,15 +51,70 @@ function getZod(): typeof import('zod') {
  * shim that CJS caches aggressively, so the second `require` is a no-op
  * and new keys never reach `process.env` — the root cause of the
  * "DATABASE_URL undefined until restart" bug on Windows dev.
+ *
+ * Which file(s) get read is decided by {@link resolveEnvFiles}.
  */
-function tryLoadDotenv(): void {
+function isTestRun(): boolean {
+  return process.env['NODE_ENV'] === 'test' || !!process.env['VITEST']
+}
+
+/**
+ * Which env files dotenv should read, relative to `process.cwd()`.
+ * `null` means "read nothing".
+ *
+ * Under a test run, a `.env.test` on disk is treated as an explicit
+ * opt-in to an isolated environment, and we deliberately do **not**
+ * fall through to `.env`. That short-circuit is the whole point: with
+ * `override: false`, every key a test runner forgets to pin is
+ * silently backfilled from the developer's `.env`, so a suite can pin
+ * its database URL and still reach live development services through
+ * the keys it forgot. A Vite-style cascade (`.env.test` then `.env`)
+ * would keep exactly that hole open, so one file wins outright.
+ *
+ * `KICKJS_ENV_FILE` overrides the decision entirely — a comma-separated
+ * list of files, or `off` to skip dotenv altogether (for apps that
+ * inject env via the shell, Docker, or a secret manager).
+ */
+function resolveEnvFiles(): string[] | null {
+  const explicit = process.env['KICKJS_ENV_FILE']
+  if (explicit === 'off' || explicit === 'none') return null
+  if (explicit) {
+    return explicit
+      .split(',')
+      .map((f) => f.trim())
+      .filter(Boolean)
+  }
+  if (isTestRun() && existsSync(resolve(process.cwd(), '.env.test'))) return ['.env.test']
+  return ['.env']
+}
+
+/** One-shot guard so the test-backfill warning cannot spam a suite. */
+let warnedTestBackfill = false
+
+function tryLoadDotenv(override = false): void {
+  const files = resolveEnvFiles()
+  if (!files) return
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const dotenv = require('dotenv')
     // `quiet: true` suppresses dotenv 17's tip banner that goes to stdout.
     // Required for CLI tools whose stdout is parsed by callers (`kick explain
     // --json`, etc) — the banner would otherwise corrupt the JSON output.
-    dotenv.config({ override: false, quiet: true })
+    const result = dotenv.config({ path: files, override, quiet: true })
+
+    // `.env.test` is opt-in, and nobody discovers an opt-in. A test run
+    // that inherited the developer's `.env` says so once, on stderr.
+    if (!warnedTestBackfill && isTestRun() && files.includes('.env') && result.parsed) {
+      warnedTestBackfill = true
+      const keys = Object.keys(result.parsed)
+      if (keys.length > 0) {
+        console.warn(
+          `[kickjs] test run backfilled ${keys.length} env var(s) from .env ` +
+            `(${keys.slice(0, 5).join(', ')}${keys.length > 5 ? ', …' : ''}). ` +
+            'Create a .env.test to isolate the suite, or set KICKJS_ENV_FILE=off.',
+        )
+      }
+    }
   } catch {
     // dotenv not installed — fall through, env vars must come from
     // the environment directly. This is a valid deployment style.
@@ -255,14 +312,13 @@ export function getEnv(key: string, schema?: z.ZodObject<any>): any {
  * between cases), call {@link resetEnvCache} instead.
  */
 export function reloadEnv(): void {
-  // Re-read .env file into process.env if dotenv is installed.
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    require('dotenv').config({ override: true, quiet: true })
-  } catch {
-    // dotenv not installed — nothing to reload, env comes from the
-    // environment directly.
-  }
+  // Re-read the env file(s) into process.env if dotenv is installed.
+  // Routed through the same resolver as boot so a reload can never
+  // disagree with startup about which file is authoritative — the
+  // inline `dotenv.config()` this replaced always read `.env`, so
+  // under a test run it could clobber pinned `.env.test` values with
+  // the developer's own.
+  tryLoadDotenv(true)
 
   // Drop the parsed snapshot but keep the schema. Re-parse eagerly so
   // existing consumers (including ConfigService getters and @Value
@@ -288,6 +344,11 @@ export function reloadEnv(): void {
 export function resetEnvCache(): void {
   cachedEnv = null
   cachedSchema = null
+  // Drop the resolver too. It closes over `cachedEnv`, so leaving it
+  // installed left `@Value()` reading through a live closure over a
+  // null cache — indistinguishable from "key not set" but with no
+  // schema to re-parse against.
+  Container._envResolver = null
 }
 
 /**

--- a/packages/kickjs/src/config/env.ts
+++ b/packages/kickjs/src/config/env.ts
@@ -59,21 +59,48 @@ function isTestRun(): boolean {
 }
 
 /**
- * Which env files dotenv should read, relative to `process.cwd()`.
- * `null` means "read nothing".
+ * The mode whose env files apply — `NODE_ENV`, falling back to `test`
+ * under a runner that sets `VITEST` without `NODE_ENV`, else the same
+ * `development` default `baseEnvSchema` uses.
+ */
+function envMode(): string {
+  return process.env['NODE_ENV'] ?? (process.env['VITEST'] ? 'test' : 'development')
+}
+
+const GENERIC_ENV_FILES = ['.env.local', '.env'] as const
+
+/**
+ * Which env files dotenv should read, relative to `process.cwd()`, in
+ * **highest-precedence-first** order. `null` means "read nothing".
  *
- * Under a test run, a `.env.test` on disk is treated as an explicit
- * opt-in to an isolated environment, and we deliberately do **not**
- * fall through to `.env`. That short-circuit is the whole point: with
- * `override: false`, every key a test runner forgets to pin is
- * silently backfilled from the developer's `.env`, so a suite can pin
- * its database URL and still reach live development services through
- * the keys it forgot. A Vite-style cascade (`.env.test` then `.env`)
- * would keep exactly that hole open, so one file wins outright.
+ * The cascade follows the convention Vite popularised, where a
+ * mode-specific file outranks every generic one:
+ *
+ * ```
+ * .env.[mode].local  >  .env.[mode]  >  .env.local  >  .env
+ * ```
+ *
+ * Vars already present in `process.env` still outrank all of them —
+ * that is what `override: false` at the call site buys, and it matches
+ * Vite ("environment variables that already exist … have the highest
+ * priority and will not be overwritten by `.env` files").
+ *
+ * **Test mode is the one exception, and deliberately so.** When the mode
+ * is `test` and a `.env.test` / `.env.test.local` exists, that file is
+ * treated as an explicit opt-in to an isolated environment and the
+ * generic files are dropped rather than layered under it. Layering is
+ * exactly the hole this closes: with `override: false`, every key a test
+ * runner forgets to pin is silently backfilled from the developer's
+ * `.env`, so a suite can pin its database URL and still reach live
+ * development services through the keys it forgot. For `development` and
+ * `production` the layering is what people expect and want (shared base
+ * plus overrides), and there is no dev-resource-in-a-test failure mode
+ * to guard against, so those cascade normally.
  *
  * `KICKJS_ENV_FILE` overrides the decision entirely — a comma-separated
- * list of files, or `off` to skip dotenv altogether (for apps that
- * inject env via the shell, Docker, or a secret manager).
+ * list of files (highest precedence first), or `off` to skip dotenv
+ * altogether (for apps that inject env via the shell, Docker, or a
+ * secret manager).
  */
 function resolveEnvFiles(): string[] | null {
   const explicit = process.env['KICKJS_ENV_FILE']
@@ -84,8 +111,18 @@ function resolveEnvFiles(): string[] | null {
       .map((f) => f.trim())
       .filter(Boolean)
   }
-  if (isTestRun() && existsSync(resolve(process.cwd(), '.env.test'))) return ['.env.test']
-  return ['.env']
+
+  const exists = (f: string): boolean => existsSync(resolve(process.cwd(), f))
+  const mode = envMode()
+  const modeFiles = [`.env.${mode}.local`, `.env.${mode}`]
+
+  // A test-scoped file present = isolate. Without one we still read the
+  // generic files (so an existing project is unchanged) and warn.
+  const isolate = mode === 'test' && modeFiles.some(exists)
+  const chain = isolate ? modeFiles : [...modeFiles, ...GENERIC_ENV_FILES]
+
+  const found = chain.filter(exists)
+  return found.length > 0 ? found : null
 }
 
 /** One-shot guard so the test-backfill warning cannot spam a suite. */
@@ -100,18 +137,28 @@ function tryLoadDotenv(override = false): void {
     // `quiet: true` suppresses dotenv 17's tip banner that goes to stdout.
     // Required for CLI tools whose stdout is parsed by callers (`kick explain
     // --json`, etc) — the banner would otherwise corrupt the JSON output.
-    const result = dotenv.config({ path: files, override, quiet: true })
+    //
+    // dotenv resolves array precedence positionally, and the DIRECTION
+    // depends on `override`: with `override: false` the first file to set a
+    // key wins; with `override: true` each file overwrites the last, so the
+    // final one wins. `files` is ordered highest-precedence-first, so the
+    // override path has to reverse it — otherwise a `reloadEnv()` would
+    // silently invert the cascade and let `.env` beat `.env.production`.
+    const path = override ? files.toReversed() : files
+    const result = dotenv.config({ path, override, quiet: true })
 
-    // `.env.test` is opt-in, and nobody discovers an opt-in. A test run
-    // that inherited the developer's `.env` says so once, on stderr.
-    if (!warnedTestBackfill && isTestRun() && files.includes('.env') && result.parsed) {
+    // Isolation is opt-in, and nobody discovers an opt-in. A test run that
+    // read the generic files says so once, on stderr.
+    const usedGeneric = files.some((f) => (GENERIC_ENV_FILES as readonly string[]).includes(f))
+    if (!warnedTestBackfill && isTestRun() && usedGeneric && result.parsed) {
       warnedTestBackfill = true
       const keys = Object.keys(result.parsed)
       if (keys.length > 0) {
         console.warn(
-          `[kickjs] test run backfilled ${keys.length} env var(s) from .env ` +
-            `(${keys.slice(0, 5).join(', ')}${keys.length > 5 ? ', …' : ''}). ` +
-            'Create a .env.test to isolate the suite, or set KICKJS_ENV_FILE=off.',
+          `[kickjs] test run backfilled ${keys.length} env var(s) from ` +
+            `${files.join(', ')} (${keys.slice(0, 5).join(', ')}` +
+            `${keys.length > 5 ? ', …' : ''}). Create a .env.test to isolate the ` +
+            'suite, or set KICKJS_ENV_FILE=off.',
         )
       }
     }


### PR DESCRIPTION
## The problem

`packages/kickjs/src/config/env.ts` calls `tryLoadDotenv()` as a bare
module-top-level statement, so **any** import of `@forinda/kickjs`,
`@forinda/kickjs/config`, or `@forinda/kickjs-testing` runs:

```ts
dotenv.config({ override: false, quiet: true })   // reads ${cwd}/.env
```

`override: false` protects vars the test runner already pinned. It does nothing
for the vars it *didn't* pin — those are silently backfilled from the
developer's `.env`.

The failure mode is quiet and asymmetric: a suite can pin its database URL and
still reach live development services through every var it forgot. Nothing in
the run reports it. The test runner's `env` block ends up being the entire
defence, and it's a hand-maintained allow-list — you find out what's missing
when a test writes somewhere it shouldn't have.

Compounding it, `loadEnv()` parses `process.env` once into a module-level
`cachedEnv`. `ConfigService.get()` and `@Value()` read that snapshot, so a
`vi.stubEnv()` in `beforeAll` is a **silent no-op** for them — the parse already
happened at import time.

## The change

Under a test run (`NODE_ENV=test`, or Vitest's `VITEST`), if `.env.test` exists
in `process.cwd()`, it is read and `.env` is **not**:

```ts
function resolveEnvFiles(): string[] | null {
  const explicit = process.env['KICKJS_ENV_FILE']
  if (explicit === 'off' || explicit === 'none') return null
  if (explicit) return explicit.split(',').map((f) => f.trim()).filter(Boolean)
  if (isTestRun() && existsSync(resolve(process.cwd(), '.env.test'))) return ['.env.test']
  return ['.env']
}
```

**Deliberately not a Vite-style cascade.** A `.env.test` → `.env` fallthrough
keeps the exact hole open that this is meant to close — falling through *is* the
leak. One file wins outright.

`KICKJS_ENV_FILE` overrides the decision: a comma-separated file list, or `off`
to skip dotenv entirely (shell/Docker/secret-manager deployments).

### Two related fixes

- **`reloadEnv()`** used an inline `dotenv.config({ override: true })` hardcoded
  to `.env`. Under a test run it could clobber pinned `.env.test` values with
  the developer's own. It now routes through the same resolver as boot, so a
  reload can never disagree with startup about which file is authoritative.
- **`resetEnvCache()`** cleared `cachedEnv`/`cachedSchema` but left
  `Container._envResolver` installed — a live closure over a null cache, making
  `@Value()` reads indistinguishable from an unset key with no schema left to
  re-parse against. Now cleared.

## Backward compatibility

An app with no `.env.test` gets byte-identical behaviour, plus one stderr line
the first time a test run backfills from `.env`:

```
[kickjs] test run backfilled 14 env var(s) from .env (PORT, DATABASE_URL, …).
Create a .env.test to isolate the suite, or set KICKJS_ENV_FILE=off.
```

An opt-in nobody discovers is worth nothing, hence the warning. `KICKJS_ENV_FILE=.env`
restores the old path explicitly and silently.

Direction of failure is safe: creating a file is the safe action and takes
effect automatically; inheriting dev env into a test now requires deleting it.

## Verification

`packages/kickjs/__tests__/env-file-resolution.test.ts` covers isolation, both
`KICKJS_ENV_FILE` forms, and the no-`.env.test` fallback. It drives
`tryLoadDotenv()` through `reloadEnv()`, since the boot call only runs at module
load.

Confirmed it fails on the previous behaviour by stashing the fix:

```
× reads .env.test and does NOT fall through to .env
  AssertionError: expected 'dev' to be 'test'
× KICKJS_ENV_FILE=off skips dotenv entirely
  AssertionError: expected 'dev' to be undefined
```

The two back-compat cases pass both before and after — that's the compatibility
guarantee.

Full package suite: **707/707 pass**. `tsc --noEmit` clean, `format:check` clean.

## Docs

`docs/guide/testing.md` "Environment Isolation" is rewritten. It previously led
with `vi.stubEnv()` as the whole story and warned:

> Never use `process.env.X = 'value'` directly — it leaks across tests.

That's a wrong mental model, not just an omission — it teaches the pattern that
no-ops against `ConfigService`/`@Value()` and forbids placements that work. The
section now leads with load order, documents `.env.test` and `KICKJS_ENV_FILE`,
and shows the `resetEnvCache()` + `loadEnv()` escape hatch for mid-suite stubs.

## Not in scope

`kick new` scaffolding a `.env.test` and a `kick doctor` check for
`.env`-without-`.env.test`. Worth doing; separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment loading now follows mode-based rules, including test-specific precedence and custom file overrides.
  * Added an option to disable environment file loading entirely.
  * Added diagnostics for detecting test environments that may inherit variables from generic environment files.

* **Bug Fixes**
  * Improved environment reload behavior and test isolation.
  * Added clearer warnings and remediation guidance for missing or misconfigured test environment files.

* **Documentation**
  * Updated testing guidance with environment loading order and configuration reload recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->