### PR TITLE
docs(cli): add a guard-vs-middleware-vs-contributor skill

### DIFF
--- a/.changeset/olive-days-invite.md
+++ b/.changeset/olive-days-invite.md
@@ -1,0 +1,13 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+Add a `guard-vs-middleware-vs-contributor` skill to the generated agent docs.
+
+Guards had one mention across every generated skill — a row in the docs-lookup
+table. Nothing said that KickJS has no guard primitive (a guard is a `(ctx, next)`
+middleware attached with `@Middleware()`, not a `CanActivate` class), that
+guards run before context contributors on every runtime, or that `ctx.res` is
+engine-native so `ctx.res.status(401).json(...)` is Express-only. The new skill
+covers the three-way choice, the ordering, and those traps; `kick g guard` /
+`g middleware` / `g contributor` are now in the CLI cheatsheet too.

--- a/packages/cli/src/generators/templates/project-docs.ts
+++ b/packages/cli/src/generators/templates/project-docs.ts
@@ -1075,6 +1075,95 @@ Same-key collisions WITHIN a precedence level throw \`DuplicateContributorError\
 - \`getRequestValue<string>('traceId')\` — generic is the **key** type, not value type.`,
     },
     {
+      slug: 'guard-vs-middleware-vs-contributor',
+      frontmatterName: 'kickjs-guard-vs-middleware-vs-contributor',
+      description:
+        'Use when adding auth checks, request-scoped values, or anything "before the handler" — picks between a guard, a middleware, and a context contributor.',
+      body: `**KickJS has no guard primitive.** There is no \`@Guard\`, no \`canActivate\`, no guard
+class to implement. A guard IS a middleware — the word only names a convention
+and a directory. If you are porting NestJS habits, this is the first thing to
+unlearn.
+
+| | Guard | Middleware | Context contributor |
+|---|---|---|---|
+| What it is | a middleware, by convention | a middleware | a declarative value producer |
+| Signature | \`(ctx, next)\` | \`(ctx, next)\` on \`@Middleware()\`, \`(req, res, next)\` in \`bootstrap({ middleware })\` | \`resolve(ctx, deps)\` returning a value |
+| Can end the request | yes | yes | **no** |
+| Runs | in the middleware stage | in the middleware stage | after ALL middleware |
+| Attached by | \`@Middleware(fn)\` | \`@Middleware(fn)\` or \`bootstrap({ middleware })\` | \`@LoadX\`, or a registration at module / adapter / bootstrap level |
+| Generator | \`kick g guard <name>\` | \`kick g middleware <name>\` | \`kick g contributor <name>\` |
+| Lands in | \`src/guards/<name>.guard.ts\` | \`src/middleware/<name>.middleware.ts\` | \`src/contributors/<name>.contributor.ts\` |
+
+Add \`-m <module>\` to any of those generators to place the file inside a module
+instead of the app-level directory.
+
+**Choosing**: does the thing ever need to STOP the request?
+- Yes, and it is authorization → guard.
+- Yes, anything else (rate limit, body rewrite, response stream, work before route matching) → middleware.
+- No, it only computes a value the handler or a service reads off \`ctx\` → contributor. Typed, ordered, boot-validated, and it cannot silently swallow the request.
+
+**Ordering — guards run BEFORE contributors.** Every runtime does the same
+thing: run \`entry.middlewares\` in order, bail if the response was written,
+then run the contributor pipeline, then the handler. So:
+
+\`\`\`ts
+// WRONG — tenant is always undefined here.
+export async function tenantGuard(ctx: RequestContext, next: () => void) {
+  const tenant = ctx.get('tenant') // contributors have not run yet
+  if (!tenant) return ctx.problem.forbidden()
+  next()
+}
+\`\`\`
+
+A guard that needs a resolved value must resolve it itself, or the check
+belongs in the contributor's own \`resolve\` (throw from there and the request
+error handler takes over).
+
+**Write responses with \`ctx.*\`, never \`ctx.res\`.** \`ctx.res\` is the ENGINE-NATIVE
+response object, so \`ctx.res.status(401).json(...)\` only works on Express —
+\`FastifyReply\` has no \`.json()\` and h3's event has no \`.status()\`. Use
+\`ctx.problem.unauthorized({ detail })\` (RFC 9457) or \`ctx.json(body, status)\`;
+those work on all four runtimes.
+
+**Guard shape**:
+
+\`\`\`ts
+import type { RequestContext } from '@forinda/kickjs'
+
+export async function adminGuard(ctx: RequestContext, next: () => void): Promise<void> {
+  const user = ctx.session?.user // requires the session middleware
+  if (!user) {
+    ctx.problem.unauthorized({ detail: 'Not signed in' })
+    return // do NOT call next()
+  }
+  if (user.role !== 'admin') {
+    ctx.problem.forbidden({ detail: 'Admin only' })
+    return
+  }
+  next()
+}
+\`\`\`
+
+\`\`\`ts
+@Middleware(adminGuard)
+@Get('/admin/stats')
+stats(ctx: RequestContext) { ... }
+\`\`\`
+
+Role checks that are purely declarative (\`@Public()\`, \`@Roles('admin')\`,
+\`@Can(...)\`) come from \`@forinda/kickjs-auth\` and need its adapter mounted.
+Hand-write a guard only for logic those don't express.
+
+**Red flags**:
+- \`class AdminGuard implements CanActivate\` / \`@UseGuards()\` — NestJS, not KickJS. Export a \`(ctx, next)\` function and attach with \`@Middleware()\`.
+- A guard calling \`next()\` AND writing a response — pick one; writing then continuing double-sends.
+- A guard reading \`ctx.get(...)\` for a contributor-produced key — contributors have not run yet.
+- \`ctx.res.status(403).json(...)\` in a guard — Express-only. Use \`ctx.problem.forbidden()\`.
+- A "guard" that only sets a value and always calls \`next()\` — that is a contributor wearing a guard's name.
+- Passing a \`(ctx, next)\` guard to \`bootstrap({ middleware })\` — global middleware is connect-style \`(req, res, next)\`. Mount guards per-route with \`@Middleware()\`.
+`,
+    },
+    {
       slug: 'query-parsing-list-endpoint',
       frontmatterName: 'kickjs-query-parsing-list-endpoint',
       description:
@@ -1197,6 +1286,7 @@ afterEach(() => {
 - \`kick start\` — run the built artifact (\`NODE_ENV=production\` auto-set).
 - \`kick g module <name>\` — add a feature module; structure follows \`pattern\` in \`kick.config.ts\`.
 - \`kick g scaffold <Name> <field:type>...\` — full CRUD module from field definitions.
+- \`kick g guard <name>\` / \`kick g middleware <name>\` / \`kick g contributor <name>\` — the three "before the handler" shapes. A guard is a middleware by convention, NOT a separate primitive.
 - \`kick add <pkg>\` — install optional packages (auto-resolves peer deps + package manager).
 - \`kick g --list\` — list every available generator (built-ins + plugin-shipped).
 - \`kick info\` — environment / version dump for bug reports.


### PR DESCRIPTION
## Why

Across all 14 generated skills, guards had exactly one mention — a row in the
`docs-lookup` table reading "Middleware and guards". Not in the Key Decorators
table, not in `cli-commands-cheatsheet` (`kick g guard` was absent entirely),
not in `deny-list`.

Contributor-vs-middleware was already covered in three places. Guards were the
gap, and it's the one where an agent's prior is strongest and wrongest: nothing
in the generated docs contradicts NestJS, so "add a guard" yields
`class AdminGuard implements CanActivate`.

## What the skill says

A guard is not a primitive here. It's a `(ctx, next)` middleware, attached with
`@Middleware(fn)`, generated into `src/guards/<name>.guard.ts`. The word names a
convention and a directory — nothing else. From that, two traps follow:

**Guards run before contributors.** Every runtime runs `entry.middlewares`,
bails if the response was written, then runs the contributor pipeline
(`express.ts:58`/`:66`, `fastify.ts:260`, `h3.ts:204`, `web/handler.ts:167`).
A guard reading `ctx.get('tenant')` for a contributor-produced key always sees
`undefined`.

**`ctx.res` is engine-native.** `ctx.res.status(401).json(...)` works only on
Express — `FastifyReply` has no `.json()`, h3's event has no `.status()`. The
guard *generator's own template* warns about this; the skills didn't, so an
agent writing a guard by hand never saw it. The skill points at
`ctx.problem.unauthorized({ detail })` / `ctx.json(body, status)`.

Plus a three-way table (guard / middleware / contributor: signature, can it end
the request, when it runs, how it attaches, which generator, where the file
lands) and a "does this ever need to STOP the request?" decision rule.

## Also

`kick g guard` / `kick g middleware` / `kick g contributor` added to the CLI
cheatsheet skill.

## Verification

Every claim was checked against source, not memory:

| Claim | Checked |
|---|---|
| middleware runs before contributors | all four runtime files |
| default output dirs | `generators/{guard,middleware,contributor}.ts` |
| `-m <module>` on all three | `commands/generate.ts:441/467/511` |
| `ctx.problem.unauthorized` / `.forbidden` | `http/context.ts:56/58` |
| global middleware is connect-style | `application.ts:617` → `runtime.useConnect` |

Scaffolded a project with the built CLI and read the emitted `SKILL.md` — the
table, both fenced blocks and the escaping all render. 624 CLI tests pass.

## Not included

No test pins the new skill: `agent-docs-layout.test.ts` already asserts skills
generate, and the content is prose, not logic. Say the word if you want a
content assertion.
