### PR TITLE
feat(cli): surface test-env inheritance in doctor and explain

### DIFF
--- a/packages/cli/__tests__/doctor.test.ts
+++ b/packages/cli/__tests__/doctor.test.ts
@@ -11,6 +11,7 @@ import {
   checkKickJsInstalled,
   checkReflectMetadata,
   checkRuntimeEngine,
+  checkTestEnvIsolation,
   checkUploadDriver,
   defineDoctorCheck,
   defineDoctorExtension,
@@ -648,5 +649,66 @@ describe('defineDoctorCheck', () => {
     }))
     const results = await runChecks(dir, { extraChecks: [myCheck] })
     expect(results.find((r) => r.name === 'Bound check')?.status).toBe('pass')
+  })
+})
+
+describe('checkTestEnvIsolation', () => {
+  const VITEST_CFG = 'export default {}\n'
+
+  it('skips a project with no test runner config', () => {
+    const dir = tempProject({ '.env': 'DATABASE_URL=postgres://localhost/dev\n' })
+    expect(checkTestEnvIsolation(ctx(dir))).toBeNull()
+  })
+
+  it('skips a project with no .env — nothing can be inherited', () => {
+    const dir = tempProject({ 'vitest.config.ts': VITEST_CFG })
+    expect(checkTestEnvIsolation(ctx(dir))).toBeNull()
+  })
+
+  it('warns on the vulnerable shape: .env + a suite, no .env.test', () => {
+    const dir = tempProject({
+      'vitest.config.ts': VITEST_CFG,
+      '.env': 'DATABASE_URL=postgres://localhost/myapp_dev\n',
+    })
+    const r = checkTestEnvIsolation(ctx(dir))
+    expect(r?.status).toBe('warn')
+    expect(r?.fix).toContain('.env.test')
+    expect(r?.fix).toContain('KICKJS_ENV_FILE=off')
+  })
+
+  it('passes once .env.test exists', () => {
+    const dir = tempProject({
+      'vitest.config.ts': VITEST_CFG,
+      '.env': 'DATABASE_URL=postgres://localhost/myapp_dev\n',
+      '.env.test': 'DATABASE_URL=postgres://localhost/myapp_test\n',
+    })
+    expect(checkTestEnvIsolation(ctx(dir))?.status).toBe('pass')
+  })
+
+  it('passes when only .env.test.local provides the isolation', () => {
+    const dir = tempProject({
+      'vitest.config.ts': VITEST_CFG,
+      '.env': 'DATABASE_URL=postgres://localhost/myapp_dev\n',
+      '.env.test.local': 'DATABASE_URL=postgres://localhost/myapp_test\n',
+    })
+    expect(checkTestEnvIsolation(ctx(dir))?.status).toBe('pass')
+  })
+
+  it('warns on a bare .env.local with no .env — it leaks the same way', () => {
+    const dir = tempProject({
+      'vitest.config.ts': VITEST_CFG,
+      '.env.local': 'DATABASE_URL=postgres://localhost/myapp_dev\n',
+    })
+    const r = checkTestEnvIsolation(ctx(dir))
+    expect(r?.status).toBe('warn')
+    expect(r?.message).toContain('.env.local')
+  })
+
+  it('recognises a jest project too', () => {
+    const dir = tempProject({
+      'jest.config.js': 'module.exports = {}\n',
+      '.env': 'DATABASE_URL=postgres://localhost/myapp_dev\n',
+    })
+    expect(checkTestEnvIsolation(ctx(dir))?.status).toBe('warn')
   })
 })

--- a/packages/cli/__tests__/explain.test.ts
+++ b/packages/cli/__tests__/explain.test.ts
@@ -111,6 +111,32 @@ describe('known-issues registry', () => {
     expect(m!.diagnosis.id).toBe('cluster-in-vite-dev')
   })
 
+  it('matches test-env-leaked-from-dotenv when a suite hits a real resource', () => {
+    const m = findBestMatch('vitest run wiped the dev database — tests connected to the wrong db')
+    expect(m).not.toBeNull()
+    expect(m!.diagnosis.id).toBe('test-env-leaked-from-dotenv')
+  })
+
+  it('matches test-env-leaked-from-dotenv when vi.stubEnv appears to do nothing', () => {
+    const m = findBestMatch('in my vitest suite vi.stubEnv has no effect on ConfigService.get')
+    expect(m).not.toBeNull()
+    expect(m!.diagnosis.id).toBe('test-env-leaked-from-dotenv')
+  })
+
+  it('raises confidence when .env exists without .env.test', () => {
+    const input = 'vitest run wiped the dev database — tests connected to the wrong db'
+    const bare = findBestMatch(input)
+    const withShape = findBestMatch(input, {
+      hasFile: (p: string) => p === '.env',
+    })
+    expect(withShape!.confidence).toBeGreaterThan(bare!.confidence)
+  })
+
+  it('does not match a resource complaint with no test context', () => {
+    const m = findBestMatch('the production database was wiped during a migration')
+    expect(m?.diagnosis.id).not.toBe('test-env-leaked-from-dotenv')
+  })
+
   it('returns null for completely unrelated errors', () => {
     const m = findBestMatch('the rocket motor failed to ignite at T-minus 3')
     expect(m).toBeNull()

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -670,6 +670,66 @@ export function checkTypegenFreshness(ctx: DoctorContext): DoctorResult | null {
   }
 }
 
+/** Test-runner configs that mean "this project has a suite". */
+const TEST_RUNNER_CONFIGS = [
+  'vitest.config.ts',
+  'vitest.config.js',
+  'vitest.config.mts',
+  'vite.config.ts',
+  'jest.config.ts',
+  'jest.config.js',
+]
+
+/**
+ * Warn when a project has a `.env` and a test suite but no `.env.test`.
+ *
+ * KickJS loads dotenv at import time with `override: false`, so vars the
+ * test runner pins are safe but everything it *doesn't* pin is backfilled
+ * from the developer's `.env`. That makes the runner's `env` block a
+ * hand-maintained allow-list, and the failure is silent: a suite can pin
+ * its database URL and still reach live development services through the
+ * vars it forgot.
+ *
+ * Under a test run, a `.env.test` / `.env.test.local` is read INSTEAD of the
+ * generic `.env` and `.env.local` — no layering, no fallback — which closes
+ * that hole, but only if one of those files exists. It is opt-in, and an
+ * opt-in nobody discovers is worth nothing, hence this check.
+ */
+const TEST_ENV_FILES = ['.env.test', '.env.test.local'] as const
+const GENERIC_ENV_FILES = ['.env', '.env.local'] as const
+
+export function checkTestEnvIsolation(ctx: DoctorContext): DoctorResult | null {
+  const hasTestRunner = TEST_RUNNER_CONFIGS.some((f) => existsSync(join(ctx.cwd, f)))
+  if (!hasTestRunner) return null
+
+  const generic = GENERIC_ENV_FILES.filter((f) => existsSync(join(ctx.cwd, f)))
+  if (generic.length === 0) return null
+
+  const isolating = TEST_ENV_FILES.filter((f) => existsSync(join(ctx.cwd, f)))
+  if (isolating.length > 0) {
+    return {
+      name: 'test env isolation',
+      status: 'pass',
+      message: `${isolating.join(', ')} present`,
+    }
+  }
+
+  return {
+    name: 'test env isolation',
+    status: 'warn',
+    message: `${generic.join(', ')} present, no .env.test`,
+    fix:
+      "Under NODE_ENV=test (or vitest's VITEST) KickJS reads .env.test / .env.test.local\n" +
+      `INSTEAD of ${generic.join(' and ')} — no layering, no fallback. Without one of\n` +
+      'those files, every var your test config does not pin resolves from your\n' +
+      'development env — including DATABASE_URL and any third-party credentials.\n' +
+      '\n' +
+      'Create .env.test holding the whole environment the suite should run against\n' +
+      '(a var you leave out is then missing, not inherited), or set KICKJS_ENV_FILE=off\n' +
+      'and supply env from the test runner.',
+  }
+}
+
 // ── Runner ────────────────────────────────────────────────────────────
 
 const BUILT_IN_CHECKS: DoctorCheck[] = [
@@ -681,6 +741,7 @@ const BUILT_IN_CHECKS: DoctorCheck[] = [
   checkReflectMetadata,
   checkDecoratorTsConfig,
   checkEnvWiring,
+  checkTestEnvIsolation,
   checkTypegenFreshness,
 ]
 

--- a/packages/cli/src/explain/known-issues.ts
+++ b/packages/cli/src/explain/known-issues.ts
@@ -336,6 +336,111 @@ const moduleNotRegistered: KnownIssue = {
   },
 }
 
+// ── Issue 8: test run inherited the developer's .env ─────────────────────
+
+const testEnvLeakedFromDotenv: KnownIssue = {
+  match(input, ctx) {
+    const hasTestContext = includesAny(input, [
+      'vitest',
+      'test',
+      'spec',
+      '__tests__',
+      '.test.',
+      'jest',
+    ])
+    if (!hasTestContext) return null
+
+    // Two distinct symptoms of the same cause.
+    //   a) the suite reached a real resource it should never have touched
+    //   b) a stub/override "did nothing" to ConfigService / @Value
+    const hitRealResource = includesAny(input, [
+      'wrong database',
+      'dev database',
+      'development database',
+      'production database',
+      'wrong db',
+      'dev db',
+      'connected to the wrong',
+      'wiped',
+      'truncated',
+      'deleted rows',
+      'sent a real email',
+      'real email',
+      'live api',
+    ])
+    const stubDidNothing =
+      includesAny(input, ['stubenv', 'process.env', 'setupfiles', 'test.env', 'env override']) &&
+      includesAny(input, [
+        'no effect',
+        'not applied',
+        'ignored',
+        'still',
+        'undefined',
+        'does nothing',
+        "doesn't work",
+        'not working',
+      ])
+
+    if (!hitRealResource && !stubDidNothing) return null
+
+    // A project with a `.env` but no `.env.test` is the exact vulnerable
+    // shape, so seeing it on disk is a strong corroborating signal.
+    const vulnerableShape = ctx?.hasFile?.('.env') === true && ctx?.hasFile?.('.env.test') === false
+
+    let confidence = hitRealResource && stubDidNothing ? 85 : hitRealResource ? 75 : 65
+    if (vulnerableShape) confidence = Math.min(95, confidence + 10)
+
+    return {
+      confidence,
+      diagnosis: {
+        id: 'test-env-leaked-from-dotenv',
+        title: 'Test run inherited env vars from your development .env',
+        explanation:
+          'KickJS loads dotenv as an import-time side effect, with `override: false`.\n' +
+          'That protects the vars your test runner pinned — but every var it did NOT\n' +
+          'pin is silently backfilled from your `.env`. So a suite can pin its database\n' +
+          'URL and still reach live development services through the vars it forgot,\n' +
+          'and nothing in the run reports it.\n' +
+          '\n' +
+          'The second symptom has the same root: `loadEnv()` parses process.env ONCE\n' +
+          'into a module-level cache, and ConfigService.get() / @Value() read that\n' +
+          'snapshot. A vi.stubEnv() in beforeAll runs long after the parse, so it is a\n' +
+          'silent no-op for them (it still works for code reading process.env directly).\n' +
+          '\n' +
+          "Under a test run (NODE_ENV=test, or vitest's VITEST), KickJS reads `.env.test`\n" +
+          'if it exists — and only `.env.test`, with no fallback to `.env`. Falling\n' +
+          'through is the leak, so one file wins outright.',
+        fix:
+          'Create a .env.test next to your .env holding the WHOLE environment the suite\n' +
+          'should run against. A var you leave out will be missing rather than\n' +
+          'inherited, which is the point — the run fails loudly instead of quietly\n' +
+          'reaching your dev stack.\n' +
+          '\n' +
+          'To stub a var mid-suite, drop the cache and re-parse. To opt out of dotenv\n' +
+          'entirely, set KICKJS_ENV_FILE=off (it also takes a comma-separated file list).',
+        codeBefore:
+          '# .env  ← read by your tests today, including every var you forgot to pin\n' +
+          'DATABASE_URL=postgres://localhost:5432/myapp_dev\n',
+        codeAfter:
+          '# .env.test  ← read INSTEAD of .env under NODE_ENV=test / VITEST\n' +
+          'NODE_ENV=test\n' +
+          'DATABASE_URL=postgres://localhost:5432/myapp_test\n' +
+          'LOG_LEVEL=silent\n' +
+          '\n' +
+          '// mid-suite stubs need the cache dropped:\n' +
+          "import { loadEnv, resetEnvCache } from '@forinda/kickjs'\n" +
+          "import { envSchema } from '../src/env'\n\n" +
+          'beforeAll(() => {\n' +
+          "  vi.stubEnv('JWT_SECRET', 'x'.repeat(32))\n" +
+          '  resetEnvCache()\n' +
+          '  loadEnv(envSchema)\n' +
+          '})',
+        docs: 'https://kickjs.app/guide/testing.html#environment-isolation',
+      },
+    }
+  },
+}
+
 // ── Registry ──────────────────────────────────────────────────────────────
 
 export const KNOWN_ISSUES: KnownIssue[] = [
@@ -346,6 +451,7 @@ export const KNOWN_ISSUES: KnownIssue[] = [
   clusterInDevMode,
   reflectMetadataMissing,
   moduleNotRegistered,
+  testEnvLeakedFromDotenv,
 ]
 
 /**


### PR DESCRIPTION
> **Stacked on #500.** Base branch is `feat/env-test-isolation`, so this diff
> shows only the CLI work. Merge #500 first.

## Why

#500 makes a test run read `.env.test` / `.env.test.local` instead of the
generic `.env` / `.env.local`. That is **opt-in** — it does nothing until the
file exists. An opt-in nobody discovers is worth nothing, so this adds the two
surfaces that tell users about it: one proactive, one reactive.

## `kick doctor` — `checkTestEnvIsolation`

A project holding a generic env file **and** a test-runner config but no
`.env.test` is exactly the vulnerable shape: every var the runner doesn't pin
resolves from the developer's environment.

```
✔ test env isolation   .env.test present
⚠ test env isolation   .env present, no .env.test
```

- Silent when there's no test runner, or no generic env file — nothing to leak.
- Passes when `.env.test` **or** `.env.test.local` exists.
- Warns otherwise, naming which generic files it found and what they'd feed in.

Recognises vitest and jest config filenames. Slots in next to the existing
`checkEnvWiring`, which covers the adjacent "schema never registered" footgun.

## `kick explain` — `test-env-leaked-from-dotenv`

Matches the two symptoms of the one cause:

1. **A suite reached a real resource it shouldn't have** — "tests connected to
   the wrong db", "wiped the dev database", "sent a real email".
2. **An env override appears to do nothing** — `vi.stubEnv()` "has no effect"
   on `ConfigService.get()`. Same root: `loadEnv()` parses `process.env` once
   into a module-level cache, and the stub runs long after that, so it's a
   silent no-op for `ConfigService` / `@Value()` while still working for code
   reading `process.env` directly.

Both require test context, so a production incident report doesn't match.
Confidence is raised when the matcher can see a generic env file with no
`.env.test` on disk — `ExplainContext.hasFile` was already wired for this.

The diagnosis explains the cache behaviour, then gives both fixes: a `.env.test`
holding the whole environment, and the `resetEnvCache()` + `loadEnv()` escape
hatch for mid-suite stubs.

## Verification

`packages/cli/__tests__/doctor.test.ts` — 7 new cases: no runner, no env file,
the vulnerable shape, `.env.test` present, `.env.test.local` alone, a bare
`.env.local`, and a jest project.

`packages/cli/__tests__/explain.test.ts` — 4 new cases: both symptom shapes, the
confidence bump from `hasFile`, and a no-match guard proving a resource
complaint without test context doesn't hit this entry.

**79/79 pass** across both files.

Note: 4 files elsewhere in the CLI suite fail on `main` too — unbuilt
`@forinda/kickjs-db` (`Cannot find package '@forinda/kickjs-db/cli'`) and two
`tsc --noEmit` scaffold checks. Confirmed pre-existing by stashing this branch's
changes and re-running. Untouched here.

## Not in scope

`kick new` scaffolding a `.env.test`. The generator writes `.env` and a
`vitest.config.ts` with no `env` block, so the scaffold itself produces the
shape this check warns about. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
