### PR TITLE
fix(cli): stop scaffolding a version that does not exist

### DIFF
--- a/.changeset/cli-version-fallback-404.md
+++ b/.changeset/cli-version-fallback-404.md
@@ -9,7 +9,7 @@ back to the CLI's own version on failure. Sibling packages version
 independently, so that fallback names a release that does not exist and the
 scaffold died at install time:
 
-```
+```text
 npm error 404 '@forinda/kickjs-vite@^6.14.1' is not in this registry
 ```
 

--- a/.changeset/cli-version-fallback-404.md
+++ b/.changeset/cli-version-fallback-404.md
@@ -1,0 +1,27 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+`kick new`: stop pinning siblings to the CLI's own version when the registry query fails
+
+`resolveSiblingVersions()` queries `npm view <pkg> version` per package and fell
+back to the CLI's own version on failure. Sibling packages version
+independently, so that fallback names a release that does not exist and the
+scaffold died at install time:
+
+```
+npm error 404 '@forinda/kickjs-vite@^6.14.1' is not in this registry
+```
+
+Three changes:
+
+- The fallback is now `latest`, which always resolves. `@forinda/kickjs-cli`
+  keeps the version pin, since there it is genuinely the right one.
+- The queries actually run concurrently. `captureCommand` is `execFileSync`, so
+  the existing `Promise.all` ran all ten serially — new `captureCommandAsync`
+  fixes that.
+- The per-query timeout goes from 5s to 20s. A warm `npm view` against the
+  public registry measures 0.6–3.6s per package, so 5s was one slow response
+  away from expiring.
+
+A scaffold that had to fall back now says so instead of failing later.

--- a/packages/cli/__tests__/scaffold-version-fallback.test.ts
+++ b/packages/cli/__tests__/scaffold-version-fallback.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression guard: a failed `npm view` must never fabricate a version.
+ *
+ * `resolveSiblingVersions()` used to fall back to the CLI's own version for
+ * every sibling. Under independent versioning that names a release which does
+ * not exist, so the scaffold installed clean and then died:
+ *
+ *   npm error 404 '@forinda/kickjs-vite@^6.14.1' is not in this registry
+ *
+ * The query is a network call — measured 0.6–3.6s per package against the
+ * public registry — so the fallback path is reached in the wild, not just in
+ * theory. It must yield something installable.
+ *
+ * @module @forinda/kickjs-cli/__tests__/scaffold-version-fallback.test
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const capture = vi.fn()
+
+vi.mock('../src/utils/shell', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/utils/shell')>()),
+  captureCommandAsync: (...args: unknown[]) => capture(...args),
+}))
+
+const { resolveSiblingVersions } = await import('../src/generators/project')
+const cliVersion = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
+  .version as string
+
+describe('resolveSiblingVersions', () => {
+  it('falls back to a resolvable range when npm view fails', async () => {
+    capture.mockResolvedValue(null)
+
+    const versions = await resolveSiblingVersions()
+
+    for (const [name, range] of Object.entries(versions)) {
+      if (name === '@forinda/kickjs-cli') {
+        // The CLI's own version is the one pin that is genuinely correct.
+        expect(range).toBe(`^${cliVersion}`)
+      } else {
+        expect(range).toBe('latest')
+      }
+    }
+  })
+
+  it('never pins a sibling to the CLI version', async () => {
+    // The exact shape of the 404: every sibling wearing the CLI's version.
+    capture.mockResolvedValue(null)
+
+    const versions = await resolveSiblingVersions()
+    const siblings = Object.entries(versions).filter(([n]) => n !== '@forinda/kickjs-cli')
+
+    expect(siblings.length).toBeGreaterThan(0)
+    expect(siblings.filter(([, r]) => r === `^${cliVersion}`)).toEqual([])
+  })
+
+  it('uses the published version when npm view answers', async () => {
+    capture.mockResolvedValue('8.0.0')
+
+    const versions = await resolveSiblingVersions()
+
+    expect(versions['@forinda/kickjs-vite']).toBe('^8.0.0')
+  })
+
+  it('runs the queries concurrently, not serially', async () => {
+    // `captureCommand` is execFileSync — `Promise.all` over it gives zero
+    // concurrency, so the per-call timeout multiplies by the package count.
+    let live = 0
+    let peak = 0
+    capture.mockImplementation(async () => {
+      peak = Math.max(peak, ++live)
+      await new Promise((r) => setTimeout(r, 10))
+      live--
+      return '1.0.0'
+    })
+
+    await resolveSiblingVersions()
+
+    expect(peak).toBeGreaterThan(1)
+  })
+})

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -1,9 +1,9 @@
 import { join, dirname } from 'node:path'
 import { execSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { writeFileSafe } from '../utils/fs'
-import { captureCommand } from '../utils/shell'
+import { captureCommand, captureCommandAsync } from '../utils/shell'
 import {
   generatePackageJson,
   generateViteConfig,
@@ -30,14 +30,29 @@ import { generateReadme } from './templates/project-docs'
 import { AVAILABLE_ADD_PACKAGES } from '../commands/add'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const cliPkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
-const CLI_VERSION_FALLBACK = `^${cliPkg.version}`
+
+/**
+ * The CLI's own package.json sits one level up from the bundle
+ * (`dist/project-*.mjs`) but two levels up from this source file
+ * (`src/generators/project.ts`). Checking both is what lets this module be
+ * imported from a test at all — reading only the bundle-relative path threw
+ * ENOENT the moment anything imported it from source, which is why the
+ * version-resolution path shipped untested.
+ */
+const cliPkg = JSON.parse(
+  readFileSync(
+    [join(__dirname, '..', 'package.json'), join(__dirname, '..', '..', 'package.json')].find(
+      existsSync,
+    )!,
+    'utf-8',
+  ),
+)
 
 /**
  * Sibling `@forinda/kickjs-*` packages whose versions are resolved
  * independently when scaffolding a new project. Each entry is queried
- * via `npm view <name> version`; failure falls back to the CLI's own
- * version (`CLI_VERSION_FALLBACK`).
+ * via `npm view <name> version`; failure falls back to `latest`
+ * (see `fallbackRange`).
  *
  * Per-package independent versioning landed with changesets — before
  * that, every sibling shipped in lockstep with the CLI so a single
@@ -59,22 +74,44 @@ const SIBLING_PACKAGES = [
 ] as const
 
 /**
+ * Range to write when `npm view <name> version` gives us nothing.
+ *
+ * It must never be the CLI's own version. Sibling packages version
+ * independently, so `@forinda/kickjs-vite@^${cliVersion}` names a release
+ * that does not exist — the scaffold then dies at install time with
+ * `npm error 404 '@forinda/kickjs-vite@^6.14.1' is not in this registry`,
+ * which is worse than the under-install this fallback was meant to avoid.
+ * `latest` is the one range that is always resolvable and always current.
+ *
+ * The CLI itself is the exception: its version IS the CLI's version, and
+ * pinning it keeps a scaffold reproducible against the CLI that made it.
+ */
+function fallbackRange(name: string): string {
+  return name === '@forinda/kickjs-cli' ? `^${cliPkg.version}` : 'latest'
+}
+
+/**
  * Resolve the latest published version of every sibling package via
- * `npm view <name> version` (through `captureCommand`, which routes
- * around Windows' `.cmd` shims — see utils/shell.ts). Each query has a
- * short timeout; failures fall back to the CLI's own version with a `^`
- * prefix so the scaffold stays usable offline.
+ * `npm view <name> version` (through `captureCommandAsync`, which routes
+ * around Windows' `.cmd` shims — see utils/shell.ts).
+ *
+ * The timeout is generous and the queries are genuinely concurrent: a
+ * warm `npm view` against the public registry measures 0.6–3.6s per
+ * package, so the old 5s budget was one slow response away from expiring,
+ * and the sync `captureCommand` under `Promise.all` ran all ten serially
+ * — making the per-call budget the only thing standing between a scaffold
+ * and a package.json full of fallbacks.
  */
 export async function resolveSiblingVersions(): Promise<Record<string, string>> {
   const results = await Promise.all(
     SIBLING_PACKAGES.map(async (name) => {
       // Network failure / package not yet published / npm unavailable
-      // all surface as null → fall back to the CLI's own version.
-      const out = captureCommand('npm', ['view', name, 'version'])
+      // all surface as null → fall back to a range that always resolves.
+      const out = await captureCommandAsync('npm', ['view', name, 'version'], { timeout: 20_000 })
       if (out && /^\d+\.\d+\.\d+/.test(out)) {
         return [name, `^${out}`] as const
       }
-      return [name, CLI_VERSION_FALLBACK] as const
+      return [name, fallbackRange(name)] as const
     }),
   )
   return Object.fromEntries(results)
@@ -94,7 +131,7 @@ export async function resolveSiblingVersions(): Promise<Record<string, string>> 
  * major`).
  */
 function resolveVersionAtTag(name: string, tag: string): string | null {
-  const out = captureCommand('npm', ['view', `${name}@${tag}`, 'version'])
+  const out = captureCommand('npm', ['view', `${name}@${tag}`, 'version'], { timeout: 20_000 })
   return out && /^\d+\.\d+\.\d+/.test(out) ? out : null
 }
 
@@ -132,7 +169,9 @@ function baseVersionGte(a: string, b: string): boolean {
 }
 
 function tagExportsSubpath(name: string, tag: string, subpath: string): boolean {
-  const out = captureCommand('npm', ['view', `${name}@${tag}`, 'exports', '--json'])
+  const out = captureCommand('npm', ['view', `${name}@${tag}`, 'exports', '--json'], {
+    timeout: 20_000,
+  })
   if (!out) return false
   try {
     const exportsMap = JSON.parse(out) as Record<string, unknown>
@@ -189,6 +228,14 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
   // working offline.
   log('Resolving package versions...')
   const versions = await resolveSiblingVersions()
+
+  // A 'latest' range means the registry query failed for that package. The
+  // install still works, but the pin is looser than intended and the user
+  // should know why their package.json does not read like the docs.
+  const unresolved = Object.keys(versions).filter((name) => versions[name] === 'latest')
+  if (unresolved.length > 0) {
+    log(`WARNING: could not reach npm for ${unresolved.join(', ')} — pinned to 'latest'`)
+  }
 
   // The pluggable-runtimes work (Fastify / h3 engine subpaths, the
   // `kick/runtime` typegen, `kick add upload`, `kick doctor` runtime checks)

--- a/packages/cli/src/utils/shell.ts
+++ b/packages/cli/src/utils/shell.ts
@@ -1,4 +1,7 @@
-import { execFileSync, execSync, spawnSync } from 'node:child_process'
+import { execFile, execFileSync, execSync, spawnSync } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
 
 /**
  * Characters an argument may not contain when it has to travel through
@@ -134,5 +137,34 @@ export function runNodeWithEnv(entry: string, env: NodeJS.ProcessEnv, cwd?: stri
   })
   if (result.status !== 0) {
     process.exit(result.status ?? 1)
+  }
+}
+
+/**
+ * Async twin of `captureCommand` — same Windows `.cmd` routing, same
+ * `null`-on-any-failure contract, but genuinely concurrent.
+ *
+ * `captureCommand` is `execFileSync`, so `Promise.all` over it runs the
+ * commands one after another. Callers that fan out over a list of network
+ * queries (`npm view` per package) need real concurrency, otherwise the
+ * per-call timeout multiplies by the list length.
+ */
+export async function captureCommandAsync(
+  file: string,
+  args: string[],
+  opts: { timeout?: number; cwd?: string } = {},
+): Promise<string | null> {
+  const invocation = shellSafeInvocation(file, args)
+  if (!invocation) return null
+  try {
+    const { stdout } = await execFileAsync(invocation[0], invocation[1], {
+      encoding: 'utf-8',
+      timeout: opts.timeout ?? 5000,
+      cwd: opts.cwd,
+      windowsHide: true,
+    })
+    return stdout.toString().trim() || null
+  } catch {
+    return null
   }
 }


### PR DESCRIPTION
## The bug

A freshly scaffolded project cannot install:

```
npm error 404 Not Found - GET https://registry.npmjs.org/@forinda%2fkickjs-vite - Not found
npm error 404 '@forinda/kickjs-vite@^6.14.1' is not in this registry
```

`6.14.1` is the **CLI's** version. `@forinda/kickjs-vite` has never published a
`6.14.1` — its published line is `…6.1.0, 7.0.0, 7.0.1, 8.0.0`.

## Why

`resolveSiblingVersions()` asks `npm view <pkg> version` for each of the ten
sibling packages and, when a query returns nothing, pins that package to the
CLI's own version. Since per-package independent versioning landed with
changesets, that pin names a release that does not exist. The header comment on
`SIBLING_PACKAGES` already warned that pinning to the CLI version
"under-installs adopters" — the fallback did exactly that, and the outcome is
worse than an under-install: a hard 404.

The fallback is not an edge case. Measured against the public registry on a
healthy connection:

| package | time |
| --- | --- |
| `@forinda/kickjs` | 604ms |
| `@forinda/kickjs-queue` | **3604ms** |
| `@forinda/kickjs-devtools` | 1847ms |

The timeout was **5s**. And `captureCommand` is `execFileSync`, so the
`Promise.all` wrapping it provided no concurrency whatsoever — all ten queries
ran back to back, with the per-call budget as the only thing between a scaffold
and a package.json full of fallbacks.

## The fix

- **Fall back to `latest`.** It always resolves and is always current.
  `@forinda/kickjs-cli` keeps `^<cliVersion>` — there the pin is genuinely
  right, and it keeps a scaffold reproducible against the CLI that made it.
- **`captureCommandAsync`** — an async twin of `captureCommand` with the same
  Windows `.cmd` routing and the same `null`-on-any-failure contract, so the
  queries actually run in parallel.
- **20s per query**, now that the budget no longer multiplies by ten.
- **Tell the user** when a package fell back, rather than letting it surface as
  an install failure minutes later.

## Testability

`resolveSiblingVersions` shipped untested because importing the module threw
`ENOENT`: it read the CLI's `package.json` at the path that exists in the built
bundle (`dist/../package.json`) but not from source
(`src/generators/../package.json`). It now checks both, so the module can be
imported by a test at all.

## Verification

`packages/cli/__tests__/scaffold-version-fallback.test.ts` — 4 tests. Reverting
`fallbackRange` to the old behavior fails exactly the two that name the 404.

End to end:

```bash
# registry pointed at a dead port — every sibling falls back
$ npm_config_registry=http://127.0.0.1:9 kick new offline-app --yes --no-install
  WARNING: could not reach npm for @forinda/kickjs, … — pinned to 'latest'
  "@forinda/kickjs": "latest", "@forinda/kickjs-vite": "latest",
  "@forinda/kickjs-cli": "^6.14.1"

# live registry
$ kick new online-app --yes --no-install        # 2271ms total
  "@forinda/kickjs": "^7.4.0"
  "@forinda/kickjs-vite": "^8.0.0"              # was ^6.14.1 → 404
```

Every dependency in both generated projects resolves against the registry.

`pnpm --filter @forinda/kickjs-cli test` — 630 passed (57 files). Lint, token
lint, format, typecheck clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved project scaffolding when package registry queries fail.
  - Sibling packages now fall back to the `latest` version instead of incorrectly using the CLI version.
  - Added warnings when fallback versions are used.

- **Bug Fixes**
  - Prevented scaffold installation failures caused by invalid package version references.
  - Increased version lookup timeouts to improve reliability.
  - Version checks now run concurrently for faster project creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->