### PR TITLE
fix(http): tear down the previous app on HMR rebuild

### DIFF
--- a/.changeset/hmr-adapter-teardown.md
+++ b/.changeset/hmr-adapter-teardown.md
@@ -33,3 +33,12 @@ is skipped too — the server keeps serving, so there is nothing to drain toward
 
 Teardown failures are logged rather than thrown, so one broken adapter cannot
 leave the dev server with no app at all.
+
+Plugins are torn down alongside adapters — `shutdown()` step 3 always ran both,
+so a plugin holding a timer or connection leaked identically.
+
+Docs: the HMR guide previously listed database pools, Redis clients, and the
+Socket.IO server as _preserved across HMR_. They were not preserved so much as
+abandoned, which is the bug. They are now rebuilt, and the guide says so, along
+with what an adapter must do to be restartable — release the handle **and clear
+the reference**, since the same instance is often mounted again.

--- a/.changeset/hmr-adapter-teardown.md
+++ b/.changeset/hmr-adapter-teardown.md
@@ -1,0 +1,35 @@
+---
+'@forinda/kickjs': patch
+---
+
+Dispose the previous app on HMR rebuild instead of leaking it
+
+`bootstrap()` keeps the live app on `globalThis.__app`, and the reload path
+already tested for it — then replaced it without tearing it down:
+
+```ts
+if (g.__app) {
+  const freshApp = new Application(options)
+  g.__app = freshApp // old one dropped, still running
+}
+```
+
+`shutdown()` ran only from the `SIGINT` / `SIGTERM` handler, so in a dev session
+every save added another live adapter set on top of the last.
+
+Seen in production dev environments as a single API process holding several
+Kafka consumer-group members. On a single-partition topic only one member can
+hold the assignment, and it was a leaked consumer from an earlier reload wired
+to nothing — so queued jobs silently stopped being processed, and the group had
+never committed an offset. The same leak put two socket.io servers on one HTTP
+server, crashing `handleUpgrade()`.
+
+`Application.shutdown()` gains `{ closeServer?: boolean }`, and the reload path
+passes `false`. That distinction is load-bearing: in dev the HTTP server is
+shared across rebuilds via `globalThis.__kickjs_httpServer`, so a full shutdown
+would close the listening socket and kill HMR on the first save. Adapters,
+plugins, and disposables are torn down; the socket stays up. In-flight draining
+is skipped too — the server keeps serving, so there is nothing to drain toward.
+
+Teardown failures are logged rather than thrown, so one broken adapter cannot
+leave the dev server with no app at all.

--- a/docs/guide/hmr.md
+++ b/docs/guide/hmr.md
@@ -1,6 +1,6 @@
 # Hot Module Replacement (HMR)
 
-KickJS uses Vite's HMR to provide zero-downtime reloading during development. When you save a file, the Express handler is rebuilt and swapped on the existing HTTP server. Database pools, Redis connections, and port bindings survive across reloads.
+KickJS uses Vite's HMR to provide zero-downtime reloading during development. When you save a file, the handler is rebuilt and swapped on the existing HTTP server, so the port binding and open TCP connections survive across reloads. Anything an adapter or plugin owns — database pools, Redis clients, queue consumers — is torn down and rebuilt, because the previous app's `shutdown()` runs first. Only resources outside the adapter/plugin lifecycle persist.
 
 ## How It Works
 
@@ -17,7 +17,7 @@ import { modules } from './modules'
 bootstrap({ modules })
 ```
 
-On the first call, `bootstrap()` creates the application, registers error/shutdown handlers, and starts the HTTP server. On subsequent calls (triggered by HMR), it **tears the previous app down**, rebuilds the Express app, and swaps the request handler on the existing server — no restart needed.
+On the first call, `bootstrap()` creates the application and registers error/shutdown handlers. In dev, Vite owns the `http.Server` and exposes it as `globalThis.__kickjs_httpServer`; `bootstrap()` attaches to that server rather than creating or listening on its own. (Outside dev, with no such global, it does create and listen.) On subsequent calls (triggered by HMR), it **tears the previous app down**, rebuilds the Express app, and swaps the request handler on the existing server — no restart needed.
 
 ### What Is Preserved
 
@@ -30,8 +30,8 @@ On the first call, `bootstrap()` creates the application, registers error/shutdo
 |                        | Controller / service instances |
 |                        | Adapters and plugins           |
 
-The HTTP server is created once and never recreated. Only the request handler is
-swapped, so existing connections and listeners remain intact.
+The HTTP server is created once — by Vite in dev — and never recreated. Only the
+request handler is swapped, so existing connections and listeners remain intact.
 
 Everything an adapter or plugin owns — database pools, Redis clients, Socket.IO
 servers, message-queue consumers — is **rebuilt**, because the previous app's

--- a/docs/guide/hmr.md
+++ b/docs/guide/hmr.md
@@ -17,20 +17,42 @@ import { modules } from './modules'
 bootstrap({ modules })
 ```
 
-On the first call, `bootstrap()` creates the application, registers error/shutdown handlers, and starts the HTTP server. On subsequent calls (triggered by HMR), it rebuilds the Express app and swaps the request handler on the existing server — no restart needed.
+On the first call, `bootstrap()` creates the application, registers error/shutdown handlers, and starts the HTTP server. On subsequent calls (triggered by HMR), it **tears the previous app down**, rebuilds the Express app, and swaps the request handler on the existing server — no restart needed.
 
 ### What Is Preserved
 
-| Preserved across HMR      | Rebuilt on each reload  |
-| ------------------------- | ----------------------- |
-| `http.Server` instance    | Express app             |
-| Port binding              | Middleware stack        |
-| TCP connections           | Route table             |
-| Database connection pools | DI container singletons |
-| Redis clients             | Controller instances    |
-| Socket.IO server          | Service instances       |
+| Preserved across HMR   | Rebuilt on each reload         |
+| ---------------------- | ------------------------------ |
+| `http.Server` instance | Express app                    |
+| Port binding           | Middleware stack               |
+| TCP connections        | Route table                    |
+|                        | DI container singletons        |
+|                        | Controller / service instances |
+|                        | Adapters and plugins           |
 
-The HTTP server is created once and never recreated. Only the request handler is swapped, so existing connections and listeners remain intact.
+The HTTP server is created once and never recreated. Only the request handler is
+swapped, so existing connections and listeners remain intact.
+
+Everything an adapter or plugin owns — database pools, Redis clients, Socket.IO
+servers, message-queue consumers — is **rebuilt**, because the previous app's
+`shutdown()` runs before the new one starts.
+
+::: warning This changed
+Adapter-held resources used to be described as preserved. They were not
+preserved so much as **abandoned**: the old app was replaced without being shut
+down, so its adapters kept running and each save added another set.
+
+That surfaced as one process holding several message-queue consumer-group
+members — on a single-partition topic only one can hold the assignment, and it
+was a leaked consumer wired to nothing, so jobs silently stopped being
+processed. Two Socket.IO servers on the same HTTP server crashed
+`handleUpgrade()` the same way.
+
+The trade is deliberate: reconnecting a pool on each reload costs a moment,
+whereas leaking one costs a debugging session. If a resource is genuinely
+expensive to rebuild, hold it outside the adapter lifecycle — on `globalThis`,
+or behind a module-level singleton the adapter reuses.
+:::
 
 ## Configuring Vite
 
@@ -78,15 +100,54 @@ import.meta.hot?.on('kickjs:typecheck', (data) => {
 })
 ```
 
+### Writing an adapter that survives reloads
+
+Because `shutdown()` now runs on every rebuild and the adapter is then mounted
+again — often the _same instance_, since `config/adapters.ts` may not
+re-evaluate — an adapter has to be restartable, not just stoppable. Release the
+handle and null it out, so the next `beforeMount()` builds a fresh one:
+
+```ts
+let io: Server | undefined
+
+export const SocketAdapter = defineAdapter({
+  name: 'Socket',
+  build: () => ({
+    beforeStart({ server }) {
+      io = new Server(server) // rebuilt on each reload
+    },
+    async shutdown() {
+      if (!io) return
+      await new Promise<void>((resolve) => io!.close(() => resolve()))
+      io = undefined // ← without this, the next mount reuses a closed handle
+    },
+  }),
+})
+```
+
+An adapter that closes a resource without clearing its reference will appear to
+work on first boot and fail on the first save.
+
 ## Graceful Shutdown
 
-When the process receives `SIGINT` or `SIGTERM`, `bootstrap()` calls `app.shutdown()` which:
+`app.shutdown()` runs on two paths, and they differ in one respect.
 
-1. Runs all adapter `shutdown()` methods concurrently via `Promise.allSettled`
-2. Closes the HTTP server
-3. Exits the process
+**On `SIGINT` / `SIGTERM`** — the full sequence:
 
-Adapter shutdown failures are logged but do not prevent other adapters from cleaning up.
+1. Closes the HTTP server to stop accepting connections
+2. Waits for in-flight requests to drain (up to `shutdownTimeout`, default 30s)
+3. Runs all plugin and adapter `shutdown()` methods concurrently via `Promise.allSettled`
+4. Releases framework-owned resources (session / rate-limit intervals)
+5. Exits the process
+
+**On an HMR rebuild** — `shutdown({ closeServer: false })`, which runs steps 3
+and 4 only. The dev HTTP server is shared across rebuilds, so closing it would
+kill HMR on the first save; draining is skipped for the same reason, since the
+server keeps serving and there is nothing to drain toward.
+
+Plugin and adapter shutdown failures are logged but do not prevent the others
+from cleaning up — and on the HMR path a failure cannot leave the dev server
+with no app at all.
 
 ## Troubleshooting
 

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -108,7 +108,7 @@ beforeStart(ctx)
 | `onRouteMount(ctrl, path)` | After each module's routes are mounted          | OpenAPI spec generation, dependency-graph collection, route inventory                          |
 | `beforeStart(ctx)`         | After all routes mounted, before server listens | Log config summary, validate setup, late-stage DI                                              |
 | `afterStart(ctx)`          | After the HTTP server is listening              | Attach upgrade handlers (Socket.IO, gRPC), warm caches                                         |
-| `shutdown()`               | On SIGTERM/SIGINT                               | Close DB pools, flush logs, disconnect WS — runs concurrently via `Promise.allSettled`         |
+| `shutdown()`               | On SIGTERM/SIGINT **and on every HMR rebuild**  | Close DB pools, flush logs, disconnect WS — runs concurrently via `Promise.allSettled`         |
 
 Per-request teardown is separate from process shutdown: a REQUEST-scoped
 service method decorated with `@PreDestroy()` runs when its request's scope

--- a/packages/kickjs/__tests__/hmr-adapter-teardown.test.ts
+++ b/packages/kickjs/__tests__/hmr-adapter-teardown.test.ts
@@ -76,7 +76,11 @@ describe('shutdown({ closeServer: false }) — the HMR teardown path', () => {
     g.__kickjs_httpServer = server
     try {
       const app = new Application({ modules: [], adapters: [], port: 0 })
-      await app.setup()
+      // `start()`, not `setup()` — only `start()` adopts the shared
+      // `__kickjs_httpServer`. Under `setup()` `app.httpServer` stays undefined,
+      // so `closeServer` is never reached and this passed even when the flag
+      // was ignored outright.
+      await app.start()
 
       await app.shutdown({ closeServer: false })
 
@@ -186,16 +190,34 @@ describe('bootstrap() HMR rebuild', () => {
     __kickBootstrapped?: boolean
     __kickjs_container?: unknown
     __kickjs_httpServer?: http.Server
+    __kickjs_app_shutdown?: unknown
   }
-  let saved: typeof g
+  // Every global `bootstrap()`/`start()` touch, not just the two this suite
+  // sets itself — `__kickjs_container` and `__kickjs_app_shutdown` are written
+  // as a side effect, and leaving either behind hands the next test file a
+  // stale container or a shutdown hook bound to a dead app.
+  const GLOBAL_KEYS = [
+    '__app',
+    '__kickBootstrapped',
+    '__kickjs_container',
+    '__kickjs_httpServer',
+    '__kickjs_app_shutdown',
+  ] as const
+  let saved: Partial<Record<(typeof GLOBAL_KEYS)[number], unknown>>
 
   beforeEach(() => {
-    saved = { __app: g.__app, __kickBootstrapped: g.__kickBootstrapped }
+    saved = {}
+    for (const k of GLOBAL_KEYS) saved[k] = g[k]
     delete g.__app
   })
   afterEach(() => {
-    g.__app = saved.__app
-    g.__kickBootstrapped = saved.__kickBootstrapped
+    for (const k of GLOBAL_KEYS) {
+      // Restore absence as absence — assigning `undefined` leaves the key
+      // present, and `if (g.__kickjs_httpServer)` reads differently from
+      // a key that was never set.
+      if (saved[k] === undefined) delete (g as Record<string, unknown>)[k]
+      else (g as Record<string, unknown>)[k] = saved[k]
+    }
   })
 
   it('shuts the previous app down before replacing it', async () => {
@@ -207,19 +229,17 @@ describe('bootstrap() HMR rebuild', () => {
     await new Promise<void>((resolve) => server.listen(0, resolve))
     g.__kickjs_httpServer = server
 
-    try {
-      const opts = () => ({ modules: [], adapters: [countingAdapter(log, 'Kafka')], port: 0 })
-      await bootstrap(opts())
-      // The "save a file" moment.
-      await bootstrap(opts())
+    // No try/finally — the suite-level afterEach restores
+    // `__kickjs_httpServer` to whatever it was, which `delete` did not do.
+    const opts = () => ({ modules: [], adapters: [countingAdapter(log, 'Kafka')], port: 0 })
+    await bootstrap(opts())
+    // The "save a file" moment.
+    await bootstrap(opts())
 
-      // Previously: two live adapter sets, zero shutdowns — one leaked
-      // consumer per reload.
-      expect(log.filter((l) => l === 'Kafka:shutdown')).toHaveLength(1)
-      // And the shared dev server must survive the rebuild.
-      expect(server.listening).toBe(true)
-    } finally {
-      delete g.__kickjs_httpServer
-    }
+    // Previously: two live adapter sets, zero shutdowns — one leaked
+    // consumer per reload.
+    expect(log.filter((l) => l === 'Kafka:shutdown')).toHaveLength(1)
+    // And the shared dev server must survive the rebuild.
+    expect(server.listening).toBe(true)
   })
 })

--- a/packages/kickjs/__tests__/hmr-adapter-teardown.test.ts
+++ b/packages/kickjs/__tests__/hmr-adapter-teardown.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Every HMR rebuild used to leak an adapter set.
+ *
+ * `bootstrap()` keeps the live app on `globalThis.__app`, and the reload path
+ * even tested for it — then replaced it without calling `shutdown()`:
+ *
+ *   if (g.__app) {
+ *     const freshApp = new Application(options)
+ *     g.__app = freshApp        // old one dropped, still running
+ *   }
+ *
+ * `shutdown()` ran only from the SIGINT / SIGTERM handler, so in a dev session
+ * every save added another set of live adapters. Observed as one process
+ * holding several Kafka consumer-group members — on a single-partition topic
+ * only one can hold the assignment, and it was a leaked consumer wired to
+ * nothing, so jobs silently stopped being processed. A second socket.io server
+ * on the same HTTP server crashed `handleUpgrade()` by the same mechanism.
+ *
+ * The fix cannot simply call `shutdown()`: in dev the HTTP server is SHARED
+ * across rebuilds, so closing it kills the dev server on the first save. Hence
+ * `closeServer: false` — tear down adapters, keep the socket.
+ */
+import 'reflect-metadata'
+import http from 'node:http'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { Container } from '../src/index'
+import { Application } from '../src/http/application'
+import type { AppAdapter } from '../src/core'
+
+function countingAdapter(log: string[], name = 'Counting'): AppAdapter {
+  return {
+    name,
+    beforeMount: () => {
+      log.push(`${name}:start`)
+    },
+    shutdown: async () => {
+      log.push(`${name}:shutdown`)
+    },
+  }
+}
+
+let servers: http.Server[] = []
+beforeEach(() => Container.reset())
+afterEach(() => {
+  for (const s of servers.splice(0)) s.close()
+})
+
+describe('shutdown({ closeServer: false }) — the HMR teardown path', () => {
+  it('runs adapter shutdown', async () => {
+    const log: string[] = []
+    const app = new Application({ modules: [], adapters: [countingAdapter(log)], port: 0 })
+    await app.setup()
+
+    await app.shutdown({ closeServer: false })
+
+    expect(log).toContain('Counting:shutdown')
+  })
+
+  it('leaves the shared HTTP server listening', async () => {
+    // The load-bearing half. A full shutdown closes the server, which in dev
+    // is reused across rebuilds — doing that on reload kills HMR outright.
+    const server = http.createServer()
+    servers.push(server)
+    await new Promise<void>((resolve) => server.listen(0, resolve))
+    const g = globalThis as unknown as { __kickjs_httpServer?: http.Server }
+    const prev = g.__kickjs_httpServer
+    g.__kickjs_httpServer = server
+    try {
+      const app = new Application({ modules: [], adapters: [], port: 0 })
+      await app.setup()
+
+      await app.shutdown({ closeServer: false })
+
+      expect(server.listening).toBe(true)
+    } finally {
+      g.__kickjs_httpServer = prev
+    }
+  })
+
+  it('still closes the server on a real shutdown', async () => {
+    // The SIGINT path must be unchanged.
+    const app = new Application({ modules: [], adapters: [], port: 0 })
+    await app.start()
+    const server = app.getHttpServer()
+    expect(server).not.toBeNull()
+    servers.push(server!)
+
+    await app.shutdown()
+
+    expect(server!.listening).toBe(false)
+  })
+
+  it('tears down every adapter, not just the first', async () => {
+    const log: string[] = []
+    const app = new Application({
+      modules: [],
+      adapters: [countingAdapter(log, 'Ws'), countingAdapter(log, 'Kafka')],
+      port: 0,
+    })
+    await app.setup()
+
+    await app.shutdown({ closeServer: false })
+
+    expect(log).toContain('Ws:shutdown')
+    expect(log).toContain('Kafka:shutdown')
+  })
+
+  it('does not let one failing adapter block the others', async () => {
+    // A reload must not be wedged by a single bad teardown.
+    const log: string[] = []
+    const exploding: AppAdapter = {
+      name: 'Exploding',
+      shutdown: async () => {
+        throw new Error('teardown failed')
+      },
+    }
+    const app = new Application({
+      modules: [],
+      adapters: [exploding, countingAdapter(log, 'Kafka')],
+      port: 0,
+    })
+    await app.setup()
+
+    await expect(app.shutdown({ closeServer: false })).resolves.toBeUndefined()
+    expect(log).toContain('Kafka:shutdown')
+  })
+})
+
+/**
+ * The leak itself, through the real reload path.
+ *
+ * `bootstrap()` treats a populated `globalThis.__app` as "this is an HMR
+ * rebuild". Calling it twice in one process is exactly what a dev-server save
+ * does, so this counts how many adapter sets are left running.
+ */
+describe('bootstrap() HMR rebuild', () => {
+  const g = globalThis as unknown as {
+    __app?: unknown
+    __kickBootstrapped?: boolean
+    __kickjs_container?: unknown
+    __kickjs_httpServer?: http.Server
+  }
+  let saved: typeof g
+
+  beforeEach(() => {
+    saved = { __app: g.__app, __kickBootstrapped: g.__kickBootstrapped }
+    delete g.__app
+  })
+  afterEach(() => {
+    g.__app = saved.__app
+    g.__kickBootstrapped = saved.__kickBootstrapped
+  })
+
+  it('shuts the previous app down before replacing it', async () => {
+    const { bootstrap } = await import('../src/http/bootstrap')
+    const log: string[] = []
+    // A shared server, as the Vite plugin provides in dev.
+    const server = http.createServer()
+    servers.push(server)
+    await new Promise<void>((resolve) => server.listen(0, resolve))
+    g.__kickjs_httpServer = server
+
+    try {
+      const opts = () => ({ modules: [], adapters: [countingAdapter(log, 'Kafka')], port: 0 })
+      await bootstrap(opts())
+      // The "save a file" moment.
+      await bootstrap(opts())
+
+      // Previously: two live adapter sets, zero shutdowns — one leaked
+      // consumer per reload.
+      expect(log.filter((l) => l === 'Kafka:shutdown')).toHaveLength(1)
+      // And the shared dev server must survive the rebuild.
+      expect(server.listening).toBe(true)
+    } finally {
+      delete g.__kickjs_httpServer
+    }
+  })
+})

--- a/packages/kickjs/__tests__/hmr-adapter-teardown.test.ts
+++ b/packages/kickjs/__tests__/hmr-adapter-teardown.test.ts
@@ -25,7 +25,7 @@ import http from 'node:http'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { Container } from '../src/index'
 import { Application } from '../src/http/application'
-import type { AppAdapter } from '../src/core'
+import type { AppAdapter, KickPlugin } from '../src/core'
 
 function countingAdapter(log: string[], name = 'Counting'): AppAdapter {
   return {
@@ -33,6 +33,15 @@ function countingAdapter(log: string[], name = 'Counting'): AppAdapter {
     beforeMount: () => {
       log.push(`${name}:start`)
     },
+    shutdown: async () => {
+      log.push(`${name}:shutdown`)
+    },
+  }
+}
+
+function countingPlugin(log: string[], name = 'Metrics'): KickPlugin {
+  return {
+    name,
     shutdown: async () => {
       log.push(`${name}:shutdown`)
     },
@@ -102,6 +111,44 @@ describe('shutdown({ closeServer: false }) — the HMR teardown path', () => {
     await app.shutdown({ closeServer: false })
 
     expect(log).toContain('Ws:shutdown')
+    expect(log).toContain('Kafka:shutdown')
+  })
+
+  it('tears plugins down too, not only adapters', async () => {
+    // Step 3 of shutdown runs plugins and adapters together, so a plugin
+    // holding a timer or a connection leaked exactly the same way.
+    const log: string[] = []
+    const app = new Application({
+      modules: [],
+      adapters: [countingAdapter(log, 'Kafka')],
+      plugins: [countingPlugin(log, 'Metrics')],
+      port: 0,
+    })
+    await app.setup()
+
+    await app.shutdown({ closeServer: false })
+
+    expect(log).toContain('Metrics:shutdown')
+    expect(log).toContain('Kafka:shutdown')
+  })
+
+  it('does not let one failing plugin block adapter teardown', async () => {
+    const log: string[] = []
+    const exploding: KickPlugin = {
+      name: 'Exploding',
+      shutdown: async () => {
+        throw new Error('plugin teardown failed')
+      },
+    }
+    const app = new Application({
+      modules: [],
+      adapters: [countingAdapter(log, 'Kafka')],
+      plugins: [exploding],
+      port: 0,
+    })
+    await app.setup()
+
+    await expect(app.shutdown({ closeServer: false })).resolves.toBeUndefined()
     expect(log).toContain('Kafka:shutdown')
   })
 

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -56,6 +56,18 @@ const log = createLogger('Application')
  */
 export type MiddlewareEntry = RequestHandler | { path: string; handler: RequestHandler }
 
+/** Options for {@link Application.shutdown}. */
+export interface ShutdownOptions {
+  /**
+   * Close the HTTP server and drain in-flight requests. Default `true`.
+   *
+   * Set `false` for a dev HMR rebuild, where the server is shared across
+   * reloads — adapters, plugins, and disposables are still torn down, which is
+   * the part a reload needs.
+   */
+  closeServer?: boolean
+}
+
 export interface ApplicationOptions {
   /**
    * Feature modules to load. Accepts both class form
@@ -964,7 +976,13 @@ export class Application {
    *
    * Safe to call multiple times — subsequent calls return the same promise.
    */
-  async shutdown(): Promise<void> {
+  async shutdown(options: ShutdownOptions = {}): Promise<void> {
+    // `closeServer: false` is the HMR reload path. In dev the HTTP server is
+    // SHARED across rebuilds via `globalThis.__kickjs_httpServer`, so closing
+    // it would kill the dev server on the first save — which is why the reload
+    // path used to skip teardown entirely, leaking an adapter set per reload.
+    // Everything below Step 2 is what a reload actually needs.
+    const closeServer = options.closeServer ?? true
     // Prevent double-shutdown — return immediately if already initiated
     if (this._shutdownInitiated) {
       log.debug('Shutdown already in progress, skipping duplicate call')
@@ -992,12 +1010,15 @@ export class Application {
       // server.close() prevents new connections. Its callback fires only when
       // ALL existing connections are fully closed, so we do NOT await it here —
       // we track request draining separately via the tracking middleware.
-      if (this.httpServer) {
+      if (closeServer && this.httpServer) {
         this.httpServer.close(() => {})
       }
 
-      // Step 2: Wait for in-flight requests to drain (or timeout)
-      if (this._inFlightRequests > 0) {
+      // Step 2: Wait for in-flight requests to drain (or timeout).
+      // Skipped on a reload: the server keeps listening and the fresh app
+      // takes over, so there is nothing to drain toward — waiting would just
+      // stall the rebuild for up to `shutdownTimeout`.
+      if (closeServer && this._inFlightRequests > 0) {
         log.debug(`Waiting for ${this._inFlightRequests} in-flight request(s) to complete...`)
         const drainPromise = new Promise<'drained'>((resolve) => {
           this._drainResolvers.push(() => resolve('drained'))

--- a/packages/kickjs/src/http/bootstrap.ts
+++ b/packages/kickjs/src/http/bootstrap.ts
@@ -106,6 +106,29 @@ export async function bootstrap(options: ApplicationOptions): Promise<Applicatio
   // ── HMR rebuild ──────────────────────────────────────────────────────
   if (g.__app) {
     log.debug('HMR rebuild triggered')
+
+    // Tear the PREVIOUS app down before replacing it. Without this the old
+    // Application was dropped on the floor still running: its adapters kept
+    // their sockets and consumers open, so every save added another set.
+    //
+    // Observed in the wild as one process holding several consumer-group
+    // members — on a single-partition topic only one can hold the assignment,
+    // and it was a leaked consumer no longer wired to anything, so jobs
+    // stopped being processed. A second socket.io server on the same HTTP
+    // server crashed `handleUpgrade()` the same way.
+    //
+    // `closeServer: false` is load-bearing: the dev HTTP server is shared
+    // across rebuilds, so a full shutdown would close the listening socket and
+    // kill HMR on the first save.
+    //
+    // Failures are logged, not thrown — one broken adapter must not leave the
+    // dev server wedged with no app at all.
+    try {
+      await g.__app.shutdown({ closeServer: false })
+    } catch (err) {
+      log.error(err as Error, 'HMR teardown of the previous app failed')
+    }
+
     tryReloadEnv()
     Container.reset()
 


### PR DESCRIPTION
Framework fix for a leak diagnosed in the field: one API process holding several
Kafka consumer-group members, a crashed `handleUpgrade()`, and migration jobs
stuck unprocessed — all one bug.

## Root cause

`bootstrap()` keeps the live app on `globalThis.__app`. The reload path already
tested for it, then replaced it without tearing it down:

```ts
if (g.__app) {
  const freshApp = new Application(options)
  g.__app = freshApp        // old one dropped, still running
}
```

`shutdown()` ran only from the `SIGINT` / `SIGTERM` handler. So every save in a
dev session stacked another live adapter set on the last.

That matches the symptoms exactly. On a single-partition topic only one group
member can hold the assignment, and it was a leaked consumer from an earlier
reload wired to nothing — so jobs silently stopped being processed and the group
had never committed an offset. A second Socket.IO server on the same HTTP server
crashed `handleUpgrade()` by the same mechanism.

## Why the obvious fix breaks dev

`shutdown()` step 1 is `httpServer.close()`, and in dev the server is **shared
across rebuilds** via `globalThis.__kickjs_httpServer`. Calling plain
`shutdown()` on reload closes the listening socket and kills HMR on the first
save — almost certainly why the call was omitted rather than forgotten.

So `shutdown()` gains `{ closeServer?: boolean }` and the reload path passes
`false`:

| Step | SIGINT | HMR reload |
| --- | --- | --- |
| close HTTP server | ✓ | — shared across rebuilds |
| drain in-flight | ✓ | — server keeps serving |
| plugin + adapter `shutdown()` | ✓ | ✓ |
| release framework resources | ✓ | ✓ |

Teardown failures are logged, not thrown — one broken adapter must not leave the
dev server with no app at all.

## Verification

8 tests. The important one drives `bootstrap()` **twice**, which is exactly what
a save does, and asserts one teardown plus a still-listening server. Verified by
removing the call and watching it fail:

```text
× shuts the previous app down before replacing it
× tears plugins down too, not only adapters   (with step 3's plugin line removed)
```

Checked against the reporting app: its Kafka adapter calls
`consumer.disconnect()` and its Socket.IO adapter calls `io.close()`. Both were
already correct — they were simply never invoked.

## Docs, including a correction

`hmr.md` listed database pools, Redis clients, and the Socket.IO server as
**preserved across HMR**. They were not preserved so much as *abandoned* — that
was the bug. Those rows now say "rebuilt", with the reason.

The consequence most likely to bite adapter authors is documented too:
`shutdown()` now runs on every rebuild and the adapter is mounted again, often as
the **same instance** (`config/adapters.ts` may not re-evaluate). An adapter must
release its handle *and clear the reference* — one that closes a resource without
nulling it works on first boot and fails on the first save.

The trade is deliberate: reconnecting a pool per reload costs a moment, leaking
one costs a debugging session.

**787/787**, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved hot reload behavior by cleaning up the previous application before rebuilding.
  * Preserves the development server and active connections during hot reloads.
  * Recreates adapters, plugins, database, Redis, and Socket.IO resources cleanly.

* **Bug Fixes**
  * Prevents resource leaks during hot reloads.
  * Teardown errors are logged while allowing the rebuild to continue.
  * Ensures one failed cleanup does not block other shutdown operations.

* **Documentation**
  * Updated hot reload and application lifecycle guidance, including restartable adapter requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->