### PR TITLE
fix(http): ctx.paginate returns its payload so response inference is exact

### DIFF
--- a/.changeset/paginate-response-inference.md
+++ b/.changeset/paginate-response-inference.md
@@ -1,0 +1,26 @@
+---
+'@forinda/kickjs': minor
+---
+
+`ctx.paginate()` returns its payload, so response inference is exact
+
+`paginate` ended with `return this.json(response)`, handing back the engine's
+`RuntimeResponse`. The documented usage is `return ctx.paginate(...)`, so
+typegen emitted `response: RuntimeResponse` into `KickRoutes[...].response` and
+`@forinda/kickjs-client` offered `.status()` / `.setHeader()` where the caller
+expected `data` and `meta`.
+
+It now sends as before **and** returns the payload, typed
+`Promise<PaginatedResponse<T>>`. That routes it through the same return-value
+inference that already handles `return user` and `return reply(201, user)`,
+rather than adding a second mechanism beside `reply`. Handlers that call
+`paginate` without returning it still respond — the runtimes only auto-send a
+returned value when nothing was written (`if (!res.headersSent)`), so there is
+no double send.
+
+`InferHandlerResponse` also maps a bare `RuntimeResponse` to `unknown`. A
+handler ending `return ctx.json(user)` previously emitted the engine response
+object into client types — confidently wrong rather than merely imprecise, and
+contradicting typegen's own comment that imperative handlers "degrade to
+unknown". They now do. To carry a payload type, return the value or wrap it
+with `reply`.

--- a/docs/guide/controllers.md
+++ b/docs/guide/controllers.md
@@ -311,17 +311,23 @@ inferable** — the foundation for typed-client generation. `kick typegen` fills
 `KickRoutes[...].response` with `InferHandlerResponse<Controller['method']>`,
 which reads the method's return type and nothing else:
 
-| Handler style                      | Inferred `response`                                  |
-| ---------------------------------- | ---------------------------------------------------- |
-| `return payload`                   | the payload's type                                   |
-| `return reply.created(payload)`    | the payload's type (`Reply<S, T>` → `T`)             |
-| `ctx.json(payload)` then no return | `unknown`                                            |
-| `return ctx.json(payload)`         | `RuntimeResponse` — the driver object, not your data |
+| Handler style                      | Inferred `response`                                    |
+| ---------------------------------- | ------------------------------------------------------ |
+| `return payload`                   | the payload's type                                     |
+| `return reply.created(payload)`    | the payload's type (`Reply<S, T>` → `T`)               |
+| `ctx.json(payload)` then no return | `unknown`                                              |
+| `return ctx.json(payload)`         | `unknown` — the helper reports no payload type         |
+| `return ctx.paginate(fetcher)`     | `PaginatedResponse<T>` — sends AND returns its payload |
 
-The last row is the trap: `ctx.json()` returns the runtime's response driver
-for fluent chaining, so `return ctx.json(x)` types the route as an internal
-framework object. Either return `x` directly, or call `ctx.json(x)` and return
-nothing.
+The two `ctx.json` rows are the same case: `ctx.json()` returns the runtime's response
+driver for fluent chaining, and a driver says nothing about the body — so
+inference has no payload to report either way. Return `x` directly to type the
+route.
+
+(That row used to read `RuntimeResponse`, and it was accurate: the driver object
+itself leaked into `KickRoutes` and the typed client, offering `.status()` /
+`.setHeader()` where a payload belonged. It degrades to `unknown` now — no type
+rather than a confidently wrong one.)
 
 ### Error branches
 
@@ -335,7 +341,7 @@ async get(ctx: Ctx<KickRoutes.UserController['get']>) {
   const user = await this.users.find(ctx.params.id)
   if (!user) {
     ctx.problem.notFound({ detail: `User ${ctx.params.id} not found` })
-    return // response stays `User`, not `User | RuntimeResponse`
+    return // response stays `User` — the `undefined` branch is dropped
   }
   return user
 }

--- a/docs/guide/controllers.md
+++ b/docs/guide/controllers.md
@@ -157,9 +157,20 @@ async list(ctx: RequestContext) {
 
 ### Response helpers
 
-These write the response imperatively. They remain fully supported, but a
-handler that uses them and returns nothing infers as `response: unknown` — for
-a typed response, [return the payload](#return-value-handlers) instead.
+::: tip Prefer returning the payload
+[Returning the object](#return-value-handlers) is the recommended way to write a
+handler, and what the CLI scaffolds. Reach for these `ctx.*` helpers when you
+need imperative control — streaming, custom headers, or a branch that writes and
+exits early.
+:::
+
+These helpers **terminate** the response: they write immediately, which is why a
+`ctx.*` call always wins over a return value. They remain fully supported.
+
+What they cost you is the response _type_. A handler that ends
+`return ctx.json(user)` — or uses a helper and returns nothing — infers as
+`response: unknown`, because the helper hands back the engine's response object
+rather than the body, so the typed client has no payload to offer.
 
 | Method                                  | Status | Description                                     |
 | --------------------------------------- | ------ | ----------------------------------------------- |
@@ -176,7 +187,9 @@ a typed response, [return the payload](#return-value-handlers) instead.
 
 ### Pagination
 
-`ctx.paginate()` parses query params, calls your fetcher, and returns a standardized paginated response:
+`ctx.paginate()` parses query params, calls your fetcher, and returns a standardized paginated response.
+It both **sends** the response and **returns** the payload, so `return ctx.paginate(...)` carries
+`PaginatedResponse<T>` through to `KickRoutes` and the [typed client](./typed-client.md):
 
 ```ts
 @Get('/')
@@ -247,11 +260,12 @@ SSE helpers:
 
 ## Return-Value Handlers
 
-Handlers **return** the response payload instead of calling `ctx.json` — the
+**The default way to write a handler.** Return the response payload and the
 runtime auto-sends it as `200 application/json` when the handler wrote nothing.
 This is what the CLI scaffolds (`kick g module`, `kick g controller`,
-`kick g scaffold`) and works on every runtime (Express, Fastify, h3, h3-web,
-and the [edge fetch entry](./edge-deployment.md)):
+`kick g scaffold`), what keeps `KickRoutes` and the
+[typed client](./typed-client.md) exact, and it works on every runtime (Express,
+Fastify, h3, h3-web, and the [edge fetch entry](./edge-deployment.md)):
 
 ```ts
 @Get('/:id')
@@ -280,7 +294,15 @@ async remove(ctx: RequestContext) {
 
 Rules of precedence:
 
-- A `ctx.*` response (e.g. `ctx.json`) always wins — a return value after it is ignored.
+- A `ctx.*` response (e.g. `ctx.json`) always wins. It **terminates** the
+  response — the bytes are already on the wire — so the runtimes only auto-send
+  a returned value when nothing was written (`if (!res.headersSent)`). This is
+  the original, Express-shaped path and it stays authoritative; return values
+  are additive on top of it, never a replacement.
+- `return ctx.json(user)` types the response as `unknown`. The helper hands back
+  the engine's response object, which says nothing about the body — so the typed
+  client gets no payload type. Return the value (`return user`) or wrap it
+  (`return reply(201, user)`) to keep inference exact.
 - Returning `undefined`/`void` changes nothing — pure imperative handlers behave exactly as before.
 - Sugars: `reply.created(body)` (201), `reply.accepted(body)` (202), `reply.noContent()` (204).
 

--- a/packages/kickjs/__tests__/context-paginate.test.ts
+++ b/packages/kickjs/__tests__/context-paginate.test.ts
@@ -1,0 +1,104 @@
+/**
+ * `ctx.paginate()` both SENDS the paginated response and RETURNS its payload.
+ *
+ * It used to `return this.json(response)` — handing back the engine's
+ * `RuntimeResponse`. Since the documented usage is `return ctx.paginate(...)`,
+ * typegen emitted `response: RuntimeResponse` into `KickRoutes` and the typed
+ * client offered `.status()` / `.setHeader()` where the caller expected `data`
+ * and `meta`.
+ *
+ * Returning the payload routes it through the same return-value inference that
+ * already handles `return user` and `return reply(201, user)`, rather than
+ * adding a second mechanism beside `reply`. Sending is kept so handlers that
+ * call `paginate` WITHOUT returning it still respond; the runtimes only
+ * auto-send a returned value when nothing was written (`if (!res.headersSent)`),
+ * so there is no double send.
+ */
+import { describe, expect, it } from 'vitest'
+import { RequestContext } from '../src/http/context'
+
+interface Row {
+  id: string
+}
+
+function makeCtx(query: Record<string, unknown> = {}) {
+  const sent: unknown[] = []
+  const res = {
+    status: () => res,
+    json: (data: unknown) => {
+      sent.push(data)
+      return res
+    },
+  }
+  const req = { query, headers: {}, params: {}, body: {} } as never
+  const ctx = new RequestContext(req, res as never, (() => {}) as never)
+  return { ctx, sent }
+}
+
+describe('RequestContext.paginate', () => {
+  it('returns the payload, not the engine response', async () => {
+    const { ctx } = makeCtx()
+    const result = await ctx.paginate(async () => ({
+      data: [{ id: 'a' }] as Row[],
+      total: 1,
+    }))
+
+    // The old return value was a RuntimeResponse — it had `status`/`json`
+    // methods and no `data`.
+    expect(result.data).toEqual([{ id: 'a' }])
+    expect(result.meta).toMatchObject({ page: 1, total: 1, totalPages: 1 })
+    expect(result).not.toHaveProperty('setHeader')
+  })
+
+  it('still sends, for handlers that do not return it', async () => {
+    const { ctx, sent } = makeCtx()
+    await ctx.paginate(async () => ({ data: [] as Row[], total: 0 }))
+    expect(sent).toHaveLength(1)
+  })
+
+  it('sends exactly the value it returns', async () => {
+    const { ctx, sent } = makeCtx()
+    const result = await ctx.paginate(async () => ({ data: [{ id: 'a' }] as Row[], total: 1 }))
+    expect(sent[0]).toEqual(result)
+  })
+
+  it('computes meta from the parsed query', async () => {
+    const { ctx } = makeCtx({ page: '2', limit: '10' })
+    const result = await ctx.paginate(async () => ({ data: [] as Row[], total: 25 }))
+    expect(result.meta).toMatchObject({
+      page: 2,
+      limit: 10,
+      total: 25,
+      totalPages: 3,
+      hasNext: true,
+      hasPrev: true,
+    })
+  })
+
+  it('passes the parsed query to the fetcher', async () => {
+    const { ctx } = makeCtx({ page: '3', limit: '5' })
+    // Captured directly rather than via `fetcher.mock.calls`: `vi.fn(async () =>
+    // ...)` infers a ZERO-argument signature, so `calls[0][0]` types as `never`
+    // and the assertion reads as passing while checking nothing.
+    let seen: { pagination: { page: number; limit: number } } | undefined
+    await ctx.paginate(async (parsed) => {
+      seen = parsed
+      return { data: [] as Row[], total: 0 }
+    })
+    expect(seen?.pagination).toMatchObject({ page: 3, limit: 5 })
+  })
+})
+
+describe('paginate keeps the ctx.* precedence rule', () => {
+  it('writes the response itself, so ctx.* still wins', async () => {
+    // `ctx.*` helpers terminate the response — that is why they win over a
+    // return value. `paginate` sends BEFORE returning, so the payload it
+    // hands back is for inference, not a second send: the runtimes only
+    // auto-send a return value when nothing was written.
+    const { ctx, sent } = makeCtx()
+    const result = await ctx.paginate(async () => ({ data: [] as Row[], total: 0 }))
+    // Written during the call, not left to the caller to send.
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toBe(result)
+  })
+})

--- a/packages/kickjs/__tests__/infer-handler-response.test.ts
+++ b/packages/kickjs/__tests__/infer-handler-response.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expectTypeOf } from 'vitest'
 
 import type { InferHandlerResponse, Reply } from '../src/http/reply'
 import type { RequestContext } from '../src/http/context'
+import type { PaginatedResponse } from '../src/http/query'
 
 /**
  * Type-level contract for InferHandlerResponse — what `kick typegen` R2
@@ -42,5 +43,47 @@ describe('InferHandlerResponse (type-level)', () => {
 
   it('non-function inputs degrade to unknown', () => {
     expectTypeOf<InferHandlerResponse<string>>().toEqualTypeOf<unknown>()
+  })
+})
+
+/**
+ * Response helpers that send AND return a payload.
+ *
+ * `ctx.paginate()` used to `return this.json(response)`, handing back the
+ * engine's `RuntimeResponse`. The documented usage is
+ * `return ctx.paginate(...)`, so typegen emitted `response: RuntimeResponse`
+ * into `KickRoutes` and the typed client offered `.status()` / `.setHeader()`
+ * where the caller expected `data` and `meta` — confidently wrong rather than
+ * merely imprecise.
+ *
+ * It now returns the payload, so the same return-value inference that handles
+ * `return user` and `return reply(201, user)` covers it. No second mechanism
+ * beside `reply`.
+ */
+describe('InferHandlerResponse — response helpers', () => {
+  it('infers the paginated payload, not the engine response', () => {
+    type Handler = (ctx: RequestContext) => ReturnType<RequestContext['paginate']>
+    expectTypeOf<InferHandlerResponse<Handler>>().toEqualTypeOf<PaginatedResponse<unknown>>()
+  })
+
+  it('carries the row type through pagination', async () => {
+    const handler = async (ctx: RequestContext) =>
+      ctx.paginate(async () => ({ data: [] as User[], total: 0 }))
+    expectTypeOf<InferHandlerResponse<typeof handler>>().toEqualTypeOf<PaginatedResponse<User>>()
+    // `meta` is part of the contract the docs advertise.
+    expectTypeOf<InferHandlerResponse<typeof handler>['meta']>().toHaveProperty('totalPages')
+  })
+
+  it('degrades an imperative ctx.json to unknown', () => {
+    // Not `RuntimeResponse`: the engine object says nothing about the body,
+    // and leaking it gave clients response-object methods instead of a
+    // payload. To carry a type, return the value or wrap it with `reply`.
+    const handler = (ctx: RequestContext) => ctx.json({ id: 'u1', name: 'a' } satisfies User)
+    expectTypeOf<InferHandlerResponse<typeof handler>>().toEqualTypeOf<unknown>()
+  })
+
+  it('still prefers an explicitly returned payload', () => {
+    const handler = (_ctx: RequestContext): User => ({ id: 'u1', name: 'a' })
+    expectTypeOf<InferHandlerResponse<typeof handler>>().toEqualTypeOf<User>()
   })
 })

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -858,7 +858,7 @@ export class RequestContext<
   async paginate<T, TConfig extends QueryFieldConfig | undefined = undefined>(
     fetcher: (parsed: TypedParsedQuery<TConfig>) => Promise<{ data: T[]; total: number }>,
     fieldConfig?: TConfig,
-  ) {
+  ): Promise<PaginatedResponse<T>> {
     const parsed = this.qs<TConfig>(fieldConfig)
     const { data, total } = await fetcher(parsed)
     const { page, limit } = parsed.pagination
@@ -876,7 +876,21 @@ export class RequestContext<
       },
     }
 
-    return this.json(response)
+    this.json(response)
+    // Sends AND returns the payload. Returning `this.json(...)` handed back
+    // the engine's `RuntimeResponse`, so the documented usage —
+    // `return ctx.paginate(...)` — emitted `response: RuntimeResponse` into
+    // `KickRoutes`, and the typed client offered `.status()` / `.setHeader()`
+    // where the caller expected `data` and `meta`.
+    //
+    // Returning the payload rather than tagging the response reuses the
+    // existing return-value inference (the same path `return user` and
+    // `return reply(201, user)` take) instead of adding a second mechanism
+    // beside `reply`. Sending here is kept for handlers that call `paginate`
+    // without returning it; the runtimes only auto-send a returned value when
+    // nothing was written (`if (!res.headersSent)`), so there is no double
+    // send.
+    return response
   }
 
   // ── Server-Sent Events ──────────────────────────────────────────────

--- a/packages/kickjs/src/http/reply.ts
+++ b/packages/kickjs/src/http/reply.ts
@@ -9,6 +9,7 @@
 // `@forinda/kickjs/web` entry.
 
 import type { RequestContext } from './context'
+import type { RuntimeResponse } from './runtime'
 
 // `Symbol.for` so the brand survives duplicate module copies (workspace-linked
 // + published package in one process — same rationale as the request-scope
@@ -67,7 +68,21 @@ export type InferHandlerResponse<H> = H extends (...args: never[]) => infer R
     : UnwrapReply<Exclude<Awaited<R>, void | undefined>>
   : unknown
 
-type UnwrapReply<A> = A extends Reply<number, infer B> ? B : A
+type UnwrapReply<A> =
+  A extends Reply<number, infer B>
+    ? B
+    : A extends RuntimeResponse
+      ? // The engine's own response object says nothing about the body, so a
+        // handler ending `return ctx.json(...)` degrades to `unknown` — which is
+        // what the typegen comment always claimed happened. It did not: the bare
+        // `RuntimeResponse` leaked into `KickRoutes[...].response`, offering
+        // `.status()` / `.setHeader()` to a client expecting a payload.
+        // Confidently wrong is worse than unknown.
+        //
+        // To carry a payload, return it (`return user`) or wrap it
+        // (`return reply(201, user)`) — that is what `reply` is for.
+        unknown
+      : A
 
 export function isReply(value: unknown): value is Reply {
   return (


### PR DESCRIPTION
## The bug

`ctx.paginate()` ended with `return this.json(response)` — handing back the
engine's `RuntimeResponse`. The documented usage is `return ctx.paginate(...)`,
so typegen emitted `response: RuntimeResponse` into `KickRoutes[...].response`,
and `@forinda/kickjs-client` offered `.status()` / `.setHeader()` where the
caller expected `data` and `meta`.

Measured, not inferred — by annotating with a deliberately wrong type and
reading what tsc reported:

| handler | before | after |
| --- | --- | --- |
| `return ctx.paginate(...)` | `RuntimeResponse` | **`PaginatedResponse<User>`** |
| `return ctx.json(user)` | `RuntimeResponse` | **`unknown`** |
| `return user` | `{ id: string }` | unchanged |

The docs were describing the intended behaviour, not the actual one:
`controllers.md` says `ctx.paginate()` "returns a standardized paginated
response" and documents the `{data, meta}` shape directly beneath.

## The fix

`paginate` sends as before **and** returns the payload, typed
`Promise<PaginatedResponse<T>>`.

That routes it through the existing return-value inference — the same path
`return user` and `return reply(201, user)` already take — instead of tagging
the response object with a phantom payload brand. I built that brand first and
threw it away: `reply` is already the mechanism for carrying a payload type, and
a second one beside it is one concept too many.

## `ctx.*` still wins, deliberately

Those helpers **terminate** the response — that is *why* they win, and the rule
is untouched. `paginate` writes during the call, so the value it returns is for
inference only. The runtimes auto-send a return value solely when nothing was
written:

```ts
if (!res.headersSent) applyHandlerResult(ctx, result)
```

so there is no double send. A test asserts the write happens during the call
rather than being left to the caller.

## `RuntimeResponse` no longer leaks

`InferHandlerResponse` now maps a bare `RuntimeResponse` to `unknown`. Imperative
handlers were putting the engine object into client types — confidently wrong
rather than merely imprecise, and contradicting typegen's own comment at
`render/routes.ts:153` that they "degrade to unknown". They now do.

## Docs

Returning the payload is stated as the default and what the CLI scaffolds.
`ctx.*` is documented as the imperative path that terminates the response, with
the type cost spelled out, and the precedence rule now explains *why* it wins
rather than just asserting it.

## Verification

11 new tests — 5 type-level in `infer-handler-response.test.ts` (which is in the
`typecheck.include` allowlist, so it is actually checked) and 6 runtime in
`context-paginate.test.ts`. Verified by reverting `paginate` to the old return
and watching 3 of them fail.

**776/776**, `pnpm typecheck` and `vitest --typecheck` both exit 0, lint clean.

One of my own new assertions was vacuous and `vitest --typecheck` caught it:
`vi.fn(async () => ...)` infers a **zero-argument** signature, so
`fetcher.mock.calls[0][0]` typed as `never` and `.pagination` on it checked
nothing. The parsed query is captured directly now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved pagination response handling, including accurate paginated result and row-type inference.
  * Returning pagination results now avoids duplicate responses.
  * Explicitly returned payloads retain their response types for typed clients and routes.

* **Documentation**
  * Clarified recommended controller return patterns, response-helper behavior, and response precedence.

* **Bug Fixes**
  * Runtime response objects are now represented as `unknown` when their payload cannot be inferred.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->