### PR TITLE
fix(http): time-box shutdown hooks so one wedged adapter cannot stall HMR

### DIFF
--- a/.changeset/timebox-shutdown-hooks.md
+++ b/.changeset/timebox-shutdown-hooks.md
@@ -29,3 +29,9 @@ teardown.
 
 A reload that ends with the shared server no longer listening now logs an
 explicit error naming the cause, instead of failing silently.
+
+Documents the rule this exposed: `shutdown()` runs on every HMR reload, and an
+adapter or plugin must release only what it owns — never the shared HTTP
+server. Covered in the adapter and plugin guides, the `AppAdapter` /
+`KickPlugin` type docs, and both generator scaffolds, which previously said
+`shutdown()` runs on SIGINT/SIGTERM only.

--- a/.changeset/timebox-shutdown-hooks.md
+++ b/.changeset/timebox-shutdown-hooks.md
@@ -1,0 +1,31 @@
+---
+'@forinda/kickjs': patch
+---
+
+Time-box each adapter and plugin `shutdown()` hook so one that never settles
+cannot wedge an HMR reload, and log an error when a hook closes the shared dev
+server.
+
+`shutdown()` awaited an unbounded `Promise.allSettled` over every hook. A hook
+with no path to settle hung the teardown forever. Since adapter teardown now
+runs on every reload, that turned one misbehaving adapter into a dev server
+that stopped rebuilding after the first save — with no error explaining why.
+
+The trigger in the wild was a socket.io adapter calling `io.close(cb)`. Two
+distinct traps, both fatal here:
+
+- `io.close()` closes the HTTP server socket.io was constructed with. In dev
+  that is the Vite server, and nothing rebinds it — every later request is
+  ECONNREFUSED and the process stays alive, so it reads as a hang rather than
+  a crash.
+- Its callback fires only once every client disconnects, so a single open
+  browser tab meant the promise never resolved.
+
+Each hook now gets its own budget: `shutdownTimeout` on a real shutdown, or
+`min(shutdownTimeout, 5s)` on a reload — nobody should wait 30s per save. A
+hook that overruns is logged by name and skipped, and the remaining hooks
+still run, so one wedged adapter no longer costs its neighbours their
+teardown.
+
+A reload that ends with the shared server no longer listening now logs an
+explicit error naming the cause, instead of failing silently.

--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -118,7 +118,72 @@ The `Application.setup()` method executes these steps in order:
 10. **Error handlers** -- notFound + global error handler
 11. **Adapter `beforeStart` hooks**
 
-After setup, when the HTTP server starts listening, `afterStart` is called. On shutdown, all adapter `shutdown` methods run concurrently via `Promise.allSettled` -- one failure does not block others.
+After setup, when the HTTP server starts listening, `afterStart` is called. On shutdown, all adapter `shutdown` methods run concurrently via `Promise.allSettled` -- one failure does not block others, and each hook is time-boxed so one that never settles cannot stall the others (see [Shutdown discipline](#shutdown-discipline) below).
+
+## Shutdown discipline
+
+**Close only what your adapter owns.** The `server` handed to `afterStart` is
+shared -- it belongs to the application, and in dev it belongs to Vite. Closing
+it from an adapter takes down the whole process's listener.
+
+This matters more than it looks, because adapter `shutdown()` runs on **every
+HMR reload**, not just on exit. A hook that is merely impolite at process exit
+becomes a hook that fires on every file save.
+
+### The socket.io trap
+
+`io.close()` is the canonical way to get this wrong:
+
+```ts
+// ✗ Wrong — two separate failures, both fatal in dev
+async shutdown() {
+  await new Promise<void>((resolve) => io.close(() => resolve()))
+}
+```
+
+1. `io.close()` **closes the HTTP server socket.io was constructed with**. In
+   dev that is Vite's listener. Nothing rebinds it, so every request after the
+   first save is `ECONNREFUSED` -- and because the process stays alive, it
+   reads as a hang rather than a crash.
+2. The callback fires only once **every client has disconnected**. One open
+   browser tab and the promise never settles, so the reload never finishes.
+
+Detach instead. `engine.close()` disconnects the clients and removes the
+`upgrade` / `request` listeners engine.io attached -- everything the adapter
+actually owns -- while leaving the server listening:
+
+```ts
+// ✓ Right — releases what the adapter owns, leaves the server alone
+async shutdown() {
+  io.disconnectSockets(true)
+  io.engine.close()
+  io.removeAllListeners()
+}
+```
+
+The same rule covers any `ws` / engine.io / GraphQL-WS server built on the
+shared `server`. On a real shutdown the framework closes that server itself, so
+an adapter never needs to.
+
+### Hooks are time-boxed
+
+Each `shutdown()` gets its own budget: `shutdownTimeout` (default 30s) on a real
+shutdown, or `min(shutdownTimeout, 5s)` on an HMR reload -- waiting the full
+timeout on every save would be unusable. A hook that overruns is logged by name
+and skipped:
+
+```
+WARN  Adapter 'Realtime' did not finish shutting down within 5000ms —
+      continuing without it. Its resources may still be held.
+```
+
+The remaining hooks still run, so one wedged adapter does not cost its
+neighbours their teardown. Treat that warning as a bug in the adapter: the
+budget keeps the dev server alive, it does not release the resource.
+
+If a reload ends with the shared server no longer listening, the framework logs
+an error naming the likely cause -- a silent dead port is the worst failure mode
+a dev server can have.
 
 ## Writing a Custom Adapter
 

--- a/docs/guide/hmr.md
+++ b/docs/guide/hmr.md
@@ -37,6 +37,16 @@ Everything an adapter or plugin owns — database pools, Redis clients, Socket.I
 servers, message-queue consumers — is **rebuilt**, because the previous app's
 `shutdown()` runs before the new one starts.
 
+::: warning Your `shutdown()` now runs on every save
+Because teardown runs per reload, an adapter that closes the **shared** HTTP
+server takes the dev server down on the first save and it never rebinds — the
+process stays alive, so it looks like a hang, not a crash. `io.close()` on a
+socket.io server does exactly this.
+
+Close only what your adapter owns. See
+[Shutdown discipline](./adapters.md#shutdown-discipline).
+:::
+
 ::: warning This changed
 Adapter-held resources used to be described as preserved. They were not
 preserved so much as **abandoned**: the old app was replaced without being shut

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -127,19 +127,43 @@ interface KickPluginInstance {
 }
 ```
 
-| Method           | When it runs                   | Use Case                                                                                  |
-| ---------------- | ------------------------------ | ----------------------------------------------------------------------------------------- |
-| `dependsOn`      | Topo-sorted at boot            | Names of other plugins that must mount first — see [Ordering](#plugin-ordering-dependson) |
-| `register()`     | Before modules load            | Bind services in DI                                                                       |
-| `modules()`      | Before user modules (static)   | Add feature modules — array form, statically introspectable                               |
-| `setup()`        | After `modules()`, before user | Conditionally `.mount(module)` based on captured config / env / runtime                   |
-| `adapters()`     | Before user adapters           | Add lifecycle adapters                                                                    |
-| `middleware()`   | Before user middleware         | Add global middleware                                                                     |
-| `contributors()` | Per-route, at mount            | Ship typed [Context Contributors](./context-decorators.md) the plugin owns                |
-| `onReady()`      | After server starts            | Post-startup tasks                                                                        |
-| `shutdown()`     | On SIGINT/SIGTERM              | Cleanup resources                                                                         |
-| `introspect()`   | DevTools poll                  | Snapshot of plugin state for the DevTools dashboard (counters, flags, tokens)             |
-| `devtoolsTabs()` | DevTools mount                 | Plugin-owned tabs rendered inside the DevTools UI                                         |
+| Method           | When it runs                     | Use Case                                                                                  |
+| ---------------- | -------------------------------- | ----------------------------------------------------------------------------------------- |
+| `dependsOn`      | Topo-sorted at boot              | Names of other plugins that must mount first — see [Ordering](#plugin-ordering-dependson) |
+| `register()`     | Before modules load              | Bind services in DI                                                                       |
+| `modules()`      | Before user modules (static)     | Add feature modules — array form, statically introspectable                               |
+| `setup()`        | After `modules()`, before user   | Conditionally `.mount(module)` based on captured config / env / runtime                   |
+| `adapters()`     | Before user adapters             | Add lifecycle adapters                                                                    |
+| `middleware()`   | Before user middleware           | Add global middleware                                                                     |
+| `contributors()` | Per-route, at mount              | Ship typed [Context Contributors](./context-decorators.md) the plugin owns                |
+| `onReady()`      | After server starts              | Post-startup tasks                                                                        |
+| `shutdown()`     | On shutdown AND every HMR reload | Release what the plugin owns                                                              |
+| `introspect()`   | DevTools poll                    | Snapshot of plugin state for the DevTools dashboard (counters, flags, tokens)             |
+| `devtoolsTabs()` | DevTools mount                   | Plugin-owned tabs rendered inside the DevTools UI                                         |
+
+### Shutdown discipline
+
+`shutdown()` runs on a real shutdown **and on every HMR reload** — in dev it is
+a hot path, not an exit-only courtesy. Two rules follow:
+
+**Release only what the plugin owns.** Never close the shared HTTP server. In
+dev that is Vite's listener; closing it leaves the port dead with no rebind,
+and since the process stays alive it presents as a hang rather than a crash.
+The framework closes that server itself on a real shutdown. Adapters hit this
+most often via socket.io — see
+[Shutdown discipline](./adapters.md#shutdown-discipline) for the full example.
+
+**Make it settle.** Each hook is time-boxed — `shutdownTimeout` on a real
+shutdown, `min(shutdownTimeout, 5s)` on a reload — and one that overruns is
+logged by name and skipped so it cannot stall its siblings:
+
+```
+WARN  Plugin 'Realtime' did not finish shutting down within 5000ms —
+      continuing without it. Its resources may still be held.
+```
+
+That warning is a bug report about the plugin. The budget keeps the dev server
+alive; it does not release the resource.
 
 ### `modules()` vs `setup()`
 

--- a/packages/cli/src/generators/adapter.ts
+++ b/packages/cli/src/generators/adapter.ts
@@ -181,11 +181,18 @@ export const ${pascal}Adapter = defineAdapter<${pascal}AdapterConfig>({
       },
 
       /**
-       * Runs on graceful shutdown (SIGINT/SIGTERM). Clean up long-lived
-       * resources the adapter owns: close connections, flush buffers,
-       * cancel timers. The framework runs every adapter's \`shutdown\`
-       * concurrently via \`Promise.allSettled\` — one failure won't block
-       * sibling adapters.
+       * Runs on graceful shutdown AND on every HMR reload. Clean up
+       * long-lived resources the adapter OWNS: close connections, flush
+       * buffers, cancel timers.
+       *
+       * Close only what you own — \`ctx.server\` is shared (in dev it is
+       * Vite's listener), and closing it kills the dev server with no
+       * rebind. socket.io's \`io.close()\` does this; use
+       * \`io.engine.close()\` to detach instead.
+       *
+       * The framework runs every adapter's \`shutdown\` concurrently via
+       * \`Promise.allSettled\`, each time-boxed — one failure or hang won't
+       * block sibling adapters.
        *
        * Delete this hook if your adapter holds no resources.
        */

--- a/packages/cli/src/generators/plugin.ts
+++ b/packages/cli/src/generators/plugin.ts
@@ -64,7 +64,7 @@ export interface ${pascal}PluginConfig {
  *   4. \`middleware()\`         — plugin middleware runs before user middleware.
  *   5. \`contributors()\`       — Context Contributors merged into every route.
  *   6. \`onReady(container)\`   — runs after the app has fully bootstrapped.
- *   7. \`shutdown()\`           — runs on graceful shutdown.
+ *   7. \`shutdown()\`           — on shutdown AND every HMR reload.
  *
  * @example
  * \`\`\`ts
@@ -161,8 +161,10 @@ export const ${pascal}Plugin = definePlugin<${pascal}PluginConfig>({
     },
 
     /**
-     * Called during graceful shutdown. Clean up any long-lived
-     * resources this plugin owns (connections, timers, subscriptions).
+     * Called during graceful shutdown AND on every HMR reload. Clean up
+     * long-lived resources this plugin OWNS (connections, timers,
+     * subscriptions). Never close the shared HTTP server — in dev that is
+     * Vite's listener and it will not rebind.
      */
     async shutdown(): Promise<void> {
       // Example: await this.connection?.close()

--- a/packages/kickjs/__tests__/hmr-adapter-teardown.test.ts
+++ b/packages/kickjs/__tests__/hmr-adapter-teardown.test.ts
@@ -184,6 +184,46 @@ describe('shutdown({ closeServer: false }) — the HMR teardown path', () => {
  * rebuild". Calling it twice in one process is exactly what a dev-server save
  * does, so this counts how many adapter sets are left running.
  */
+describe('a wedged shutdown hook cannot stall the reload', () => {
+  /** An adapter whose shutdown never settles — socket.io's `io.close(cb)` with a client still connected. */
+  const hangingAdapter = (): AppAdapter => ({
+    name: 'Hanging',
+    shutdown: () => new Promise<void>(() => {}),
+  })
+
+  it('gives up on a hook that never settles and finishes the teardown', async () => {
+    const app = new Application({
+      modules: [],
+      adapters: [hangingAdapter()],
+      port: 0,
+      shutdownTimeout: 50,
+    })
+    await app.setup()
+
+    // Without the per-hook time-box this never resolves: `allSettled` waits
+    // on a promise with no path to settle, so every save wedges forever with
+    // no app and no error.
+    await expect(app.shutdown({ closeServer: false })).resolves.toBeUndefined()
+  })
+
+  it('still runs the other adapters when one hangs', async () => {
+    const log: string[] = []
+    const app = new Application({
+      modules: [],
+      adapters: [hangingAdapter(), countingAdapter(log, 'Kafka')],
+      port: 0,
+      shutdownTimeout: 50,
+    })
+    await app.setup()
+
+    await app.shutdown({ closeServer: false })
+
+    // A wedged neighbour must not cost the Kafka consumer its teardown —
+    // that leak is the whole reason this path runs at all.
+    expect(log).toContain('Kafka:shutdown')
+  })
+})
+
 describe('bootstrap() HMR rebuild', () => {
   const g = globalThis as unknown as {
     __app?: unknown

--- a/packages/kickjs/__tests__/hmr-adapter-teardown.test.ts
+++ b/packages/kickjs/__tests__/hmr-adapter-teardown.test.ts
@@ -22,9 +22,10 @@
  */
 import 'reflect-metadata'
 import http from 'node:http'
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Container } from '../src/index'
 import { Application } from '../src/http/application'
+import { Logger } from '../src/core'
 import type { AppAdapter, KickPlugin } from '../src/core'
 
 function countingAdapter(log: string[], name = 'Counting'): AppAdapter {
@@ -220,6 +221,76 @@ describe('a wedged shutdown hook cannot stall the reload', () => {
 
     // A wedged neighbour must not cost the Kafka consumer its teardown —
     // that leak is the whole reason this path runs at all.
+    expect(log).toContain('Kafka:shutdown')
+  })
+})
+
+describe('time-box edge cases', () => {
+  it('does not warn about a hook that finished in time', async () => {
+    const warn = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => {})
+    try {
+      const app = new Application({
+        modules: [],
+        adapters: [countingAdapter([], 'Fast')],
+        port: 0,
+        shutdownTimeout: 30,
+      })
+      await app.setup()
+      await app.shutdown({ closeServer: false })
+
+      // Outlive the budget. `Promise.race` left the timer armed, so the
+      // warning fired here — accusing a hook that had already finished.
+      await new Promise((r) => setTimeout(r, 80))
+      expect(warn.mock.calls.flat().join(' ')).not.toContain('did not finish shutting down')
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('treats shutdownTimeout: 0 as no budget, not a zero-ms one', async () => {
+    const log: string[] = []
+    // Must be ASYNC to discriminate: a synchronous hook finishes before any
+    // timer can fire, so it passes either way and proves nothing.
+    const slowAdapter: AppAdapter = {
+      name: 'Kafka',
+      shutdown: async () => {
+        await new Promise((r) => setTimeout(r, 20))
+        log.push('Kafka:shutdown')
+      },
+    }
+    const app = new Application({
+      modules: [],
+      adapters: [slowAdapter],
+      port: 0,
+      shutdownTimeout: 0,
+    })
+    await app.setup()
+
+    // `Math.min(0, 5000)` is 0, so a zero-ms timer beat the hook and
+    // shutdown returned early — the exact opposite of "no forced exit".
+    await app.shutdown({ closeServer: false })
+    expect(log).toContain('Kafka:shutdown')
+  })
+
+  it('isolates a hook that throws synchronously', async () => {
+    const log: string[] = []
+    const exploding: AppAdapter = {
+      name: 'Exploding',
+      shutdown: () => {
+        throw new Error('sync boom')
+      },
+    }
+    const app = new Application({
+      modules: [],
+      adapters: [exploding, countingAdapter(log, 'Kafka')],
+      port: 0,
+      shutdownTimeout: 50,
+    })
+    await app.setup()
+
+    // The throw used to escape at the argument site, before `allSettled`
+    // could wrap it — taking the whole teardown down with it.
+    await expect(app.shutdown({ closeServer: false })).resolves.toBeUndefined()
     expect(log).toContain('Kafka:shutdown')
   })
 })

--- a/packages/kickjs/src/core/adapter.ts
+++ b/packages/kickjs/src/core/adapter.ts
@@ -223,7 +223,21 @@ export interface AppAdapter {
    */
   onHealthCheck?(): Promise<{ name: string; status: 'up' | 'down' }>
 
-  /** Called on shutdown — clean up connections */
+  /**
+   * Called on shutdown — release what this adapter owns.
+   *
+   * Runs on a real shutdown AND on **every HMR reload**, so treat it as a hot
+   * path in dev, not an exit-only courtesy.
+   *
+   * Close only what you own. The `server` from {@link AdapterContext} is
+   * SHARED — in dev it is Vite's listener — and closing it takes the dev
+   * server down with no way to rebind. `io.close()` on a socket.io server
+   * does exactly that; detach with `io.engine.close()` instead. The framework
+   * closes the shared server itself on a real shutdown.
+   *
+   * Time-boxed: `shutdownTimeout` on a real shutdown, `min(shutdownTimeout,
+   * 5s)` on a reload. Overruns are logged by name and skipped.
+   */
   shutdown?(): MaybePromise
 
   /**

--- a/packages/kickjs/src/core/plugin.ts
+++ b/packages/kickjs/src/core/plugin.ts
@@ -181,8 +181,18 @@ export interface KickPlugin {
   onReady?(container: Container): void | Promise<void>
 
   /**
-   * Called during application shutdown.
-   * Clean up plugin resources (connections, intervals, etc.).
+   * Called during application shutdown — release what this plugin owns
+   * (connections, intervals, subscriptions).
+   *
+   * Runs on a real shutdown AND on **every HMR reload**, so it is a hot path
+   * in dev, not an exit-only courtesy.
+   *
+   * Close only what you own. Never close the shared HTTP server: in dev it is
+   * Vite's listener, and closing it leaves the port dead with no rebind. The
+   * framework closes it itself on a real shutdown.
+   *
+   * Time-boxed: `shutdownTimeout` on a real shutdown, `min(shutdownTimeout,
+   * 5s)` on a reload. Overruns are logged by name and skipped.
    */
   shutdown?(): void | Promise<void>
 

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -1064,11 +1064,53 @@ export class Application {
         }
       }
 
-      // Step 3: Run all plugin + adapter shutdowns concurrently
+      // Step 3: Run all plugin + adapter shutdowns concurrently.
+      //
+      // Each hook is time-boxed INDIVIDUALLY. An unbounded `allSettled` here
+      // means one hook that never settles wedges the whole shutdown, and on
+      // the reload path that leaves the dev server with no app and no error —
+      // it just stops rebuilding. Seen with a socket.io adapter calling
+      // `io.close(cb)`: that callback fires only once every client
+      // disconnects, so a single open browser tab hung every save forever.
+      //
+      // A reload gets a much shorter budget than a real shutdown — nobody
+      // wants to wait `shutdownTimeout` (30s by default) per keystroke-save.
+      const hookTimeoutMs = closeServer ? timeoutMs : Math.min(timeoutMs, 5_000)
+      const timeBoxed = (label: string, hook: unknown): Promise<unknown> =>
+        Promise.race([
+          Promise.resolve(hook),
+          new Promise<undefined>((resolve) => {
+            const t = setTimeout(() => {
+              log.warn(
+                `${label} did not finish shutting down within ${hookTimeoutMs}ms — continuing without it. ` +
+                  `Its resources may still be held.`,
+              )
+              resolve(undefined)
+            }, hookTimeoutMs)
+            t.unref()
+          }),
+        ])
+
+      const wasListening = this.httpServer?.listening === true
       const results = await Promise.allSettled([
-        ...this.plugins.map((plugin) => Promise.resolve(plugin.shutdown?.())),
-        ...this.adapters.map((adapter) => Promise.resolve(adapter.shutdown?.())),
+        ...this.plugins.map((plugin) => timeBoxed(`Plugin '${plugin.name}'`, plugin.shutdown?.())),
+        ...this.adapters.map((adapter) =>
+          timeBoxed(`Adapter '${adapter.name}'`, adapter.shutdown?.()),
+        ),
       ])
+
+      // A reload must leave the shared dev server listening. If a hook closed
+      // it, every later request is ECONNREFUSED and the port never comes back
+      // — with nothing in the log to say why. socket.io's `close()` does
+      // exactly this: it closes the HTTP server it was constructed with.
+      if (!closeServer && wasListening && this.httpServer?.listening === false) {
+        log.error(
+          'An adapter or plugin closed the shared HTTP server during an HMR reload. ' +
+            'The dev server is now unreachable and will not rebind until you restart it. ' +
+            "Close only what you own: socket.io's `io.close()` closes the HTTP server passed " +
+            'to its constructor — on a reload, disconnect the sockets instead.',
+        )
+      }
       for (const result of results) {
         if (result.status === 'rejected') {
           log.error({ err: result.reason }, 'Adapter shutdown failed')

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -1075,27 +1075,50 @@ export class Application {
       //
       // A reload gets a much shorter budget than a real shutdown — nobody
       // wants to wait `shutdownTimeout` (30s by default) per keystroke-save.
+      // `shutdownTimeout: 0` means "no forced exit" for the drain above, so it
+      // disables the per-hook budget too. Anything else would invert the
+      // setting: `Math.min(0, 5_000)` is a ZERO-ms budget, which fires before
+      // any hook can settle and silently skips every cleanup there is.
       const hookTimeoutMs = closeServer ? timeoutMs : Math.min(timeoutMs, 5_000)
-      const timeBoxed = (label: string, hook: unknown): Promise<unknown> =>
-        Promise.race([
-          Promise.resolve(hook),
-          new Promise<undefined>((resolve) => {
-            const t = setTimeout(() => {
-              log.warn(
-                `${label} did not finish shutting down within ${hookTimeoutMs}ms — continuing without it. ` +
-                  `Its resources may still be held.`,
-              )
-              resolve(undefined)
-            }, hookTimeoutMs)
-            t.unref()
-          }),
-        ])
+      const timeBoxed = (label: string, run: () => unknown): Promise<unknown> => {
+        // Invoke inside the promise: a hook that throws SYNCHRONOUSLY would
+        // otherwise escape at the argument site, before `allSettled` wraps it,
+        // taking down the whole teardown instead of just its own entry.
+        const hook = (async () => run())()
+        if (hookTimeoutMs <= 0) return hook
+        return new Promise<unknown>((resolve, reject) => {
+          const t = setTimeout(() => {
+            log.warn(
+              `${label} did not finish shutting down within ${hookTimeoutMs}ms — continuing without it. ` +
+                `Its resources may still be held.`,
+            )
+            resolve(undefined)
+          }, hookTimeoutMs)
+          t.unref()
+          // Clear on BOTH paths. `Promise.race` alone leaves the timer armed,
+          // so a hook that finished promptly still logged a timeout warning
+          // once the budget elapsed — on the reload path that is a false
+          // accusation after every save.
+          hook.then(
+            (value) => {
+              clearTimeout(t)
+              resolve(value)
+            },
+            (err) => {
+              clearTimeout(t)
+              reject(err)
+            },
+          )
+        })
+      }
 
       const wasListening = this.httpServer?.listening === true
       const results = await Promise.allSettled([
-        ...this.plugins.map((plugin) => timeBoxed(`Plugin '${plugin.name}'`, plugin.shutdown?.())),
+        ...this.plugins.map((plugin) =>
+          timeBoxed(`Plugin '${plugin.name}'`, () => plugin.shutdown?.()),
+        ),
         ...this.adapters.map((adapter) =>
-          timeBoxed(`Adapter '${adapter.name}'`, adapter.shutdown?.()),
+          timeBoxed(`Adapter '${adapter.name}'`, () => adapter.shutdown?.()),
         ),
       ])
 


### PR DESCRIPTION
## Symptom

Reported against `7.1.0`: after any save the dev server stops responding and
never rebinds its port. The node process stays alive, so it reads as a hang
rather than a crash. Nothing in the log explains it.

```
INFO: cron adapter: stopped all scheduled tasks
INFO: kafka adapter: shut down
INFO: control-db adapter closed
INFO: tenant-db adapter closed
  HMR invalidated 1 token: index.ts
<nothing — port dead, process alive>
```

## Root cause

Two bugs that only combine into this once adapter teardown runs on reload
(#519).

**1. Unbounded hook await (this repo).** `shutdown()` awaited
`Promise.allSettled` over every plugin and adapter hook with no timeout. The
`shutdownTimeout` race guarded only Step 2, which the reload path skips. Any
hook with no path to settle hung the teardown forever, so the rebuild never
reached `start()`.

**2. `io.close()` on a shared server (app side).** The reporting app's
socket.io adapter called:

```ts
await new Promise<void>((resolve) => io?.close(() => resolve()))
```

`io.close()` closes the HTTP server socket.io was constructed with — in dev
that is Vite's listener. Nothing rebinds it. And the callback fires only once
every client disconnects, so one open browser tab meant the promise never
settled. That is both halves of the symptom: port closed immediately, teardown
never finished.

## Fix

Each hook is time-boxed individually — `shutdownTimeout` on a real shutdown,
`min(shutdownTimeout, 5s)` on a reload, since nobody should wait 30s per save.
An overrun is logged by name and skipped, and the remaining hooks still run: a
wedged adapter must not cost the Kafka consumer its teardown, which is the leak
this path exists to fix.

A reload that ends with the shared server no longer listening now logs an
explicit error naming the likely cause. Silent ECONNREFUSED is the worst
failure mode a dev server can have.

## Verification

Both new tests fail without the fix by timing out — the reported symptom
exactly, not a proxy for it:

```
× gives up on a hook that never settles and finishes the teardown  4001ms
× still runs the other adapters when one hangs                     4003ms
Error: Test timed out in 4000ms.
```

824 tests pass with it.

## Note for adapter authors

An adapter must close only what it owns. Anything constructed with the shared
`ctx.server` — socket.io, engine.io, a WebSocket server — should detach rather
than close it; the framework closes that server itself during a real shutdown.
For socket.io, `io.engine.close()` disconnects clients and removes the
upgrade/request listeners without touching the HTTP server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shutdown and reload operations now continue when an adapter or plugin does not finish shutting down.
  * Configured shutdown timeouts are honored during normal shutdowns.
  * Reload hooks are limited to five seconds, with timed-out hooks logged and skipped.
  * Reloads now report an explicit error if the shared development server is no longer running.

* **Tests**
  * Added coverage confirming shutdown completes and remaining adapters are still closed when a hook hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->