### PR TITLE
feat(http): add reply.ok(body) 200 sugar

### DIFF
--- a/.changeset/plain-otters-look.md
+++ b/.changeset/plain-otters-look.md
@@ -1,0 +1,9 @@
+---
+'@forinda/kickjs': minor
+---
+
+Add `reply.ok(body)` — the 200 sugar alongside `reply.created` / `reply.accepted` / `reply.noContent`.
+
+A bare `return body` already sends 200, but handlers that mix statuses ended up
+half-wrapped and half-bare. `reply.ok(body)` lets every branch read the same way
+and carries `Reply<200, T>` through response inference exactly like the others.

--- a/docs/guide/controllers.md
+++ b/docs/guide/controllers.md
@@ -305,7 +305,11 @@ Rules of precedence:
   client gets no payload type. Return the value (`return user`) or wrap it
   (`return reply(201, user)`) to keep inference exact.
 - Returning `undefined`/`void` changes nothing — pure imperative handlers behave exactly as before.
-- Sugars: `reply.ok(body)` (200), `reply.created(body)` (201), `reply.accepted(body)` (202), `reply.noContent()` (204). `reply.ok(body)` is the explicit form of a bare `return body` — same result, useful when a handler mixes statuses and you want every branch to read alike.
+- Sugars: `reply.ok(body)` (200), `reply.created(body)` (201), `reply.accepted(body)` (202), `reply.noContent()` (204). `reply.ok(body)` is the explicit form of a bare `return body` for any defined
+  body — useful when a handler mixes statuses and you want every branch to read
+  alike. The two differ for `undefined`: a bare `return undefined` sends nothing
+  (the imperative path stays in charge), while `reply.ok(undefined)` is an
+  explicit 200 with an empty json body.
 
 Returning values is what makes the handler's **response type statically
 inferable** — the foundation for typed-client generation. `kick typegen` fills

--- a/docs/guide/controllers.md
+++ b/docs/guide/controllers.md
@@ -305,7 +305,7 @@ Rules of precedence:
   client gets no payload type. Return the value (`return user`) or wrap it
   (`return reply(201, user)`) to keep inference exact.
 - Returning `undefined`/`void` changes nothing — pure imperative handlers behave exactly as before.
-- Sugars: `reply.created(body)` (201), `reply.accepted(body)` (202), `reply.noContent()` (204).
+- Sugars: `reply.ok(body)` (200), `reply.created(body)` (201), `reply.accepted(body)` (202), `reply.noContent()` (204). `reply.ok(body)` is the explicit form of a bare `return body` — same result, useful when a handler mixes statuses and you want every branch to read alike.
 
 Returning values is what makes the handler's **response type statically
 inferable** — the foundation for typed-client generation. `kick typegen` fills

--- a/packages/kickjs/__tests__/return-value-handlers.test.ts
+++ b/packages/kickjs/__tests__/return-value-handlers.test.ts
@@ -34,6 +34,11 @@ function makeControllers() {
       return [1, 2, 3]
     }
 
+    @Get('/ok')
+    ok(_ctx: RequestContext) {
+      return reply.ok({ via: 'reply.ok' })
+    }
+
     @Post('/created')
     create(_ctx: RequestContext) {
       return reply(201, { id: 'x1' })
@@ -103,6 +108,12 @@ for (const rt of RUNTIMES) {
       const app = await makeApp()
       const res = await request(app.handle.bind(app)).post('/api/v1/r/created').expect(201)
       expect(res.body).toEqual({ id: 'x1' })
+    })
+
+    it('reply.ok() sends 200 with the body', async () => {
+      const app = await makeApp()
+      const res = await request(app.handle.bind(app)).get('/api/v1/r/ok').expect(200)
+      expect(res.body).toEqual({ via: 'reply.ok' })
     })
 
     it('reply.noContent() sends an empty 204', async () => {

--- a/packages/kickjs/src/http/reply.ts
+++ b/packages/kickjs/src/http/reply.ts
@@ -41,6 +41,8 @@ export function reply<S extends number, T>(status: S, body: T): Reply<S, T> {
   return { [REPLY_BRAND]: true, status, body }
 }
 
+/** `reply(200, body)` — explicit form of a bare `return body`. */
+reply.ok = <T>(body: T): Reply<200, T> => reply(200, body)
 /** `reply(201, body)` */
 reply.created = <T>(body: T): Reply<201, T> => reply(201, body)
 /** `reply(202, body)` */


### PR DESCRIPTION
## Why

`reply` had sugars for 201/202/204 but not 200. A bare `return body` already
sends 200, so the gap was invisible until a handler mixed statuses — then it
read half-wrapped, half-bare:

```ts
if (cached) return cached                    // 200
return reply.created(await this.create(...)) // 201
```

## What

```ts
/** `reply(200, body)` — explicit form of a bare `return body`. */
reply.ok = <T>(body: T): Reply<200, T> => reply(200, body)
```

Carries `Reply<200, T>` through `InferHandlerResponse` exactly like the other
sugars, so the typed client still sees `T`.

## Tests

`packages/kickjs/__tests__/return-value-handlers.test.ts` — one case, run by the
shared suite across express, fastify and h3.

Verified it has teeth: temporarily made `reply.ok` emit `299` and all three
runtime variants failed; reverted, all 25 pass.

## Not included

No 4xx/5xx sugars — errors route through exception filters, not this path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `reply.ok(body)` as a convenient way to return successful HTTP 200 responses.
  - Preserves response type inference for returned payloads.

- **Documentation**
  - Updated controller guidance to document `reply.ok(body)` and its equivalence to returning a payload directly.

- **Tests**
  - Added coverage confirming the helper returns HTTP 200 responses with the expected JSON body across supported runtimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->