### PR TITLE
fix(hooks): lint and format files sitting directly in packages/*/src

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,6 +12,14 @@
 # Commands below run in parallel. Each `glob:` filters the command to
 # the files actually staged in this commit, so a commit that touches
 # only Markdown skips the token-lint pass entirely.
+#
+# Each source glob is listed TWICE — `dir/*.ts` alongside `dir/**/*.ts`.
+# lefthook's `**` requires at least one intervening directory, so
+# `packages/*/src/**/*.ts` matches `src/http/application.ts` but NOT
+# `src/web.ts`. Without the single-star twin, every file sitting directly
+# in `packages/*/src` or `packages/*/__tests__` reported
+# "no files for inspection" and skipped both format and lint — 300+ files,
+# including every package's `index.ts`. Only CI caught them.
 
 pre-commit:
   parallel: true
@@ -21,7 +29,7 @@ pre-commit:
     # (VitePress docs, README, articles), mirroring the
     # `format:check` script.
     format:
-      glob: '{packages/*/src/**/*.{ts,tsx,js,mjs,cjs},packages/*/__tests__/**/*.{ts,tsx},packages/*/spa/src/**/*.{ts,tsx},docs/**/*.md,docs/.vitepress/**/*.{ts,mts,vue},tutorials/**/*.md,scripts/*.{ts,js,mjs},*.md}'
+      glob: '{packages/*/src/*.{ts,tsx,js,mjs,cjs},packages/*/src/**/*.{ts,tsx,js,mjs,cjs},packages/*/__tests__/*.{ts,tsx},packages/*/__tests__/**/*.{ts,tsx},packages/*/spa/src/*.{ts,tsx},packages/*/spa/src/**/*.{ts,tsx},docs/**/*.md,docs/.vitepress/**/*.{ts,mts,vue},tutorials/**/*.md,scripts/*.{ts,js,mjs},*.md}'
       # CHANGELOGs are changesets-generated and oxfmt-ignored (.oxfmtrc).
       # Without this exclude, the release bot's version commit stages ONLY
       # changelogs, oxfmt sees zero unignored targets, exits 2, and the
@@ -32,7 +40,7 @@ pre-commit:
     # repo). Runs only when a TS file under packages/ is staged so
     # markdown-only or example-only commits skip lint.
     lint:
-      glob: '{packages/*/src/**/*.{ts,tsx},packages/*/__tests__/**/*.{ts,tsx},packages/*/spa/src/**/*.{ts,tsx},scripts/*.ts,docs/.vitepress/**/*.{ts,mts}}'
+      glob: '{packages/*/src/*.{ts,tsx},packages/*/src/**/*.{ts,tsx},packages/*/__tests__/*.{ts,tsx},packages/*/__tests__/**/*.{ts,tsx},packages/*/spa/src/*.{ts,tsx},packages/*/spa/src/**/*.{ts,tsx},scripts/*.ts,docs/.vitepress/**/*.{ts,mts}}'
       run: pnpm exec oxlint {staged_files}
     # Token-convention lint (kick-lint). Runs only when a TS file
     # under packages/ is staged — adopters editing docs / examples


### PR DESCRIPTION
## The bug

lefthook's `**` requires **at least one intervening directory**. So this glob:

```
packages/*/src/**/*.{ts,tsx}
```

matches `packages/kickjs/src/http/application.ts` but **not** `packages/kickjs/src/web.ts`.

Staging only a top-level file printed:

```
│  format (skip) no files for inspection
│  lint (skip) no files for inspection
```

…and the commit went through unchecked.

## Blast radius

| Location | Files skipped |
| --- | --- |
| `packages/*/src/*.ts` | 111 |
| `packages/*/__tests__/*.ts` | 207 |

Every package's `index.ts`, plus `web.ts`, `cli.ts`, `config.ts`, and roughly two thirds of the test suite. Only the CI `Lint (oxlint)` and `Format` jobs ever looked at them.

## How it surfaced

While finishing #537 I left the same dangling import in two files. The hook rejected the one in `src/http/application.ts` and passed the one in `src/web.ts` — same commit, same rule, same error. Chasing the asymmetry found this.

## Fix

Each source glob gets a single-star twin alongside its `**` form. The `**` patterns are untouched, so nested matching is unchanged by construction.

```diff
-glob: '{packages/*/src/**/*.{ts,tsx}, …}'
+glob: '{packages/*/src/*.{ts,tsx},packages/*/src/**/*.{ts,tsx}, …}'
```

Applied to both `format` and `lint`, across `src`, `__tests__`, and `spa/src`. `lint-tokens` already used `packages/**/*.ts` and was never affected.

A comment above the block records why the duplication exists, so nobody "tidies" the twins away.

## Verification

Staged a `src/web.ts` carrying an unused variable and deliberate bad formatting, then ran the hook.

Before:
```
format (skip) no files for inspection
lint   (skip) no files for inspection
```

After:
```
packages/kickjs/src/web.ts:243:9: error eslint(no-unused-vars): Variable 'bad' is declared but never used.
Format issues found in above 1 files.
🥊 lint (0.41 seconds)
🥊 format (0.44 seconds)
```

Both commands fire and both fail, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViFD8FXyNzwnAd3ixx7biB
