### PR TITLE
fix(cli): key-remapped mapped types emitted any, and new projects could not generate the client map

### DIFF
--- a/.changeset/remapped-mapped-type-values.md
+++ b/.changeset/remapped-mapped-type-values.md
@@ -1,0 +1,28 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+typegen: carry values through key-remapped mapped types in the client route map
+
+A handler returning a mapped type with an `as` clause emitted the remapped keys
+correctly and `any` for every value:
+
+```ts
+type CamelizeKeys<T> = { [K in keyof T as Camel<K>]: T[K] }
+
+// was:  { contactName: any; schoolCount: any }
+// now:  { contactName: string; schoolCount: number }
+```
+
+Key remapping produces _synthesized_ properties, which have no declaration at
+all. The expander fell back to `getDeclaredTypeOfSymbol` for those — a function
+that answers for type symbols (aliases, interfaces, classes) and returns the
+error type when handed a property. `getTypeOfSymbol` answers for both kinds and
+is now used throughout. The homomorphic form (`{ [K in keyof T]: T[K] }`) only
+ever worked by accident: its properties keep a declaration pointing back at the
+source property.
+
+`any` was the worst available degradation here — `unknown` forces a cast at the
+call site, `any` silently type-checks against anything — so a route returning a
+remapped DTO was less safe than one still emitting `unknown`. On a real
+1,940-route app this removes all 66 `any` fields.

--- a/packages/cli/__tests__/client-expand-type.test.ts
+++ b/packages/cli/__tests__/client-expand-type.test.ts
@@ -193,6 +193,53 @@ describe('TypeExpander', () => {
     expect(out.text).toBe('{ a?: undefined | string }')
   })
 
+  it('carries values through a key-remapped mapped type (#547)', () => {
+    // `as` produces SYNTHESIZED properties — no declaration at all — and the
+    // old fallback asked getDeclaredTypeOfSymbol, which answers for type
+    // symbols and hands back the error type for a property. Every remapped
+    // field came out `any`, which is worse than the `unknown` it replaced:
+    // unknown forces a cast, any silently type-checks against anything.
+    const out = expand(`
+      type Camel<S extends string> = S extends \`\${infer H}_\${infer M}\${infer T}\`
+        ? \`\${H}\${Uppercase<M>}\${Camel<T>}\`
+        : S
+      type Plain = { contact_name: string; school_count: number }
+      type Remap<T> = { [K in keyof T as K extends string ? Camel<K> : K]: T[K] }
+      type Target = Remap<Plain>
+    `)
+    expect(out.text).toBe('{ contactName: string; schoolCount: number }')
+    expect(out.text).not.toContain('any')
+  })
+
+  it('carries values through a composed remap over a picked row (#547)', () => {
+    // The reported shape: CamelizeKeys<DateToIsoValues<Pick<Row, …>>>, which is
+    // how a DTO stays bound to the table type.
+    const out = expand(`
+      type Camel<S extends string> = S extends \`\${infer H}_\${infer M}\${infer T}\`
+        ? \`\${H}\${Uppercase<M>}\${Camel<T>}\`
+        : S
+      type DateToIso<V> = V extends Date ? string : V
+      type DateToIsoValues<T> = { [K in keyof T]: DateToIso<T[K]> }
+      type CamelizeKeys<T> = { [K in keyof T as K extends string ? Camel<K> : K]: T[K] }
+      type Dto<Row> = CamelizeKeys<DateToIsoValues<Row>>
+      interface Row { id: string; contact_name: string; created_at: Date; extra: number }
+      type Target = Dto<Pick<Row, 'id' | 'contact_name' | 'created_at'>>
+    `)
+    expect(out.text).toBe('{ id: string; contactName: string; createdAt: string }')
+    expect(out.text).not.toContain('any')
+  })
+
+  it('keeps a homomorphic mapped type working', () => {
+    // This one always worked, but only by accident — its properties keep a
+    // declaration pointing back at the source property. Pin it.
+    const out = expand(`
+      type Plain = { contact_name: string; school_count: number }
+      type Identity<T> = { [K in keyof T]: T[K] }
+      type Target = Identity<Plain>
+    `)
+    expect(out.text).toBe('{ contact_name: string; school_count: number }')
+  })
+
   it('emits an index signature', () => {
     expect(expand('type Target = { [k: string]: number }').text).toBe('{ [key: string]: number }')
   })

--- a/packages/cli/src/typegen/client/expand-type.ts
+++ b/packages/cli/src/typegen/client/expand-type.ts
@@ -135,10 +135,7 @@ export class TypeExpander {
     }
 
     for (const prop of this.checker.getPropertiesOfType(type)) {
-      const decl = prop.valueDeclaration ?? prop.declarations?.[0]
-      const propType = decl
-        ? this.checker.getTypeOfSymbolAtLocation(prop, decl)
-        : this.checker.getDeclaredTypeOfSymbol(prop)
+      const propType = this.typeOfProperty(prop)
       const optional = (prop.flags & this.ts.SymbolFlags.Optional) !== 0
       const rendered = this.renderPropertyType(propType, optional, prop, depth + 1)
       const readonly = this.isReadonlyProp(prop) ? 'readonly ' : ''
@@ -147,6 +144,39 @@ export class TypeExpander {
       )
     }
     return lines.join(join === '\n' ? '\n' : join)
+  }
+
+  /**
+   * The type of a property, declared or synthesized.
+   *
+   * `getTypeOfSymbol` is the only API that answers for both. A key-remapped
+   * mapped type — `{ [K in keyof T as Camel<K>]: T[K] }` — produces properties
+   * with NO declaration at all, and the previous code fell back to
+   * `getDeclaredTypeOfSymbol` for those. That function answers for *type*
+   * symbols (aliases, interfaces, classes); handed a property symbol it
+   * returns the error type, so every remapped field emitted `any`:
+   *
+   *     { [K in keyof T as Camel<K>]: T[K] }  →  { contactName: any }
+   *     { [K in keyof T]: T[K] }              →  { contact_name: string }
+   *
+   * The homomorphic form only ever worked by accident — its properties keep a
+   * declaration pointing back at the source property.
+   *
+   * `any` is the worst possible degradation here: `unknown` forces a cast at
+   * the call site, `any` silently type-checks against anything, so a route
+   * that degraded this way was less safe than one still emitting `unknown`.
+   */
+  private typeOfProperty(prop: ts.Symbol): ts.Type {
+    const checker = this.checker as ts.TypeChecker & {
+      getTypeOfSymbol?: (symbol: ts.Symbol) => ts.Type
+    }
+    if (typeof checker.getTypeOfSymbol === 'function') return checker.getTypeOfSymbol(prop)
+    // Older compiler APIs: the location-based call, which is correct for any
+    // property that has a declaration to point at.
+    const decl = prop.valueDeclaration ?? prop.declarations?.[0]
+    return decl
+      ? this.checker.getTypeOfSymbolAtLocation(prop, decl)
+      : this.checker.getDeclaredTypeOfSymbol(prop)
   }
 
   /**


### PR DESCRIPTION
Closes #547, plus the scaffolding gap the same feature left behind. Two changesets, both `@forinda/kickjs-cli`.

## 1. Key-remapped mapped types emitted `any` (#547)

Key remapping produces **synthesized** properties — no `valueDeclaration`, no `declarations` at all. Probed both forms side by side:

```
TargetA.contactName    decl=undefined   getDeclaredTypeOfSymbol → any      getTypeOfSymbol → string
TargetB.contact_name   decl=c.ts        getTypeOfSymbolAtLocation → string  getTypeOfSymbol → string
```

The expander asked `getTypeOfSymbolAtLocation` when a property had a declaration and fell back to `getDeclaredTypeOfSymbol` when it did not. That fallback is the bug: `getDeclaredTypeOfSymbol` answers for *type* symbols — aliases, interfaces, classes — and returns the error type when handed a property symbol.

The homomorphic form (`{ [K in keyof T]: T[K] }`) was never fixed by anything; it worked by accident, its properties keeping a declaration that points back at the source property. That is why the issue's A/B repro isolated the `as` clause so cleanly. `getTypeOfSymbol` answers for both kinds and is now used for every property.

**Why it mattered more than its size.** `any` is the worst available degradation. A route still on `ctx.json` emits `response: unknown`, which forces a cast at the call site; a converted route backed by a remapped DTO emitted `any`, which silently type-checks against anything — so migrating those routes to bare returns made call-site safety *worse*, the opposite of the point.

Verified on the reporting app, 1,940 routes:

| | before | after |
| --- | --- | --- |
| `: any` fields | **66** | **0** |
| routes | 1,940 | 1,940 |
| hoisted interfaces | 10 | 10 |

The interface quoted in the issue now resolves completely, `DateToIso` included:

```ts
{ id: string; status: "closed" | "new" | "contacted" | "converted"
  createdAt: string; region: null | string; contactName: string }
```

Three tests from the report's own shapes — the bare `as` remap, the composed `CamelizeKeys<DateToIsoValues<Pick<Row, …>>>`, and a pin on the homomorphic case that had been passing for the wrong reason. Sabotage-verified: removing the one line fails exactly the two `as` tests and leaves the homomorphic one green, which is the issue's A/B split reproduced in CI.

## 2. New projects could not generate the map at all

Generated projects pin `typescript@^7.0.2`, and TypeScript 7 ships no JS compiler API — so a freshly scaffolded project warned on every `kick typegen` and never produced the file:

```text
kick/client: skipped — … neither 'typescript' nor '@typescript/typescript6' resolved
```

The scaffold now pins `@typescript/typescript6` alongside it. Verified by scaffolding a fullstack project with a real install: both routes resolve to literal shapes, no warning.

```ts
export interface KickApi {
  "GET /hello/health": { …; response: { status: string; uptime: number }; … }
  "GET /hello": { …; response: { message: string; timestamp: string }; … }
}
```

## 3. The fullstack template keeps the bridge, and says why

Deliberately **not** switched to the client map. The template's headline is the live loop — rename a field in the service, the web app stops compiling — and that depends on `kick dev` refreshing the route types on save, which the client map deliberately does not do. At that scale the bridge is also cheap: measured on a real 17-route app, 0.67s / 420 MB against 0.33s / 268 MB.

Instead the generated README gains **"When to switch to `kick__client.d.ts`"**: the one-line swap, the two lines to delete afterwards, the fact that call sites do not change (both maps carry the same types, the second being produced by resolving the first), and the trade — no refresh under `kick dev`, with `--check` as the CI backstop. Switch when the frontend lives in its own repo, sets `verbatimModuleSyntax`, or has started paying for the server's typecheck.

The documented import path is compiled in a real scaffolded project rather than written from memory.

## Verification

681 tests in the CLI package across 63 files; scaffold suites green. Lint, token lint and format clean.

Note for anyone running the suite: the workspace `dist/` outputs must exist first (`pnpm build`) or 96 tests fail on `CLI binary not found` — unrelated to these changes.
