### PR TITLE
fix: generated guards/middleware and the error handler stop assuming Express

### DIFF
--- a/.changeset/generators-engine-neutral.md
+++ b/.changeset/generators-engine-neutral.md
@@ -1,0 +1,28 @@
+---
+'@forinda/kickjs-cli': patch
+'@forinda/kickjs': patch
+---
+
+Generated guards, middleware, and the default error handler stop assuming Express
+
+Three places emitted or ran Express-only code under a framework that advertises
+a pluggable engine. All three were invisible because the default runtime is
+Express.
+
+**`kick g middleware`** emitted `import type { Request, Response, NextFunction }
+from 'express'`. A Fastify or h3 scaffold has neither `express` nor
+`@types/express` — it installs `fastify` + `@fastify/middie` — so that was a
+compile error on a freshly generated file. Now typed from `node:http`, which is
+what the connect-style handler actually receives on every engine.
+
+**`kick g guard`** emitted `ctx.res.status(401).json(...)`. `ctx.res` is the
+ENGINE-NATIVE response: `FastifyReply` has no `.json()` (verified against
+Fastify's own types) and h3's event has no `.status()`. Now uses
+`ctx.problem.unauthorized({ detail })` — RFC 9457, engine-neutral, and what the
+error-branch guidance in the controllers guide already teaches.
+
+**The default `errorHandler()`** read `req.originalUrl`, which only Express
+adds. Fastify and h3 pass `request.raw`, so every error logged
+`GET undefined — <error>`: the path silently dropped from the one line meant to
+identify the failing request. It now falls back to `req.url`, and both it and
+`notFoundHandler()` are typed from node / `RuntimeResponse` rather than Express.

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -377,6 +377,9 @@ class SocialAuthController {
     const state = randomBytes(32).toString('hex')
     ctx.session.data.oauthState = state
     const url = googleAuth.getAuthorizationUrl(state)
+    // `ctx.res.redirect()` is engine-native: Express and Fastify both have it,
+    // h3 does not. On h3, set the header yourself —
+    // `ctx.res.setHeader('location', url)` with a 302.
     return ctx.res.redirect(url)
   }
 
@@ -384,7 +387,10 @@ class SocialAuthController {
   @Public()
   async googleCallback(ctx: RequestContext) {
     const user = await googleAuth.validate(ctx.req)
-    if (!user) return ctx.res.status(401).json({ error: 'Auth failed' })
+    if (!user) {
+      ctx.problem.unauthorized({ detail: 'Auth failed' })
+      return
+    }
     // Clean up state
     delete ctx.session.data.oauthState
     // Issue your own JWT after social login
@@ -430,7 +436,10 @@ loginWithGoogle(ctx: RequestContext) {
 async googleCallback(ctx: RequestContext) {
   // PKCE verifier is read automatically from req.session.data.oauthCodeVerifier
   const user = await googleAuth.validate(ctx.req)
-  if (!user) return ctx.res.status(401).json({ error: 'Auth failed' })
+  if (!user) {
+    ctx.problem.unauthorized({ detail: 'Auth failed' })
+    return
+  }
   delete ctx.session.data.oauthState
   delete ctx.session.data.oauthCodeVerifier
   return ctx.json({ token: jwt.sign(user, JWT_SECRET), user })

--- a/docs/guide/authorization.md
+++ b/docs/guide/authorization.md
@@ -289,8 +289,13 @@ kick g guard ip-whitelist
 // src/guards/ip-whitelist.guard.ts
 export async function ipWhitelistGuard(ctx: RequestContext, next: () => void) {
   const allowed = ['10.0.0.0/8', '192.168.1.0/24']
+  // `ctx.req` is the ENGINE-NATIVE request, and `.ip` is Express-only —
+  // under Fastify / h3 read `ctx.req.socket.remoteAddress` (or your proxy's
+  // `x-forwarded-for` header) instead.
   if (!allowed.some((range) => isInSubnet(ctx.req.ip, range))) {
-    ctx.res.status(403).json({ message: 'IP not allowed' })
+    // `ctx.res` is the ENGINE-NATIVE response — `.json()` is Express-only
+    // (FastifyReply has no `.json()`, h3's event has no `.status()`).
+    ctx.problem.forbidden({ detail: 'IP not allowed' })
     return
   }
   next()

--- a/docs/guide/sessions.md
+++ b/docs/guide/sessions.md
@@ -53,7 +53,10 @@ class AuthController {
   @Get('/me')
   async me(ctx: RequestContext) {
     const userId = ctx.session.data.userId
-    if (!userId) return ctx.res.status(401).json({ message: 'Not authenticated' })
+    if (!userId) {
+      ctx.problem.unauthorized({ detail: 'Not authenticated' })
+      return
+    }
     const user = await this.userService.findById(userId)
     ctx.json(user)
   }

--- a/packages/cli/__tests__/generators-engine-neutral.test.ts
+++ b/packages/cli/__tests__/generators-engine-neutral.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Generated code must run on every runtime the framework supports.
+ *
+ * Two generators emitted Express-only code, and neither branched on the
+ * project's runtime:
+ *
+ *   `kick g middleware` → `import type { Request, Response, NextFunction }
+ *                          from 'express'`
+ *   `kick g guard`      → `ctx.res.status(401).json(...)`
+ *
+ * Both are broken on a Fastify or h3 scaffold. `express` is not a dependency
+ * there at all (the scaffold installs `fastify` + `@fastify/middie`), so the
+ * import is a compile error on a freshly generated file. And `ctx.res` is the
+ * ENGINE-NATIVE response: `FastifyReply` has no `.json()` — verified against
+ * Fastify's own types — and h3's event has no `.status()`.
+ *
+ * Invisible until someone ran a non-Express project, because the default
+ * runtime is Express.
+ */
+import { describe, expect, it, afterEach } from 'vitest'
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { generateGuard } from '../src/generators/guard'
+import { generateMiddleware } from '../src/generators/middleware'
+
+const dirs: string[] = []
+function tempDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'kick-gen-'))
+  dirs.push(d)
+  return d
+}
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+/** Source with comment lines removed — assertions target CODE, not prose. */
+function codeOf(src: string): string {
+  return src
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('//') && !line.trim().startsWith('*'))
+    .join('\n')
+}
+
+function readOnly(dir: string): string {
+  const files = readdirSync(dir, { recursive: true, withFileTypes: true }).filter((e) => e.isFile())
+  expect(files).toHaveLength(1)
+  return readFileSync(join(files[0]!.parentPath ?? dir, files[0]!.name), 'utf8')
+}
+
+describe('kick g middleware', () => {
+  it('does not import from express', async () => {
+    const dir = tempDir()
+    await generateMiddleware({ name: 'audit', outDir: dir })
+    const src = readOnly(dir)
+    // A Fastify / h3 scaffold has neither `express` nor `@types/express`.
+    expect(src).not.toContain("from 'express'")
+    expect(src).toContain("from 'node:http'")
+  })
+
+  it('types the handler from node, not the engine', async () => {
+    const dir = tempDir()
+    await generateMiddleware({ name: 'audit', outDir: dir })
+    const src = readOnly(dir)
+    expect(src).toContain('req: IncomingMessage')
+    expect(src).toContain('res: ServerResponse')
+  })
+})
+
+describe('kick g guard', () => {
+  it('answers through ctx, not the engine-native response', async () => {
+    const dir = tempDir()
+    await generateGuard({ name: 'adminOnly', outDir: dir })
+    const src = readOnly(dir)
+    // `ctx.res.status(...).json(...)` is Express-only. Checked against code
+    // only: the template deliberately NAMES the broken idiom in a comment so
+    // the next editor knows why it is avoided.
+    expect(codeOf(src)).not.toMatch(/ctx\.res\.status\(/)
+    expect(src).toContain('ctx.problem.unauthorized(')
+  })
+
+  it('says why, so the next editor does not reach for ctx.res again', async () => {
+    const dir = tempDir()
+    await generateGuard({ name: 'adminOnly', outDir: dir })
+    expect(readOnly(dir)).toMatch(/ENGINE-NATIVE/)
+  })
+})

--- a/packages/cli/src/generators/guard.ts
+++ b/packages/cli/src/generators/guard.ts
@@ -50,7 +50,11 @@ export async function ${camel}Guard(ctx: RequestContext, next: () => void): Prom
   // Example: check for an authorization header
   const header = ctx.headers.authorization
   if (!header?.startsWith('Bearer ')) {
-    ctx.res.status(401).json({ message: 'Missing or invalid authorization header' })
+    // \`ctx.problem.*\` (RFC 9457) rather than \`ctx.res\`: \`ctx.res\` is the
+    // ENGINE-NATIVE response, so \`ctx.res.status(401).json(...)\` only works on
+    // Express — \`FastifyReply\` has no \`.json()\`, and h3's event has no
+    // \`.status()\`. The \`ctx.*\` helpers work on every runtime.
+    ctx.problem.unauthorized({ detail: 'Missing or invalid authorization header' })
     return
   }
 
@@ -65,7 +69,7 @@ export async function ${camel}Guard(ctx: RequestContext, next: () => void): Prom
 
     next()
   } catch {
-    ctx.res.status(401).json({ message: 'Invalid or expired token' })
+    ctx.problem.unauthorized({ detail: 'Invalid or expired token' })
   }
 }
 `,

--- a/packages/cli/src/generators/middleware.ts
+++ b/packages/cli/src/generators/middleware.ts
@@ -31,7 +31,7 @@ export async function generateMiddleware(options: GenerateMiddlewareOptions): Pr
   const filePath = join(outDir, `${kebab}.middleware.ts`)
   await writeFileSafe(
     filePath,
-    `import type { Request, Response, NextFunction } from 'express'
+    `import type { IncomingMessage, ServerResponse } from 'node:http'
 
 export interface ${toPascalCase(name)}Options {
   // Add configuration options here. The factory below closes over the
@@ -74,7 +74,14 @@ export interface ${toPascalCase(name)}Options {
  *   @Middleware(${camel}())
  */
 export function ${camel}(options: ${toPascalCase(name)}Options = {}) {
-  return (req: Request, res: Response, next: NextFunction) => {
+  // Typed from \`node:http\`, not \`express\`. Global middleware is connect-style
+  // on every engine, but a Fastify / h3 project has no \`express\` dependency —
+  // importing its types there is a compile error on a freshly generated file.
+  // Under Fastify the handler receives \`request.raw\` / a reply driver, and
+  // under h3 the node objects, so anything Express-only (\`req.originalUrl\`,
+  // \`res.json\`) is absent. Reach for \`ctx.*\` helpers when you need a typed
+  // response.
+  return (req: IncomingMessage, res: ServerResponse, next: () => void) => {
     // Implement your middleware logic here. \`options\` is captured by
     // closure — log or read it anywhere in this handler body.
     void options

--- a/packages/kickjs/__tests__/error-handler-engine-neutral.test.ts
+++ b/packages/kickjs/__tests__/error-handler-engine-neutral.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The default error handler runs under EVERY runtime, so it must not assume
+ * Express.
+ *
+ * Fastify and h3 hand it `request.raw` — a plain node `IncomingMessage`. It
+ * read `req.originalUrl`, which only Express adds, so the one log line meant
+ * to identify the failing request read `GET undefined — <error>` on those
+ * runtimes. The path silently vanished exactly when it was needed.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { errorHandler, notFoundHandler } from '../src/http/middleware/error-handler'
+import { Logger } from '../src/core'
+
+function makeRes() {
+  const calls: Array<{ status?: number; body?: unknown }> = []
+  const res = {
+    headersSent: false,
+    setHeader: () => res,
+    status: (code: number) => {
+      calls.push({ status: code })
+      return res
+    },
+    json: (body: unknown) => {
+      calls[calls.length - 1]!.body = body
+      return res
+    },
+  }
+  return { res, calls }
+}
+
+function captureErrorLog() {
+  const messages: string[] = []
+  vi.spyOn(Logger.prototype, 'error').mockImplementation(((_e: unknown, m?: string) => {
+    messages.push(String(m))
+  }) as never)
+  return messages
+}
+
+describe('errorHandler — engine neutrality', () => {
+  it('logs the path from a raw node request (fastify / h3 shape)', () => {
+    const messages = captureErrorLog()
+    const { res } = makeRes()
+    // Exactly what Fastify passes: `request.raw`, with `url` and no `originalUrl`.
+    const req = { method: 'GET', url: '/boom', headers: {} }
+
+    errorHandler()(new Error('kaboom'), req as never, res as never, () => {})
+
+    expect(messages[0]).toContain('/boom')
+    expect(messages[0]).not.toContain('undefined')
+  })
+
+  it('still prefers originalUrl when Express provides it', () => {
+    // Express rewrites `url` when mounting routers; `originalUrl` is the
+    // full path, so it stays the better source when present.
+    const messages = captureErrorLog()
+    const { res } = makeRes()
+    const req = { method: 'GET', url: '/inner', originalUrl: '/api/v1/inner', headers: {} }
+
+    errorHandler()(new Error('kaboom'), req as never, res as never, () => {})
+
+    expect(messages[0]).toContain('/api/v1/inner')
+  })
+
+  it('notFoundHandler answers through the runtime response surface', () => {
+    const { res, calls } = makeRes()
+    notFoundHandler()({ method: 'GET', url: '/nope', headers: {} } as never, res as never, () => {})
+    expect(calls[0]).toEqual({ status: 404, body: { message: 'Not Found' } })
+  })
+})

--- a/packages/kickjs/src/http/middleware/error-handler.ts
+++ b/packages/kickjs/src/http/middleware/error-handler.ts
@@ -1,4 +1,20 @@
-import type { Request, Response, NextFunction } from 'express'
+import type { RuntimeResponse } from '../runtime'
+
+/**
+ * The slice of the request this handler reads, spelled from node's
+ * `IncomingMessage` rather than Express's `Request`.
+ *
+ * Fastify and h3 hand the error handler `request.raw` — a plain
+ * `IncomingMessage` — so anything Express-only is `undefined` there. This is
+ * the default handler for EVERY runtime, so it must not assume Express.
+ */
+interface ErrorRequest {
+  method?: string
+  url?: string
+  /** Express-only; absent on the raw node request the other runtimes pass. */
+  originalUrl?: string
+  headers: Record<string, string | string[] | undefined>
+}
 import {
   HttpException,
   ProblemException,
@@ -11,7 +27,7 @@ const log = createLogger('ErrorHandler')
 
 /** Catch-all for unmatched routes */
 export function notFoundHandler() {
-  return (_req: Request, res: Response, _next: NextFunction) => {
+  return (_req: ErrorRequest, res: RuntimeResponse, _next: () => void) => {
     res.status(404).json({ message: 'Not Found' })
   }
 }
@@ -37,7 +53,7 @@ export function notFoundHandler() {
  */
 export function errorHandler() {
   const isProduction = process.env.NODE_ENV === 'production'
-  return (err: any, req: Request, res: Response, _next: NextFunction) => {
+  return (err: any, req: ErrorRequest, res: RuntimeResponse, _next: () => void) => {
     // Don't write after headers are already sent
     if (res.headersSent) {
       log.warn(`Error after headers sent: ${err?.message || 'Unknown'}`)
@@ -92,7 +108,11 @@ export function errorHandler() {
     const requestId = (req as any).requestId ?? req.headers['x-request-id']
     log.error(
       err,
-      `${req.method} ${req.originalUrl} — ${describeError(err)}${
+      // `originalUrl` is Express-only. Fastify and h3 pass `request.raw`, so
+      // this logged `GET undefined — <error>` on every error under those
+      // runtimes — the path silently dropped from the one line meant to
+      // identify the failing request.
+      `${req.method} ${req.originalUrl ?? req.url} — ${describeError(err)}${
         requestId ? ` [${requestId}]` : ''
       }`,
     )


### PR DESCRIPTION
Audited every generator against all three runtimes. Three places emitted or ran
Express-only code — all invisible because the default runtime is Express.

## `kick g middleware` — imported from a package that isn't there

```ts
import type { Request, Response, NextFunction } from 'express'
```

Verified on a real Fastify scaffold: it has neither `express` nor
`@types/express`. The scaffold installs `fastify` + `@fastify/middie` instead, so
that import is a hard `TS2307` on a **freshly generated file**.

Now typed from `node:http` — what the connect-style handler actually receives on
every engine.

## `kick g guard` — reached past the neutral helpers to the native response

```ts
ctx.res.status(401).json({ message: '...' })
```

`ctx.res` is `ActiveRuntime['response']` — the **engine-native** object:

| runtime | `ctx.res` | `.status().json()` |
| --- | --- | --- |
| Express | `Response` | works |
| Fastify | `FastifyReply` | **no `.json()`** |
| h3 | `H3EventType` | **no `.status()`** |

Compiled the exact emitted idiom against Fastify's own types rather than
assuming:

```text
Property 'json' does not exist on type 'FastifyReply<...>'
```

The framework's own code confirms the intent — `fastify.ts:386` passes a *driver*
rather than the raw reply specifically so `res.status().json()` works. `.json()`
is a driver affordance, not native, and `ctx.res` hands back the native object.

Now `ctx.problem.unauthorized({ detail })` — RFC 9457, engine-neutral, and what
the error-branch guidance in the controllers guide already teaches. The template
**names** the broken idiom in a comment so the next editor knows why it is
avoided.

## The default `errorHandler()` lost the request path

It read `req.originalUrl`, which only Express adds. Fastify and h3 pass
`request.raw` — a plain `IncomingMessage`. Probed before fixing:

```text
PROBE LOG: GET undefined — Error: kaboom
```

The path silently vanished from the one log line meant to identify the failing
request. Falls back to `req.url` now, and both it and `notFoundHandler()` are
typed from node / `RuntimeResponse` rather than Express.

## Checked and left alone

- `project-app.ts` already gates its `express` import and `express.json()` on
  `isExpress` — correct as-is.
- The remaining `express` mentions in `project-docs.ts` are prose warning readers
  off Express-specific assumptions, not emitted code.

## Verification

Seven tests. Each verified by restoring the old template or behaviour and
watching the matching ones fail:

```text
old middleware import  → × does not import from express
old guard response     → × answers through ctx, not the engine-native response
originalUrl only       → × logs the path from a raw node request
```

Plus an end-to-end regeneration into a Fastify scaffold to confirm the emitted
files are clean.

The guard assertion strips comments before matching — the template deliberately
quotes the broken idiom, and an earlier version of the test flagged its own
explanation as a violation.

**779/779** kickjs, **72/72** CLI, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated middleware and error handlers now support Node-native and multiple HTTP runtimes without relying on Express-specific types.
  * Authorization guards return consistent unauthorized errors through the runtime-neutral response system.
  * Error logs preserve request paths across supported runtimes.

* **Bug Fixes**
  * Improved default 404 and unexpected-error handling for non-Express environments.

* **Tests**
  * Added coverage for runtime-neutral middleware, guards, and HTTP error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->