### PR TITLE
feat(cli): type kick g middleware for the configured runtime

### DIFF
--- a/.changeset/tidy-moons-shave.md
+++ b/.changeset/tidy-moons-shave.md
@@ -1,0 +1,17 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+`kick g middleware` now types the handler for the project's configured runtime.
+
+With `runtime: 'express'` in `kick.config.ts` it emits
+`(req: Request, res: Response, next: NextFunction)` from `express` — those
+scaffolds already carry `@types/express`, and only Express hands the handler its
+own request/response, so `req.originalUrl` and `res.json()` stop needing a cast.
+Fastify and h3 keep `node:http` types, which is what they actually receive
+(`request.raw` under Fastify, the node objects under h3).
+
+The express shape is opt-in on an explicit `runtime: 'express'`, never on an
+absent field: an unset `runtime` means a hand-written or pre-`--runtime` config
+that says nothing about the engine, and emitting `express` imports there is
+exactly how the original cross-runtime bug shipped.

--- a/packages/cli/__tests__/generators-engine-neutral.test.ts
+++ b/packages/cli/__tests__/generators-engine-neutral.test.ts
@@ -71,6 +71,9 @@ describe('kick g middleware', () => {
     const src = readOnly(dir)
     expect(src).not.toContain("from 'express'")
     expect(src).toContain('req: IncomingMessage')
+    // The comment interpolates the engine name; with no engine to name it must
+    // not say the project runs on `undefined`.
+    expect(src).not.toContain('undefined')
   })
 
   it('types the handler from express when the config says express', async () => {

--- a/packages/cli/__tests__/generators-engine-neutral.test.ts
+++ b/packages/cli/__tests__/generators-engine-neutral.test.ts
@@ -50,21 +50,41 @@ function readOnly(dir: string): string {
 }
 
 describe('kick g middleware', () => {
-  it('does not import from express', async () => {
+  for (const runtime of ['fastify', 'h3'] as const) {
+    it(`does not import from express on ${runtime}`, async () => {
+      const dir = tempDir()
+      await generateMiddleware({ name: 'audit', outDir: dir, runtime })
+      const src = readOnly(dir)
+      // A Fastify / h3 scaffold has neither `express` nor `@types/express`.
+      expect(src).not.toContain("from 'express'")
+      expect(src).toContain("from 'node:http'")
+      expect(src).toContain('req: IncomingMessage')
+      expect(src).toContain('res: ServerResponse')
+    })
+  }
+
+  it('stays on node:http when the config declares no runtime', async () => {
+    // An unset `runtime` is a hand-written or pre-`--runtime` config — it says
+    // nothing about the engine, so the portable shape is the only safe one.
     const dir = tempDir()
     await generateMiddleware({ name: 'audit', outDir: dir })
     const src = readOnly(dir)
-    // A Fastify / h3 scaffold has neither `express` nor `@types/express`.
     expect(src).not.toContain("from 'express'")
-    expect(src).toContain("from 'node:http'")
+    expect(src).toContain('req: IncomingMessage')
   })
 
-  it('types the handler from node, not the engine', async () => {
+  it('types the handler from express when the config says express', async () => {
+    // `@types/express` is a devDependency on exactly those scaffolds, and only
+    // Express hands the handler its own request/response — `req.originalUrl`
+    // and `res.json()` are real there and absent everywhere else.
     const dir = tempDir()
-    await generateMiddleware({ name: 'audit', outDir: dir })
+    await generateMiddleware({ name: 'audit', outDir: dir, runtime: 'express' })
     const src = readOnly(dir)
-    expect(src).toContain('req: IncomingMessage')
-    expect(src).toContain('res: ServerResponse')
+    expect(src).toContain("from 'express'")
+    expect(src).toContain('req: Request')
+    expect(src).toContain('res: Response')
+    expect(src).toContain('next: NextFunction')
+    expect(src).not.toContain("from 'node:http'")
   })
 })
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -424,7 +424,7 @@ export function registerGenerateCommand(program: Command, ctx?: KickCliPluginCon
   gen
     .command('middleware <name>')
     .description(
-      'Generate an Express middleware function\n' +
+      'Generate a global middleware function, typed for the configured runtime\n' +
         '  Use -m to scope it to a module: kick g middleware auth -m users',
     )
     .option('-o, --out <dir>', 'Output directory (overrides --module)')
@@ -442,6 +442,7 @@ export function registerGenerateCommand(program: Command, ctx?: KickCliPluginCon
         modulesDir,
         pattern: config?.pattern,
         pluralize: mc.pluralize ?? true,
+        runtime: config?.runtime,
       })
       printGenerated(files, dryRun)
     })

--- a/packages/cli/src/generators/middleware.ts
+++ b/packages/cli/src/generators/middleware.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path'
 import { writeFileSafe } from '../utils/fs'
 import { toPascalCase, toKebabCase, toCamelCase } from '../utils/naming'
 import { resolveOutDir } from '../utils/resolve-out-dir'
-import type { ProjectPattern } from '../config'
+import type { KickConfig, ProjectPattern } from '../config'
 
 interface GenerateMiddlewareOptions {
   name: string
@@ -11,10 +11,24 @@ interface GenerateMiddlewareOptions {
   modulesDir?: string
   pattern?: ProjectPattern
   pluralize?: boolean
+  /**
+   * The engine from `kick.config.ts`. Global middleware is connect-style on
+   * every runtime, but only Express hands the handler an `express.Request` —
+   * Fastify passes `request.raw` and h3 the node objects, so `node:http` is
+   * the honest type there (and those projects have no `express` dependency to
+   * import types from).
+   */
+  runtime?: KickConfig['runtime']
 }
 
 export async function generateMiddleware(options: GenerateMiddlewareOptions): Promise<string[]> {
   const { name, moduleName, modulesDir, pattern } = options
+  // Explicit opt-in, not a fallback: an unset `runtime` means a hand-written or
+  // pre-`--runtime` kick.config, which says nothing about the engine. Emitting
+  // express types there is how the original bug shipped — `express` isn't a
+  // dependency on a Fastify / h3 scaffold, so the import fails to compile.
+  // `kick new` always writes the field, so real Express projects still opt in.
+  const isExpress = options.runtime === 'express'
   const outDir = resolveOutDir({
     type: 'middleware',
     outDir: options.outDir,
@@ -31,7 +45,11 @@ export async function generateMiddleware(options: GenerateMiddlewareOptions): Pr
   const filePath = join(outDir, `${kebab}.middleware.ts`)
   await writeFileSafe(
     filePath,
-    `import type { IncomingMessage, ServerResponse } from 'node:http'
+    `${
+      isExpress
+        ? `import type { Request, Response, NextFunction } from 'express'`
+        : `import type { IncomingMessage, ServerResponse } from 'node:http'`
+    }
 
 export interface ${toPascalCase(name)}Options {
   // Add configuration options here. The factory below closes over the
@@ -74,14 +92,23 @@ export interface ${toPascalCase(name)}Options {
  *   @Middleware(${camel}())
  */
 export function ${camel}(options: ${toPascalCase(name)}Options = {}) {
-  // Typed from \`node:http\`, not \`express\`. Global middleware is connect-style
-  // on every engine, but a Fastify / h3 project has no \`express\` dependency —
-  // importing its types there is a compile error on a freshly generated file.
-  // Under Fastify the handler receives \`request.raw\` / a reply driver, and
-  // under h3 the node objects, so anything Express-only (\`req.originalUrl\`,
-  // \`res.json\`) is absent. Reach for \`ctx.*\` helpers when you need a typed
-  // response.
-  return (req: IncomingMessage, res: ServerResponse, next: () => void) => {
+${
+  isExpress
+    ? `  // Typed from \`express\` because that is this project's runtime
+  // (\`runtime: 'express'\` in kick.config.ts). Global middleware is
+  // connect-style on every engine, but only Express hands the handler its own
+  // request / response objects — so \`req.originalUrl\`, \`req.query\` and
+  // \`res.json()\` are all available here. Switching \`runtime\` later means
+  // re-typing this signature from \`node:http\`.
+  return (req: Request, res: Response, next: NextFunction) => {`
+    : `  // Typed from \`node:http\`, not \`express\`. Global middleware is connect-style
+  // on every engine, but this project runs on ${options.runtime} and has no
+  // \`express\` dependency to import types from. Under Fastify the handler
+  // receives \`request.raw\` / a reply driver, and under h3 the node objects, so
+  // anything Express-only (\`req.originalUrl\`, \`res.json\`) is absent. Reach
+  // for \`ctx.*\` helpers when you need a typed response.
+  return (req: IncomingMessage, res: ServerResponse, next: () => void) => {`
+}
     // Implement your middleware logic here. \`options\` is captured by
     // closure — log or read it anywhere in this handler body.
     void options

--- a/packages/cli/src/generators/middleware.ts
+++ b/packages/cli/src/generators/middleware.ts
@@ -29,6 +29,13 @@ export async function generateMiddleware(options: GenerateMiddlewareOptions): Pr
   // dependency on a Fastify / h3 scaffold, so the import fails to compile.
   // `kick new` always writes the field, so real Express projects still opt in.
   const isExpress = options.runtime === 'express'
+  // An unset `runtime` is a hand-written or pre-`--runtime` kick.config, so the
+  // comment must not claim the project runs on one.
+  const engineClause = options.runtime
+    ? `this project runs on ${options.runtime} and has no
+  // \`express\``
+    : `this project declares no \`runtime\` in kick.config.ts, so it
+  // may have no \`express\``
   const outDir = resolveOutDir({
     type: 'middleware',
     outDir: options.outDir,
@@ -102,8 +109,7 @@ ${
   // re-typing this signature from \`node:http\`.
   return (req: Request, res: Response, next: NextFunction) => {`
     : `  // Typed from \`node:http\`, not \`express\`. Global middleware is connect-style
-  // on every engine, but this project runs on ${options.runtime} and has no
-  // \`express\` dependency to import types from. Under Fastify the handler
+  // on every engine, but ${engineClause} dependency to import types from. Under Fastify the handler
   // receives \`request.raw\` / a reply driver, and under h3 the node objects, so
   // anything Express-only (\`req.originalUrl\`, \`res.json\`) is absent. Reach
   // for \`ctx.*\` helpers when you need a typed response.


### PR DESCRIPTION
## Why

`kick g middleware` emitted the same signature on every project:

```ts
return (req: IncomingMessage, res: ServerResponse, next: () => void) => {
```

That is *correct* for Fastify and h3 — the handler really does receive
`request.raw` under Fastify and the node objects under h3 — but it's lossy on
Express, where `req.originalUrl`, `req.query` and `res.json()` all genuinely
exist and every use needed a cast. Express scaffolds already install
`@types/express`.

The CLI has known the engine for a while: `kick new --runtime` writes `runtime`
into `kick.config.ts`, and the `kick/runtime` typegen already uses it to flip
`AdapterContext.app` / `getRuntimeApp()` to native types. This generator just
wasn't reading it.

## What changed

With `runtime: 'express'`:

```ts
import type { Request, Response, NextFunction } from 'express'
...
return (req: Request, res: Response, next: NextFunction) => {
```

Fastify and h3 are byte-for-byte unchanged apart from the comment naming the
engine.

## The bit worth reviewing

The express shape keys off an **explicit** `runtime: 'express'`, not
`options.runtime ?? 'express'`.

`generators-engine-neutral.test.ts` exists because this generator once emitted
express imports unconditionally, which doesn't compile on a Fastify scaffold —
`express` isn't a dependency there. An absent `runtime` field means a
hand-written or pre-`--runtime` config, which says nothing about the engine, so
defaulting it to Express would reopen exactly that hole for the projects least
likely to notice. `kick new` always writes the field, so real Express projects
opt in on their own.

## Tests

The existing "does not import from express" case now runs per non-Express
runtime, plus two new ones: the unset-config fallback, and the Express shape.

Confirmed they bite — flipping the condition to `options.runtime !== 'h3'`
fails two:

```
FAIL  kick g middleware > does not import from express on fastify
FAIL  kick g middleware > stays on node:http when the config declares no runtime
```

Also generated middleware end to end against a real `kick.config.ts` for both
express and fastify. 626 CLI tests pass.

## Scope

Only this generator. `kick g guard` and `@Middleware()` handlers are `(ctx, next)`
— engine-neutral by construction, nothing to condition. Scaffolded `src/index.ts`
was already runtime-correct (right factory, `express.json()` only on Express).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Middleware generation now adapts handler types to the configured runtime.
  * Express projects receive Express-specific request, response, and next-function types.
  * Fastify, h3, and projects without a configured runtime retain portable Node.js HTTP types.
* **Documentation**
  * Updated generator descriptions and generated comments to reflect runtime-specific behavior.
* **Tests**
  * Added coverage for Express, Fastify, h3, and runtime-neutral middleware generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->