### PR TITLE
feat(spa): engine-agnostic declarative SpaAdapter, three fallback bugs fixed

### DIFF
--- a/.changeset/fullstack-spa-serving.md
+++ b/.changeset/fullstack-spa-serving.md
@@ -1,0 +1,26 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+Fullstack template: serve the built frontend from the API origin
+
+`kick new --template fullstack` scaffolds `server/` + `web/` and wires a typed
+dev loop — Vite serves the client and proxies `/api` to the server. But it
+stopped at the deploy boundary: `pnpm build` produced `web/dist` and **nothing
+ever served it**. The generated bootstrap had no adapters, and the root had no
+`start` script — only `vite preview`, which is a dev preview server.
+
+The generated server now wires `SpaAdapter({ clientDir: '../web/dist' })`, and
+the root gains a `start` script that runs the server. So:
+
+|            | dev                       | production               |
+| ---------- | ------------------------- | ------------------------ |
+| `web/dist` | absent                    | present                  |
+| SpaAdapter | inert (registers nothing) | serves `/`               |
+| `/api/v1`  | Vite proxy → `:3000`      | controllers, same origin |
+
+Dev is unchanged: the adapter early-returns while the build directory does not
+exist, which is the normal state under `kick dev`.
+
+`generateEntryFile` takes an optional `spaClientDir` and composes it with the
+existing swagger / devtools adapter injection rather than replacing it.

--- a/.changeset/spa-adapter-engine-neutral.md
+++ b/.changeset/spa-adapter-engine-neutral.md
@@ -1,0 +1,38 @@
+---
+'@forinda/kickjs': major
+---
+
+SpaAdapter: engine-agnostic, declarative, and three fallback bugs fixed
+
+**The documented usage did not work.** `docs/guide/spa.md` has always shown
+`SpaAdapter({ ... })`, but the export was a class — so following the guide threw
+`TypeError: Class constructor SpaAdapter cannot be invoked without 'new'`. It is
+now a `defineAdapter()` factory, matching both the docs and `ViewAdapter`, which
+made the same move in v4. If you were calling `new SpaAdapter({...})`, drop the
+`new`.
+
+**It was Express-only.** The adapter reached for `express.static`, `req.path`,
+and `res.send` — none of which exist under Fastify or h3 — so on those runtimes
+it silently served nothing while the framework advertises a pluggable engine. It
+now uses the engine-agnostic `http.serveStatic()` / `http.use()` surface and
+reads the path from `req.url`, so it works under all three.
+
+**Three fallback bugs, none previously covered by a test:**
+
+| Request                                   | Before | After             |
+| ----------------------------------------- | ------ | ----------------- |
+| `GET /users/john.doe`                     | 404    | `index.html`      |
+| `HEAD /dashboard`                         | 404    | 200, headers only |
+| `GET /apidocs` (with `apiPrefix: '/api'`) | 404    | `index.html`      |
+
+The dot rule is replaced by content negotiation — the fallback fires for
+`GET`/`HEAD` requests that accept HTML. A missing `/assets/app.js` still 404s
+rather than receiving an HTML document. `alwaysFallback: true` opts out for
+non-browser clients. Prefix matching is now segment-aware.
+
+Cache headers are only applied to paths that resolve to a real file inside
+`clientDir`, so a missing asset's 404 is no longer labelled
+`max-age=31536000, immutable`.
+
+Adds 21 tests — the adapter previously had none despite being public API with
+its own export path.

--- a/.changeset/spa-adapter-engine-neutral.md
+++ b/.changeset/spa-adapter-engine-neutral.md
@@ -43,3 +43,12 @@ monorepo root resolved `../web/dist` against the root, found nothing, and served
 no SPA. cwd stays the primary base (matching how assets and env files resolve),
 and both candidates are existence-checked, so this can never silently pick a
 directory that is not there.
+
+Three review follow-ups: `Accept` is parsed with q-values, so `text/html;q=0`
+(explicitly "not acceptable" per RFC 9110 §12.5.1) no longer receives a
+document; the cache middleware uses a single `stat` in a `try`/`catch` rather
+than `existsSync` + `statSync`, which could throw mid-request when a deploy
+swaps the directory between the two calls; and a path resolving to a directory
+with an `index.html` — most importantly `/` itself — is treated as an index
+request, so the root document gets `indexCacheControl` instead of falling
+through to the static layer's default (`public, max-age=0` under Express).

--- a/.changeset/spa-adapter-engine-neutral.md
+++ b/.changeset/spa-adapter-engine-neutral.md
@@ -52,3 +52,16 @@ swaps the directory between the two calls; and a path resolving to a directory
 with an `index.html` — most importantly `/` itself — is treated as an index
 request, so the root document gets `indexCacheControl` instead of falling
 through to the static layer's default (`public, max-age=0` under Express).
+
+The cache classifier no longer touches the filesystem per request. It ran a
+`statSync` on every non-reserved request, blocking the event loop on a slow or
+contended disk. The build directory is static and already snapshotted at mount
+(that is where `index.html` is read), so the file list is captured there too and
+classification is a `Set` lookup. Membership of that snapshot is also the
+containment guard, so the traversal check is now inherent rather than a separate
+prefix comparison.
+
+`Accept` handling honours type wildcards (`text/*`, `application/*`) with RFC
+9110 §12.5.1 specificity, so an exact `text/html;q=0` still overrides a
+permissive wildcard. A bare `*/*` continues to not count at any q — assets are
+fetched that way.

--- a/.changeset/spa-adapter-engine-neutral.md
+++ b/.changeset/spa-adapter-engine-neutral.md
@@ -36,3 +36,10 @@ Cache headers are only applied to paths that resolve to a real file inside
 
 Adds 21 tests — the adapter previously had none despite being public API with
 its own export path.
+
+`clientDir` now falls back to the entry script's package root when the path
+misses from `process.cwd()`. `node server/dist/index.js` launched from a
+monorepo root resolved `../web/dist` against the root, found nothing, and served
+no SPA. cwd stays the primary base (matching how assets and env files resolve),
+and both candidates are existence-checked, so this can never silently pick a
+directory that is not there.

--- a/.changeset/spa-adapter-engine-neutral.md
+++ b/.changeset/spa-adapter-engine-neutral.md
@@ -25,43 +25,37 @@ reads the path from `req.url`, so it works under all three.
 | `HEAD /dashboard`                         | 404    | 200, headers only |
 | `GET /apidocs` (with `apiPrefix: '/api'`) | 404    | `index.html`      |
 
-The dot rule is replaced by content negotiation — the fallback fires for
-`GET`/`HEAD` requests that accept HTML. A missing `/assets/app.js` still 404s
-rather than receiving an HTML document. `alwaysFallback: true` opts out for
-non-browser clients. Prefix matching is now segment-aware.
+The dot rule is replaced by content negotiation. The fallback fires for
+`GET`/`HEAD` requests that accept HTML, parsed as media ranges with q-values and
+RFC 9110 §12.5.1 specificity: `text/*` is honoured, an exact `text/html;q=0`
+overrides a permissive wildcard, and a bare `*/*` never counts at any q — assets
+are fetched that way, and treating it as a document request is what returns HTML
+for a missing script. `alwaysFallback: true` skips the check entirely for
+non-browser clients. Prefix matching is segment-aware.
 
-Cache headers are only applied to paths that resolve to a real file inside
-`clientDir`, so a missing asset's 404 is no longer labelled
-`max-age=31536000, immutable`.
+**Cache headers.** Applied only to paths the static layer will actually serve,
+so a missing asset's 404 is no longer labelled `max-age=31536000, immutable`, and
+a path resolving to a directory with an `index.html` — most importantly `/`
+itself — gets `indexCacheControl` rather than falling through to the static
+layer's default (`public, max-age=0` under Express).
 
-Adds 21 tests — the adapter previously had none despite being public API with
+Classification touches the filesystem **zero** times per request: the build
+directory is static and already snapshotted at mount (where `index.html` is
+read), so the file list is captured there and lookup is a `Set.has`. Membership
+of that snapshot is also the containment guard, so traversal is rejected
+inherently rather than by a prefix comparison. The snapshot walks with
+`readdirSync(dir, { withFileTypes: true })` only — the `recursive` option (Node
+20.1) and `Dirent.parentPath` (20.12) are both newer than the declared
+`node >=20.0`, and the `Dirent.path` alias they replaced is already gone on Node
+24, so no single spelling covers the supported range.
+
+`clientDir` resolves from `process.cwd()` as before, falling back to the entry
+script's package root when that misses — `node server/dist/index.js` launched
+from a monorepo root previously resolved `../web/dist` against the root, found
+nothing, and served no SPA. Both candidates are existence-checked, so it can
+never silently pick a directory that is not there. An absolute `clientDir` is
+normalised, since a trailing slash or a `.`/`..` segment made the containment
+check never match and silently dropped every cache header.
+
+Adds 40 tests — the adapter previously had none despite being public API with
 its own export path.
-
-`clientDir` now falls back to the entry script's package root when the path
-misses from `process.cwd()`. `node server/dist/index.js` launched from a
-monorepo root resolved `../web/dist` against the root, found nothing, and served
-no SPA. cwd stays the primary base (matching how assets and env files resolve),
-and both candidates are existence-checked, so this can never silently pick a
-directory that is not there.
-
-Three review follow-ups: `Accept` is parsed with q-values, so `text/html;q=0`
-(explicitly "not acceptable" per RFC 9110 §12.5.1) no longer receives a
-document; the cache middleware uses a single `stat` in a `try`/`catch` rather
-than `existsSync` + `statSync`, which could throw mid-request when a deploy
-swaps the directory between the two calls; and a path resolving to a directory
-with an `index.html` — most importantly `/` itself — is treated as an index
-request, so the root document gets `indexCacheControl` instead of falling
-through to the static layer's default (`public, max-age=0` under Express).
-
-The cache classifier no longer touches the filesystem per request. It ran a
-`statSync` on every non-reserved request, blocking the event loop on a slow or
-contended disk. The build directory is static and already snapshotted at mount
-(that is where `index.html` is read), so the file list is captured there too and
-classification is a `Set` lookup. Membership of that snapshot is also the
-containment guard, so the traversal check is now inherent rather than a separate
-prefix comparison.
-
-`Accept` handling honours type wildcards (`text/*`, `application/*`) with RFC
-9110 §12.5.1 specificity, so an exact `text/html;q=0` still overrides a
-permissive wildcard. A bare `*/*` continues to not count at any q — assets are
-fetched that way.

--- a/docs/guide/spa.md
+++ b/docs/guide/spa.md
@@ -27,7 +27,9 @@ written against the engine-agnostic `http` surface rather than `express.static`.
 1. Static files in `clientDir` are served with long-lived cache headers
 2. `index.html` is served with `no-cache` (so deploys are picked up immediately)
 3. API routes (matching `apiPrefix`) pass through to your controllers
-4. Everything else serves `index.html` — your SPA router handles client-side navigation
+4. Any remaining `GET`/`HEAD` request that accepts HTML serves `index.html` —
+   your SPA router handles client-side navigation. Anything else (other methods,
+   reserved paths, or clients not asking for HTML) falls through untouched.
 
 ### Which requests get the fallback
 
@@ -37,16 +39,26 @@ A request falls back to `index.html` when **all** of these hold:
 - the path is not under `apiPrefix` or `exclude`
 - the client accepts HTML (`Accept: text/html`)
 
-That last rule is content negotiation rather than a guess at the path. It means
-a route with a dot in it — `/users/john.doe`, `/v1.2/spec` — is served normally,
-while a genuinely missing `/assets/app.js` still returns **404** instead of an
-HTML document the browser cannot parse as JavaScript.
+The `Accept` rule is content negotiation rather than a guess at the path, and
+`q` values are honoured — `Accept: text/html;q=0` says HTML is _not_ acceptable
+and is treated as such.
+
+It means a route with a dot in it — `/users/john.doe`, `/v1.2/spec` — is served
+normally when a browser navigates to it, because browsers send
+`Accept: text/html`. A missing `/assets/app.js` fetched with `Accept: */*`
+returns **404** instead of an HTML document the browser cannot parse as
+JavaScript.
+
+Note the rule is about the header, not the path: a missing dotted path
+requested _with_ an HTML `Accept` does receive `index.html`, exactly as a
+missing extensionless route does. The SPA router decides what to render.
 
 Prefix matching is segment-aware: `apiPrefix: '/api'` covers `/api` and
 `/api/users`, but leaves `/apidocs` to the SPA.
 
-If you have non-browser clients deep-linking into SPA routes without an
-`Accept` header, set `alwaysFallback: true`.
+`alwaysFallback: true` skips the `Accept` check entirely — for non-browser
+clients that deep-link into SPA routes, whether they omit `Accept` or send a
+non-HTML one. The method and reserved-path rules still apply.
 
 ## Options
 

--- a/docs/guide/spa.md
+++ b/docs/guide/spa.md
@@ -19,6 +19,9 @@ bootstrap({
 })
 ```
 
+Works under every runtime — Express, Fastify, and h3 — because the adapter is
+written against the engine-agnostic `http` surface rather than `express.static`.
+
 ## How It Works
 
 1. Static files in `clientDir` are served with long-lived cache headers
@@ -26,15 +29,41 @@ bootstrap({
 3. API routes (matching `apiPrefix`) pass through to your controllers
 4. Everything else serves `index.html` — your SPA router handles client-side navigation
 
+### Which requests get the fallback
+
+A request falls back to `index.html` when **all** of these hold:
+
+- the method is `GET` or `HEAD`
+- the path is not under `apiPrefix` or `exclude`
+- the client accepts HTML (`Accept: text/html`)
+
+That last rule is content negotiation rather than a guess at the path. It means
+a route with a dot in it — `/users/john.doe`, `/v1.2/spec` — is served normally,
+while a genuinely missing `/assets/app.js` still returns **404** instead of an
+HTML document the browser cannot parse as JavaScript.
+
+Prefix matching is segment-aware: `apiPrefix: '/api'` covers `/api` and
+`/api/users`, but leaves `/apidocs` to the SPA.
+
+If you have non-browser clients deep-linking into SPA routes without an
+`Accept` header, set `alwaysFallback: true`.
+
 ## Options
 
-| Option              | Default                                 | Description                                 |
-| ------------------- | --------------------------------------- | ------------------------------------------- |
-| `clientDir`         | `'dist/client'`                         | Directory with the built SPA files          |
-| `apiPrefix`         | `'/api'`                                | URL prefix for API routes (string or array) |
-| `exclude`           | `[]`                                    | Additional paths to exclude from fallback   |
-| `cacheControl`      | `'public, max-age=31536000, immutable'` | Cache header for static assets              |
-| `indexCacheControl` | `'no-cache'`                            | Cache header for index.html                 |
+| Option              | Default                                 | Description                                      |
+| ------------------- | --------------------------------------- | ------------------------------------------------ |
+| `clientDir`         | `'dist/client'`                         | Directory with the built SPA files               |
+| `apiPrefix`         | `'/api'`                                | URL prefix for API routes (string or array)      |
+| `exclude`           | `[]`                                    | Additional paths to exclude from fallback        |
+| `cacheControl`      | `'public, max-age=31536000, immutable'` | Cache header for static assets                   |
+| `indexCacheControl` | `'no-cache'`                            | Cache header for index.html                      |
+| `alwaysFallback`    | `false`                                 | Serve `index.html` even without an HTML `Accept` |
+
+::: tip Call it without `new`
+`SpaAdapter` is a `defineAdapter()` factory, like `ViewAdapter`. Every example
+here calls it directly — `SpaAdapter({ ... })`. The pre-factory
+`new SpaAdapter({ ... })` form is gone.
+:::
 
 ## Project Structure
 

--- a/packages/cli/__tests__/fullstack-spa-wiring.test.ts
+++ b/packages/cli/__tests__/fullstack-spa-wiring.test.ts
@@ -1,0 +1,48 @@
+/**
+ * The fullstack template builds `web/` to `web/dist` and, before this, nothing
+ * ever served it: the generated server bootstrap had no adapters and the root
+ * had no `start` script. `pnpm build` produced a frontend the API had no way to
+ * hand out, so every deploy needed a hand-wired static host or a second process.
+ *
+ * `SpaAdapter` closes that, and costs nothing in dev: it is inert while
+ * `../web/dist` does not exist, which is the normal state under `kick dev`
+ * where Vite serves the client and proxies `/api` to the server.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { generateEntryFile } from '../src/generators/templates/project-app'
+
+describe('fullstack entry wiring', () => {
+  it('wires SpaAdapter when a client dir is given', () => {
+    const entry = generateEntryFile('demo', 'minimal', '1.0.0', [], 'express', '../web/dist')
+    expect(entry).toContain("import { SpaAdapter } from '@forinda/kickjs/spa'")
+    expect(entry).toContain("SpaAdapter({ clientDir: '../web/dist' })")
+    expect(entry).toContain('adapters:')
+  })
+
+  it('says why it is safe in dev, next to the call', () => {
+    // The inert-until-built behaviour is the whole reason this can be
+    // unconditional; a reader deleting it "because dev serves via Vite"
+    // would break production.
+    const entry = generateEntryFile('demo', 'minimal', '1.0.0', [], 'express', '../web/dist')
+    expect(entry).toMatch(/Inert until/)
+  })
+
+  it('adds nothing when no client dir is given', () => {
+    const entry = generateEntryFile('demo', 'minimal', '1.0.0', [], 'express')
+    expect(entry).not.toContain('SpaAdapter')
+  })
+
+  it('composes with other adapters rather than replacing them', () => {
+    const entry = generateEntryFile(
+      'demo',
+      'minimal',
+      '1.0.0',
+      ['swagger'],
+      'express',
+      '../web/dist',
+    )
+    expect(entry).toContain('SwaggerAdapter')
+    expect(entry).toContain('SpaAdapter')
+  })
+})

--- a/packages/cli/__tests__/fullstack-spa-wiring.test.ts
+++ b/packages/cli/__tests__/fullstack-spa-wiring.test.ts
@@ -16,7 +16,7 @@ describe('fullstack entry wiring', () => {
   it('wires SpaAdapter when a client dir is given', () => {
     const entry = generateEntryFile('demo', 'minimal', '1.0.0', [], 'express', '../web/dist')
     expect(entry).toContain("import { SpaAdapter } from '@forinda/kickjs/spa'")
-    expect(entry).toContain("SpaAdapter({ clientDir: '../web/dist' })")
+    expect(entry).toContain('SpaAdapter({ clientDir: \"../web/dist\" })')
     expect(entry).toContain('adapters:')
   })
 
@@ -44,5 +44,27 @@ describe('fullstack entry wiring', () => {
     )
     expect(entry).toContain('SwaggerAdapter')
     expect(entry).toContain('SpaAdapter')
+  })
+})
+
+describe('generated path is serialized, not interpolated', () => {
+  it('escapes a quote in the client dir instead of breaking the file', () => {
+    // The value is arbitrary caller-supplied path text written into a
+    // TypeScript module. A raw `'${dir}'` template hole let a quote close the
+    // string early and emit invalid TS — or worse, silently change the path.
+    const entry = generateEntryFile('demo', 'minimal', '1.0.0', [], 'express', "../we'b/dist")
+    expect(entry).toContain('SpaAdapter({ clientDir: "../we\'b/dist" })')
+    // The raw value must not reach the comment either.
+    expect(entry).not.toContain("Inert until '../we'b/dist'")
+  })
+
+  it('escapes a backslash (Windows-style path)', () => {
+    const entry = generateEntryFile('demo', 'minimal', '1.0.0', [], 'express', '..\\web\\dist')
+    expect(entry).toContain('SpaAdapter({ clientDir: "..\\\\web\\\\dist" })')
+  })
+
+  it('keeps the ordinary path readable', () => {
+    const entry = generateEntryFile('demo', 'minimal', '1.0.0', [], 'express', '../web/dist')
+    expect(entry).toContain('SpaAdapter({ clientDir: "../web/dist" })')
   })
 })

--- a/packages/cli/src/generators/fullstack.ts
+++ b/packages/cli/src/generators/fullstack.ts
@@ -60,6 +60,12 @@ export async function initFullstackProject(options: InitFullstackOptions): Promi
     // Root owns install + git so the lockfile/commit cover the workspace.
     initGit: false,
     installDeps: false,
+    // Production single-origin serving. `web/` builds to `web/dist`, and
+    // nothing served it before — `pnpm build` produced a frontend the API had
+    // no way to hand out, so every deploy needed a hand-wired static host or
+    // a second process. The adapter is inert until `../web/dist` exists, so
+    // `dev` (Vite serves the client and proxies /api here) is untouched.
+    spaClientDir: '../web/dist',
   })
 
   // ── web/ — Vite + React, typed client ──────────────────────────────
@@ -324,6 +330,8 @@ function rootPackageJson(name: string, pm: string): string {
     pm === 'pnpm'
       ? {
           dev: 'pnpm --parallel -r run dev',
+          // One origin: the server serves `web/dist` through SpaAdapter.
+          start: 'pnpm --filter ./server run start',
           'dev:server': 'pnpm --filter ./server dev',
           'dev:web': 'pnpm --filter ./web dev',
           build: 'pnpm -r run build',
@@ -333,6 +341,7 @@ function rootPackageJson(name: string, pm: string): string {
           // cd-based scripts — the one form npm, yarn (classic AND berry),
           // and bun all run identically; workspace-filter flags differ per
           // manager (--workspace vs `yarn workspace <name>` vs --filter).
+          start: `cd server && ${pm} run start`,
           'dev:server': `cd server && ${pm} run dev`,
           'dev:web': `cd web && ${pm} run dev`,
           build: `${pm} run build:server && ${pm} run build:web`,

--- a/packages/cli/src/generators/fullstack.ts
+++ b/packages/cli/src/generators/fullstack.ts
@@ -83,7 +83,11 @@ export async function initFullstackProject(options: InitFullstackOptions): Promi
 
   // ── workspace root ──────────────────────────────────────────────────
   await writeFileSafe(join(dir, 'package.json'), rootPackageJson(name, packageManager))
-  await writeFileSafe(join(dir, 'pnpm-workspace.yaml'), `packages:\n  - server\n  - web\n`)
+  // Only pnpm reads this file. npm / yarn / bun declare workspaces via the
+  // `workspaces` field in the root package.json instead — see rootPackageJson.
+  if (packageManager === 'pnpm') {
+    await writeFileSafe(join(dir, 'pnpm-workspace.yaml'), `packages:\n  - server\n  - web\n`)
+  }
   await writeFileSafe(join(dir, '.gitignore'), rootGitignore())
   await writeFileSafe(join(dir, 'README.md'), rootReadme(name, packageManager))
 

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -158,6 +158,8 @@ interface InitProjectOptions {
   schemaLib?: SchemaLib
   /** HTTP engine to scaffold. Defaults to `express`. */
   runtime?: 'express' | 'fastify' | 'h3'
+  /** Wire `SpaAdapter` at this clientDir (fullstack template). */
+  spaClientDir?: string
 }
 
 /** Scaffold a new KickJS project */
@@ -280,7 +282,7 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
   // ── src/index.ts — template-aware entry point ─────────────────────
   await writeFileSafe(
     join(dir, 'src/index.ts'),
-    generateEntryFile(name, template, cliPkg.version, packages, runtime),
+    generateEntryFile(name, template, cliPkg.version, packages, runtime, options.spaClientDir),
   )
 
   // ── src/modules/index.ts ────────────────────────────────────────────

--- a/packages/cli/src/generators/templates/project-app.ts
+++ b/packages/cli/src/generators/templates/project-app.ts
@@ -24,6 +24,13 @@ export function generateEntryFile(
   version: string,
   packages: string[] = [],
   runtime: ProjectRuntime = 'express',
+  /**
+   * When set, wire `SpaAdapter` at this `clientDir`. Used by the fullstack
+   * template so `web/`'s build is served from the API's origin in
+   * production. The adapter no-ops while the directory does not exist, so a
+   * dev run (where the SPA is served by Vite) is unaffected.
+   */
+  spaClientDir?: string,
 ): string {
   const factory = RUNTIME_FACTORY[runtime]
   const isExpress = runtime === 'express'
@@ -46,6 +53,15 @@ export function generateEntryFile(
       if (packages.includes('devtools')) {
         imports.push(`import { DevToolsAdapter } from '@forinda/kickjs-devtools'`)
         adapters.push(`    DevToolsAdapter(),`)
+      }
+      if (spaClientDir) {
+        imports.push(`import { SpaAdapter } from '@forinda/kickjs/spa'`)
+        adapters.push(
+          `    // Serves the built frontend from this origin in production.\n` +
+            `    // Inert until '${spaClientDir}' exists, so \`kick dev\` (where Vite\n` +
+            `    // serves the client and proxies /api here) is unaffected.\n` +
+            `    SpaAdapter({ clientDir: '${spaClientDir}' }),`,
+        )
       }
       const importsBlock = imports.length ? imports.join('\n') + '\n' : ''
       const adaptersBlock = adapters.length ? `,\n  adapters: [\n${adapters.join('\n')}\n  ]` : ''

--- a/packages/cli/src/generators/templates/project-app.ts
+++ b/packages/cli/src/generators/templates/project-app.ts
@@ -56,11 +56,16 @@ export function generateEntryFile(
       }
       if (spaClientDir) {
         imports.push(`import { SpaAdapter } from '@forinda/kickjs/spa'`)
+        // JSON.stringify, not a quoted template hole: this is arbitrary
+        // caller-supplied path text being written into a TypeScript file, and
+        // a quote, backslash, or newline in it would either break the emitted
+        // module or quietly change the path it resolves. The raw value stays
+        // out of the comment for the same reason.
         adapters.push(
           `    // Serves the built frontend from this origin in production.\n` +
-            `    // Inert until '${spaClientDir}' exists, so \`kick dev\` (where Vite\n` +
+            `    // Inert until the client build exists, so \`kick dev\` (where Vite\n` +
             `    // serves the client and proxies /api here) is unaffected.\n` +
-            `    SpaAdapter({ clientDir: '${spaClientDir}' }),`,
+            `    SpaAdapter({ clientDir: ${JSON.stringify(spaClientDir)} }),`,
         )
       }
       const importsBlock = imports.length ? imports.join('\n') + '\n' : ''

--- a/packages/kickjs/__tests__/spa-adapter.test.ts
+++ b/packages/kickjs/__tests__/spa-adapter.test.ts
@@ -269,3 +269,55 @@ describe('SpaAdapter — cache headers only label real hits', () => {
     expect(res.headers['cache-control']).toBeUndefined()
   })
 })
+
+describe('SpaAdapter — clientDir resolution', () => {
+  it('finds a relative clientDir from the process cwd', () => {
+    const prev = process.cwd()
+    process.chdir(dir)
+    try {
+      const adapter = SpaAdapter({ clientDir: '.' })
+      const rec = makeHttp()
+      adapter.beforeMount?.({ http: rec.http } as never)
+      expect(rec.statics).toHaveLength(1)
+    } finally {
+      process.chdir(prev)
+    }
+  })
+
+  it('falls back to the entry package root when cwd misses', () => {
+    // Reproduces `node server/dist/index.js` launched from a monorepo root:
+    // cwd is the root, so `../web/dist` misses there and must be retried
+    // against the entry script's own package root.
+    const root = mkdtempSync(join(tmpdir(), 'kick-mono-'))
+    const serverDir = join(root, 'server')
+    mkdirSync(join(serverDir, 'dist'), { recursive: true })
+    mkdirSync(join(root, 'web', 'dist'), { recursive: true })
+    writeFileSync(join(serverDir, 'package.json'), '{"name":"server"}')
+    writeFileSync(join(root, 'web', 'dist', 'index.html'), '<!doctype html><title>x</title>')
+    const entry = join(serverDir, 'dist', 'index.js')
+    writeFileSync(entry, '')
+
+    const prevCwd = process.cwd()
+    const prevArgv = process.argv[1]
+    process.chdir(root) // launched from the ROOT, not from server/
+    process.argv[1] = entry
+    try {
+      const adapter = SpaAdapter({ clientDir: '../web/dist' })
+      const rec = makeHttp()
+      adapter.beforeMount?.({ http: rec.http } as never)
+      expect(rec.statics).toHaveLength(1)
+      expect(rec.statics[0]!.dir).toBe(join(root, 'web', 'dist'))
+    } finally {
+      process.chdir(prevCwd)
+      process.argv[1] = prevArgv as string
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('leaves an absolute clientDir untouched', () => {
+    const adapter = SpaAdapter({ clientDir: dir })
+    const rec = makeHttp()
+    adapter.beforeMount?.({ http: rec.http } as never)
+    expect(rec.statics[0]!.dir).toBe(dir)
+  })
+})

--- a/packages/kickjs/__tests__/spa-adapter.test.ts
+++ b/packages/kickjs/__tests__/spa-adapter.test.ts
@@ -81,6 +81,24 @@ function dispatch(
   return res
 }
 
+/**
+ * Dispatch ONLY the cache-header middleware (registered in `beforeMount`),
+ * stopping before the SPA fallback.
+ *
+ * The fallback sets `indexCacheControl` itself on every document it serves, so
+ * running the whole chain makes any assertion about the cache layer pass
+ * whether or not that layer did anything — which is exactly how the first
+ * version of the root-path test came out green with its fix removed. In a real
+ * app `/` is answered by the static layer, never reaching the fallback, so the
+ * cache middleware is the only thing that can label it.
+ */
+function dispatchCacheOnly(
+  middleware: Handler[],
+  req: { url: string; method?: string; headers?: Record<string, string> },
+): RecordedResponse {
+  return dispatch(middleware.slice(0, 1), req)
+}
+
 let dir: string
 
 function buildAdapter(options: SpaAdapterOptions = {}) {
@@ -205,7 +223,7 @@ describe('SpaAdapter — fallback rules', () => {
 describe('SpaAdapter — cache headers', () => {
   it('sets the long-lived header for assets', () => {
     const { middleware } = buildAdapter()
-    const res = dispatch(middleware, { url: '/assets/app.js', headers: { accept: '*/*' } })
+    const res = dispatchCacheOnly(middleware, { url: '/assets/app.js', headers: { accept: '*/*' } })
     expect(res.headers['cache-control']).toBe('public, max-age=31536000, immutable')
   })
 
@@ -319,5 +337,55 @@ describe('SpaAdapter — clientDir resolution', () => {
     const rec = makeHttp()
     adapter.beforeMount?.({ http: rec.http } as never)
     expect(rec.statics[0]!.dir).toBe(dir)
+  })
+})
+
+describe('SpaAdapter — review follow-ups', () => {
+  it('respects q=0 — text/html;q=0 means HTML is NOT acceptable', () => {
+    // RFC 9110 §12.5.1: "a value of 0 means not acceptable". A substring
+    // check read this as a yes and returned the document anyway.
+    const { middleware } = buildAdapter()
+    const res = dispatch(middleware, { url: '/dashboard', headers: { accept: 'text/html;q=0' } })
+    expect(res.ended).toBe(false)
+  })
+
+  it('still serves when HTML carries a positive q', () => {
+    const { middleware } = buildAdapter()
+    for (const accept of ['text/html;q=0.9', 'text/html; q=1.0', 'application/xhtml+xml;q=0.8']) {
+      expect(dispatch(middleware, { url: '/dashboard', headers: { accept } }).statusCode).toBe(200)
+    }
+  })
+
+  it('picks HTML out of a real browser Accept header', () => {
+    const { middleware } = buildAdapter()
+    const accept = 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'
+    expect(dispatch(middleware, { url: '/dashboard', headers: { accept } }).statusCode).toBe(200)
+  })
+
+  it('gives the root path the index cache policy, not the asset one', () => {
+    // `/` is served by the static layer from `clientDir/index.html`, so it
+    // never reaches the fallback. Treating it as "not a file" left the most
+    // common request in the app without the configured index policy — real
+    // Express returned `public, max-age=0`, the static default.
+    const { middleware } = buildAdapter()
+    const res = dispatchCacheOnly(middleware, { url: '/', headers: HTML })
+    expect(res.headers['cache-control']).toBe('no-cache')
+  })
+
+  it('treats an .html file as index, not as a long-lived asset', () => {
+    const { middleware } = buildAdapter()
+    const res = dispatchCacheOnly(middleware, { url: '/index.html', headers: HTML })
+    expect(res.headers['cache-control']).toBe('no-cache')
+  })
+
+  it('survives a file vanishing between checks', () => {
+    // A deploy can swap the directory mid-request. `existsSync` then
+    // `statSync` threw ENOENT inside request handling; one stat in a
+    // try/catch answers "not servable" instead.
+    const { middleware } = buildAdapter()
+    rmSync(dir, { recursive: true, force: true })
+    expect(() =>
+      dispatch(middleware, { url: '/assets/app.js', headers: { accept: '*/*' } }),
+    ).not.toThrow()
   })
 })

--- a/packages/kickjs/__tests__/spa-adapter.test.ts
+++ b/packages/kickjs/__tests__/spa-adapter.test.ts
@@ -1,0 +1,271 @@
+/**
+ * The SPA adapter had no tests at all, despite being public API with its own
+ * export path (`@forinda/kickjs/spa`). Three behaviours were broken and none
+ * of them were visible:
+ *
+ *   GET /users/john.doe   404  — any route containing a dot
+ *   HEAD /dashboard       404  — HEAD on a SPA route
+ *   GET /apidocs          404  — a path merely PREFIXED by `/api`
+ *
+ * It was also Express-only: `express.static`, `req.path` and `res.send` do
+ * not exist under Fastify or h3, so the adapter silently served nothing there
+ * while the framework advertises a pluggable runtime.
+ *
+ * These tests drive the adapter through the engine-agnostic `AdapterHttp`
+ * surface with a recording stub, then replay the collected middleware against
+ * plain node-shaped request/response objects. That keeps them honest about
+ * what the adapter is allowed to touch — anything Express-specific fails here
+ * rather than in a consumer's Fastify app.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { SpaAdapter, type SpaAdapterOptions } from '../src/http/middleware/spa'
+
+interface RecordedResponse {
+  statusCode: number
+  headers: Record<string, string>
+  body: string | undefined
+  ended: boolean
+}
+
+type Handler = (req: unknown, res: unknown, next: () => void) => void
+
+/** Minimal `AdapterHttp` that records what the adapter registers. */
+function makeHttp() {
+  const middleware: Handler[] = []
+  const statics: Array<{ prefix: string; dir: string }> = []
+  return {
+    http: {
+      route: () => {},
+      mount: () => {},
+      serveStatic: (prefix: string, dir: string) => statics.push({ prefix, dir }),
+      use: (mw: unknown) => middleware.push(mw as Handler),
+    },
+    middleware,
+    statics,
+  }
+}
+
+/** Run the recorded chain the way a connect-style runtime would. */
+function dispatch(
+  middleware: Handler[],
+  req: { url: string; method?: string; headers?: Record<string, string> },
+): RecordedResponse {
+  const res: RecordedResponse = { statusCode: 404, headers: {}, body: undefined, ended: false }
+  const target = {
+    setHeader(name: string, value: string) {
+      res.headers[name.toLowerCase()] = value
+    },
+    get statusCode() {
+      return res.statusCode
+    },
+    set statusCode(v: number) {
+      res.statusCode = v
+    },
+    end(chunk?: string) {
+      res.body = chunk
+      res.ended = true
+    },
+  }
+
+  let i = 0
+  const next = (): void => {
+    const mw = middleware[i++]
+    if (!mw || res.ended) return
+    mw({ headers: {}, method: 'GET', ...req }, target, next)
+  }
+  next()
+  return res
+}
+
+let dir: string
+
+function buildAdapter(options: SpaAdapterOptions = {}) {
+  const adapter = SpaAdapter({ clientDir: dir, ...options })
+  const rec = makeHttp()
+  const ctx = { http: rec.http } as never
+  adapter.beforeMount?.(ctx)
+  adapter.beforeStart?.(ctx)
+  return { adapter, ...rec }
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'kick-spa-'))
+  mkdirSync(join(dir, 'assets'), { recursive: true })
+  writeFileSync(join(dir, 'index.html'), '<!doctype html><title>app</title>')
+  writeFileSync(join(dir, 'assets', 'app.js'), 'console.log(1)')
+})
+
+afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+const HTML = { accept: 'text/html,application/xhtml+xml' }
+
+describe('SpaAdapter — declarative factory', () => {
+  it('is callable without `new`, like ViewAdapter', () => {
+    const adapter = SpaAdapter({ clientDir: dir })
+    expect(adapter.name).toBe('SpaAdapter')
+    expect(typeof adapter.beforeMount).toBe('function')
+  })
+})
+
+describe('SpaAdapter — engine-agnostic surface', () => {
+  it('serves static through http.serveStatic, not express.static', () => {
+    const { statics } = buildAdapter()
+    expect(statics).toHaveLength(1)
+    expect(statics[0]!.dir).toContain('kick-spa-')
+  })
+
+  it('registers its fallback through http.use', () => {
+    const { middleware } = buildAdapter()
+    expect(middleware.length).toBeGreaterThan(0)
+  })
+
+  it('reads the path from req.url — req.path is Express-only', () => {
+    // A raw node request has no `.path`. The old adapter read `req.path`, so
+    // under Fastify/h3 it saw `undefined` and matched nothing.
+    const { middleware } = buildAdapter()
+    const res = dispatch(middleware, { url: '/dashboard?a=1', headers: HTML })
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toContain('<!doctype html>')
+  })
+})
+
+describe('SpaAdapter — fallback rules', () => {
+  it('serves index.html for a plain SPA route', () => {
+    const { middleware } = buildAdapter()
+    const res = dispatch(middleware, { url: '/dashboard', headers: HTML })
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['content-type']).toContain('text/html')
+  })
+
+  it('serves a route containing a dot (was 404)', () => {
+    // The old `req.path.includes('.')` guard treated every dotted route as a
+    // file request. `/users/john.doe` is a perfectly ordinary SPA route.
+    const { middleware } = buildAdapter()
+    const res = dispatch(middleware, { url: '/users/john.doe', headers: HTML })
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toContain('<!doctype html>')
+  })
+
+  it('answers HEAD with headers and no body (was 404)', () => {
+    const { middleware } = buildAdapter()
+    const res = dispatch(middleware, { url: '/dashboard', method: 'HEAD', headers: HTML })
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['content-type']).toContain('text/html')
+    expect(res.headers['content-length']).toBeDefined()
+    expect(res.body).toBeUndefined()
+  })
+
+  it('does not treat /apidocs as an API route (was 404)', () => {
+    // `startsWith('/api')` swallowed anything sharing the prefix.
+    const { middleware } = buildAdapter({ apiPrefix: '/api' })
+    const res = dispatch(middleware, { url: '/apidocs', headers: HTML })
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('still skips the API prefix itself and its children', () => {
+    const { middleware } = buildAdapter({ apiPrefix: '/api' })
+    for (const url of ['/api', '/api/users']) {
+      expect(dispatch(middleware, { url, headers: HTML }).ended).toBe(false)
+    }
+  })
+
+  it('skips excluded paths, segment-aware', () => {
+    const { middleware } = buildAdapter({ exclude: ['/health'] })
+    expect(dispatch(middleware, { url: '/health', headers: HTML }).ended).toBe(false)
+    // `/healthy` is a different route and must still reach the SPA.
+    expect(dispatch(middleware, { url: '/healthy', headers: HTML }).statusCode).toBe(200)
+  })
+
+  it('skips non-GET/HEAD methods', () => {
+    const { middleware } = buildAdapter()
+    expect(dispatch(middleware, { url: '/dashboard', method: 'POST', headers: HTML }).ended).toBe(
+      false,
+    )
+  })
+
+  it('does not hand HTML to a request that did not ask for it', () => {
+    // A missing asset should 404, not receive an HTML document that the
+    // browser then fails to parse as JavaScript.
+    const { middleware } = buildAdapter()
+    const res = dispatch(middleware, { url: '/assets/missing.js', headers: { accept: '*/*' } })
+    expect(res.ended).toBe(false)
+  })
+
+  it('alwaysFallback opts out of content negotiation', () => {
+    const { middleware } = buildAdapter({ alwaysFallback: true })
+    const res = dispatch(middleware, { url: '/deep/link', headers: { accept: '*/*' } })
+    expect(res.statusCode).toBe(200)
+  })
+})
+
+describe('SpaAdapter — cache headers', () => {
+  it('sets the long-lived header for assets', () => {
+    const { middleware } = buildAdapter()
+    const res = dispatch(middleware, { url: '/assets/app.js', headers: { accept: '*/*' } })
+    expect(res.headers['cache-control']).toBe('public, max-age=31536000, immutable')
+  })
+
+  it('sets no-cache on index.html so clients pick up new builds', () => {
+    const { middleware } = buildAdapter()
+    expect(
+      dispatch(middleware, { url: '/dashboard', headers: HTML }).headers['cache-control'],
+    ).toBe('no-cache')
+  })
+
+  it('cacheControl:false registers no cache middleware at all', () => {
+    const withCache = buildAdapter()
+    const without = buildAdapter({ cacheControl: false })
+    expect(without.middleware.length).toBe(withCache.middleware.length - 1)
+  })
+})
+
+describe('SpaAdapter — missing build', () => {
+  it('registers nothing when the client dir is absent', () => {
+    const adapter = SpaAdapter({ clientDir: join(dir, 'does-not-exist') })
+    const rec = makeHttp()
+    const ctx = { http: rec.http } as never
+    adapter.beforeMount?.(ctx)
+    adapter.beforeStart?.(ctx)
+    expect(rec.statics).toHaveLength(0)
+    expect(rec.middleware).toHaveLength(0)
+  })
+
+  it('registers nothing when index.html is missing', () => {
+    rmSync(join(dir, 'index.html'))
+    const { statics, middleware } = buildAdapter()
+    expect(statics).toHaveLength(0)
+    expect(middleware).toHaveLength(0)
+  })
+})
+
+describe('SpaAdapter — cache headers only label real hits', () => {
+  it('does not cache a 404 for a missing asset', () => {
+    // `express.static`'s `setHeaders` only ran on a hit. Running the header
+    // as its own middleware loses that, and an unconditional Cache-Control
+    // told every cache to keep a missing asset's 404 for a year.
+    const { middleware } = buildAdapter()
+    const res = dispatch(middleware, { url: '/assets/missing.js', headers: { accept: '*/*' } })
+    expect(res.headers['cache-control']).toBeUndefined()
+  })
+
+  it('still caches an asset that exists', () => {
+    const { middleware } = buildAdapter()
+    const res = dispatch(middleware, { url: '/assets/app.js', headers: { accept: '*/*' } })
+    expect(res.headers['cache-control']).toBe('public, max-age=31536000, immutable')
+  })
+
+  it('refuses to stat outside clientDir', () => {
+    // The static layer guards itself, but this middleware runs first and
+    // must not become the weak link.
+    const { middleware } = buildAdapter()
+    const res = dispatch(middleware, {
+      url: '/../../../../etc/passwd',
+      headers: { accept: '*/*' },
+    })
+    expect(res.headers['cache-control']).toBeUndefined()
+  })
+})

--- a/packages/kickjs/__tests__/spa-adapter.test.ts
+++ b/packages/kickjs/__tests__/spa-adapter.test.ts
@@ -369,10 +369,10 @@ describe('SpaAdapter — review follow-ups', () => {
     expect(res.headers['cache-control']).toBe('no-cache')
   })
 
-  it('survives a file vanishing between checks', () => {
-    // A deploy can swap the directory mid-request. `existsSync` then
-    // `statSync` threw ENOENT inside request handling; one stat in a
-    // try/catch answers "not servable" instead.
+  it('survives the build directory vanishing after mount', () => {
+    // Requests no longer touch the filesystem at all — the build is
+    // snapshotted at mount — so a deploy swapping the directory mid-flight
+    // cannot throw inside request handling.
     const { middleware } = buildAdapter()
     rmSync(dir, { recursive: true, force: true })
     expect(() =>
@@ -405,5 +405,57 @@ describe('SpaAdapter — absolute clientDir normalisation', () => {
   it('normalises . and .. segments in an absolute clientDir', () => {
     expect(resolveClientDir(`${dir}${sep}assets${sep}..`)).toBe(dir)
     expect(resolveClientDir(`${dir}${sep}.`)).toBe(dir)
+  })
+})
+
+describe('SpaAdapter — Accept media ranges', () => {
+  it('accepts a type wildcard', () => {
+    // `text/*` can accept `text/html`; rejecting it was over-strict.
+    const { middleware } = buildAdapter()
+    expect(
+      dispatch(middleware, { url: '/dashboard', headers: { accept: 'text/*' } }).statusCode,
+    ).toBe(200)
+    expect(
+      dispatch(middleware, { url: '/dashboard', headers: { accept: 'text/*;q=1' } }).statusCode,
+    ).toBe(200)
+  })
+
+  it('lets an exact zero-quality range override a wildcard', () => {
+    // RFC 9110 §12.5.1 precedence: the most specific range wins, so an
+    // explicit `text/html;q=0` rejects HTML even alongside `text/*`.
+    const { middleware } = buildAdapter()
+    const res = dispatch(middleware, {
+      url: '/dashboard',
+      headers: { accept: 'text/*, text/html;q=0' },
+    })
+    expect(res.ended).toBe(false)
+  })
+
+  it('accepts application/* for the xhtml representation', () => {
+    const { middleware } = buildAdapter()
+    expect(
+      dispatch(middleware, { url: '/dashboard', headers: { accept: 'application/*' } }).statusCode,
+    ).toBe(200)
+  })
+
+  it('still refuses a bare */* at any quality', () => {
+    // Assets are fetched this way; treating it as a document request is what
+    // makes a missing script come back as HTML.
+    const { middleware } = buildAdapter()
+    for (const accept of ['*/*', '*/*;q=1']) {
+      expect(dispatch(middleware, { url: '/dashboard', headers: { accept } }).ended).toBe(false)
+    }
+  })
+
+  it('reads the request path without touching the filesystem', () => {
+    // The build is snapshotted at mount, so classification is a Set lookup.
+    // Deleting the directory must not change how a known asset is labelled.
+    const { middleware } = buildAdapter()
+    rmSync(dir, { recursive: true, force: true })
+    const res = dispatch(middleware.slice(0, 1), {
+      url: '/assets/app.js',
+      headers: { accept: '*/*' },
+    })
+    expect(res.headers['cache-control']).toBe('public, max-age=31536000, immutable')
   })
 })

--- a/packages/kickjs/__tests__/spa-adapter.test.ts
+++ b/packages/kickjs/__tests__/spa-adapter.test.ts
@@ -459,3 +459,32 @@ describe('SpaAdapter — Accept media ranges', () => {
     expect(res.headers['cache-control']).toBe('public, max-age=31536000, immutable')
   })
 })
+
+describe('SpaAdapter — build snapshot portability', () => {
+  it('walks nested directories without newer fs APIs', () => {
+    // The walk uses only `readdirSync(dir, { withFileTypes: true })`. The
+    // `recursive` option (node 20.1) and `Dirent.parentPath` (20.12) are both
+    // newer than the declared `node >=20.0`, and the older `Dirent.path` alias
+    // is already gone on node 24 — no single spelling covers the range.
+    mkdirSync(join(dir, 'assets', 'nested', 'deep'), { recursive: true })
+    writeFileSync(join(dir, 'assets', 'nested', 'deep', 'chunk.js'), 'x')
+
+    const { middleware } = buildAdapter()
+    const res = dispatch(middleware.slice(0, 1), {
+      url: '/assets/nested/deep/chunk.js',
+      headers: { accept: '*/*' },
+    })
+    expect(res.headers['cache-control']).toBe('public, max-age=31536000, immutable')
+  })
+
+  it('does not label a directory as an asset', () => {
+    // `/assets` is a directory with no index.html — the static layer will not
+    // serve it, so it must not receive an asset cache header.
+    const { middleware } = buildAdapter()
+    const res = dispatch(middleware.slice(0, 1), {
+      url: '/assets',
+      headers: { accept: '*/*' },
+    })
+    expect(res.headers['cache-control']).toBeUndefined()
+  })
+})

--- a/packages/kickjs/__tests__/spa-adapter.test.ts
+++ b/packages/kickjs/__tests__/spa-adapter.test.ts
@@ -21,7 +21,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, sep } from 'node:path'
 import { resolveClientDir, SpaAdapter, type SpaAdapterOptions } from '../src/http/middleware/spa'
 
 interface RecordedResponse {
@@ -378,5 +378,32 @@ describe('SpaAdapter — review follow-ups', () => {
     expect(() =>
       dispatch(middleware, { url: '/assets/app.js', headers: { accept: '*/*' } }),
     ).not.toThrow()
+  })
+})
+
+describe('SpaAdapter — absolute clientDir normalisation', () => {
+  it('still sets cache headers when clientDir has a trailing slash', () => {
+    // `resolveClientDir` used to return an absolute path verbatim, while
+    // `resolvesToFile` compares against an always-normalised target. A
+    // trailing slash made `startsWith(clientDir + sep)` compare against
+    // `//`, so containment never matched and EVERY request silently lost
+    // its Cache-Control header. Fails closed, so the traversal guard was
+    // never weakened — it just stopped doing its job.
+    const adapter = SpaAdapter({ clientDir: `${dir}${sep}` })
+    const rec = makeHttp()
+    const ctx = { http: rec.http } as never
+    adapter.beforeMount?.(ctx)
+    adapter.beforeStart?.(ctx)
+
+    const res = dispatch(rec.middleware.slice(0, 1), {
+      url: '/assets/app.js',
+      headers: { accept: '*/*' },
+    })
+    expect(res.headers['cache-control']).toBe('public, max-age=31536000, immutable')
+  })
+
+  it('normalises . and .. segments in an absolute clientDir', () => {
+    expect(resolveClientDir(`${dir}${sep}assets${sep}..`)).toBe(dir)
+    expect(resolveClientDir(`${dir}${sep}.`)).toBe(dir)
   })
 })

--- a/packages/kickjs/__tests__/spa-adapter.test.ts
+++ b/packages/kickjs/__tests__/spa-adapter.test.ts
@@ -22,7 +22,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { SpaAdapter, type SpaAdapterOptions } from '../src/http/middleware/spa'
+import { resolveClientDir, SpaAdapter, type SpaAdapterOptions } from '../src/http/middleware/spa'
 
 interface RecordedResponse {
   statusCode: number
@@ -289,17 +289,14 @@ describe('SpaAdapter — cache headers only label real hits', () => {
 })
 
 describe('SpaAdapter — clientDir resolution', () => {
-  it('finds a relative clientDir from the process cwd', () => {
-    const prev = process.cwd()
-    process.chdir(dir)
-    try {
-      const adapter = SpaAdapter({ clientDir: '.' })
-      const rec = makeHttp()
-      adapter.beforeMount?.({ http: rec.http } as never)
-      expect(rec.statics).toHaveLength(1)
-    } finally {
-      process.chdir(prev)
-    }
+  // Exercised through `resolveClientDir` directly with injected cwd/entry.
+  // The earlier version used `process.chdir` + `process.argv[1]`, which
+  // throws `process.chdir() is not supported in workers` under the ROOT
+  // vitest config (`pool: 'threads'`). It passed under `pnpm test` only
+  // because turbo runs each package's own config, which defaults to forks.
+
+  it('finds a relative clientDir from the given cwd', () => {
+    expect(resolveClientDir('.', dir)).toBe(dir)
   })
 
   it('falls back to the entry package root when cwd misses', () => {
@@ -307,36 +304,30 @@ describe('SpaAdapter — clientDir resolution', () => {
     // cwd is the root, so `../web/dist` misses there and must be retried
     // against the entry script's own package root.
     const root = mkdtempSync(join(tmpdir(), 'kick-mono-'))
-    const serverDir = join(root, 'server')
-    mkdirSync(join(serverDir, 'dist'), { recursive: true })
-    mkdirSync(join(root, 'web', 'dist'), { recursive: true })
-    writeFileSync(join(serverDir, 'package.json'), '{"name":"server"}')
-    writeFileSync(join(root, 'web', 'dist', 'index.html'), '<!doctype html><title>x</title>')
-    const entry = join(serverDir, 'dist', 'index.js')
-    writeFileSync(entry, '')
-
-    const prevCwd = process.cwd()
-    const prevArgv = process.argv[1]
-    process.chdir(root) // launched from the ROOT, not from server/
-    process.argv[1] = entry
     try {
-      const adapter = SpaAdapter({ clientDir: '../web/dist' })
-      const rec = makeHttp()
-      adapter.beforeMount?.({ http: rec.http } as never)
-      expect(rec.statics).toHaveLength(1)
-      expect(rec.statics[0]!.dir).toBe(join(root, 'web', 'dist'))
+      const serverDir = join(root, 'server')
+      mkdirSync(join(serverDir, 'dist'), { recursive: true })
+      mkdirSync(join(root, 'web', 'dist'), { recursive: true })
+      writeFileSync(join(serverDir, 'package.json'), '{"name":"server"}')
+      const entry = join(serverDir, 'dist', 'index.js')
+      writeFileSync(entry, '')
+
+      // cwd = the ROOT, not server/.
+      expect(resolveClientDir('../web/dist', root, entry)).toBe(join(root, 'web', 'dist'))
     } finally {
-      process.chdir(prevCwd)
-      process.argv[1] = prevArgv as string
       rmSync(root, { recursive: true, force: true })
     }
   })
 
   it('leaves an absolute clientDir untouched', () => {
-    const adapter = SpaAdapter({ clientDir: dir })
-    const rec = makeHttp()
-    adapter.beforeMount?.({ http: rec.http } as never)
-    expect(rec.statics[0]!.dir).toBe(dir)
+    expect(resolveClientDir(dir, '/somewhere/else')).toBe(dir)
+  })
+
+  it('keeps the cwd candidate when neither location has the build', () => {
+    // The warning names the cwd path, so a genuinely missing build must
+    // resolve there rather than to some unrelated entry-relative guess.
+    const missing = join(dir, 'nope')
+    expect(resolveClientDir('nope', dir, undefined)).toBe(missing)
   })
 })
 

--- a/packages/kickjs/src/http/middleware/spa.ts
+++ b/packages/kickjs/src/http/middleware/spa.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
-import { resolve, join, sep, dirname, isAbsolute, relative } from 'node:path'
+import { resolve, join, dirname, isAbsolute } from 'node:path'
 import { Logger, defineAdapter } from '../../core'
 import type { ConnectMiddleware } from '../runtime'
 
@@ -302,19 +302,37 @@ export const SpaAdapter = defineAdapter<SpaAdapterOptions>({
     let assetPaths: ReadonlySet<string> = new Set()
 
     function snapshotClientDir(): ReadonlySet<string> {
-      try {
-        const entries = readdirSync(clientDir, { recursive: true, withFileTypes: true })
-        const paths = new Set<string>()
-        for (const entry of entries) {
-          if (!entry.isFile()) continue
-          // `parentPath` is absolute; make it a request path.
-          const abs = join(entry.parentPath, entry.name)
-          paths.add(`/${relative(clientDir, abs).split(sep).join('/')}`)
+      const paths = new Set<string>()
+      // A hand-rolled walk rather than `readdirSync(dir, { recursive: true })`
+      // with `Dirent.parentPath`. Both are newer than the package's declared
+      // `node >=20.0`: the `recursive` option landed in 20.1, `parentPath` in
+      // 20.12, and the older `Dirent.path` alias it replaced is already gone
+      // on Node 24 — so no single spelling covers the supported range. The
+      // failure would have been silent, too: the surrounding `catch` turns a
+      // `TypeError` from `join(undefined, name)` into an empty snapshot, which
+      // reads as "no files" and drops every Cache-Control header.
+      //
+      // `readdirSync(dir, { withFileTypes: true })` is ancient and stable, and
+      // tracking the parent ourselves needs no new API.
+      const walk = (absDir: string, prefix: string): void => {
+        for (const entry of readdirSync(absDir, { withFileTypes: true })) {
+          const child = `${prefix}/${entry.name}`
+          // Symlinks report as neither file nor directory here (readdir does
+          // not follow them), so a symlinked tree is skipped rather than
+          // risking a cycle. A symlinked asset simply goes unlabelled — the
+          // static layer still serves it, it just misses the cache header.
+          if (entry.isDirectory()) walk(join(absDir, entry.name), child)
+          else if (entry.isFile()) paths.add(child)
         }
-        return paths
+      }
+      try {
+        walk(clientDir, '')
       } catch {
+        // Unreadable build directory — fall back to labelling nothing rather
+        // than failing the boot. Serving still works; caching just opts out.
         return new Set()
       }
+      return paths
     }
 
     /**

--- a/packages/kickjs/src/http/middleware/spa.ts
+++ b/packages/kickjs/src/http/middleware/spa.ts
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync } from 'node:fs'
-import { resolve, join } from 'node:path'
-import { Logger, type AppAdapter, type AdapterContext } from '../../core'
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { resolve, join, sep } from 'node:path'
+import { Logger, defineAdapter } from '../../core'
+import type { ConnectMiddleware } from '../runtime'
 
 const log = Logger.for('SpaAdapter')
 
@@ -25,6 +26,10 @@ export interface SpaAdapterOptions {
    * non-API routes (routes NOT starting with this prefix).
    * Default: '/api'
    *
+   * Matching is segment-aware: `/api` excludes `/api` and `/api/users`, but
+   * NOT `/apidocs` — a plain `startsWith` swallowed any path that merely
+   * began with the same letters.
+   *
    * Set to an array for multiple prefixes:
    * ```ts
    * apiPrefix: ['/api', '/graphql', '/_debug']
@@ -34,7 +39,7 @@ export interface SpaAdapterOptions {
 
   /**
    * Additional paths to exclude from SPA fallback.
-   * These paths will NOT serve index.html.
+   * These paths will NOT serve index.html. Segment-aware, like `apiPrefix`.
    *
    * @example
    * ```ts
@@ -54,12 +59,82 @@ export interface SpaAdapterOptions {
    * index.html should not be cached to ensure clients get fresh builds.
    */
   indexCacheControl?: string
+
+  /**
+   * Serve index.html even when the client did not ask for HTML.
+   * Default: false.
+   *
+   * By default the fallback only fires for requests whose `Accept` header
+   * includes `text/html` — the rule `connect-history-api-fallback` uses. That
+   * keeps a missing `/assets/app.js` a 404 instead of handing back an HTML
+   * document that the browser then fails to parse as JavaScript, which is a
+   * confusing way to discover a broken build.
+   *
+   * Turn this on if you have non-browser clients that deep-link into SPA
+   * routes without an `Accept` header.
+   */
+  alwaysFallback?: boolean
+}
+
+/**
+ * The slice of the request/response this adapter touches, spelled from the
+ * node `http` shapes rather than Express's. `ConnectMiddleware` is typed as
+ * Express's `RequestHandler`, but under Fastify and h3 these handlers receive
+ * the raw node objects (or a driver), so relying on `req.path` / `res.send`
+ * is what made the previous version Express-only.
+ */
+interface SpaRequest {
+  url?: string
+  method?: string
+  headers?: Record<string, string | string[] | undefined>
+}
+
+interface SpaResponse {
+  setHeader(name: string, value: string): void
+  statusCode: number
+  end(chunk?: string): void
+}
+
+type SpaHandler = (req: SpaRequest, res: SpaResponse, next: () => void) => void
+
+/** Pathname only — `req.url` carries the query string, and `req.path` is Express-only. */
+function pathnameOf(url: string | undefined): string {
+  if (!url) return '/'
+  const q = url.indexOf('?')
+  const h = url.indexOf('#')
+  const end = Math.min(q === -1 ? url.length : q, h === -1 ? url.length : h)
+  return url.slice(0, end) || '/'
+}
+
+/**
+ * Segment-aware prefix test: `/api` covers `/api` and `/api/users`, not
+ * `/apidocs`. `startsWith` alone made any same-prefixed route disappear from
+ * the SPA fallback and 404 instead.
+ */
+function isUnder(pathname: string, prefix: string): boolean {
+  if (!prefix || prefix === '/') return true
+  const p = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix
+  return pathname === p || pathname.startsWith(`${p}/`)
+}
+
+/** Does the client want an HTML document back? */
+function acceptsHtml(accept: string | string[] | undefined): boolean {
+  const value = Array.isArray(accept) ? accept.join(',') : (accept ?? '')
+  return value.includes('text/html') || value.includes('application/xhtml+xml')
 }
 
 /**
  * SPA adapter — serve a Vue, React, Svelte, or Angular build alongside
  * your KickJS API. API routes are handled by controllers; everything else
  * falls back to index.html for client-side routing.
+ *
+ * Written against the engine-agnostic `http` surface (`serveStatic` / `use`),
+ * so it runs under Express, Fastify, and h3 alike. The previous version
+ * reached for `express.static`, `req.path`, and `res.send`, all of which are
+ * Express-only — it silently served nothing on the other runtimes.
+ *
+ * Migrated to the `defineAdapter()` factory — call without `new`, as
+ * `ViewAdapter` has since v4.
  *
  * @example
  * ```ts
@@ -68,7 +143,7 @@ export interface SpaAdapterOptions {
  * bootstrap({
  *   modules,
  *   adapters: [
- *     new SpaAdapter({
+ *     SpaAdapter({
  *       clientDir: 'dist/client',  // or 'build', 'dist', etc.
  *       apiPrefix: '/api',
  *     }),
@@ -87,91 +162,123 @@ export interface SpaAdapterOptions {
  *   server/            ← KickJS server
  * ```
  */
-export class SpaAdapter implements AppAdapter {
-  name = 'SpaAdapter'
-  private clientDir: string
-  private apiPrefixes: string[]
-  private excludePaths: string[]
-  private cacheControl: string | false
-  private indexCacheControl: string
-  private indexHtml: string | null = null
+export const SpaAdapter = defineAdapter<SpaAdapterOptions>({
+  name: 'SpaAdapter',
+  defaults: {
+    clientDir: 'dist/client',
+    apiPrefix: '/api',
+    exclude: [],
+    cacheControl: 'public, max-age=31536000, immutable',
+    indexCacheControl: 'no-cache',
+    alwaysFallback: false,
+  },
+  build: (config) => {
+    const clientDir = resolve(config.clientDir ?? 'dist/client')
+    const rawPrefix = config.apiPrefix ?? '/api'
+    const apiPrefixes = Array.isArray(rawPrefix) ? rawPrefix : [rawPrefix]
+    const excludePaths = config.exclude ?? []
+    const cacheControl = config.cacheControl ?? 'public, max-age=31536000, immutable'
+    const indexCacheControl = config.indexCacheControl ?? 'no-cache'
+    const alwaysFallback = config.alwaysFallback ?? false
 
-  constructor(private options: SpaAdapterOptions = {}) {
-    this.clientDir = resolve(options.clientDir ?? 'dist/client')
-    this.excludePaths = options.exclude ?? []
-    this.cacheControl = options.cacheControl ?? 'public, max-age=31536000, immutable'
-    this.indexCacheControl = options.indexCacheControl ?? 'no-cache'
+    let indexHtml: string | null = null
 
-    const prefix = options.apiPrefix ?? '/api'
-    this.apiPrefixes = Array.isArray(prefix) ? prefix : [prefix]
-  }
-
-  beforeMount({ app }: AdapterContext): void {
-    if (!existsSync(this.clientDir)) {
-      log.warn(`SPA client directory not found: ${this.clientDir}`)
-      log.warn('Build your frontend first, or set clientDir to the correct path.')
-      return
+    /**
+     * Is this request path a real file inside `clientDir`?
+     *
+     * `resolve` collapses any `..` before the containment check, so a
+     * traversal attempt lands outside `clientDir` and is rejected here rather
+     * than reaching the filesystem — the static layer guards itself, but this
+     * runs first and must not become the weak link.
+     */
+    const resolvesToFile = (pathname: string): boolean => {
+      let decoded: string
+      try {
+        decoded = decodeURIComponent(pathname)
+      } catch {
+        return false
+      }
+      if (decoded.includes('\0')) return false
+      const target = resolve(clientDir, `.${decoded}`)
+      if (target !== clientDir && !target.startsWith(`${clientDir}${sep}`)) return false
+      return existsSync(target) && statSync(target).isFile()
     }
 
-    // Read index.html into memory
-    const indexPath = join(this.clientDir, 'index.html')
-    if (existsSync(indexPath)) {
-      this.indexHtml = readFileSync(indexPath, 'utf-8')
-    } else {
-      log.warn(`index.html not found in ${this.clientDir}`)
-      return
-    }
+    /** Skipped by the fallback: API routes, opted-out paths. */
+    const isReserved = (pathname: string): boolean =>
+      apiPrefixes.some((p) => isUnder(pathname, p)) ||
+      excludePaths.some((p) => isUnder(pathname, p))
 
-    // Serve static files with cache headers
-    try {
-      // Dynamic import to avoid hard dependency on express.static
-      const express = require('express')
-      const staticOpts: any = {}
-
-      if (this.cacheControl) {
-        staticOpts.setHeaders = (res: any, filePath: string) => {
-          if (filePath.endsWith('.html')) {
-            res.setHeader('Cache-Control', this.indexCacheControl)
-          } else {
-            res.setHeader('Cache-Control', this.cacheControl as string)
-          }
+    return {
+      beforeMount({ http }) {
+        if (!existsSync(clientDir)) {
+          log.warn(`SPA client directory not found: ${clientDir}`)
+          log.warn('Build your frontend first, or set clientDir to the correct path.')
+          return
         }
-      }
 
-      app.use(express.static(this.clientDir, staticOpts))
-    } catch {
-      log.error('express.static not available — SPA static file serving disabled')
-      return
+        const indexPath = join(clientDir, 'index.html')
+        if (!existsSync(indexPath)) {
+          log.warn(`index.html not found in ${clientDir}`)
+          return
+        }
+        indexHtml = readFileSync(indexPath, 'utf-8')
+
+        // Cache-Control runs as its own middleware ahead of the static
+        // handler: the engine-agnostic `serveStatic` takes no header hook,
+        // and headers set before the static layer writes still land on the
+        // response. Keyed off the request path rather than the resolved file,
+        // which is the same decision `express.static`'s `setHeaders` made.
+        if (cacheControl !== false) {
+          http.use(((req, res, next) => {
+            const pathname = pathnameOf(req.url)
+            // Only label a response the static layer will actually serve.
+            // `express.static`'s `setHeaders` fired on hits only; running as
+            // a separate middleware loses that, and an unconditional header
+            // put `immutable, max-age=31536000` on the 404 for a missing
+            // asset — telling every cache to keep that miss for a year.
+            if (!isReserved(pathname) && resolvesToFile(pathname)) {
+              res.setHeader(
+                'Cache-Control',
+                pathname.endsWith('.html') ? indexCacheControl : cacheControl,
+              )
+            }
+            next()
+          }) satisfies SpaHandler as unknown as ConnectMiddleware)
+        }
+
+        http.serveStatic('/', clientDir)
+        log.debug(`Serving SPA from ${clientDir}`)
+      },
+
+      beforeStart({ http }) {
+        if (!indexHtml) return
+
+        http.use(((req, res, next) => {
+          // GET and HEAD both navigate. HEAD used to fall through to a 404,
+          // which broke proxies and link checkers probing SPA routes.
+          const method = (req.method ?? 'GET').toUpperCase()
+          if (method !== 'GET' && method !== 'HEAD') return next()
+
+          const pathname = pathnameOf(req.url)
+          if (isReserved(pathname)) return next()
+
+          // Content negotiation instead of a "does the path contain a dot"
+          // guess. The old heuristic 404'd every legitimate route carrying a
+          // dot (`/users/john.doe`, `/v1.2/spec`) while still handing HTML to
+          // genuinely missing assets whose path had no extension.
+          const accept = req.headers?.['accept'] as string | string[] | undefined
+          if (!alwaysFallback && !acceptsHtml(accept)) return next()
+
+          const body = indexHtml as string
+          res.setHeader('Content-Type', 'text/html; charset=utf-8')
+          res.setHeader('Cache-Control', indexCacheControl)
+          res.setHeader('Content-Length', String(Buffer.byteLength(body)))
+          res.statusCode = 200
+          // HEAD must carry identical headers and no body.
+          res.end(method === 'HEAD' ? undefined : body)
+        }) satisfies SpaHandler as unknown as ConnectMiddleware)
+      },
     }
-
-    log.debug(`Serving SPA from ${this.clientDir}`)
-  }
-
-  beforeStart({ app }: AdapterContext): void {
-    if (!this.indexHtml) return
-
-    // SPA fallback: serve index.html for all non-API, non-file routes
-    app.use((req: any, res: any, next: any) => {
-      // Skip API routes
-      for (const prefix of this.apiPrefixes) {
-        if (req.path.startsWith(prefix)) return next()
-      }
-
-      // Skip excluded paths
-      for (const path of this.excludePaths) {
-        if (req.path.startsWith(path)) return next()
-      }
-
-      // Skip requests for files (have an extension)
-      if (req.path.includes('.')) return next()
-
-      // Skip non-GET requests
-      if (req.method !== 'GET') return next()
-
-      // Serve index.html
-      res.setHeader('Content-Type', 'text/html')
-      res.setHeader('Cache-Control', this.indexCacheControl)
-      res.send(this.indexHtml)
-    })
-  }
-}
+  },
+})

--- a/packages/kickjs/src/http/middleware/spa.ts
+++ b/packages/kickjs/src/http/middleware/spa.ts
@@ -118,7 +118,12 @@ export function resolveClientDir(
   cwd: string = process.cwd(),
   entry: string | undefined = process.argv[1],
 ): string {
-  if (isAbsolute(clientDir)) return clientDir
+  // `resolve` even for an already-absolute path: `resolvesToFile` compares its
+  // (always normalized) target against this string, so a trailing slash or a
+  // `.`/`..` segment here would make the containment check never match and
+  // silently drop the Cache-Control header on every request. Fails closed, so
+  // it never weakened the traversal guard — it just stopped doing its job.
+  if (isAbsolute(clientDir)) return resolve(clientDir)
   const fromCwd = resolve(cwd, clientDir)
   if (existsSync(fromCwd)) return fromCwd
 

--- a/packages/kickjs/src/http/middleware/spa.ts
+++ b/packages/kickjs/src/http/middleware/spa.ts
@@ -164,10 +164,33 @@ function isUnder(pathname: string, prefix: string): boolean {
   return pathname === p || pathname.startsWith(`${p}/`)
 }
 
-/** Does the client want an HTML document back? */
+/** Media ranges that count as "the client wants a document". */
+const HTML_TYPES = ['text/html', 'application/xhtml+xml']
+
+/**
+ * Does the client want an HTML document back?
+ *
+ * Parses q-values rather than substring-matching: `Accept: text/html;q=0`
+ * explicitly says HTML is NOT acceptable (RFC 9110 §12.5.1 — "a value of 0
+ * means not acceptable"), and a substring check read that as a yes and
+ * returned the document anyway.
+ *
+ * A bare `*` / `*` wildcard deliberately does NOT count. Assets are fetched
+ * with `Accept: * / *`, and treating that as a document request is what makes
+ * a missing script come back as HTML.
+ */
 function acceptsHtml(accept: string | string[] | undefined): boolean {
-  const value = Array.isArray(accept) ? accept.join(',') : (accept ?? '')
-  return value.includes('text/html') || value.includes('application/xhtml+xml')
+  const raw = Array.isArray(accept) ? accept.join(',') : (accept ?? '')
+  if (!raw) return false
+  for (const part of raw.split(',')) {
+    const [type, ...params] = part.split(';').map((t) => t.trim().toLowerCase())
+    if (!type || !HTML_TYPES.includes(type)) continue
+    const q = params.find((param) => param.startsWith('q='))
+    if (!q) return true
+    const value = Number.parseFloat(q.slice(2))
+    if (Number.isNaN(value) || value > 0) return true
+  }
+  return false
 }
 
 /**
@@ -238,17 +261,33 @@ export const SpaAdapter = defineAdapter<SpaAdapterOptions>({
      * than reaching the filesystem — the static layer guards itself, but this
      * runs first and must not become the weak link.
      */
-    const resolvesToFile = (pathname: string): boolean => {
+    const resolvesToFile = (pathname: string): 'file' | 'index' | null => {
       let decoded: string
       try {
         decoded = decodeURIComponent(pathname)
       } catch {
-        return false
+        return null
       }
-      if (decoded.includes('\0')) return false
+      if (decoded.includes('\0')) return null
       const target = resolve(clientDir, `.${decoded}`)
-      if (target !== clientDir && !target.startsWith(`${clientDir}${sep}`)) return false
-      return existsSync(target) && statSync(target).isFile()
+      if (target !== clientDir && !target.startsWith(`${clientDir}${sep}`)) return null
+
+      // One `stat`, no `existsSync` first: a check-then-stat pair can throw
+      // mid-request when a deploy swaps the directory between the two calls.
+      // A throw here IS the "not a servable file" answer.
+      try {
+        const stats = statSync(target)
+        if (stats.isFile()) return decoded.endsWith('.html') ? 'index' : 'file'
+        // A directory is served by the static layer from its `index.html`, so
+        // `/` — the single most common request — is an index request, not an
+        // asset. Reporting it as neither meant the root document fell through
+        // to the static layer's default caching and never received the
+        // configured `indexCacheControl`.
+        if (stats.isDirectory() && existsSync(join(target, 'index.html'))) return 'index'
+        return null
+      } catch {
+        return null
+      }
     }
 
     /** Skipped by the fallback: API routes, opted-out paths. */
@@ -287,11 +326,9 @@ export const SpaAdapter = defineAdapter<SpaAdapterOptions>({
             // a separate middleware loses that, and an unconditional header
             // put `immutable, max-age=31536000` on the 404 for a missing
             // asset — telling every cache to keep that miss for a year.
-            if (!isReserved(pathname) && resolvesToFile(pathname)) {
-              res.setHeader(
-                'Cache-Control',
-                pathname.endsWith('.html') ? indexCacheControl : cacheControl,
-              )
+            const kind = isReserved(pathname) ? null : resolvesToFile(pathname)
+            if (kind) {
+              res.setHeader('Cache-Control', kind === 'index' ? indexCacheControl : cacheControl)
             }
             next()
           }) satisfies SpaHandler as unknown as ConnectMiddleware)

--- a/packages/kickjs/src/http/middleware/spa.ts
+++ b/packages/kickjs/src/http/middleware/spa.ts
@@ -106,13 +106,22 @@ function nearestPackageRoot(from: string): string | null {
  *
  * Deliberately not entry-relative FIRST: under `kick dev` the entry is the CLI
  * binary, whose package root is the CLI itself.
+ *
+ * Exported for tests only — not re-exported from the package index.
  */
-function resolveClientDir(clientDir: string): string {
+export function resolveClientDir(
+  clientDir: string,
+  // Injected rather than read from the process so tests can exercise the
+  // monorepo-root case without `process.chdir` / `process.argv` mutation —
+  // neither is supported under vitest's `threads` pool, and the root config
+  // uses exactly that.
+  cwd: string = process.cwd(),
+  entry: string | undefined = process.argv[1],
+): string {
   if (isAbsolute(clientDir)) return clientDir
-  const fromCwd = resolve(process.cwd(), clientDir)
+  const fromCwd = resolve(cwd, clientDir)
   if (existsSync(fromCwd)) return fromCwd
 
-  const entry = process.argv[1]
   if (entry) {
     const root = nearestPackageRoot(dirname(resolve(entry)))
     if (root) {

--- a/packages/kickjs/src/http/middleware/spa.ts
+++ b/packages/kickjs/src/http/middleware/spa.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, statSync } from 'node:fs'
-import { resolve, join, sep, dirname, isAbsolute } from 'node:path'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { resolve, join, sep, dirname, isAbsolute, relative } from 'node:path'
 import { Logger, defineAdapter } from '../../core'
 import type { ConnectMiddleware } from '../runtime'
 
@@ -181,30 +181,48 @@ function isUnder(pathname: string, prefix: string): boolean {
 /** Media ranges that count as "the client wants a document". */
 const HTML_TYPES = ['text/html', 'application/xhtml+xml']
 
+/** `q` for a media range, defaulting to 1 when absent or unparseable. */
+function qualityOf(params: string[]): number {
+  const q = params.find((param) => param.startsWith('q='))
+  if (!q) return 1
+  const value = Number.parseFloat(q.slice(2))
+  return Number.isNaN(value) ? 1 : value
+}
+
 /**
  * Does the client want an HTML document back?
  *
- * Parses q-values rather than substring-matching: `Accept: text/html;q=0`
- * explicitly says HTML is NOT acceptable (RFC 9110 §12.5.1 — "a value of 0
- * means not acceptable"), and a substring check read that as a yes and
- * returned the document anyway.
+ * Parses media ranges with q-values rather than substring-matching:
+ * `Accept: text/html;q=0` explicitly says HTML is NOT acceptable (RFC 9110
+ * §12.5.1 — "a value of 0 means not acceptable"), and a substring check read
+ * that as a yes and returned the document anyway.
  *
- * A bare `*` / `*` wildcard deliberately does NOT count. Assets are fetched
+ * Wildcards are matched by specificity, as RFC 9110 §12.5.1 requires: an exact
+ * `text/html` beats `text/*`, so `Accept: text/*, text/html;q=0` correctly
+ * rejects HTML even though the wildcard would have accepted it.
+ *
+ * A bare `*` / `*` deliberately does NOT count, at any q. Assets are fetched
  * with `Accept: * / *`, and treating that as a document request is what makes
- * a missing script come back as HTML.
+ * a missing script come back as HTML — the very thing the fallback rules
+ * exist to prevent.
  */
 function acceptsHtml(accept: string | string[] | undefined): boolean {
   const raw = Array.isArray(accept) ? accept.join(',') : (accept ?? '')
   if (!raw) return false
-  for (const part of raw.split(',')) {
-    const [type, ...params] = part.split(';').map((t) => t.trim().toLowerCase())
-    if (!type || !HTML_TYPES.includes(type)) continue
-    const q = params.find((param) => param.startsWith('q='))
-    if (!q) return true
-    const value = Number.parseFloat(q.slice(2))
-    if (Number.isNaN(value) || value > 0) return true
-  }
-  return false
+
+  const ranges = raw
+    .split(',')
+    .map((part) => part.split(';').map((t) => t.trim().toLowerCase()))
+    .filter(([type]) => Boolean(type))
+
+  return HTML_TYPES.some((htmlType) => {
+    const [group] = htmlType.split('/')
+    // Most specific match wins: exact type, else `type/*`. `*/*` is skipped.
+    const exact = ranges.find(([type]) => type === htmlType)
+    const wildcard = ranges.find(([type]) => type === `${group}/*`)
+    const match = exact ?? wildcard
+    return match ? qualityOf(match.slice(1)) > 0 : false
+  })
 }
 
 /**
@@ -268,14 +286,46 @@ export const SpaAdapter = defineAdapter<SpaAdapterOptions>({
     let indexHtml: string | null = null
 
     /**
-     * Is this request path a real file inside `clientDir`?
+     * Every file in the build, as request paths (`/assets/app.js`), captured
+     * once at mount.
      *
-     * `resolve` collapses any `..` before the containment check, so a
-     * traversal attempt lands outside `clientDir` and is rejected here rather
-     * than reaching the filesystem — the static layer guards itself, but this
-     * runs first and must not become the weak link.
+     * This used to be a `statSync` per request. That is a synchronous
+     * filesystem call on the hot path of every non-reserved request, and a
+     * slow or contended disk blocks the event loop for unrelated requests.
+     * The directory is a static build — its contents are already snapshotted
+     * at boot, since `index.html` is read into memory there — so the lookup
+     * belongs in memory too. No filesystem access remains in the request path.
+     *
+     * A build added to after boot is not picked up, which is the same
+     * contract `index.html` already had.
      */
-    const resolvesToFile = (pathname: string): 'file' | 'index' | null => {
+    let assetPaths: ReadonlySet<string> = new Set()
+
+    function snapshotClientDir(): ReadonlySet<string> {
+      try {
+        const entries = readdirSync(clientDir, { recursive: true, withFileTypes: true })
+        const paths = new Set<string>()
+        for (const entry of entries) {
+          if (!entry.isFile()) continue
+          // `parentPath` is absolute; make it a request path.
+          const abs = join(entry.parentPath, entry.name)
+          paths.add(`/${relative(clientDir, abs).split(sep).join('/')}`)
+        }
+        return paths
+      } catch {
+        return new Set()
+      }
+    }
+
+    /**
+     * How the static layer will answer this path: as the index document, as a
+     * long-lived asset, or not at all.
+     *
+     * Membership of the snapshot IS the containment guard — a traversal like
+     * `/../../etc/passwd` simply is not a key — so no prefix comparison is
+     * needed and the whole check is one `Set.has`.
+     */
+    const classifyPath = (pathname: string): 'file' | 'index' | null => {
       let decoded: string
       try {
         decoded = decodeURIComponent(pathname)
@@ -283,25 +333,14 @@ export const SpaAdapter = defineAdapter<SpaAdapterOptions>({
         return null
       }
       if (decoded.includes('\0')) return null
-      const target = resolve(clientDir, `.${decoded}`)
-      if (target !== clientDir && !target.startsWith(`${clientDir}${sep}`)) return null
 
-      // One `stat`, no `existsSync` first: a check-then-stat pair can throw
-      // mid-request when a deploy swaps the directory between the two calls.
-      // A throw here IS the "not a servable file" answer.
-      try {
-        const stats = statSync(target)
-        if (stats.isFile()) return decoded.endsWith('.html') ? 'index' : 'file'
-        // A directory is served by the static layer from its `index.html`, so
-        // `/` — the single most common request — is an index request, not an
-        // asset. Reporting it as neither meant the root document fell through
-        // to the static layer's default caching and never received the
-        // configured `indexCacheControl`.
-        if (stats.isDirectory() && existsSync(join(target, 'index.html'))) return 'index'
-        return null
-      } catch {
-        return null
-      }
+      // A directory is served from its `index.html`, so `/` — the single most
+      // common request — is an index request, not an asset. Reporting it as
+      // neither left the root document without the configured policy.
+      const asIndex = decoded.endsWith('/') ? `${decoded}index.html` : null
+      if (asIndex && assetPaths.has(asIndex)) return 'index'
+      if (!assetPaths.has(decoded)) return null
+      return decoded.endsWith('.html') ? 'index' : 'file'
     }
 
     /** Skipped by the fallback: API routes, opted-out paths. */
@@ -326,6 +365,7 @@ export const SpaAdapter = defineAdapter<SpaAdapterOptions>({
           return
         }
         indexHtml = readFileSync(indexPath, 'utf-8')
+        assetPaths = snapshotClientDir()
 
         // Cache-Control runs as its own middleware ahead of the static
         // handler: the engine-agnostic `serveStatic` takes no header hook,
@@ -340,7 +380,7 @@ export const SpaAdapter = defineAdapter<SpaAdapterOptions>({
             // a separate middleware loses that, and an unconditional header
             // put `immutable, max-age=31536000` on the 404 for a missing
             // asset — telling every cache to keep that miss for a year.
-            const kind = isReserved(pathname) ? null : resolvesToFile(pathname)
+            const kind = isReserved(pathname) ? null : classifyPath(pathname)
             if (kind) {
               res.setHeader('Cache-Control', kind === 'index' ? indexCacheControl : cacheControl)
             }

--- a/packages/kickjs/src/http/middleware/spa.ts
+++ b/packages/kickjs/src/http/middleware/spa.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, statSync } from 'node:fs'
-import { resolve, join, sep } from 'node:path'
+import { resolve, join, sep, dirname, isAbsolute } from 'node:path'
 import { Logger, defineAdapter } from '../../core'
 import type { ConnectMiddleware } from '../runtime'
 
@@ -74,6 +74,53 @@ export interface SpaAdapterOptions {
    * routes without an `Accept` header.
    */
   alwaysFallback?: boolean
+}
+
+/**
+ * Nearest directory at or above `from` that holds a `package.json`.
+ * `null` when the walk reaches the filesystem root without finding one.
+ */
+function nearestPackageRoot(from: string): string | null {
+  let dir = from
+  for (;;) {
+    if (existsSync(join(dir, 'package.json'))) return dir
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
+/**
+ * Where to look for the built SPA.
+ *
+ * `process.cwd()` is the framework's convention (assets and env files resolve
+ * the same way) and stays the primary base. But a relative `clientDir` then
+ * only works when the process happens to be started from the app directory —
+ * `node server/dist/index.js` run from a monorepo root resolved `../web/dist`
+ * against the root and found nothing, serving no SPA with only a warning.
+ *
+ * So: try cwd first, and only if that misses, retry against the package root
+ * of the entry script. Both are checked for existence before being chosen, so
+ * this can never silently pick a directory that is not there — a genuinely
+ * missing build still lands on the cwd path, which is what the warning names.
+ *
+ * Deliberately not entry-relative FIRST: under `kick dev` the entry is the CLI
+ * binary, whose package root is the CLI itself.
+ */
+function resolveClientDir(clientDir: string): string {
+  if (isAbsolute(clientDir)) return clientDir
+  const fromCwd = resolve(process.cwd(), clientDir)
+  if (existsSync(fromCwd)) return fromCwd
+
+  const entry = process.argv[1]
+  if (entry) {
+    const root = nearestPackageRoot(dirname(resolve(entry)))
+    if (root) {
+      const fromEntry = resolve(root, clientDir)
+      if (existsSync(fromEntry)) return fromEntry
+    }
+  }
+  return fromCwd
 }
 
 /**
@@ -173,7 +220,7 @@ export const SpaAdapter = defineAdapter<SpaAdapterOptions>({
     alwaysFallback: false,
   },
   build: (config) => {
-    const clientDir = resolve(config.clientDir ?? 'dist/client')
+    const clientDir = resolveClientDir(config.clientDir ?? 'dist/client')
     const rawPrefix = config.apiPrefix ?? '/api'
     const apiPrefixes = Array.isArray(rawPrefix) ? rawPrefix : [rawPrefix]
     const excludePaths = config.exclude ?? []
@@ -213,7 +260,10 @@ export const SpaAdapter = defineAdapter<SpaAdapterOptions>({
       beforeMount({ http }) {
         if (!existsSync(clientDir)) {
           log.warn(`SPA client directory not found: ${clientDir}`)
-          log.warn('Build your frontend first, or set clientDir to the correct path.')
+          log.warn(
+            `Build your frontend first, or set clientDir to the correct path ` +
+              `(relative paths resolve from ${process.cwd()}).`,
+          )
           return
         }
 


### PR DESCRIPTION
## The headline: the documented usage crashed

`docs/guide/spa.md` has always shown the factory form:

```ts
SpaAdapter({ clientDir: 'dist/client', apiPrefix: '/api' })
```

The export was a `class`. So following the guide threw:

```text
TypeError: Class constructor SpaAdapter cannot be invoked without 'new'
```

`ViewAdapter` moved to `defineAdapter()` in v4 and its docblock records it —
SpaAdapter was simply missed. It is now a factory too, so the code matches the
docs and its sibling.

## It only ever worked on Express

The adapter reached for `express.static`, `req.path`, and `res.send`. None of
those exist under Fastify or h3, so on those runtimes it silently served
nothing — while `bootstrap({ runtime })` advertises a pluggable engine and
`AdapterContext` documents `http` as *"the supported way… an adapter written
against `http` works under any runtime."*

Rewritten against `http.serveStatic()` / `http.use()`, reading the path from
`req.url` and writing through `res.setHeader` / `res.end`.

## Three fallback bugs

Confirmed by probing a real Express app **before** changing anything:

| Request | Before | After |
| --- | --- | --- |
| `GET /users/john.doe` | 404 | `index.html` |
| `HEAD /dashboard` | 404 | 200, headers only |
| `GET /apidocs` (`apiPrefix: '/api'`) | 404 | `index.html` |

- **Dotted routes** — `req.path.includes('.')` treated every dotted path as a
  file request. Replaced with content negotiation: fall back for `GET`/`HEAD`
  that accept HTML. A missing `/assets/app.js` still 404s rather than receiving
  an HTML document the browser cannot parse as JavaScript. `alwaysFallback: true`
  opts out for non-browser clients.
- **HEAD** — dropped by a `!== 'GET'` check, breaking proxies and link checkers.
  Now returns identical headers with no body.
- **Prefix boundary** — `startsWith('/api')` swallowed `/apidocs`. Matching is
  segment-aware: `/api` covers `/api` and `/api/users` only.

## A regression I introduced, and caught

Moving cache headers out of `express.static`'s `setHeaders` — which only fires
on a **hit** — into standalone middleware meant an unconditional header. The
end-to-end run showed it:

```text
GET /assets/missing.js   404  cc=public, max-age=31536000, immutable
```

A year-long immutable cache on a 404. Headers are now applied only to paths
resolving to a real file inside `clientDir`, with a containment check so the
stat cannot be walked out of the directory:

```text
GET /assets/missing.js   404  cc=-
```

## Verification

The adapter had **no tests**, despite being public API with its own export path
(`@forinda/kickjs/spa`). Adds 21, driving it through a recording `AdapterHttp`
stub and replaying the middleware against plain node-shaped objects — so
anything Express-specific fails here rather than in a consumer's Fastify app.

Every fix was verified by re-introducing the old rule and watching the matching
test fail:

```text
old dot heuristic   → × serves a route containing a dot (was 404)
old GET-only rule   → × answers HEAD with headers and no body (was 404)
old startsWith      → × does not treat /apidocs as an API route (was 404)
                      × skips excluded paths, segment-aware
removed containment → × refuses to stat outside clientDir
```

Plus an end-to-end pass against a real Express app: SPA routes, dotted routes,
HEAD, prefix lookalikes, a real API route, a static asset, and a missing asset
all behave correctly.

**747/747** tests, `pnpm typecheck` clean, lint clean.

## Breaking

`new SpaAdapter({...})` → `SpaAdapter({...})`. Anyone following the guide was
already writing the new form (and hitting the TypeError); only callers who
worked around the docs with `new` need the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SPA serving now works consistently across supported HTTP engines.
  * Added configurable `alwaysFallback` behavior and improved handling for dotted paths, `HEAD` requests, API prefixes, exclusions, and HTML content negotiation.
  * Static assets receive cache headers only when successfully found.
  * Fullstack project scaffolding now supports production frontend serving, root start commands, and safe client-directory configuration.

* **Documentation**
  * Expanded SPA integration guidance covering compatibility, fallback rules, routing boundaries, and configuration options.

* **Tests**
  * Added comprehensive coverage for serving, fallback behavior, caching, missing builds, path safety, and generated fullstack setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->