### PR TITLE
docs(client): show how to drive the typed client with axios

### DIFF
--- a/docs/guide/typed-client-recipes.md
+++ b/docs/guide/typed-client-recipes.md
@@ -204,12 +204,17 @@ the inferred return types all work the same way.
   `304` must be constructed with `null`, hence the `empty` guard. Without it a
   `noContent()` handler fails in the adapter rather than resolving to
   `undefined`.
-- **SSE does not work.** [`api.stream()`](./typed-client.md#typed-sse-streams)
-  reads `response.body` as a `ReadableStream`; `responseType: 'arraybuffer'`
-  produces none, and in the browser axios is XHR-based and cannot stream at all.
-  On Node you can special-case streaming requests with `responseType: 'stream'`
-  plus `Readable.toWeb()`, but there is no browser fix. **If the app calls
-  `api.stream()`, keep native fetch.**
+- **SSE hangs — it does not fail.**
+  [`api.stream()`](./typed-client.md#typed-sse-streams) consumes
+  `response.body` incrementally, but `responseType: 'arraybuffer'` makes axios
+  buffer: it resolves only once the response _ends_, and an SSE response never
+  ends. So `await axios(...)` never returns. The stream is not the problem —
+  the `Response` this adapter builds does carry a `body` — the buffering is.
+  Axios can stream (`responseType: 'stream'` on Node's `http` adapter, or the
+  `fetch` adapter, which is not the browser default — that's `xhr`), but each
+  route needs a second code path in the adapter, and the `fetch` adapter puts
+  you back on fetch anyway. **If the app calls `api.stream()`, keep native
+  fetch for it.**
 
 ### Do you actually need axios?
 
@@ -227,12 +232,18 @@ Two of the usual reasons are already covered without the dependency:
   native fetch and you keep streaming:
   ```ts
   fetch: async (request) => {
+    // Replay only what is safe to repeat. A 5xx does NOT prove the server
+    // ignored the request — retrying a POST can double-charge a customer.
+    const replayable = request.method === 'GET' || request.method === 'HEAD'
     for (let attempt = 0; ; attempt++) {
       const res = await fetch(request.clone())
-      if (res.status < 500 || attempt === 2) return res
+      if (!replayable || res.status < 500 || attempt === 2) return res
     }
   }
   ```
+  Retrying writes needs more than a method check: the endpoint has to be
+  idempotent on the server, usually via a client-sent idempotency key it
+  dedupes on. Don't widen the condition without that guarantee.
 
 axios earns its place when you need something native fetch genuinely lacks —
 upload/download progress events, or a shared instance the rest of a legacy app

--- a/docs/guide/typed-client-recipes.md
+++ b/docs/guide/typed-client-recipes.md
@@ -153,6 +153,91 @@ function NewTask() {
 }
 ```
 
+## axios instead of native fetch
+
+The client never calls global `fetch` directly — it goes through the optional
+`fetch` option, which takes a web-standard `Request` and returns a `Response`.
+Anything matching that shape works, so axios needs an adapter, not a wrapper
+package:
+
+```ts
+// src/api.ts
+import axios from 'axios'
+import { createClient } from '@forinda/kickjs-client'
+
+export const api = createClient<KickApi>({
+  baseUrl: '/api/v1',
+  fetch: async (request) => {
+    const res = await axios({
+      url: request.url,
+      method: request.method,
+      headers: Object.fromEntries(request.headers),
+      data: request.body ? await request.text() : undefined,
+      signal: request.signal,
+      responseType: 'arraybuffer',
+      validateStatus: () => true, // KickClientError owns non-2xx, not axios
+    })
+
+    const headers = new Headers()
+    for (const [key, value] of Object.entries(res.headers.toJSON())) {
+      for (const one of Array.isArray(value) ? value : [value]) {
+        headers.append(key, String(one))
+      }
+    }
+    const empty = res.status === 204 || res.status === 205 || res.status === 304
+    return new Response(empty ? null : res.data, { status: res.status, headers })
+  },
+})
+```
+
+Everything downstream is unchanged — the recipes above, `KickClientError`, and
+the inferred return types all work the same way.
+
+### Three things that will bite you
+
+- **`validateStatus: () => true` is mandatory.** axios rejects on 4xx/5xx by
+  default, so the axios error escapes before the client can build a
+  [`KickClientError`](./typed-client.md#errors). Every `catch` block that reads
+  `err.status` / `err.body` breaks. Let axios resolve every status and leave the
+  throwing to the client.
+- **Null-body statuses throw in the `Response` constructor.** `204`, `205` and
+  `304` must be constructed with `null`, hence the `empty` guard. Without it a
+  `noContent()` handler fails in the adapter rather than resolving to
+  `undefined`.
+- **SSE does not work.** [`api.stream()`](./typed-client.md#typed-sse-streams)
+  reads `response.body` as a `ReadableStream`; `responseType: 'arraybuffer'`
+  produces none, and in the browser axios is XHR-based and cannot stream at all.
+  On Node you can special-case streaming requests with `responseType: 'stream'`
+  plus `Readable.toWeb()`, but there is no browser fix. **If the app calls
+  `api.stream()`, keep native fetch.**
+
+### Do you actually need axios?
+
+Two of the usual reasons are already covered without the dependency:
+
+- **Auth interceptors** — `headers` accepts an async factory that runs per
+  request, so token refresh needs no interceptor:
+  ```ts
+  createClient<KickApi>({
+    baseUrl: '/api/v1',
+    headers: async () => ({ authorization: `Bearer ${await getToken()}` }),
+  })
+  ```
+- **Retries, logging, tracing** — the `fetch` option is the interceptor. Wrap
+  native fetch and you keep streaming:
+  ```ts
+  fetch: async (request) => {
+    for (let attempt = 0; ; attempt++) {
+      const res = await fetch(request.clone())
+      if (res.status < 500 || attempt === 2) return res
+    }
+  }
+  ```
+
+axios earns its place when you need something native fetch genuinely lacks —
+upload/download progress events, or a shared instance the rest of a legacy app
+already configures.
+
 ## Conventions that pay off
 
 - **One `api.ts`, one place for auth** — the `headers` factory runs per request,

--- a/docs/guide/typed-client.md
+++ b/docs/guide/typed-client.md
@@ -156,6 +156,11 @@ expect(await api.get('/tasks/:id', { params: { id: '1' } })).toEqual(task)
   with `@Get('/', { response: schema })` (which also feeds
   [Swagger](./swagger.md#declared-response-schemas)).
 
+- The `fetch` option is the transport seam — pass any
+  `(request: Request) => Promise<Response>` to swap in a platform fetch, add
+  retries/logging, or drive the client with axios. See
+  [axios instead of native fetch](./typed-client-recipes.md#axios-instead-of-native-fetch).
+
 Using TanStack Query or SWR? See the
 [recipes](./typed-client-recipes.md) — the client's inference flows straight
 through `queryFn`/fetchers, no wrapper needed.


### PR DESCRIPTION
## Why

The typed client already has a transport seam — `ClientOptions.fetch` accepts any
`(request: Request) => Promise<Response>` ([`packages/client/src/index.ts:154`](https://github.com/forinda/kick-js/blob/main/packages/client/src/index.ts#L154), used for both `run()` and `openStream()` at `:271`).

Nothing outside `createTestClient` documented it, so two reasonable questions had no answer in the docs:

- "how do I use axios instead of native fetch?"
- "where do interceptors go?"

Docs-only. No package change, no new dependency, no changeset.

## What

**`docs/guide/typed-client-recipes.md`** — new `## axios instead of native fetch` section:

- the adapter (about 15 lines, pasteable)
- three failure modes, each of which silently breaks a different part of the client
- a "do you actually need axios?" subsection

**`docs/guide/typed-client.md`** — one Notes bullet pointing at it, so the seam is discoverable from the main guide rather than only from the recipes page.

## The three traps, and why they're in the docs rather than left to the reader

| Trap | What breaks |
| --- | --- |
| `validateStatus: () => true` omitted | axios rejects on 4xx/5xx by default, so the axios error escapes **before** the client constructs `KickClientError`. Every `catch` reading `err.status` / `err.body` breaks. |
| Null-body guard omitted | `new Response(body, { status: 204 })` throws. A `noContent()` handler fails inside the adapter instead of resolving to `undefined`. |
| SSE | `api.stream()` reads `response.body` as a `ReadableStream`. `responseType: 'arraybuffer'` produces none, and browser axios is XHR-based and cannot stream at all. Node has a `responseType: 'stream'` + `Readable.toWeb()` workaround; the browser has none. **If the app calls `api.stream()`, keep native fetch.** |

## Interceptors

The section answers this directly, because two of the three usual reasons to reach for axios don't need it:

- **auth** — `headers` accepts an async factory that runs per request, so token refresh needs no interceptor
- **retries / logging / tracing** — the `fetch` option *is* the interceptor, and wrapping native fetch keeps streaming working

axios earns its place for progress events or a shared instance a legacy app already configures. That's stated rather than implied.

## Verification

Ran the documented snippet against the real `createClient` with a stub matching axios' response contract (`status` / arraybuffer `data` / `headers.toJSON()` / `validateStatus`): json round-trip, 204, non-2xx, and request body all pass.

Sabotage-checked both fixable traps:

- relaxing to `validateStatus: (s) => s < 400` → `expected Error: axios threw to be an instance of KickClientError`
- `const empty = false` → `× 204 does not throw in the Response constructor`

The scratch test is **not** committed. It would only re-test a copy of the snippet and drift from it; `client.test.ts` already covers the `fetch` seam itself.

`pnpm docs:build` passes (VitePress fails on dead links, so the three new cross-refs resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViFD8FXyNzwnAd3ixx7biB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using a configurable fetch transport with the typed client.
  * Added an Axios adapter recipe covering request forwarding, response handling, abort signals, and empty-body responses.
  * Documented considerations for non-2xx responses, browser-based SSE streaming, retries, logging, and tracing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->