### PR TITLE
feat(http): add ctx.ip and ctx.redirect — engine-neutral by construction

### DIFF
--- a/.changeset/ctx-ip-redirect.md
+++ b/.changeset/ctx-ip-redirect.md
@@ -12,8 +12,9 @@ carry "this breaks on X" caveats instead of showing portable code.
 **`ctx.ip`** resolves `req.ip` → `socket.remoteAddress` → forwarded headers. It prefers the address the runtime computed — Express derives `req.ip`
 from `trust proxy`, Fastify from `trustProxy` — because raw forwarded headers
 are client-**spoofable** on deployments that do not normalize them. It falls back
-to `cf-connecting-ip` / `x-forwarded-for` / `x-real-ip` only for runtimes that
-compute no address (notably the web/edge entry), then to the node socket.
+to the node socket address next, and consults `cf-connecting-ip` /
+`x-forwarded-for` / `x-real-ip` only when neither exists (notably the web/edge
+entry) — a spoofable header must never outrank a real connection address.
 
 That resolution already existed inside the rate-limit guard; it now lives on the
 context and the guard reuses it rather than keeping a second copy.

--- a/.changeset/ctx-ip-redirect.md
+++ b/.changeset/ctx-ip-redirect.md
@@ -22,3 +22,20 @@ context and the guard reuses it rather than keeping a second copy.
 through the runtime response surface, so it works everywhere. Its docblock warns
 against passing an unvalidated user-supplied URL — an attacker-controlled
 destination is an open redirect.
+
+Sweeping the same pattern turned up three shipped middlewares reading Express-only
+members, all of which receive the RAW node request under Fastify and h3:
+
+- **`rateLimit`** keyed every caller as its `'127.0.0.1'` fallback, because
+  `req.ip` is undefined there — a single shared bucket, so one client could
+  exhaust the limit for everyone. It now resolves the address the same way
+  `ctx.ip` does.
+- **`csrf`** matched `ignorePaths` against `req.path`, which is undefined, so
+  `has(undefined)` never matched and configured exemptions were silently dead.
+  (It failed closed, so CSRF stayed enforced — the feature simply did nothing.)
+- **`requestLogger`** THREW `Cannot read properties of undefined (reading
+'startsWith')` on every request once any `skip` prefix was configured, and
+  logged `GET undefined 200 12ms` otherwise.
+
+The resolution lives in one place (`http/client-ip.ts`) rather than a fourth
+copy drifting from the others.

--- a/.changeset/ctx-ip-redirect.md
+++ b/.changeset/ctx-ip-redirect.md
@@ -9,7 +9,7 @@ nothing neutral to use. Both are engine-native: `req.ip` is Express-only, and
 `res.redirect()` exists on Express and Fastify but not h3. Documentation had to
 carry "this breaks on X" caveats instead of showing portable code.
 
-**`ctx.ip`** prefers the address the runtime computed — Express derives `req.ip`
+**`ctx.ip`** resolves `req.ip` → `socket.remoteAddress` → forwarded headers. It prefers the address the runtime computed — Express derives `req.ip`
 from `trust proxy`, Fastify from `trustProxy` — because raw forwarded headers
 are client-**spoofable** on deployments that do not normalize them. It falls back
 to `cf-connecting-ip` / `x-forwarded-for` / `x-real-ip` only for runtimes that
@@ -39,3 +39,10 @@ members, all of which receive the RAW node request under Fastify and h3:
 
 The resolution lives in one place (`http/client-ip.ts`) rather than a fourth
 copy drifting from the others.
+
+The socket is consulted **before** forwarded headers. A raw Fastify or h3 request
+has no `req.ip`, so reading `x-forwarded-for` first let a direct client vary the
+header per request and land in a fresh rate-limit bucket each time, evading the
+limit entirely. Headers are used only where there is no socket at all — the
+web/edge entry. Behind a real proxy, configure the runtime's trust-proxy setting
+so `req.ip` answers rather than relying on an unverified header.

--- a/.changeset/ctx-ip-redirect.md
+++ b/.changeset/ctx-ip-redirect.md
@@ -1,0 +1,24 @@
+---
+'@forinda/kickjs': minor
+---
+
+Add `ctx.ip` and `ctx.redirect()` — engine-neutral versions of two Express-only patterns
+
+The guide reached for `ctx.req.ip` and `ctx.res.redirect()` because there was
+nothing neutral to use. Both are engine-native: `req.ip` is Express-only, and
+`res.redirect()` exists on Express and Fastify but not h3. Documentation had to
+carry "this breaks on X" caveats instead of showing portable code.
+
+**`ctx.ip`** prefers the address the runtime computed — Express derives `req.ip`
+from `trust proxy`, Fastify from `trustProxy` — because raw forwarded headers
+are client-**spoofable** on deployments that do not normalize them. It falls back
+to `cf-connecting-ip` / `x-forwarded-for` / `x-real-ip` only for runtimes that
+compute no address (notably the web/edge entry), then to the node socket.
+
+That resolution already existed inside the rate-limit guard; it now lives on the
+context and the guard reuses it rather than keeping a second copy.
+
+**`ctx.redirect(url, status = 302)`** writes the status and `Location` header
+through the runtime response surface, so it works everywhere. Its docblock warns
+against passing an unvalidated user-supplied URL — an attacker-controlled
+destination is an open redirect.

--- a/.changeset/on-error-contract.md
+++ b/.changeset/on-error-contract.md
@@ -1,0 +1,33 @@
+---
+'@forinda/kickjs': minor
+---
+
+`onError` / `onNotFound`: document what each runtime actually passes
+
+The docblock called `onError` "the standard Express error-handling signature".
+That holds on exactly one of the three runtimes:
+
+|         | `req`            | `res`             | `next`      |
+| ------- | ---------------- | ----------------- | ----------- |
+| Express | native `Request` | native `Response` | real `next` |
+| Fastify | `request.raw`    | reply driver      | **no-op**   |
+| h3      | `event.node.req` | response driver   | no-op       |
+
+Two consequences that were undocumented and bite silently:
+
+- **`next(err)` does nothing on Fastify and h3.** It is bound to an inert
+  function (`const NOOP_NEXT = (): void => {}`), so a handler that delegates to
+  the default handler drops the error instead.
+- **Express-only request members are `undefined` elsewhere.** A handler reading
+  `req.originalUrl` — as the shipped example did — logs `undefined` on two of
+  three engines.
+
+`res` is now typed `RuntimeResponse` rather than `any`, which is what every
+engine genuinely provides (`status`, `json`, `send`, `setHeader`, `render`,
+`writeHead`, `end`); Express's own `Response` satisfies it. `next` is typed
+`(err?: unknown) => void`. `req` stays permissive because it genuinely differs
+per engine, and the docblock now says how.
+
+A handler using Express-only _response_ members (`res.locals`, and anything
+outside `RuntimeResponse`) will now fail to compile. That is the point: those
+members are absent at runtime on Fastify and h3.

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -377,10 +377,9 @@ class SocialAuthController {
     const state = randomBytes(32).toString('hex')
     ctx.session.data.oauthState = state
     const url = googleAuth.getAuthorizationUrl(state)
-    // `ctx.res.redirect()` is engine-native: Express and Fastify both have it,
-    // h3 does not. On h3, set the header yourself —
-    // `ctx.res.setHeader('location', url)` with a 302.
-    return ctx.res.redirect(url)
+    // `ctx.redirect()` works on every runtime. (`ctx.res.redirect()` is
+    // engine-native — h3's event has no such method.)
+    return ctx.redirect(url)
   }
 
   @Get('/google/callback')
@@ -428,7 +427,7 @@ loginWithGoogle(ctx: RequestContext) {
   const { url, codeVerifier } = googleAuth.getAuthorizationUrlWithPkce(state)
   ctx.session.data.oauthState = state
   ctx.session.data.oauthCodeVerifier = codeVerifier
-  return ctx.res.redirect(url)
+  return ctx.redirect(url)
 }
 
 @Get('/google/callback')

--- a/docs/guide/authorization.md
+++ b/docs/guide/authorization.md
@@ -289,10 +289,8 @@ kick g guard ip-whitelist
 // src/guards/ip-whitelist.guard.ts
 export async function ipWhitelistGuard(ctx: RequestContext, next: () => void) {
   const allowed = ['10.0.0.0/8', '192.168.1.0/24']
-  // `ctx.req` is the ENGINE-NATIVE request, and `.ip` is Express-only —
-  // under Fastify / h3 read `ctx.req.socket.remoteAddress` (or your proxy's
-  // `x-forwarded-for` header) instead.
-  if (!allowed.some((range) => isInSubnet(ctx.req.ip, range))) {
+  // `ctx.ip` works on every runtime. (`ctx.req.ip` is Express-only.)
+  if (!allowed.some((range) => isInSubnet(ctx.ip ?? '', range))) {
     // `ctx.res` is the ENGINE-NATIVE response — `.json()` is Express-only
     // (FastifyReply has no `.json()`, h3's event has no `.status()`).
     ctx.problem.forbidden({ detail: 'IP not allowed' })

--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -1960,7 +1960,7 @@ type RateLimitParams = {
 const RateLimited = defineHttpContextDecorator.withParams<RateLimitParams>()({
   key: 'rate-limit',
   deps: { limiter: RATE_LIMITER },
-  paramDefaults: { window: '1m', max: 60, keyOf: (ctx) => ctx.ip },
+  paramDefaults: { window: '1m', max: 60, keyOf: (ctx) => ctx.ip ?? 'anonymous' },
   resolve: (ctx, { limiter }, params) => limiter.check(params.keyOf(ctx), params),
 })
 
@@ -2086,7 +2086,8 @@ bootstrap({
   modules: [TenantModule],
   contributors: [
     LoadTenant.with({ source: 'header', headerName: 'x-org-id' }).registration,
-    RateLimited.with({ window: '1m', max: 1000, keyOf: (ctx) => ctx.ip }).registration,
+    RateLimited.with({ window: '1m', max: 1000, keyOf: (ctx) => ctx.ip ?? 'anonymous' })
+      .registration,
   ],
 })
 ```

--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -1756,7 +1756,7 @@ export const RateLimited = defineHttpContextDecorator.withParams<RateLimitParams
   paramDefaults: {
     window: '1m',
     max: 60,
-    keyOf: (ctx) => ctx.ip,
+    keyOf: (ctx) => ctx.ip ?? 'anonymous',
   },
   resolve: (ctx, { limiter }, params) => limiter.check(params.keyOf(ctx), params),
 })
@@ -1765,7 +1765,7 @@ export const RateLimited = defineHttpContextDecorator.withParams<RateLimitParams
 @RateLimited({
   window: '1m',
   max: 100,
-  keyOf: (ctx) => ctx.user?.id ?? ctx.ip,
+  keyOf: (ctx) => ctx.user?.id ?? ctx.ip ?? 'anonymous',
 })
 @Get('/api/expensive')
 expensive(ctx: RequestContext) {}
@@ -1819,7 +1819,7 @@ Same primitive, ten domains. Each entry shows the **old approach** (forking the 
 **4. Rate-limit override**
 
 - _Old_: per-route Express middleware with `rateLimit({ window, max, key })` inlined; lost type safety + DI.
-- _New_: `@RateLimited({ window: '1m', max: 100, keyOf: (ctx) => ctx.user?.id ?? ctx.ip })`. Typed, DI-resolved limiter.
+- _New_: `@RateLimited({ window: '1m', max: 100, keyOf: (ctx) => ctx.user?.id ?? ctx.ip ?? 'anonymous' })`. Typed, DI-resolved limiter.
 
 **5. Feature flag gate**
 
@@ -1964,7 +1964,7 @@ const RateLimited = defineHttpContextDecorator.withParams<RateLimitParams>()({
   resolve: (ctx, { limiter }, params) => limiter.check(params.keyOf(ctx), params),
 })
 
-@RateLimited({ window: '1m', max: 100, keyOf: (ctx) => ctx.user?.id ?? ctx.ip })
+@RateLimited({ window: '1m', max: 100, keyOf: (ctx) => ctx.user?.id ?? ctx.ip ?? 'anonymous' })
 @Get('/api/expensive') expensive(ctx) {}
 ```
 

--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -1756,7 +1756,7 @@ export const RateLimited = defineHttpContextDecorator.withParams<RateLimitParams
   paramDefaults: {
     window: '1m',
     max: 60,
-    keyOf: (ctx) => ctx.req.ip,
+    keyOf: (ctx) => ctx.ip,
   },
   resolve: (ctx, { limiter }, params) => limiter.check(params.keyOf(ctx), params),
 })
@@ -1765,7 +1765,7 @@ export const RateLimited = defineHttpContextDecorator.withParams<RateLimitParams
 @RateLimited({
   window: '1m',
   max: 100,
-  keyOf: (ctx) => ctx.user?.id ?? ctx.req.ip,
+  keyOf: (ctx) => ctx.user?.id ?? ctx.ip,
 })
 @Get('/api/expensive')
 expensive(ctx: RequestContext) {}
@@ -1819,7 +1819,7 @@ Same primitive, ten domains. Each entry shows the **old approach** (forking the 
 **4. Rate-limit override**
 
 - _Old_: per-route Express middleware with `rateLimit({ window, max, key })` inlined; lost type safety + DI.
-- _New_: `@RateLimited({ window: '1m', max: 100, keyOf: (ctx) => ctx.user?.id ?? ctx.req.ip })`. Typed, DI-resolved limiter.
+- _New_: `@RateLimited({ window: '1m', max: 100, keyOf: (ctx) => ctx.user?.id ?? ctx.ip })`. Typed, DI-resolved limiter.
 
 **5. Feature flag gate**
 
@@ -1960,11 +1960,11 @@ type RateLimitParams = {
 const RateLimited = defineHttpContextDecorator.withParams<RateLimitParams>()({
   key: 'rate-limit',
   deps: { limiter: RATE_LIMITER },
-  paramDefaults: { window: '1m', max: 60, keyOf: (ctx) => ctx.req.ip },
+  paramDefaults: { window: '1m', max: 60, keyOf: (ctx) => ctx.ip },
   resolve: (ctx, { limiter }, params) => limiter.check(params.keyOf(ctx), params),
 })
 
-@RateLimited({ window: '1m', max: 100, keyOf: (ctx) => ctx.user?.id ?? ctx.req.ip })
+@RateLimited({ window: '1m', max: 100, keyOf: (ctx) => ctx.user?.id ?? ctx.ip })
 @Get('/api/expensive') expensive(ctx) {}
 ```
 
@@ -2086,7 +2086,7 @@ bootstrap({
   modules: [TenantModule],
   contributors: [
     LoadTenant.with({ source: 'header', headerName: 'x-org-id' }).registration,
-    RateLimited.with({ window: '1m', max: 1000, keyOf: (ctx) => ctx.req.ip }).registration,
+    RateLimited.with({ window: '1m', max: 1000, keyOf: (ctx) => ctx.ip }).registration,
   ],
 })
 ```

--- a/docs/guide/controllers.md
+++ b/docs/guide/controllers.md
@@ -182,6 +182,7 @@ rather than the body, so the typed client has no payload to offer.
 | `ctx.notFound(message?)`                | 404    | **Deprecated** — use `ctx.problem.notFound()`   |
 | `ctx.badRequest(message)`               | 400    | **Deprecated** — use `ctx.problem.badRequest()` |
 | `ctx.html(content, status?)`            | 200    | HTML response                                   |
+| `ctx.redirect(url, status?)`            | 302    | Redirect (works on every runtime)               |
 | `ctx.download(buffer, filename, type?)` | --     | File download                                   |
 | `ctx.render(template, data?)`           | 200    | Render a template (requires ViewAdapter)        |
 

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -244,7 +244,7 @@ Two consequences to write for:
   `req.originalUrl`, `req.path`, and `req.ip` are absent on the raw node
   request — use `req.url`, or `ctx.ip` where a `RequestContext` is in scope.
 
-`res` is a {@link RuntimeResponse} on every engine, so `status`, `json`,
+`res` is a `RuntimeResponse` on every engine, so `status`, `json`,
 `send`, `setHeader`, `render`, `writeHead`, and `end` are all available.
 When omitted, the built-in handlers are used.
 

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -213,9 +213,10 @@ bootstrap({
 ```ts
 bootstrap({
   modules,
-  onError: (err, req, res, next) => {
+  onError: (err, req, res) => {
     const status = err.status ?? 500
-    logger.error({ err, method: req.method, url: req.originalUrl })
+    // `req.url`, not `req.originalUrl` — the latter is Express-only.
+    logger.error({ err, method: req.method, url: req.url })
     res.status(status).json({
       error: err.message,
       code: err.code ?? 'INTERNAL_ERROR',
@@ -224,7 +225,28 @@ bootstrap({
 })
 ```
 
-Both use the standard Express signature: `onNotFound` receives `(req, res, next)` and `onError` receives `(err, req, res, next)`. When omitted, the built-in handlers are used.
+Both are connect-**shaped** — `onNotFound` receives `(req, res, next)` and
+`onError` receives `(err, req, res, next)` — but they are not Express-
+**semantic** on every engine. What arrives differs:
+
+|         | `req`            | `res`             | `next`      |
+| ------- | ---------------- | ----------------- | ----------- |
+| Express | native `Request` | native `Response` | real `next` |
+| Fastify | `request.raw`    | reply driver      | **no-op**   |
+| h3      | `event.node.req` | response driver   | no-op       |
+
+Two consequences to write for:
+
+- **`next(err)` does nothing on Fastify and h3.** It is an inert function
+  there, so delegating to the default handler silently drops the error. Send a
+  response yourself instead.
+- **Express-only request members are `undefined` elsewhere.**
+  `req.originalUrl`, `req.path`, and `req.ip` are absent on the raw node
+  request — use `req.url`, or `ctx.ip` where a `RequestContext` is in scope.
+
+`res` is a {@link RuntimeResponse} on every engine, so `status`, `json`,
+`send`, `setHeader`, `render`, `writeHead`, and `end` are all available.
+When omitted, the built-in handlers are used.
 
 ## Writing Reusable Middleware
 

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -201,7 +201,7 @@ bootstrap({
   onNotFound: (req, res) => {
     res.status(404).json({
       error: 'Route not found',
-      path: req.originalUrl,
+      path: req.url, // not `originalUrl` — Express-only
       timestamp: new Date().toISOString(),
     })
   },

--- a/packages/kickjs/__tests__/context-ip-redirect.test.ts
+++ b/packages/kickjs/__tests__/context-ip-redirect.test.ts
@@ -90,3 +90,48 @@ describe('ctx.redirect', () => {
     expect(calls[0]).toEqual(['status', 301])
   })
 })
+
+/**
+ * `ctx.redirect()` on the web/edge entry.
+ *
+ * h3 has its own `sendRedirect(event, location, code)`, and Express and
+ * Fastify each have `res.redirect()` — three engine-specific spellings, none
+ * of them shared. Writing status + `Location` through the runtime response
+ * surface is the one form that works on all four, including the edge driver,
+ * which is a `Response` builder rather than a node socket.
+ */
+describe('ctx.redirect on the edge driver', () => {
+  it('produces a real 302 Response with a Location header', async () => {
+    const { WebResponseDriver } = await import('../src/http/web/driver')
+    const driver = new WebResponseDriver()
+    const ctx = new RequestContext(
+      { headers: {}, params: {}, query: {}, body: {} } as never,
+      driver as never,
+      (() => {}) as never,
+      driver as never,
+    )
+
+    ctx.redirect('/login')
+
+    const res = await driver.ready
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('/login')
+  })
+
+  it('honours an explicit status at the edge', async () => {
+    const { WebResponseDriver } = await import('../src/http/web/driver')
+    const driver = new WebResponseDriver()
+    const ctx = new RequestContext(
+      { headers: {}, params: {}, query: {}, body: {} } as never,
+      driver as never,
+      (() => {}) as never,
+      driver as never,
+    )
+
+    ctx.redirect('https://example.com/next', 308)
+
+    const res = await driver.ready
+    expect(res.status).toBe(308)
+    expect(res.headers.get('location')).toBe('https://example.com/next')
+  })
+})

--- a/packages/kickjs/__tests__/context-ip-redirect.test.ts
+++ b/packages/kickjs/__tests__/context-ip-redirect.test.ts
@@ -1,0 +1,92 @@
+/**
+ * `ctx.ip` and `ctx.redirect()` — the two engine-neutral accessors the guide
+ * previously had no way to express.
+ *
+ * `ctx.req.ip` is Express-only, and `ctx.res.redirect()` exists on Express and
+ * Fastify but not h3, so the docs had to carry "this breaks on X" caveats
+ * instead of showing portable code.
+ */
+import { describe, expect, it } from 'vitest'
+import { RequestContext } from '../src/http/context'
+
+function makeCtx(req: Record<string, unknown>) {
+  const calls: Array<[string, unknown]> = []
+  const res = {
+    status(code: number) {
+      calls.push(['status', code])
+      return res
+    },
+    setHeader(name: string, value: unknown) {
+      calls.push([`header:${name}`, value])
+      return res
+    },
+    end(data?: unknown) {
+      calls.push(['end', data])
+      return res
+    },
+    json: () => res,
+  }
+  const ctx = new RequestContext(
+    { headers: {}, params: {}, query: {}, body: {}, ...req } as never,
+    res as never,
+    (() => {}) as never,
+  )
+  return { ctx, calls }
+}
+
+describe('ctx.ip', () => {
+  it('prefers the address the runtime computed', () => {
+    // Express derives `req.ip` from `trust proxy`; Fastify from `trustProxy`.
+    // That is the value that has actually been vetted.
+    const { ctx } = makeCtx({ ip: '203.0.113.9', headers: { 'x-forwarded-for': '10.0.0.1' } })
+    expect(ctx.ip).toBe('203.0.113.9')
+  })
+
+  it('does not let a forwarded header override a computed address', () => {
+    // Raw forwarded headers are client-spoofable. Preferring them would let a
+    // caller pick their own rate-limit bucket or audit identity.
+    const { ctx } = makeCtx({ ip: '203.0.113.9', headers: { 'x-forwarded-for': '1.2.3.4' } })
+    expect(ctx.ip).not.toBe('1.2.3.4')
+  })
+
+  it('falls back to forwarded headers only when the runtime computed none', () => {
+    // The web/edge entry has no `ip` field at all.
+    const { ctx } = makeCtx({ headers: { 'cf-connecting-ip': '198.51.100.7' } })
+    expect(ctx.ip).toBe('198.51.100.7')
+  })
+
+  it('takes the first hop of a comma-separated forwarded chain', () => {
+    const { ctx } = makeCtx({ headers: { 'x-forwarded-for': '198.51.100.7, 10.0.0.1' } })
+    expect(ctx.ip).toBe('198.51.100.7')
+  })
+
+  it('falls back to the node socket', () => {
+    // Fastify/h3 raw requests when no proxy header is present.
+    const { ctx } = makeCtx({ socket: { remoteAddress: '192.0.2.5' } })
+    expect(ctx.ip).toBe('192.0.2.5')
+  })
+
+  it('is undefined when nothing can determine it', () => {
+    const { ctx } = makeCtx({})
+    expect(ctx.ip).toBeUndefined()
+  })
+})
+
+describe('ctx.redirect', () => {
+  it('writes status and Location through the runtime surface', () => {
+    // Not `ctx.res.redirect()` — h3's event has no such method.
+    const { ctx, calls } = makeCtx({})
+    ctx.redirect('/login')
+    expect(calls).toEqual([
+      ['status', 302],
+      ['header:location', '/login'],
+      ['end', undefined],
+    ])
+  })
+
+  it('accepts an explicit status', () => {
+    const { ctx, calls } = makeCtx({})
+    ctx.redirect('https://example.com/next', 301)
+    expect(calls[0]).toEqual(['status', 301])
+  })
+})

--- a/packages/kickjs/__tests__/edge-stores.test.ts
+++ b/packages/kickjs/__tests__/edge-stores.test.ts
@@ -7,7 +7,7 @@ import type { KvLike } from '../src/web'
 import { Container } from '../src/core/container'
 import { Controller, Get } from '../src/core/decorators'
 import { defineModule } from '../src/core/define-module'
-import type { RequestContext } from '../src/http/context'
+import { RequestContext } from '../src/http/context'
 
 /**
  * Edge-ready stores (KvLike) + the ctx-style rateLimitGuard — the pieces
@@ -167,10 +167,20 @@ describe('rateLimitGuard on the web entry', () => {
         reset: async () => {},
       },
     })
-    const fakeCtx = (ip: string | undefined, headers: Record<string, string>) =>
-      ({ req: { ip }, headers, setHeader: () => {}, json: () => {} }) as never
-    await guard(fakeCtx('10.0.0.1', { 'x-forwarded-for': 'spoofed' }), () => {})
-    await guard(fakeCtx(undefined, { 'x-forwarded-for': 'fallback, hop2' }), () => {})
+    // A REAL RequestContext, not an object literal: the key comes from
+    // `ctx.ip`, which is a getter on the class. A hand-rolled literal has no
+    // such property, so the assertion would pass or fail for reasons
+    // unrelated to the resolution being tested.
+    const realCtx = (ip: string | undefined, headers: Record<string, string>) => {
+      const res = { setHeader: () => res, status: () => res, json: () => res, end: () => res }
+      return new RequestContext(
+        { ip, headers, params: {}, query: {}, body: {} } as never,
+        res as never,
+        (() => {}) as never,
+      ) as never
+    }
+    await guard(realCtx('10.0.0.1', { 'x-forwarded-for': 'spoofed' }), () => {})
+    await guard(realCtx(undefined, { 'x-forwarded-for': 'fallback, hop2' }), () => {})
     expect(seen).toEqual(['10.0.0.1', 'fallback'])
   })
 })

--- a/packages/kickjs/__tests__/middleware-engine-neutral.test.ts
+++ b/packages/kickjs/__tests__/middleware-engine-neutral.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Connect-style middleware receives the RAW node request under Fastify and h3,
+ * so the Express conveniences (`req.ip`, `req.path`) are `undefined` there.
+ * Three shipped middlewares read them directly:
+ *
+ *   rateLimit  → every caller keyed as the `'127.0.0.1'` fallback: ONE shared
+ *                bucket, so a single client could exhaust the limit for
+ *                everyone
+ *   csrf       → `ignorePaths` never matched, so configured exemptions were
+ *                silently dead (fails closed, but the feature did nothing)
+ *   requestLogger → covered in its own file
+ */
+import { describe, expect, it } from 'vitest'
+import { rateLimit } from '../src/http/middleware/rate-limit'
+import { csrf } from '../src/http/middleware/csrf'
+import { resolveClientIp, resolvePathname } from '../src/http/client-ip'
+
+/** Fastify / h3 shape: raw node request. */
+const raw = (url: string, method = 'GET', extra: object = {}) =>
+  ({ method, url, headers: {}, ...extra }) as never
+
+describe('resolveClientIp', () => {
+  it('prefers the runtime-computed address over a spoofable header', () => {
+    expect(resolveClientIp({ ip: '203.0.113.9', headers: { 'x-forwarded-for': '1.2.3.4' } })).toBe(
+      '203.0.113.9',
+    )
+  })
+
+  it('uses the socket when no proxy header and no computed address', () => {
+    expect(resolveClientIp({ socket: { remoteAddress: '10.0.0.7' } })).toBe('10.0.0.7')
+  })
+})
+
+describe('resolvePathname', () => {
+  it('strips the query string from a raw url', () => {
+    expect(resolvePathname({ url: '/health?verbose=1' })).toBe('/health')
+  })
+
+  it('prefers Express req.path when present', () => {
+    expect(resolvePathname({ path: '/health', url: '/health?x=1' })).toBe('/health')
+  })
+})
+
+describe('rateLimit — engine neutrality', () => {
+  it('keys distinct clients separately on a raw node request', async () => {
+    const keys: string[] = []
+    const mw = rateLimit({
+      max: 100,
+      store: {
+        increment: async (k: string) => (keys.push(k), { totalHits: 1, resetTime: new Date() }),
+        decrement: async () => {},
+        reset: async () => {},
+      } as never,
+    })
+    const res = { setHeader: () => {}, status: () => res, json: () => {} }
+    await mw(raw('/a', 'GET', { socket: { remoteAddress: '10.0.0.1' } }), res as never, () => {})
+    await mw(raw('/b', 'GET', { socket: { remoteAddress: '10.0.0.2' } }), res as never, () => {})
+
+    // Previously both were '127.0.0.1' — a single shared bucket.
+    expect(keys).toEqual(['10.0.0.1', '10.0.0.2'])
+  })
+
+  it('honours skipPaths on a raw node request', async () => {
+    let nexted = false
+    const mw = rateLimit({ skipPaths: ['/health'] })
+    const res = { setHeader: () => {}, status: () => res, json: () => {} }
+    await mw(raw('/health'), res as never, () => {
+      nexted = true
+    })
+    expect(nexted).toBe(true)
+  })
+})
+
+describe('csrf — engine neutrality', () => {
+  it('honours ignorePaths on a raw node request', () => {
+    let nexted = false
+    const mw = csrf({ ignorePaths: ['/webhook'] })
+    const res = { status: () => res, json: () => {}, setHeader: () => {}, cookie: () => {} }
+    mw(
+      raw('/webhook', 'POST', { cookies: {} }),
+      res as never,
+      (() => {
+        nexted = true
+      }) as never,
+    )
+    expect(nexted).toBe(true)
+  })
+})

--- a/packages/kickjs/__tests__/middleware-engine-neutral.test.ts
+++ b/packages/kickjs/__tests__/middleware-engine-neutral.test.ts
@@ -29,6 +29,27 @@ describe('resolveClientIp', () => {
   it('uses the socket when no proxy header and no computed address', () => {
     expect(resolveClientIp({ socket: { remoteAddress: '10.0.0.7' } })).toBe('10.0.0.7')
   })
+
+  it('prefers the socket over a forwarded header a direct client could forge', () => {
+    // A raw Fastify / h3 request has no `req.ip`. If forwarded headers were
+    // consulted first, a DIRECT client could send a different value on each
+    // request and land in a fresh rate-limit bucket every time — evading the
+    // limit entirely. The socket cannot be spoofed.
+    expect(
+      resolveClientIp({
+        socket: { remoteAddress: '10.0.0.7' },
+        headers: { 'x-forwarded-for': 'attacker-chosen' },
+      }),
+    ).toBe('10.0.0.7')
+  })
+
+  it('still reaches headers where there is no socket (edge)', () => {
+    // The web/edge entry terminates the connection at the platform, so these
+    // headers are the only signal that exists there.
+    expect(resolveClientIp({ headers: { 'cf-connecting-ip': '198.51.100.7' } })).toBe(
+      '198.51.100.7',
+    )
+  })
 })
 
 describe('resolvePathname', () => {
@@ -42,6 +63,33 @@ describe('resolvePathname', () => {
 })
 
 describe('rateLimit — engine neutrality', () => {
+  it('cannot be evaded by varying x-forwarded-for on a direct connection', async () => {
+    // The same socket must land in the same bucket no matter what the client
+    // claims in the header.
+    const keys: string[] = []
+    const mw = rateLimit({
+      max: 100,
+      store: {
+        increment: async (k: string) => (keys.push(k), { totalHits: 1, resetTime: new Date() }),
+        decrement: async () => {},
+        reset: async () => {},
+      } as never,
+    })
+    const res = { setHeader: () => {}, status: () => res, json: () => {} }
+    const socket = { remoteAddress: '10.0.0.9' }
+    await mw(
+      { method: 'GET', url: '/a', headers: { 'x-forwarded-for': 'one' }, socket } as never,
+      res as never,
+      () => {},
+    )
+    await mw(
+      { method: 'GET', url: '/a', headers: { 'x-forwarded-for': 'two' }, socket } as never,
+      res as never,
+      () => {},
+    )
+    expect(keys).toEqual(['10.0.0.9', '10.0.0.9'])
+  })
+
   it('keys distinct clients separately on a raw node request', async () => {
     const keys: string[] = []
     const mw = rateLimit({

--- a/packages/kickjs/__tests__/middleware-engine-neutral.test.ts
+++ b/packages/kickjs/__tests__/middleware-engine-neutral.test.ts
@@ -62,6 +62,35 @@ describe('resolvePathname', () => {
   })
 })
 
+describe('web Request shapes', () => {
+  // No runtime hands these helpers a raw `Request` today — `WebRequestShim`
+  // normalizes first on both web paths (web/handler.ts, runtimes/h3-web.ts).
+  // These lock the defensive handling: `Headers` is not index-accessible and
+  // `Request.url` is absolute, so BOTH would fail silently rather than throw.
+  it('reads a Headers object, which has no index access', () => {
+    const req = new Request('https://example.com/api/users', {
+      headers: { 'x-forwarded-for': '203.0.113.5, 70.41.3.18' },
+    })
+    expect(resolveClientIp({ headers: req.headers })).toBe('203.0.113.5')
+  })
+
+  it('reduces an absolute Request.url to its pathname', () => {
+    const req = new Request('https://example.com/health?verbose=1')
+    // The bug this guards: returning the whole absolute URL means a
+    // `skip: ['/health']` prefix never matches and the path is logged in full.
+    expect(resolvePathname({ url: req.url })).toBe('/health')
+  })
+
+  it('still prefers a real socket address over a spoofable header', () => {
+    const req = new Request('https://example.com/', {
+      headers: { 'x-forwarded-for': '1.2.3.4' },
+    })
+    expect(resolveClientIp({ headers: req.headers, socket: { remoteAddress: '10.0.0.7' } })).toBe(
+      '10.0.0.7',
+    )
+  })
+})
+
 describe('rateLimit — engine neutrality', () => {
   it('cannot be evaded by varying x-forwarded-for on a direct connection', async () => {
     // The same socket must land in the same bucket no matter what the client

--- a/packages/kickjs/__tests__/on-error-contract.test.ts
+++ b/packages/kickjs/__tests__/on-error-contract.test.ts
@@ -1,0 +1,60 @@
+/**
+ * `bootstrap({ onError })` is connect-SHAPED but not Express-SEMANTIC.
+ *
+ * The docblock used to call it "the standard Express error-handling
+ * signature", which holds on exactly one of three runtimes:
+ *
+ *   Express  req = native Request   res = native Response   next = real
+ *   Fastify  req = request.raw      res = reply driver      next = NO-OP
+ *   h3       req = event.node.req   res = response driver   next = no-op
+ *
+ * Two consequences a handler author has to know: `next(err)` silently drops
+ * the error off Express, and Express-only request members are `undefined`.
+ * These assertions pin the runtimes' side of that contract so it cannot drift
+ * from the documentation.
+ */
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const src = (p: string) => readFileSync(join(__dirname, '..', 'src', p), 'utf8')
+
+describe('onError contract — what each runtime passes', () => {
+  it('fastify hands the raw request, a reply driver, and a no-op next', () => {
+    const s = src('http/runtimes/fastify.ts')
+    // The error path passes these three, in this order.
+    expect(s).toMatch(/setErrorHandler\(app, mw: ConnectMiddleware\)/)
+    expect(s).toContain('request.raw')
+    expect(s).toContain('replyDriver(reply)')
+    expect(s).toContain('NOOP_NEXT')
+    // NOOP_NEXT really is inert — the reason `next(err)` cannot delegate.
+    expect(s).toMatch(/const NOOP_NEXT = \(\): void => \{\}/)
+  })
+
+  it('h3 also defines an inert next', () => {
+    expect(src('http/runtimes/h3.ts')).toMatch(/const NOOP_NEXT = \(\): void => \{\}/)
+  })
+
+  it('express alone passes its native objects through', () => {
+    // `app.use(mw)` — Express calls the handler with its own req/res/next.
+    expect(src('http/runtimes/express.ts')).toMatch(
+      /setErrorHandler\(app, mw: ConnectMiddleware\) \{\s*;\(app as any\)\.use\(mw\)/,
+    )
+  })
+})
+
+describe('onError contract — documentation matches the code', () => {
+  const options = src('http/application.ts')
+
+  it('no longer claims the Express signature holds everywhere', () => {
+    expect(options).not.toContain('standard Express error-handling signature')
+  })
+
+  it('warns that next() is inert off Express', () => {
+    expect(options).toMatch(/`next\(err\)` does nothing on Fastify and h3/)
+  })
+
+  it('warns that Express-only request members are absent', () => {
+    expect(options).toMatch(/`req\.originalUrl`, `req\.path`, and `req\.ip` do not exist/)
+  })
+})

--- a/packages/kickjs/__tests__/request-logger-engine-neutral.test.ts
+++ b/packages/kickjs/__tests__/request-logger-engine-neutral.test.ts
@@ -93,3 +93,16 @@ describe('requestLogger — engine neutrality', () => {
     expect(messages[0]).toContain('/api/v1/inner')
   })
 })
+
+describe('requestLogger — url fallback', () => {
+  it('never logs "undefined" when neither url member exists', () => {
+    // `originalUrl` and `url` are both optional; without a floor the line
+    // reads `GET undefined` again, just by a different route.
+    const messages = captureLogs()
+    const { res, finish } = makeRes()
+    requestLogger()({ method: 'GET', headers: {} } as never, res, () => {})
+    finish()
+    expect(messages[0]).not.toContain('undefined')
+    expect(messages[0]).toContain('GET /')
+  })
+})

--- a/packages/kickjs/__tests__/request-logger-engine-neutral.test.ts
+++ b/packages/kickjs/__tests__/request-logger-engine-neutral.test.ts
@@ -1,0 +1,95 @@
+/**
+ * `requestLogger()` runs under every runtime, and Fastify / h3 hand connect
+ * middleware the RAW node request. Two Express-only reads made it misbehave
+ * there:
+ *
+ *   req.path        → undefined, so `skip` threw
+ *                     "Cannot read properties of undefined (reading 'startsWith')"
+ *                     on EVERY request once any prefix was configured
+ *   req.originalUrl → undefined, so every line logged `GET undefined 200 12ms`
+ *
+ * The first is a crash, not a degradation: the middleware failed the request
+ * rather than declining to log it.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { requestLogger } from '../src/http/middleware/request-logger'
+import { Logger } from '../src/core'
+
+/** Fastify / h3 shape: raw node request — `url`, no `path`, no `originalUrl`. */
+function rawReq(url: string, method = 'GET') {
+  return { method, url, headers: {} } as never
+}
+
+function makeRes() {
+  const handlers: Record<string, () => void> = {}
+  const res = {
+    statusCode: 200,
+    on: (event: string, fn: () => void) => {
+      handlers[event] = fn
+    },
+  }
+  return { res: res as never, finish: () => handlers.finish?.() }
+}
+
+function captureLogs() {
+  const messages: string[] = []
+  for (const level of ['info', 'warn', 'error', 'debug'] as const) {
+    vi.spyOn(Logger.prototype, level).mockImplementation(((a: unknown) => {
+      messages.push(String(a))
+    }) as never)
+  }
+  return messages
+}
+
+describe('requestLogger — engine neutrality', () => {
+  it('does not throw when skip is set and the request is raw node', () => {
+    captureLogs()
+    const { res } = makeRes()
+    expect(() =>
+      requestLogger({ skip: ['/health'] })(rawReq('/health'), res, () => {}),
+    ).not.toThrow()
+  })
+
+  it('still skips the configured prefix', () => {
+    const messages = captureLogs()
+    const { res, finish } = makeRes()
+    let nexted = false
+    requestLogger({ skip: ['/health'] })(rawReq('/health'), res, () => {
+      nexted = true
+    })
+    finish()
+    expect(nexted).toBe(true)
+    expect(messages).toHaveLength(0)
+  })
+
+  it('ignores the query string when matching skip prefixes', () => {
+    const messages = captureLogs()
+    const { res, finish } = makeRes()
+    requestLogger({ skip: ['/health'] })(rawReq('/health?verbose=1'), res, () => {})
+    finish()
+    expect(messages).toHaveLength(0)
+  })
+
+  it('logs the path rather than undefined', () => {
+    const messages = captureLogs()
+    const { res, finish } = makeRes()
+    requestLogger()(rawReq('/orders/42'), res, () => {})
+    finish()
+    expect(messages[0]).toContain('/orders/42')
+    expect(messages[0]).not.toContain('undefined')
+  })
+
+  it('still prefers originalUrl when Express provides it', () => {
+    // Express rewrites `url` under a mounted router; `originalUrl` is the
+    // full path and stays the better source when present.
+    const messages = captureLogs()
+    const { res, finish } = makeRes()
+    requestLogger()(
+      { method: 'GET', url: '/inner', originalUrl: '/api/v1/inner', headers: {} } as never,
+      res,
+      () => {},
+    )
+    finish()
+    expect(messages[0]).toContain('/api/v1/inner')
+  })
+})

--- a/packages/kickjs/__tests__/request-logger-engine-neutral.test.ts
+++ b/packages/kickjs/__tests__/request-logger-engine-neutral.test.ts
@@ -11,7 +11,7 @@
  * The first is a crash, not a degradation: the middleware failed the request
  * rather than declining to log it.
  */
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { requestLogger } from '../src/http/middleware/request-logger'
 import { Logger } from '../src/core'
 
@@ -30,6 +30,13 @@ function makeRes() {
   }
   return { res: res as never, finish: () => handlers.finish?.() }
 }
+
+afterEach(() => {
+  // `captureLogs()` spies on `Logger.prototype` and no vitest config sets
+  // `restoreMocks`, so without this each test stacks another spy on the shared
+  // prototype and later assertions read the earlier tests' lines too.
+  vi.restoreAllMocks()
+})
 
 function captureLogs() {
   const messages: string[] = []

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -263,7 +263,8 @@ export interface ApplicationOptions {
    * bootstrap({
    *   modules,
    *   onNotFound: (req, res) => {
-   *     res.status(404).json({ error: 'Route not found', path: req.originalUrl })
+   *     // `req.originalUrl` is Express-only — use `req.url` for portability.
+   *     res.status(404).json({ error: 'Route not found', path: req.url })
    *   },
    * })
    * ```

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -255,9 +255,13 @@ export interface ApplicationOptions {
   cluster?: boolean | { workers?: number }
 
   /**
-   * Custom 404 handler for unmatched routes. Receives the raw Express
-   * `(req, res, next)` args. When omitted, the built-in handler returns
-   * `{ message: 'Not Found' }` with status 404.
+   * Custom 404 handler for unmatched routes. When omitted, the built-in
+   * handler returns `{ message: 'Not Found' }` with status 404.
+   *
+   * Connect-**shaped**, not Express-**semantic** — see {@link onError} for the
+   * per-runtime table. The same two caveats apply: `next()` is inert on
+   * Fastify and h3, and Express-only request members (`req.originalUrl`,
+   * `req.path`, `req.ip`) are `undefined` there, so read `req.url`.
    *
    * @example
    * ```ts

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -45,6 +45,7 @@ import type {
   HttpRuntime,
   RouteEntry,
   RuntimeCapabilities,
+  RuntimeResponse,
 } from './runtime'
 import { requestStore } from './request-store'
 
@@ -269,25 +270,49 @@ export interface ApplicationOptions {
    * })
    * ```
    */
-  onNotFound?: (req: any, res: any, next: any) => void
+  onNotFound?: (req: any, res: RuntimeResponse, next: (err?: unknown) => void) => void
 
   /**
-   * Custom global error handler. Receives `(err, req, res, next)` — the
-   * standard Express error-handling signature. When omitted, the built-in
-   * handler formats ZodError, HttpException, and unexpected errors.
+   * Custom global error handler, receiving `(err, req, res, next)`. When
+   * omitted, the built-in handler formats ZodError, HttpException, and
+   * unexpected errors.
+   *
+   * The shape is connect-style, but it is NOT "the standard Express error
+   * handler" on every engine — what you actually receive differs, and the
+   * differences bite:
+   *
+   * | | `req` | `res` | `next` |
+   * | --- | --- | --- | --- |
+   * | Express | native `Request` | native `Response` | real `next` |
+   * | Fastify | `request.raw` | reply driver | **no-op** |
+   * | h3 | `event.node.req` | response driver | no-op (or dev fall-through) |
+   *
+   * Two consequences worth knowing before you write one:
+   *
+   * - **`next(err)` does nothing on Fastify and h3.** It is a no-op function
+   *   there, so delegating to the default handler silently drops the error.
+   *   Send a response yourself rather than passing it on.
+   * - **Express-only request members are `undefined` elsewhere.**
+   *   `req.originalUrl`, `req.path`, and `req.ip` do not exist on the raw node
+   *   request — use `req.url` and the `x-forwarded-*` headers, or reach for
+   *   `ctx.ip` in a contributor / guard where a `RequestContext` is available.
+   *
+   * `res` is typed {@link RuntimeResponse} because that is what every engine
+   * genuinely provides: `status`, `json`, `send`, `setHeader`, `render`,
+   * `writeHead`, `end`. Express's own `Response` satisfies it.
    *
    * @example
    * ```ts
    * bootstrap({
    *   modules,
-   *   onError: (err, req, res, next) => {
-   *     logger.error(err)
+   *   onError: (err, req, res) => {
+   *     logger.error(err, `${req.method} ${req.url}`) // not `originalUrl`
    *     res.status(err.status ?? 500).json({ error: err.message })
    *   },
    * })
    * ```
    */
-  onError?: (err: any, req: any, res: any, next: any) => void
+  onError?: (err: any, req: any, res: RuntimeResponse, next: (err?: unknown) => void) => void
 
   /**
    * Security defaults applied automatically unless opted out.

--- a/packages/kickjs/src/http/client-ip.ts
+++ b/packages/kickjs/src/http/client-ip.ts
@@ -1,0 +1,65 @@
+/**
+ * Client address + pathname resolution shared by everything that runs as
+ * connect-style middleware.
+ *
+ * Fastify and h3 hand middleware the RAW node request, so the Express
+ * conveniences (`req.ip`, `req.path`, `req.originalUrl`) are `undefined`
+ * there. Reading them directly produced two live bugs:
+ *
+ *   rate-limit → every caller keyed as the `'127.0.0.1'` fallback, i.e. ONE
+ *                shared bucket, so a single client could exhaust the limit
+ *                for everyone
+ *   csrf       → `ignorePaths` never matched, so configured exemptions were
+ *                silently dead
+ *
+ * Edge-safe: no node imports.
+ */
+
+/** The request members these helpers read, from node's shape rather than Express's. */
+export interface ClientRequestLike {
+  url?: string
+  /** Express-only convenience. */
+  path?: string
+  /** Express-only; the full path before router mounting rewrote `url`. */
+  originalUrl?: string
+  /** Express and Fastify compute this from their trust-proxy settings. */
+  ip?: unknown
+  headers?: Record<string, string | string[] | undefined>
+  socket?: { remoteAddress?: string }
+}
+
+/** First entry of a possibly comma-separated header value. */
+function firstHop(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value.split(',')[0]!.trim() : undefined
+}
+
+/**
+ * The client's IP address, or `undefined` when it cannot be determined.
+ *
+ * Prefers the address the runtime computed — Express derives `req.ip` from
+ * `trust proxy`, Fastify from `trustProxy` — because raw forwarded headers are
+ * client-SPOOFABLE wherever nothing normalizes them. h3 takes the same stance:
+ * its `getRequestIP` only consults `x-forwarded-for` when explicitly opted in.
+ *
+ * Header fallbacks apply only to runtimes that compute no address at all
+ * (notably the web/edge entry, which has no socket either).
+ */
+export function resolveClientIp(req: ClientRequestLike): string | undefined {
+  if (typeof req.ip === 'string' && req.ip.length > 0) return req.ip
+  const h = req.headers ?? {}
+  return (
+    firstHop(h['cf-connecting-ip']) ??
+    firstHop(h['x-forwarded-for']) ??
+    firstHop(h['x-real-ip']) ??
+    (req.socket?.remoteAddress || undefined)
+  )
+}
+
+/** Pathname only — `req.url` carries the query string, and `req.path` is Express-only. */
+export function resolvePathname(req: ClientRequestLike): string {
+  if (typeof req.path === 'string' && req.path.length > 0) return req.path
+  const url = req.url
+  if (!url) return '/'
+  const q = url.indexOf('?')
+  return (q === -1 ? url : url.slice(0, q)) || '/'
+}

--- a/packages/kickjs/src/http/client-ip.ts
+++ b/packages/kickjs/src/http/client-ip.ts
@@ -41,17 +41,36 @@ function firstHop(value: unknown): string | undefined {
  * client-SPOOFABLE wherever nothing normalizes them. h3 takes the same stance:
  * its `getRequestIP` only consults `x-forwarded-for` when explicitly opted in.
  *
- * Header fallbacks apply only to runtimes that compute no address at all
- * (notably the web/edge entry, which has no socket either).
+ * Order is `req.ip` → `socket.remoteAddress` → forwarded headers. The socket
+ * comes BEFORE the headers deliberately: it cannot be spoofed, whereas a direct
+ * client can vary `x-forwarded-for` per request to get a fresh rate-limit
+ * bucket each time. Headers are consulted only where there is no socket — the
+ * web/edge entry, where the platform terminates the connection.
  */
 export function resolveClientIp(req: ClientRequestLike): string | undefined {
+  // 1. What the runtime computed. Express derives `req.ip` from `trust proxy`,
+  //    Fastify from `trustProxy` — a value vetted against a CONFIGURED proxy,
+  //    which is the only reason to believe a forwarded header at all.
   if (typeof req.ip === 'string' && req.ip.length > 0) return req.ip
+
+  // 2. The socket. Unspoofable, and present on every node runtime.
+  //
+  //    This MUST precede the headers. A raw Fastify / h3 request has no
+  //    `req.ip`, so consulting `x-forwarded-for` first let a DIRECT client send
+  //    a different value per request and land in a fresh rate-limit bucket each
+  //    time — evading the limit entirely. Behind a real proxy the socket is the
+  //    proxy's address, which buckets clients together; the fix for that is to
+  //    configure the runtime's trust-proxy setting so step 1 answers, not to
+  //    trust an unverified header here.
+  const socketAddress = req.socket?.remoteAddress
+  if (socketAddress) return socketAddress
+
+  // 3. Headers, only where there is no socket at all — the web/edge entry,
+  //    where the platform terminates the connection and these are the only
+  //    signal available.
   const h = req.headers ?? {}
   return (
-    firstHop(h['cf-connecting-ip']) ??
-    firstHop(h['x-forwarded-for']) ??
-    firstHop(h['x-real-ip']) ??
-    (req.socket?.remoteAddress || undefined)
+    firstHop(h['cf-connecting-ip']) ?? firstHop(h['x-forwarded-for']) ?? firstHop(h['x-real-ip'])
   )
 }
 

--- a/packages/kickjs/src/http/client-ip.ts
+++ b/packages/kickjs/src/http/client-ip.ts
@@ -24,13 +24,32 @@ export interface ClientRequestLike {
   originalUrl?: string
   /** Express and Fastify compute this from their trust-proxy settings. */
   ip?: unknown
-  headers?: Record<string, string | string[] | undefined>
+  /**
+   * A plain object on every path the framework currently takes — `WebRequestShim`
+   * normalizes a WHATWG `Headers` before the context is built. A `Headers`
+   * instance is accepted defensively: it is not index-accessible, so if one ever
+   * did arrive, every lookup would return `undefined` SILENTLY and drop each
+   * caller into one shared rate-limit bucket.
+   */
+  headers?: Record<string, string | string[] | undefined> | Headers
   socket?: { remoteAddress?: string }
 }
 
 /** First entry of a possibly comma-separated header value. */
 function firstHop(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value.split(',')[0]!.trim() : undefined
+}
+
+/** Read one header from either a plain object or a WHATWG `Headers`. */
+function headerValue(
+  headers: Record<string, string | string[] | undefined> | Headers | undefined,
+  name: string,
+): unknown {
+  if (!headers) return undefined
+  // `Headers` has no index access, so `headers[name]` silently yields
+  // `undefined` rather than the value.
+  if (typeof (headers as Headers).get === 'function') return (headers as Headers).get(name)
+  return (headers as Record<string, string | string[] | undefined>)[name]
 }
 
 /**
@@ -68,9 +87,11 @@ export function resolveClientIp(req: ClientRequestLike): string | undefined {
   // 3. Headers, only where there is no socket at all — the web/edge entry,
   //    where the platform terminates the connection and these are the only
   //    signal available.
-  const h = req.headers ?? {}
+  const h = req.headers
   return (
-    firstHop(h['cf-connecting-ip']) ?? firstHop(h['x-forwarded-for']) ?? firstHop(h['x-real-ip'])
+    firstHop(headerValue(h, 'cf-connecting-ip')) ??
+    firstHop(headerValue(h, 'x-forwarded-for')) ??
+    firstHop(headerValue(h, 'x-real-ip'))
   )
 }
 
@@ -79,6 +100,16 @@ export function resolvePathname(req: ClientRequestLike): string {
   if (typeof req.path === 'string' && req.path.length > 0) return req.path
   const url = req.url
   if (!url) return '/'
+  // `WebRequestShim` already reduces the WHATWG `Request.url` to path+search,
+  // but an ABSOLUTE url would otherwise be returned whole — so a skip prefix
+  // like `/health` would never match `https://host/health`.
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(url)) {
+    try {
+      return new URL(url).pathname || '/'
+    } catch {
+      return '/'
+    }
+  }
   const q = url.indexOf('?')
   return (q === -1 ? url : url.slice(0, q)) || '/'
 }

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -834,9 +834,15 @@ export class RequestContext<
   /**
    * Redirect the client. Works on every runtime.
    *
-   * `ctx.res.redirect()` is engine-native — Express and Fastify have it, h3
-   * does not — so this writes the status and `Location` header through the
-   * runtime response surface instead.
+   * Every engine spells this differently — Express and Fastify have
+   * `res.redirect()`, h3 has `sendRedirect(event, location, code)` — and none
+   * of them is shared, so this writes the status and `Location` header through
+   * the runtime response surface, which all four expose.
+   *
+   * The response carries no body. Express sends a short text line and h3 an
+   * HTML meta-refresh fallback; a bare `Location` with a 3xx is sufficient per
+   * RFC 9110, and interpolating the URL into an HTML body would add an
+   * injection surface to a value this method already warns is dangerous.
    *
    * ::: warning
    * Never pass an unvalidated user-supplied `url`. An attacker-controlled

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -804,6 +804,51 @@ export class RequestContext<
    * Express produces `text/html; charset=utf-8` for `.type('html')`, so
    * spelling it out here is byte-identical there and correct everywhere else.
    */
+  /**
+   * The client's IP address, or `undefined` when it cannot be determined.
+   *
+   * Prefers the value the runtime computed (Express derives `req.ip` from the
+   * app's `trust proxy` setting; Fastify from `trustProxy`), because raw
+   * forwarded headers are client-SPOOFABLE on deployments that do not
+   * normalize them. The header fallbacks exist for runtimes with no `ip`
+   * field at all — notably the web/edge entry.
+   *
+   * `ctx.req.ip` is Express-only, so reaching for it directly broke on
+   * Fastify and h3.
+   */
+  get ip(): string | undefined {
+    const runtimeIp = (this.req as { ip?: unknown }).ip
+    if (typeof runtimeIp === 'string' && runtimeIp.length > 0) return runtimeIp
+    const first = (v: unknown): string | undefined =>
+      typeof v === 'string' && v.length > 0 ? v.split(',')[0]!.trim() : undefined
+    const h = this.headers
+    return (
+      first(h['cf-connecting-ip']) ??
+      first(h['x-forwarded-for']) ??
+      first(h['x-real-ip']) ??
+      // Node exposes it here when the engine did not compute one.
+      ((this.req as { socket?: { remoteAddress?: string } }).socket?.remoteAddress || undefined)
+    )
+  }
+
+  /**
+   * Redirect the client. Works on every runtime.
+   *
+   * `ctx.res.redirect()` is engine-native — Express and Fastify have it, h3
+   * does not — so this writes the status and `Location` header through the
+   * runtime response surface instead.
+   *
+   * ::: warning
+   * Never pass an unvalidated user-supplied `url`. An attacker-controlled
+   * destination turns this into an open redirect, which is a common phishing
+   * primitive. Allow-list the target or keep it relative.
+   * :::
+   */
+  redirect(url: string, status = 302) {
+    this._response.status(status).setHeader('location', url)
+    return this._response.end()
+  }
+
   html(content: string, status = 200) {
     return this._response.status(status).type('text/html; charset=utf-8').send(content)
   }

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -9,6 +9,7 @@ import {
 import { normalizeProblem, type ProblemDetails, type ValidationError } from '../core/errors'
 import { MissingContextValueError } from '../core/context-errors'
 import { requestStore } from './request-store'
+import { resolveClientIp, type ClientRequestLike } from './client-ip'
 import {
   parseQuery,
   type ParseQueryOptions,
@@ -817,18 +818,7 @@ export class RequestContext<
    * Fastify and h3.
    */
   get ip(): string | undefined {
-    const runtimeIp = (this.req as { ip?: unknown }).ip
-    if (typeof runtimeIp === 'string' && runtimeIp.length > 0) return runtimeIp
-    const first = (v: unknown): string | undefined =>
-      typeof v === 'string' && v.length > 0 ? v.split(',')[0]!.trim() : undefined
-    const h = this.headers
-    return (
-      first(h['cf-connecting-ip']) ??
-      first(h['x-forwarded-for']) ??
-      first(h['x-real-ip']) ??
-      // Node exposes it here when the engine did not compute one.
-      ((this.req as { socket?: { remoteAddress?: string } }).socket?.remoteAddress || undefined)
-    )
+    return resolveClientIp(this.req as ClientRequestLike)
   }
 
   /**

--- a/packages/kickjs/src/http/middleware/csrf.ts
+++ b/packages/kickjs/src/http/middleware/csrf.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, NextFunction } from 'express'
+import { resolvePathname, type ClientRequestLike } from '../client-ip'
 
 import { randomHex } from '../../core/web-crypto'
 
@@ -78,7 +79,9 @@ export function csrf(options: CsrfOptions = {}) {
       return next()
     }
 
-    if (ignorePaths.has(req.path)) {
+    // `req.path` is Express-only, so `has(undefined)` never matched and
+    // configured exemptions were silently ignored on Fastify / h3.
+    if (ignorePaths.has(resolvePathname(req as ClientRequestLike))) {
       return next()
     }
 

--- a/packages/kickjs/src/http/middleware/rate-limit-guard.ts
+++ b/packages/kickjs/src/http/middleware/rate-limit-guard.ts
@@ -68,18 +68,10 @@ class LazyMemoryStore implements RateLimitStore {
 }
 
 function defaultKey(ctx: RequestContext): string {
-  // Prefer the runtime-computed client IP (Express derives req.ip from the
-  // app's `trust proxy` setting) — raw forwarded headers are client-spoofable
-  // on node deployments that don't normalize them. Header fallbacks cover
-  // runtimes without an `ip` field (the web/edge entry).
-  const reqIp = (ctx.req as { ip?: unknown }).ip
-  if (typeof reqIp === 'string' && reqIp.length > 0) return reqIp
-  const h = ctx.headers
-  const first = (v: unknown): string | undefined =>
-    typeof v === 'string' && v.length > 0 ? v.split(',')[0].trim() : undefined
-  return (
-    first(h['cf-connecting-ip']) ?? first(h['x-forwarded-for']) ?? first(h['x-real-ip']) ?? 'global'
-  )
+  // `ctx.ip` carries the resolution that used to live here: prefer the
+  // runtime-computed address (Express derives it from `trust proxy`), fall
+  // back to forwarded headers only for runtimes that compute none.
+  return ctx.ip ?? 'global'
 }
 
 /**

--- a/packages/kickjs/src/http/middleware/rate-limit.ts
+++ b/packages/kickjs/src/http/middleware/rate-limit.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, NextFunction } from 'express'
+import { resolveClientIp, resolvePathname, type ClientRequestLike } from '../client-ip'
 
 import { registerDisposable } from '../../core/disposables'
 
@@ -117,7 +118,12 @@ export function rateLimit(options: RateLimitOptions = {}) {
   const windowMs = options.windowMs ?? 60_000
   const message = options.message ?? 'Too Many Requests'
   const statusCode = options.statusCode ?? 429
-  const keyGenerator = options.keyGenerator ?? ((req: Request) => req.ip ?? '127.0.0.1')
+  // `req.ip` is Express-only. Under Fastify and h3 it is undefined, so EVERY
+  // caller fell back to the same `'127.0.0.1'` literal — one shared bucket,
+  // letting a single client exhaust the limit for everyone.
+  const keyGenerator =
+    options.keyGenerator ??
+    ((req: Request) => resolveClientIp(req as ClientRequestLike) ?? 'global')
   const sendHeaders = options.headers ?? true
   const store = options.store ?? new MemoryStore(windowMs)
   const skip = options.skip
@@ -125,7 +131,9 @@ export function rateLimit(options: RateLimitOptions = {}) {
 
   return async (req: Request, res: Response, next: NextFunction) => {
     // Skip if path is in the skip list
-    if (skipPaths.has(req.path)) {
+    // `req.path` is Express-only; `has(undefined)` never matched, so
+    // configured skips were silently dead on the other runtimes.
+    if (skipPaths.has(resolvePathname(req as ClientRequestLike))) {
       return next()
     }
 

--- a/packages/kickjs/src/http/middleware/request-logger.ts
+++ b/packages/kickjs/src/http/middleware/request-logger.ts
@@ -77,7 +77,9 @@ export function requestLogger(options: RequestLoggerOptions = {}) {
       // `originalUrl` is Express-only — on Fastify and h3 this logged
       // `GET undefined 200 12ms`, dropping the path from every access-log
       // line under those runtimes.
-      const path = req.originalUrl ?? req.url
+      // Both are optional, so the pair still needs a floor — otherwise the
+      // line reads `GET undefined` again, just via a different route.
+      const path = req.originalUrl ?? req.url ?? '/'
       log[level](`${req.method} ${path} ${status} ${duration}ms ${requestId}`)
     })
 

--- a/packages/kickjs/src/http/middleware/request-logger.ts
+++ b/packages/kickjs/src/http/middleware/request-logger.ts
@@ -1,4 +1,30 @@
-import type { Request, Response, NextFunction } from 'express'
+/**
+ * The slice of the request/response this logger touches, from node's shapes
+ * rather than Express's. This runs under EVERY runtime — Fastify and h3 hand
+ * connect middleware the raw node objects — so anything Express-only is
+ * `undefined` there.
+ */
+interface LoggedRequest {
+  method?: string
+  url?: string
+  /** Express-only convenience; the raw node request has only `url`. */
+  path?: string
+  /** Express-only; absent on the raw node request the other runtimes pass. */
+  originalUrl?: string
+  headers: Record<string, string | string[] | undefined>
+}
+
+interface LoggedResponse {
+  statusCode: number
+  on(event: 'finish', listener: () => void): unknown
+}
+
+/** Pathname only — `req.url` carries the query string. */
+function pathnameOf(url: string | undefined): string {
+  if (!url) return '/'
+  const q = url.indexOf('?')
+  return (q === -1 ? url : url.slice(0, q)) || '/'
+}
 import { createLogger } from '../../core'
 
 export interface RequestLoggerOptions {
@@ -31,9 +57,13 @@ export function requestLogger(options: RequestLoggerOptions = {}) {
   const level = options.level ?? 'info'
   const skip = options.skip ?? []
 
-  return (req: Request, res: Response, next: NextFunction) => {
-    // Skip logging for excluded paths
-    if (skip.some((prefix) => req.path.startsWith(prefix))) {
+  return (req: LoggedRequest, res: LoggedResponse, next: () => void) => {
+    // `req.path` is Express-only. Under Fastify and h3 it is `undefined`, so
+    // this threw `Cannot read properties of undefined (reading 'startsWith')`
+    // on EVERY request as soon as a `skip` prefix was configured — the
+    // middleware crashed the request rather than declining to log it.
+    const pathname = req.path ?? pathnameOf(req.url)
+    if (skip.some((prefix) => pathname.startsWith(prefix))) {
       return next()
     }
 
@@ -44,7 +74,11 @@ export function requestLogger(options: RequestLoggerOptions = {}) {
       const requestId = (req as any).requestId || req.headers['x-request-id'] || '-'
       const status = res.statusCode
 
-      log[level](`${req.method} ${req.originalUrl} ${status} ${duration}ms ${requestId}`)
+      // `originalUrl` is Express-only — on Fastify and h3 this logged
+      // `GET undefined 200 12ms`, dropping the path from every access-log
+      // line under those runtimes.
+      const path = req.originalUrl ?? req.url
+      log[level](`${req.method} ${path} ${status} ${duration}ms ${requestId}`)
     })
 
     next()


### PR DESCRIPTION
Closes the two API gaps the generator audit surfaced. The guide reached for
`ctx.req.ip` and `ctx.res.redirect()` because nothing neutral existed — both are
engine-native:

| API | Express | Fastify | h3 |
| --- | --- | --- | --- |
| `req.ip` | ✓ | ✓ | ✗ |
| `res.redirect()` | ✓ | ✓ | ✗ |

So the docs had to carry "this breaks on X" caveats instead of showing portable
code. Those caveats are deleted here.

## `ctx.ip`

Prefers the address **the runtime computed** — Express derives `req.ip` from
`trust proxy`, Fastify from `trustProxy` — because raw forwarded headers are
client-**spoofable** wherever nothing normalizes them. Letting a header win would
let a caller choose their own rate-limit bucket or audit identity.

Falls back to `cf-connecting-ip` / `x-forwarded-for` / `x-real-ip` only for
runtimes that compute no address (the web/edge entry), then the node socket.

That resolution already existed inside `rate-limit-guard`, comment and all. It
moves onto the context and the guard reuses it, rather than a second copy
drifting from the first.

## `ctx.redirect(url, status = 302)`

Writes the status and `Location` header through the runtime response surface, so
it works everywhere. The docblock warns against an unvalidated user-supplied
URL — an attacker-controlled destination is an open redirect, a standard
phishing primitive.

## A test that was passing for the wrong reason

`edge-stores.test.ts` faked the context with an object literal cast `as never`.
`ctx.ip` is a class getter, so a literal has no such property and the rate-limit
key silently became `'global'` — the assertion broke the moment `defaultKey`
started reading it.

Before writing that off as a test artifact I checked whether the edge entry
really builds a `RequestContext`: `src/http/web/handler.ts:139` does. So the
getter is present in production and only the fake was wrong. The test now
constructs a real context, which is what makes the assertion mean anything.

## Verification

8 new tests for the accessors, including the spoofing case. Verified by deleting
the runtime-ip preference and watching **3** tests fail across both suites:

```text
× prefers the address the runtime computed
× does not let a forwarded header override a computed address
× default key prefers runtime-computed req.ip over spoofable headers
```

Docs updated: `authorization.md`, `authentication.md`, `context-decorators.md`
now use the neutral accessors, and `ctx.redirect` is in the response-helpers
table.

**787/787**, `pnpm typecheck` and `vitest --typecheck` both exit 0, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added runtime-neutral `ctx.ip` support with socket and proxy-aware fallbacks.
  - Added `ctx.redirect(url, status?)` with custom status codes across runtimes.
  - Improved rate limiting, CSRF exclusions, and request logging outside Express.
- **Bug Fixes**
  - Fixed path detection, client identification, redirect handling, and middleware behavior across supported runtimes.
  - Clarified and strengthened cross-runtime error-handler contracts.
- **Documentation**
  - Updated authentication, authorization, controller, decorator, and middleware guidance.
- **Tests**
  - Added coverage for IP resolution, redirects, middleware compatibility, logging, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->