### PR TITLE
fix(config): VITEST outranks a non-test NODE_ENV when selecting env files

### DIFF
--- a/.changeset/env-mode-test-run.md
+++ b/.changeset/env-mode-test-run.md
@@ -1,0 +1,21 @@
+---
+'@forinda/kickjs': patch
+---
+
+Fix: `VITEST` no longer loses to a non-test `NODE_ENV` when selecting env files
+
+Two predicates disagreed about what a test run is. File selection used
+`NODE_ENV ?? (VITEST ? 'test' : 'development')`, so an explicitly-set
+`NODE_ENV=development` always won — but the backfill warning was gated on a
+separate check that counts `VITEST` on its own.
+
+The result was the worst of both: a vitest run with `NODE_ENV=development`
+exported (a shell profile, a CI image) skipped the `.env.test` sitting right
+there, loaded the developer's `.env`, and then printed a warning telling the
+user to create the very file it had just ignored. The alarm without the
+protection.
+
+`VITEST` now outranks a non-test `NODE_ENV` for file selection, so the two
+agree. Only affects runs that set `NODE_ENV` to something other than `test`
+while under a test runner; everything else resolves exactly as before. To point
+a suite at another mode's files deliberately, name them with `KICKJS_ENV_FILE`.

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -344,9 +344,15 @@ beat any amount of env plumbing, because they check the thing you actually
 care about.
 :::
 
-**Test mode is the one exception.** Under a test run (`NODE_ENV=test`, or
-Vitest's `VITEST`), if a `.env.test` or `.env.test.local` exists, those are read
-and the generic `.env` / `.env.local` are **not**. No layering, no fallback.
+**Test mode is the one exception.** Under a test run, if a `.env.test` or
+`.env.test.local` exists, those are read and the generic `.env` / `.env.local`
+are **not**. No layering, no fallback.
+
+A run counts as a test run when `NODE_ENV=test` **or** Vitest's `VITEST` is set.
+`VITEST` wins over a conflicting `NODE_ENV`, so a suite run with
+`NODE_ENV=development` exported — from a shell profile or a CI image — still
+gets test-mode isolation rather than your development files. To point a suite at
+another mode's files deliberately, name them with `KICKJS_ENV_FILE`.
 
 That short-circuit is deliberate. With a fallback, every var your test config
 forgets to pin gets silently backfilled from your development `.env`: you can
@@ -368,6 +374,19 @@ LOG_LEVEL=silent
 
 With no `.env.test` present, `.env` is read as before and KickJS prints a
 one-time warning naming what it backfilled.
+
+**Commit `.env.test`.** Unlike `.env`, it belongs in version control — that is
+the difference between _everyone_ on the team being isolated and only whoever
+wrote the file locally. It is shared, reviewable test configuration, so a
+teammate's fresh clone and CI get the same isolation you do. `kick new`
+gitignores `.env` and `*.local` and leaves `.env.test` tracked.
+
+The corollary is that it must not hold real credentials or live endpoints —
+point it at test doubles or throwaway containers. A shared database URL sitting
+in a committed `.env.test` rebuilds the trap: a whole team, and CI, quietly
+aimed at one box. Compute per-run values (a container's port, a worker-scoped
+database name) in your test config or setup file instead, where they stay out
+of the repo and `process.env` still outranks the file.
 
 ### `KICKJS_ENV_FILE` — taking manual control
 

--- a/packages/kickjs/__tests__/env-file-resolution.test.ts
+++ b/packages/kickjs/__tests__/env-file-resolution.test.ts
@@ -257,3 +257,59 @@ describe('backfill warning accounting', () => {
     }
   })
 })
+
+/**
+ * `envMode()` (file selection) and `isTestRun()` (the backfill warning)
+ * must agree about what a test run is.
+ *
+ * They didn't. `envMode()` read `NODE_ENV ?? (VITEST ? 'test' : ...)`, so an
+ * explicitly-set `NODE_ENV=development` won file selection, while
+ * `isTestRun()` counted `VITEST` on its own and still gated the warning. A
+ * vitest run with `NODE_ENV=development` exported — a shell profile, a CI
+ * image — skipped the `.env.test` sitting right there, loaded the developer's
+ * `.env`, and then printed a warning telling the user to create the very file
+ * it had just ignored.
+ */
+describe('test-run detection drives file selection', () => {
+  it('isolates when VITEST is set even if NODE_ENV says development', () => {
+    process.env.NODE_ENV = 'development'
+    process.env.VITEST = 'true'
+    writeFileSync('.env', 'KICK_TEST_X=dev\nKICK_TEST_DEV_ONLY=leaked\n')
+    writeFileSync('.env.test', 'KICK_TEST_X=test\n')
+
+    reloadEnv()
+
+    expect(process.env.KICK_TEST_X).toBe('test')
+    expect(process.env.KICK_TEST_DEV_ONLY).toBeUndefined()
+  })
+
+  it('never warns about a leak while skipping the file that prevents it', () => {
+    // The contradiction itself: warning fired, isolation bypassed.
+    process.env.NODE_ENV = 'development'
+    process.env.VITEST = 'true'
+    writeFileSync('.env', 'KICK_TEST_X=dev\nKICK_TEST_DEV_ONLY=leaked\n')
+    writeFileSync('.env.test', 'KICK_TEST_X=test\n')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      reloadEnv()
+      const told = warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes('[kickjs]'))
+      expect(told).toEqual([])
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('still honours a real non-test NODE_ENV when not under a runner', () => {
+    // The fix must not make everything look like a test run.
+    process.env.NODE_ENV = 'production'
+    delete process.env.VITEST
+    writeFileSync('.env', 'KICK_TEST_X=base\n')
+    writeFileSync('.env.production', 'KICK_TEST_X=prod\n')
+    writeFileSync('.env.test', 'KICK_TEST_X=test\n')
+
+    reloadEnv()
+
+    expect(process.env.KICK_TEST_X).toBe('prod')
+  })
+})

--- a/packages/kickjs/src/config/env.ts
+++ b/packages/kickjs/src/config/env.ts
@@ -59,12 +59,28 @@ function isTestRun(): boolean {
 }
 
 /**
- * The mode whose env files apply — `NODE_ENV`, falling back to `test`
- * under a runner that sets `VITEST` without `NODE_ENV`, else the same
- * `development` default `baseEnvSchema` uses.
+ * The mode whose env files apply. A test run is always mode `test`;
+ * otherwise `NODE_ENV`, defaulting to the same `development` value
+ * `baseEnvSchema` uses.
+ *
+ * The {@link isTestRun} check has to come FIRST, and the two predicates
+ * have to agree. They did not: this read `NODE_ENV ?? (VITEST ? 'test'
+ * : 'development')`, so an explicitly-set `NODE_ENV=development` won
+ * file selection while `isTestRun()` — which counts `VITEST` on its own
+ * — still gated the backfill warning. A vitest run with
+ * `NODE_ENV=development` exported (common in a shell profile or a CI
+ * image) therefore skipped the `.env.test` sitting right there, loaded
+ * the developer's `.env`, and printed a warning telling the user to
+ * create the very file it had just ignored. Worst of both: the alarm
+ * without the protection.
+ *
+ * So `VITEST` outranks a non-test `NODE_ENV` for file selection. To run
+ * a suite deliberately against another mode's files, name them with
+ * `KICKJS_ENV_FILE`, which still bypasses all of this.
  */
 function envMode(): string {
-  return process.env['NODE_ENV'] ?? (process.env['VITEST'] ? 'test' : 'development')
+  if (isTestRun()) return 'test'
+  return process.env['NODE_ENV'] ?? 'development'
 }
 
 const GENERIC_ENV_FILES = ['.env.local', '.env'] as const


### PR DESCRIPTION
## The bug

Two predicates disagreed about what a test run is:

```ts
function envMode()   { return process.env.NODE_ENV ?? (process.env.VITEST ? 'test' : 'development') }  // file selection
function isTestRun() { return process.env.NODE_ENV === 'test' || !!process.env.VITEST }                // warning gate
```

`envMode()` takes `NODE_ENV` whenever it is set, so `NODE_ENV=development` under
vitest selects mode `development` and loads `.env`. But `isTestRun()` counts
`VITEST` on its own, so the backfill warning still fires.

The result is the worst possible combination: the run **skips the `.env.test`
sitting right there**, loads the developer's `.env`, and then prints a warning
telling the user to create the very file it just ignored. The alarm without the
protection.

It hits anyone with `NODE_ENV=development` exported in a shell profile or baked
into a CI image — they get the warning and none of the isolation. The docs also
stated that `VITEST` selects test mode, which was only true when `NODE_ENV` was
unset.

## The fix

```diff
 function envMode(): string {
-  return process.env['NODE_ENV'] ?? (process.env['VITEST'] ? 'test' : 'development')
+  if (isTestRun()) return 'test'
+  return process.env['NODE_ENV'] ?? 'development'
 }
```

File selection is now derived from the same predicate that gates the warning, so
the two cannot drift apart again. `VITEST` outranks a non-test `NODE_ENV`.

Scope is narrow: this only changes runs that set `NODE_ENV` to something other
than `test` *while under a test runner*. Every other resolution is byte-identical.
`KICKJS_ENV_FILE` still bypasses all of it for a suite that deliberately wants
another mode's files.

## Verification

Against a real scaffolded app — `@forinda/kickjs@6.6.0`, `vitest@4.1.2`, a `.env`
holding a live-looking secret, `EMAIL_PROVIDER=smtp`, and a `DATABASE_URL`
pointing at a shared dev Postgres — with the built `dist` swapped in:

| Scenario | Before | After |
|---|---|---|
| `NODE_ENV=development`, `.env.test` present | **3/4 fail**, warning fires | **4/4 pass**, no warning |
| no `NODE_ENV`, `.env.test` present | 4/4 pass | 4/4 pass (unchanged) |
| `NODE_ENV=development`, no `.env.test` | 3/4 fail, warning fires | 3/4 fail, warning fires — correct, and now truthful |

The third row is the control: the fallback must still leak and still warn, because
there genuinely is no `.env.test`. The difference is that the warning is now
telling the truth.

Three regression tests added in `env-file-resolution.test.ts`; two fail without
the fix:

```
× isolates when VITEST is set even if NODE_ENV says development
× never warns about a leak while skipping the file that prevents it
```

The third asserts the fix does not over-reach — a real `NODE_ENV=production` run
outside a test runner still resolves `.env.production`.

**719/719** kickjs tests pass. `tsc --noEmit` and lint clean.

## Docs

- Corrected the test-run definition: `VITEST` wins over a conflicting `NODE_ENV`.
- Added an explicit statement that **`.env.test` is committed** — that is the
  difference between the whole team being isolated and only whoever wrote the
  file locally — with the corollary that it must hold no real credentials, and
  that per-run values (a container port, a worker-scoped database name) belong in
  the test config, where `process.env` still outranks the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test runs now consistently use test-specific environment files, including when `VITEST` is active alongside another `NODE_ENV` value.
  * Explicit environment-file selection remains available through `KICKJS_ENV_FILE`.

* **Documentation**
  * Updated testing guidance for environment files, including recommendations for safely managing test credentials and endpoints.

* **Bug Fixes**
  * Prevented generic environment files from being selected or warned about during test runs when test-specific files are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->