### PR TITLE
feat(cli): scaffold .env.test so new apps are test-isolated by default

### DIFF
--- a/.changeset/scaffold-env-test.md
+++ b/.changeset/scaffold-env-test.md
@@ -1,0 +1,25 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+Scaffold `.env.test` in `kick new`, and gitignore `*.local`
+
+Under a test run KickJS reads `.env.test` instead of `.env` — but that is
+opt-in, and the generator did not produce the file. A scaffolded app therefore
+shipped the exact shape `kick doctor` warns about (a `.env` plus a test runner,
+no `.env.test`), and its first test run printed the backfill warning rather
+than being isolated. The feature never reached anyone who had not read the docs.
+
+`kick new` now writes a `.env.test` declaring `NODE_ENV=test`, `PORT=0` (ask the
+OS for a free port, so a run cannot collide with a dev server on 3000) and
+`LOG_LEVEL=silent`. Deliberately not a copy of `.env.example`: a var it omits
+goes missing rather than quietly inheriting the developer's value, which is the
+entire point of the short-circuit.
+
+`.gitignore` gains `*.local`, covering `.env.local` / `.env.test.local`.
+`.env.test` itself stays committed — it is the suite's shared, reviewable
+environment.
+
+The generated `vitest.config.ts` is unchanged and deliberately has no `env`
+block: vitest's `test.env` sets `process.env` before modules load, which
+outranks every file, so pins there would stop `.env.test` taking effect.

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -327,6 +327,23 @@ found only in a generic file are still available.
 what your shell or CI exports always wins. `*.local` files are for personal
 machine overrides — add `*.local` to `.gitignore`.
 
+::: warning What this does and does not protect against
+`.env.test` closes one specific hole: values reaching your suite from an env
+**file** it never meant to read. It is not a general guard against pointing a
+test at the wrong resource.
+
+Anything already in `process.env` — a var exported in your shell, set by your
+CI job, or injected by a test-container runner — outranks every file and is
+never reported by the backfill warning. That precedence is deliberate and is
+what lets a runner hand your suite a throwaway database URL. It also means an
+exported `DATABASE_URL` aimed at the wrong host is invisible here.
+
+For that failure mode you want an explicit assertion at the point of use — a
+few lines refusing to run against a database whose name isn't the test one
+beat any amount of env plumbing, because they check the thing you actually
+care about.
+:::
+
 **Test mode is the one exception.** Under a test run (`NODE_ENV=test`, or
 Vitest's `VITEST`), if a `.env.test` or `.env.test.local` exists, those are read
 and the generic `.env` / `.env.local` are **not**. No layering, no fallback.

--- a/packages/cli/__tests__/scaffold-env-test.test.ts
+++ b/packages/cli/__tests__/scaffold-env-test.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Drift guard: a scaffolded project must be test-isolated out of the box.
+ *
+ * Under a test run KickJS reads `.env.test` INSTEAD of `.env` — no
+ * layering, no fallback. That is opt-in, so a template that writes `.env`
+ * and a vitest config but no `.env.test` ships the exact shape
+ * `kick doctor` warns about, and the app's first test run prints the
+ * backfill warning instead of being isolated. The generator has to
+ * produce the file for the feature to reach anyone who didn't read the
+ * docs.
+ */
+import { describe, it, expect } from 'vitest'
+
+import {
+  generateEnv,
+  generateEnvTest,
+  generateGitIgnore,
+  generateVitestConfig,
+} from '../src/generators/templates/project-config'
+
+describe('scaffolded .env.test', () => {
+  it('declares the base-schema vars the suite needs', () => {
+    const env = generateEnvTest()
+    expect(env).toContain('NODE_ENV=test')
+    // Port 0 = ask the OS for a free one, so a run cannot collide with a
+    // dev server already holding the scaffolded 3000.
+    expect(env).toContain('PORT=0')
+    expect(env).not.toContain('PORT=3000')
+  })
+
+  it('is not a copy of .env — an omitted var must go missing, not inherit', () => {
+    // The whole value of the short-circuit is that a var absent here is
+    // absent at runtime. Mirroring every key back in rebuilds the trap.
+    expect(generateEnvTest()).not.toBe(generateEnv())
+    expect(generateEnv()).toContain('NODE_ENV=development')
+  })
+
+  it('warns against committing real credentials', () => {
+    // It is a committed file, so the guidance has to be in the file.
+    expect(generateEnvTest().toLowerCase()).toContain('credentials')
+  })
+
+  it('leaves the vitest config free of env pins', () => {
+    // vitest `test.env` sets process.env before modules load, which
+    // outranks every file — pins there would stop `.env.test` taking
+    // effect at all.
+    expect(generateVitestConfig()).not.toContain('env:')
+  })
+
+  it('gitignores *.local but keeps .env.test committed', () => {
+    const ignore = generateGitIgnore()
+    expect(ignore).toContain('*.local')
+    // A bare `.env.test` line would defeat the point — the suite's
+    // environment is meant to be shared and reviewable.
+    expect(ignore.split('\n')).not.toContain('.env.test')
+  })
+})

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -14,6 +14,7 @@ import {
   generateGitAttributes,
   generateEnv,
   generateEnvExample,
+  generateEnvTest,
   generateVitestConfig,
 } from './templates/project-config'
 import {
@@ -262,6 +263,13 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
   await writeFileSafe(join(dir, '.env'), generateEnv())
 
   await writeFileSafe(join(dir, '.env.example'), generateEnvExample())
+
+  // `.env.test` is read INSTEAD of `.env` under a test run, so scaffolding
+  // it is what makes a new project isolated by default. Without it the
+  // generated app ships the exact shape `kick doctor` warns about — a
+  // `.env` plus a test runner — and its first test run prints the backfill
+  // warning rather than being isolated.
+  await writeFileSafe(join(dir, '.env.test'), generateEnvTest())
 
   // ── src/config/index.ts — typed env schema (read by `kick typegen`) ─
   // Lives under `src/config/` so the framework's "config" concept has a

--- a/packages/cli/src/generators/templates/project-config.ts
+++ b/packages/cli/src/generators/templates/project-config.ts
@@ -259,6 +259,9 @@ export function generateGitIgnore(): string {
   return `node_modules/
 dist/
 .env
+# Personal machine overrides. \`.env.test\` itself is COMMITTED — it is the
+# suite's shared, reviewable environment — but \`*.local\` never is.
+*.local
 coverage/
 .DS_Store
 *.tsbuildinfo
@@ -300,6 +303,35 @@ NODE_ENV=development
 export function generateEnvExample(): string {
   return `PORT=3000
 NODE_ENV=development
+`
+}
+
+/**
+ * Generate `.env.test` — the environment the test suite runs against.
+ *
+ * Under a test run KickJS reads this file INSTEAD of `.env` (no layering,
+ * no fallback), so scaffolding it is what makes a new project isolated by
+ * default rather than inheriting the developer's environment.
+ *
+ * Deliberately NOT a copy of `.env.example`. The point of the file is that
+ * a var it omits is *missing* rather than quietly inherited, so the suite
+ * fails loudly on something it forgot to declare. Copying every key back
+ * in would rebuild the exact trap this closes.
+ *
+ * `PORT=0` asks the OS for a free port, so a test run cannot collide with
+ * a dev server already on 3000.
+ */
+export function generateEnvTest(): string {
+  return `# Read INSTEAD of .env when NODE_ENV=test (or under vitest).
+# No fallback to .env — declare here everything the suite needs, so a
+# missing var fails the run instead of silently resolving to your dev value.
+#
+# Keep real endpoints and credentials OUT of this file. Point at test
+# doubles or throwaway containers; anything committed here is shared with
+# everyone who clones the repo.
+NODE_ENV=test
+PORT=0
+LOG_LEVEL=silent
 `
 }
 


### PR DESCRIPTION
## Why

#500 (now merged) makes a test run read `.env.test` instead of `.env`. It is
**opt-in** — and `kick new` never wrote the file.

So a scaffolded app shipped the exact shape `kick doctor` warns about: a `.env`,
a `vitest.config.ts`, no `.env.test`. Its first test run printed the backfill
warning rather than being isolated. A feature that only reaches people who read
the docs is not doing its job, and the generator is where the vulnerable shape
originated.

## What changed

`kick new` now writes `.env.test`:

```bash
# Read INSTEAD of .env when NODE_ENV=test (or under vitest).
# No fallback to .env — declare here everything the suite needs, so a
# missing var fails the run instead of silently resolving to your dev value.
#
# Keep real endpoints and credentials OUT of this file. Point at test
# doubles or throwaway containers; anything committed here is shared with
# everyone who clones the repo.
NODE_ENV=test
PORT=0
LOG_LEVEL=silent
```

Three deliberate choices:

- **Not a copy of `.env.example`.** The value of the short-circuit is that an
  omitted var goes *missing* rather than quietly inheriting a dev value.
  Mirroring every key back in rebuilds the trap the feature closes.
- **`PORT=0`** asks the OS for a free port, so a test run cannot collide with a
  dev server already holding the scaffolded 3000.
- **The credentials warning is in the file**, because the file is committed.

`.gitignore` gains `*.local` (covers `.env.local` / `.env.test.local`).
`.env.test` itself stays committed — it is the suite's shared, reviewable
environment.

The generated `vitest.config.ts` is **unchanged**, and that matters: it has no
`env` block. vitest's `test.env` sets `process.env` before modules load, which
outranks every file, so pins there would stop `.env.test` taking effect at all.
A test locks that in.

## Docs: what this does *not* protect against

Added, because the feature is easy to read as broader than it is:

> `.env.test` closes one specific hole: values reaching your suite from an env
> **file** it never meant to read. It is not a general guard against pointing a
> test at the wrong resource.
>
> Anything already in `process.env` — a var exported in your shell, set by your
> CI job, or injected by a test-container runner — outranks every file and is
> never reported by the backfill warning.

That precedence is deliberate: it is exactly what lets a runner hand a suite a
throwaway database URL. But it also means an exported `DATABASE_URL` aimed at
the wrong host is invisible to all of this. The docs now point at an assertion
at the point of use as the right tool for that failure mode — a few lines
refusing to run against a database whose name isn't the test one beat any
amount of env plumbing.

## Verification

End-to-end against the built CLI, not just the generator functions — scaffold,
poison the `.env`, load config in test mode:

```
$ node packages/cli/bin.js new demo-api --yes --no-install --no-git
$ echo 'LEAKED_FROM_DEV=should-not-appear' >> demo-api/.env
$ NODE_ENV=test node -e "import('@forinda/kickjs/config')"

PORT = 0 | LOG_LEVEL = silent | LEAKED_FROM_DEV = undefined
```

Plus `__tests__/scaffold-env-test.test.ts` — 5 drift guards: the base vars are
declared, it is not a copy of `.env`, the credentials warning is present, the
vitest config stays free of `env` pins, and `.gitignore` has `*.local` without
ignoring `.env.test`.

**93/93 pass** across the affected CLI test files. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New projects now include a committed `.env.test` configured for isolated testing, ephemeral ports, and silent logging.
  * Generated projects ignore `*.local` environment overrides while keeping `.env.test` tracked.

* **Documentation**
  * Added guidance explaining environment-variable precedence and the need to verify critical test resources, such as database targets.

* **Tests**
  * Added coverage to ensure generated test environments remain isolated and correctly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->