### PR TITLE
fix(cli): three client route map fixes — quiet skips, no scaffold dep, depth guard

### DIFF
--- a/.changeset/client-map-ambient-namespace.md
+++ b/.changeset/client-map-ambient-namespace.md
@@ -1,0 +1,27 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+typegen: expose the client route map as an ambient `KickClientApi` namespace
+
+The generated `kick__client.d.ts` now declares a global namespace as well as
+exporting its type, so a frontend that lists the file in its tsconfig
+`include` needs no import at all:
+
+```ts
+export const api = createClient<KickClientApi.Api>({ baseUrl: '/api/v1' })
+```
+
+The explicit form still works for anyone who would rather not have a global:
+
+```ts
+import type { Api } from '../../server/.kickjs/types/kick__client'
+```
+
+Two details the shape depends on. The hoisted `__T<n>` interfaces stay
+**module-local** — declaring them at the top level to make them ambient put all
+86 of a real app's shapes into the consuming frontend's global scope. And the
+namespace is `KickClientApi`, not `KickApi`: `kick__routes.ts` already declares
+a global `KickApi`, and both files live in `.kickjs/types`, which the server's
+own tsconfig includes — sharing the name made the _server_ fail to compile with
+`TS2300: Duplicate identifier 'KickApi'`.

--- a/.changeset/client-map-depth-hoist.md
+++ b/.changeset/client-map-depth-hoist.md
@@ -1,0 +1,26 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+typegen: stop the client route map's depth guard from firing on hoisted types
+
+A real 1,940-route app emitted 34 copies of:
+
+```text
+type nesting exceeded 12 levels — emitting 'unknown'. Declare a response schema on the route for an exact type.
+```
+
+The guard bounds how deeply types nest _inline_, but it was counting through
+hoists. Hoisting ends inline nesting — each named type becomes its own
+top-level `interface __Tn { … }` block, referenced by name — so a chain of
+named DTOs spent the whole budget on a nesting the emitted file does not
+contain. It also corrupted rather than merely truncating: a 15-link chain
+produced `interface __T12 { v: unknown }` where `v` was a plain `string`.
+
+Depth now resets when a type is hoisted. On that app: 34 warnings to 0, and
+the hoisted interfaces go from 10 to 86 as chains expand into their own blocks
+instead of being cut off. Genuinely deep inline nesting still degrades to
+`unknown`, which is what the guard is for.
+
+The warnings also name their route now (`route 'GET /x': …`). Thirty-four
+identical lines with no route between them said nothing about where to look.

--- a/.changeset/client-map-empty-export.md
+++ b/.changeset/client-map-empty-export.md
@@ -1,0 +1,19 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+typegen: fix the client route map emitted before any route exists
+
+With no routes discovered, the map re-exported `Api` from its own filename:
+
+```ts
+export type { Api } from './kick__client'
+```
+
+TypeScript rejects that with `TS2303: Circular definition of import alias`, so
+a freshly scaffolded project emitted a file that did not compile — the one
+moment every new project passes through.
+
+It now mirrors the populated form: a module-local `interface Api {}`, the
+ambient `KickClientApi` namespace, and a direct export. Both the namespace and
+the explicit-import forms compile.

--- a/.changeset/client-map-opt-in.md
+++ b/.changeset/client-map-opt-in.md
@@ -1,0 +1,34 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+typegen: only build the client route map for projects that use it
+
+Producing `.kickjs/types/kick__client.d.ts` builds a whole TypeScript program
+over the server. On a 1,940-route API that is the entire cost of `kick typegen`:
+
+|            | with the map | without    |
+| ---------- | ------------ | ---------- |
+| wall clock | 7.50s        | **0.59s**  |
+| peak RSS   | 1127 MB      | **182 MB** |
+
+Every other typegen plugin combined accounts for ~130ms of that. An API with no
+frontend was paying twelve seconds and a gigabyte for a file nothing reads.
+
+`typegen.client` now decides:
+
+```ts
+export default defineConfig({
+  typegen: { client: true },
+})
+```
+
+Off unless set — the config is the switch, not a file on disk. `kick new
+--template fullstack` writes `client: true`, because its web app reads the map.
+
+An existing map does not silently turn it back on; that would leave a project
+paying seconds and a gigabyte per typegen with nothing in its config to explain
+why. It does warn, naming the setting to add, because a map left unrefreshed is
+how a frontend ends up type-checking against routes the server no longer
+serves. Existing adopters therefore need one line of config to keep the map
+current.

--- a/.changeset/client-map-program-roots.md
+++ b/.changeset/client-map-program-roots.md
@@ -1,0 +1,30 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+typegen: stop loading project files the client route map cannot reach
+
+The client map built its TypeScript program over every file the tsconfig
+lists. It does not need to: the probe imports the generated route map, which
+imports the controllers, which import their services and DTOs — so everything
+that can contribute to a route type arrives transitively. Passing the whole
+project on top loaded files no route can reference. On a 1,940-route app, 686
+of the 2,851 roots were tests.
+
+Measured on that app, median of five runs:
+
+|            | before  | after   |
+| ---------- | ------- | ------- |
+| peak RSS   | 1376 MB | 1122 MB |
+| wall clock | 8.62s   | 7.61s   |
+
+with byte-identical output.
+
+Roots are now the tsconfig's declaration files plus everything typegen itself
+emits — and that second list is read from disk rather than taken from the
+tsconfig. TypeScript's `include` skips dot-directories, so `.kickjs/types` was
+absent from the file list unless the adopter happened to spell out a glob for
+it, and `kick__env.ts` carries a `declare global` that nothing imports. Those
+globals were therefore missing for a project that did not glob them, and a
+controller referencing one resolved against an error type — visible in the
+emitted map as a bare identifier the frontend has never heard of.

--- a/.changeset/dev-debug-inspector.md
+++ b/.changeset/dev-debug-inspector.md
@@ -15,5 +15,12 @@ and prints `inspector.url()` rather than a hand-built one — the real URL
 carries the session id, without which a debugger client cannot attach even to
 an open port.
 
+It also binds to **loopback** now, as `node --inspect` does. The old code
+hardcoded `0.0.0.0`, which never mattered while nothing was listening — but an
+attached inspector can evaluate arbitrary code in the process, so making it
+work turned that into a real open port on every interface. `--inspect-host` is
+there for containers, which legitimately need `0.0.0.0`, and warns when the
+address is not loopback.
+
 A port it cannot take (`Inspector is already activated`) is now reported with a
 pointer to `--inspect-port`, instead of being swallowed.

--- a/.changeset/dev-debug-inspector.md
+++ b/.changeset/dev-debug-inspector.md
@@ -1,0 +1,19 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+`kick dev:debug`: actually attach the debugger
+
+The command printed `Debugger: ws://0.0.0.0:9229` and attached nothing. It set
+`process.env.NODE_OPTIONS = '--inspect=…'` and then started the dev server in
+the same process — but Node reads `NODE_OPTIONS` once, at startup, and
+`startDevServer` calls Vite's `createServer` directly rather than spawning. The
+server came up normally and port 9229 stayed closed, so nothing ever failed.
+
+It now uses `inspector.open()`, which opens the port on the running process,
+and prints `inspector.url()` rather than a hand-built one — the real URL
+carries the session id, without which a debugger client cannot attach even to
+an open port.
+
+A port it cannot take (`Inspector is already activated`) is now reported with a
+pointer to `--inspect-port`, instead of being swallowed.

--- a/.changeset/fullstack-client-map-default.md
+++ b/.changeset/fullstack-client-map-default.md
@@ -1,0 +1,37 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+`kick new --template fullstack`: the web app now reads the resolved route map
+
+The scaffolded frontend consumes `server/.kickjs/types/kick__client.d.ts` as an
+ambient type package rather than bridging to the server's route types:
+
+```jsonc
+// web/tsconfig.json
+"types": ["../server/.kickjs/types/kick__client"]
+```
+
+```ts
+// web/src/api.ts
+export const api = createClient<KickClientApi.Api>({ baseUrl: '/api/v1' })
+```
+
+`web/src/types/kick-routes.d.ts` is gone, and with it `experimentalDecorators`
+— the map holds resolved literal types, so no server source enters the web
+program. `kick new` runs typegen, so a scaffolded project type-checks
+immediately.
+
+A `types` entry rather than `include` because the failure modes differ: a
+missing map is `TS2688: Cannot find type definition file` with `types`, and
+silence with `include`. Loud is right for something the app depends on. Both
+are documented, along with the explicit-import form and the fact that `types`
+replaces TypeScript's automatic `@types` inclusion.
+
+The fullstack server therefore pins `@typescript/typescript6`, the compiler API
+that resolves the map on TypeScript 7. Only that template does — rest and
+minimal have no frontend, and it is a 10 kB shim over a 24 MB `typescript@6`.
+
+One behaviour change worth knowing: the map is not refreshed by `kick dev`, so
+a renamed response field surfaces on the next `kick typegen` rather than on
+save. `kick typegen --check` catches a stale one in CI.

--- a/.changeset/kick-typecheck-command.md
+++ b/.changeset/kick-typecheck-command.md
@@ -1,0 +1,19 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+`kick typecheck`: one type-check command, whatever the package manager
+
+Generated projects had to spell type-checking in whichever dialect their
+manager speaks — `pnpm -r exec tsc --noEmit` against
+`cd server && npx tsc --noEmit` — and the fullstack template branched on the
+manager to write them. `kick typecheck` is the same command everywhere, takes
+`--cwd <dir>`, and exits non-zero on errors so it works as a gate.
+
+It resolves the project's own checker, preferring **`vue-tsc`** when installed.
+That preference matters: plain `tsc` does not understand `.vue`, so in a Vue
+project it matches no inputs and reports `TS18003: No inputs were found` while
+real errors sit unchecked in the SFCs. vue-tsc checks plain `.ts` too, so
+preferring it costs nothing.
+
+`kick dev --typecheck` picks up the same preference.

--- a/.changeset/scaffold-client-map-dep.md
+++ b/.changeset/scaffold-client-map-dep.md
@@ -2,24 +2,26 @@
 '@forinda/kickjs-cli': patch
 ---
 
-`kick new`: scaffold the compiler API the client route map needs, and document when to use it
+typegen: stop warning about the client route map in projects that do not use it
 
-Generated projects pin `typescript@^7.0.2`, which ships no JS compiler API — so
-every `kick typegen` in a freshly scaffolded project printed a skip warning and
-never produced `.kickjs/types/kick__client.d.ts`:
+`kick/client` warned on every `kick typegen` when no TypeScript compiler API
+was available, and reported having "removed the previously generated"
+`kick__client.d.ts` even in projects that never had one — `rm --force`
+succeeds either way.
 
-```text
-kick/client: skipped — … neither 'typescript' nor '@typescript/typescript6' resolved
-```
+Most projects do not consume that file. The fullstack template's web app is
+wired to the ambient `KickRoutes.Api` so it stays live under `kick dev`, and
+the rest/minimal templates have no frontend at all. The compiler API is not a
+free thing to tell them to install either: on TypeScript 7 it means
+`@typescript/typescript6`, a 10 kB shim over a 24 MB `typescript@6`.
 
-The scaffold now pins `@typescript/typescript6` alongside it, and a new project
-emits a fully-typed client map out of the box.
+So the skip is now quiet when there is no map on disk (visible under
+`LOG_LEVEL=debug`) and loud when there is one — a project with a map is using
+it, and losing it is a regression worth interrupting for. The removal notice
+only fires when a file was actually removed, and now prints after the cause it
+refers to.
 
-The fullstack template keeps the ambient bridge as its default wiring: its whole
-point is the live loop (rename a field, the web app stops compiling), which
-depends on `kick dev` refreshing the route types on save — and the client map is
-deliberately not refreshed under watch. The generated README gains a "When to
-switch to `kick__client.d.ts`" section covering the swap, what it costs, and the
-cases that call for it: a frontend in its own repo, one setting
-`verbatimModuleSyntax`, or one whose typecheck has started paying for the
-server's.
+The fullstack template's README gains a "When to switch to
+`kick__client.d.ts`" section: the one-line swap, the `@typescript/typescript6`
+install it needs on TS 7, the two lines to delete afterwards, and the trade —
+no refresh under `kick dev`, with `--check` as the CI backstop.

--- a/.changeset/scaffold-client-map-dep.md
+++ b/.changeset/scaffold-client-map-dep.md
@@ -1,0 +1,25 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+`kick new`: scaffold the compiler API the client route map needs, and document when to use it
+
+Generated projects pin `typescript@^7.0.2`, which ships no JS compiler API — so
+every `kick typegen` in a freshly scaffolded project printed a skip warning and
+never produced `.kickjs/types/kick__client.d.ts`:
+
+```text
+kick/client: skipped — … neither 'typescript' nor '@typescript/typescript6' resolved
+```
+
+The scaffold now pins `@typescript/typescript6` alongside it, and a new project
+emits a fully-typed client map out of the box.
+
+The fullstack template keeps the ambient bridge as its default wiring: its whole
+point is the live loop (rename a field, the web app stops compiling), which
+depends on `kick dev` refreshing the route types on save — and the client map is
+deliberately not refreshed under watch. The generated README gains a "When to
+switch to `kick__client.d.ts`" section covering the swap, what it costs, and the
+cases that call for it: a frontend in its own repo, one setting
+`verbatimModuleSyntax`, or one whose typecheck has started paying for the
+server's.

--- a/.changeset/scaffold-lean-scripts.md
+++ b/.changeset/scaffold-lean-scripts.md
@@ -1,0 +1,24 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+`kick new`: four scripts instead of ten, and oxfmt instead of prettier
+
+Generated projects shipped ten npm scripts, one of which could not run:
+`lint: 'eslint src/'`, with eslint in no dependency list, so `pnpm lint` failed
+with "command not found" in every scaffolded project.
+
+The set is now `dev`, `build`, `start`, `test`. Everything dropped stays one
+command away — `kick dev:debug`, `kick typegen`, `pnpm exec vitest`,
+`pnpm exec tsc --noEmit` — and a scaffold that opens with a wall of aliases
+teaches less than one that shows the binary.
+
+Formatting moves from prettier to **oxfmt**: same options, same output for
+these settings, one binary instead of a package plus plugins — and it is what
+the framework itself is formatted with, so a generated project no longer
+arrives holding a different toolchain than the repo it came from. `.prettierrc`
+becomes `.oxfmtrc.json`, and the `format` / `format:check` / `ci:check`
+commands in the generated `kick.config.ts` follow.
+
+Existing projects are unaffected; this changes only what new ones are created
+with.

--- a/.changeset/scaffold-no-npx.md
+++ b/.changeset/scaffold-no-npx.md
@@ -1,0 +1,34 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+`kick new`: oxc by default, and no `npx` in anything generated
+
+Generated scripts and `kick.config.ts` commands invoked their tools through
+`npx`, which resolves a missing binary by fetching whatever the registry has
+under that name. For a binary whose package is named differently that is a
+stranger's code: the CLI's binary is `kick`, its package is
+`@forinda/kickjs-cli`, and `kick` on npm is an unrelated AngularJS scaffolder.
+Run from a workspace root where the local binary was not visible, it installed
+that package, printed its help, and exited 0 — so a root `typecheck` script
+passed without type-checking anything.
+
+Generated steps now name tools plainly. `kick`'s custom-command runner puts the
+project's `node_modules/.bin` on PATH, so a step resolves the project's own
+binary and a missing one fails as "command not found" rather than downloading
+something. The fullstack root gains the CLI as a dependency so the bare `kick`
+in its scripts resolves there too.
+
+`oxfmt` and `oxlint` ship as scaffold dependencies, with `lint`, `format`,
+`format:check` and `ci:check` commands wired to them.
+
+Two fixes fell out of the same pass:
+
+- The fullstack root's `typecheck` ran `pnpm -r run typecheck`, which skips
+  packages lacking that script — after the script trim, that silently narrowed
+  it to the frontend.
+- A scaffolded pnpm workspace could not run any script. The non-interactive
+  install left `allowBuilds: '@swc/core': set this to true or false` in
+  `pnpm-workspace.yaml`, and pnpm then refuses every script with
+  `ERR_PNPM_IGNORED_BUILDS`. The generator answers it now — both are build
+  tools this template chose.

--- a/docs/guide/typed-client-recipes.md
+++ b/docs/guide/typed-client-recipes.md
@@ -260,7 +260,8 @@ already configures.
 - **Tests**: [`createTestClient`](./typed-client.md#network-free-testing) +
   a `QueryClientProvider` wrapper gives fully-typed hook tests with zero
   network.
-- **Separate repo or a frontend that typechecks slowly?** Import
-  `.kickjs/types/kick__client.d.ts` instead of the ambient bridge — same types,
-  no server source in your `tsc` run. See
+- **Separate repo or a frontend that typechecks slowly?** Add
+  `.kickjs/types/kick__client.d.ts` to your tsconfig `include` and swap
+  `KickApi` for `KickClientApi.Api` — same types, no server source in your
+  `tsc` run, and every example on this page works unchanged. See
   [frontends outside the server's TypeScript program](./typed-client.md#frontends-outside-the-server-s-typescript-program).

--- a/docs/guide/typed-client.md
+++ b/docs/guide/typed-client.md
@@ -63,18 +63,70 @@ imports before it compiled, and its typecheck went from 1.7s / 819 MB to 10.8s
 
 `kick typegen` also emits `.kickjs/types/kick__client.d.ts`, which removes the
 reference entirely: every type resolved to a literal shape, shared shapes
-hoisted, and **no imports at all**. A frontend of any size needs one line:
+hoisted, and **no imports at all**.
 
-```ts
-import type { KickApi } from '../../../api/.kickjs/types/kick__client'
+List it in the frontend's tsconfig `types`, the same way you would `node` or
+`vitest/globals`:
 
-export const api = createClient<KickApi>({ baseUrl: '/api/v1' })
+```json
+{
+  "compilerOptions": {
+    "types": ["../../api/.kickjs/types/kick__client"]
+  }
+}
 ```
 
-No decorator settings, no path aliases, no ambient bridge file. Every entry that
-resolves carries the same type as the ambient map — it is produced by resolving
-that map, not by inferring a second time — so moving a frontend across changes
-no call sites.
+The route map is then ambient — no import, no bridge file, no decorator
+settings, no path aliases:
+
+```ts
+export const api = createClient<KickClientApi.Api>({ baseUrl: '/api/v1' })
+```
+
+Only the namespace is global. The resolved shapes it references stay inside the
+file, so nothing else lands in your global scope.
+
+This is what `kick new --template fullstack` scaffolds.
+
+::: warning `types` replaces automatic `@types` inclusion
+Listing anything in `types` switches off TypeScript's automatic inclusion of
+every `@types/*` package. If your frontend relies on that, name what it needs
+alongside the map: `"types": ["node", "../../api/.kickjs/types/kick__client"]`.
+:::
+
+### The alternatives
+
+**`include`**, if you would rather not touch `types` at all:
+
+```json
+{ "include": ["src", "../../api/.kickjs/types/kick__client.d.ts"] }
+```
+
+The difference is what happens when the file has not been generated. A `types`
+entry reports `TS2688: Cannot find type definition file`, which is the useful
+failure for something your app depends on. An `include` entry tolerates it
+silently, and `KickClientApi` simply fails to resolve — better for a repo where
+the map is not always present.
+
+**An explicit import**, if you would rather have no global at all. The same file
+exports the type:
+
+```ts
+import type { Api } from '../../api/.kickjs/types/kick__client'
+
+export const api = createClient<Api>({ baseUrl: '/api/v1' })
+```
+
+Every entry that resolves carries the same type as the ambient map — it is
+produced by resolving that map, not by inferring a second time — so moving a
+frontend across changes no call sites, whichever wiring you pick.
+
+::: tip Why `KickClientApi` and not `KickApi`
+`kick__routes.ts` already declares a global `KickApi`, and both files live in
+`.kickjs/types`, which the server's own tsconfig includes. Sharing the name
+makes the **server** stop compiling with `TS2300: Duplicate identifier`. The two
+maps coexist under separate names, and a frontend only ever sees this one.
+:::
 
 `kick typegen --check` gates staleness in CI, exactly as with the other
 generated files.

--- a/docs/guide/typed-client.md
+++ b/docs/guide/typed-client.md
@@ -88,6 +88,27 @@ file, so nothing else lands in your global scope.
 
 This is what `kick new --template fullstack` scaffolds.
 
+::: tip Off unless the project uses it
+Producing this map builds a whole TypeScript program over the server — measured
+at 1.1 GB and ~7.6s on a 1,940-route app, against ~130ms for every other
+typegen plugin combined. An API with no frontend should not pay that for a file
+nothing reads, so `kick typegen` only builds it when the project wants it:
+
+```ts
+// kick.config.ts
+export default defineConfig({
+  typegen: { client: true },
+})
+```
+
+Off unless set. `kick new --template fullstack` writes `client: true`, so its
+web app has the map from the first run; every other project opts in here.
+
+If the file is already on disk and this is unset, `kick typegen` says so rather
+than refreshing it silently — a map left to rot is how a frontend ends up
+type-checking against routes the server no longer serves.
+:::
+
 ::: warning `types` replaces automatic `@types` inclusion
 Listing anything in `types` switches off TypeScript's automatic inclusion of
 every `@types/*` package. If your frontend relies on that, name what it needs

--- a/packages/cli/__tests__/agent-docs-layout.test.ts
+++ b/packages/cli/__tests__/agent-docs-layout.test.ts
@@ -122,8 +122,12 @@ describe('generateKickJsSkillFiles — direct contract', () => {
     const addModulePnpm = pnpmSkills.find((s) => s.slug === 'add-module')!
     const addModuleYarn = yarnSkills.find((s) => s.slug === 'add-module')!
 
-    expect(addModulePnpm.content).toMatch(/pnpm run typecheck/)
-    expect(addModuleYarn.content).toMatch(/yarn run typecheck/)
+    // `run test`, not `run typecheck`: typechecking goes through
+    // `kick typecheck` now, which is the same command under every manager —
+    // that is the point of routing it through the CLI. `test` is still a
+    // package script, so it remains the thing that must be interpolated.
+    expect(addModulePnpm.content).toMatch(/pnpm run test/)
+    expect(addModuleYarn.content).toMatch(/yarn run test/)
     // The pnpm copy should NOT mention yarn and vice versa
     expect(addModulePnpm.content).not.toMatch(/yarn run/)
     expect(addModuleYarn.content).not.toMatch(/pnpm run/)

--- a/packages/cli/__tests__/client-e2e.test.ts
+++ b/packages/cli/__tests__/client-e2e.test.ts
@@ -138,23 +138,28 @@ describe('the client route map, end to end', () => {
     expect(existsSync(TSC)).toBe(true)
   })
 
-  it('emits a file with no imports and no ambient declarations', () => {
+  it('emits a file with no imports, and only the namespace globally', () => {
     const emitted = require('node:fs').readFileSync(join(web, 'kick__client.d.ts'), 'utf-8')
     const code = emitted
       .split('\n')
       .filter((line: string) => !line.trimStart().startsWith('//'))
       .join('\n')
 
+    // No imports is the load-bearing one: an import is a dependency on the
+    // server's program, which is the thing being removed.
     expect(code).not.toContain('import ')
-    expect(code).not.toContain('declare global')
     expect(code).not.toContain('src/term')
-    expect(emitted).toContain('export interface KickApi')
+    // The ambient surface is exactly one namespace. The hoisted shapes stay
+    // module-local — see the leak test below.
+    expect(code).toContain('namespace KickClientApi')
+    expect(emitted).toContain('namespace KickClientApi')
+    expect(emitted).toContain('export type { Api }')
   })
 
   it('type-checks in a frontend with none of the server tsconfig gymnastics', () => {
     writeFileSync(
       join(web, 'src/app.ts'),
-      `import type { KickApi } from '../kick__client'
+      `import type { Api as KickApi } from '../kick__client'
 
 type Terms = KickApi['GET /terms']['response']
 
@@ -168,10 +173,34 @@ export const credits = (terms: Terms): (number | undefined)[] => terms.map((t) =
     expect(ok).toBe(true)
   })
 
+  it('is usable with no import at all, via the ambient namespace', () => {
+    // The reason the map is ambient as well as exported: a frontend that puts
+    // this file in its tsconfig "include" needs no bridge file and no import
+    // line — `KickClientApi.Api` is just there.
+    writeFileSync(
+      join(web, 'src/app.ts'),
+      `type Terms = KickClientApi.Api['GET /terms']['response']
+
+export const ids = (terms: Terms): string[] => terms.map((t) => t.id)
+`,
+    )
+
+    const { ok, output } = typecheckWeb()
+    expect(output).toBe('')
+    expect(ok).toBe(true)
+  })
+
+  it('does not leak its hoisted shapes into the consuming global scope', () => {
+    // Emitting the hoisted interfaces at the top level would make every
+    // `__T<n>` global in the frontend — 86 of them on a real app.
+    writeFileSync(join(web, 'src/app.ts'), 'export type Leaked = __T0\n')
+    expect(typecheckWeb().ok).toBe(false)
+  })
+
   it('still rejects a route that does not exist', () => {
     writeFileSync(
       join(web, 'src/app.ts'),
-      `import type { KickApi } from '../kick__client'
+      `import type { Api as KickApi } from '../kick__client'
 
 export type Nope = KickApi['GET /nope']
 `,
@@ -183,7 +212,7 @@ export type Nope = KickApi['GET /nope']
   it('still rejects a field the response does not have', () => {
     writeFileSync(
       join(web, 'src/app.ts'),
-      `import type { KickApi } from '../kick__client'
+      `import type { Api as KickApi } from '../kick__client'
 
 type Terms = KickApi['GET /terms']['response']
 

--- a/packages/cli/__tests__/client-e2e.test.ts
+++ b/packages/cli/__tests__/client-e2e.test.ts
@@ -197,6 +197,29 @@ export const ids = (terms: Terms): string[] => terms.map((t) => t.id)
     expect(typecheckWeb().ok).toBe(false)
   })
 
+  it('compiles before the first route exists', () => {
+    // A project with no routes yet is the scaffold's first moment. The empty
+    // branch used to re-export `Api` from its own filename, which TypeScript
+    // rejects with `TS2303: Circular definition of import alias` — so a fresh
+    // project emitted a file that did not compile.
+    writeFileSync(
+      join(web, 'kick__client.d.ts'),
+      renderClient({ entries: new Map(), hoisted: [] }, []),
+    )
+    writeFileSync(
+      join(web, 'src/app.ts'),
+      `import type { Api } from '../kick__client'
+
+export type Keys = keyof Api
+export type Ambient = keyof KickClientApi.Api
+`,
+    )
+
+    const { ok, output } = typecheckWeb()
+    expect(output).toBe('')
+    expect(ok).toBe(true)
+  })
+
   it('still rejects a route that does not exist', () => {
     writeFileSync(
       join(web, 'src/app.ts'),

--- a/packages/cli/__tests__/client-e2e.test.ts
+++ b/packages/cli/__tests__/client-e2e.test.ts
@@ -12,6 +12,10 @@
  * The negative half matters as much: a route that does not exist must still
  * fail to compile, or the map is not typing anything.
  *
+ * Resolved through `require.resolve` rather than a path relative to
+ * `process.cwd()`: vitest can be invoked from the repo root with `--root`,
+ * and a cwd-relative guess then points outside the repo entirely.
+ *
  * The checker used here is the repo's own `tsc` — TypeScript 7 — not the
  * TypeScript 6 compiler API the generator runs on. That is the real
  * cross-version pairing an adopter gets.
@@ -21,9 +25,10 @@
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
 
 import { resolveClientMap } from '../src/typegen/client/resolve-entries'
 import { renderClient } from '../src/typegen/render/client'
@@ -32,7 +37,14 @@ let server: string
 let web: string
 
 /** The repo's TypeScript 7 binary — what an adopter's frontend actually runs. */
-const TSC = resolve(process.cwd(), '../../node_modules/typescript/bin/tsc')
+const TSC = (() => {
+  // Not `resolve('typescript/bin/tsc')`: TypeScript 7's `exports` map does not
+  // expose that subpath. Go through the manifest and read the declared bin.
+  const req = createRequire(import.meta.url)
+  const pkgPath = req.resolve('typescript/package.json')
+  const bin = JSON.parse(readFileSync(pkgPath, 'utf-8')).bin
+  return join(dirname(pkgPath), typeof bin === 'string' ? bin : bin.tsc)
+})()
 
 beforeAll(async () => {
   const root = mkdtempSync(join(tmpdir(), 'kick-client-e2e-'))

--- a/packages/cli/__tests__/client-expand-type.test.ts
+++ b/packages/cli/__tests__/client-expand-type.test.ts
@@ -33,7 +33,11 @@ afterAll(() => rmSync(dir, { recursive: true, force: true }))
  */
 function expand(
   source: string,
-  opts: { maxDepth?: number; compilerOptions?: ts.CompilerOptions } = {},
+  opts: {
+    maxDepth?: number
+    compilerOptions?: ts.CompilerOptions
+    onWarn?: (msg: string) => void
+  } = {},
 ) {
   const file = join(dir, `case-${Math.random().toString(36).slice(2)}.ts`)
   writeFileSync(file, source)
@@ -282,6 +286,41 @@ describe('TypeExpander', () => {
       '{ a?: undefined | string }',
     )
     expect(expand('type Target = { a?: string }', opts).text).toBe('{ a?: string }')
+  })
+
+  it('does not spend the depth budget on hoisted types', () => {
+    // Hoisting ENDS inline nesting: each named type becomes its own top-level
+    // `interface __Tn { … }` block. Carrying the caller's depth into that body
+    // made a chain of named DTOs exhaust the budget on a nesting the output
+    // does not contain — a real app emitted 34 "type nesting exceeded"
+    // warnings, and a 15-link chain produced `interface __T12 { v: unknown }`
+    // where `v` was a plain `string`. Degrading real types is worse than the
+    // runaway the guard exists to stop.
+    let src = ''
+    for (let i = 0; i < 15; i++) src += `interface L${i} { v: string; next: L${i + 1} }\n`
+    src += 'interface L15 { v: string }\ntype Target = L0\n'
+
+    const warnings: string[] = []
+    const out = expand(src, { onWarn: (m) => warnings.push(m) })
+
+    expect(warnings).toEqual([])
+    expect(out.hoisted).toHaveLength(16)
+    // Every link keeps its real type, including the last one.
+    expect(out.hoisted[15]).toContain('v: string')
+    expect(out.hoisted.join('\n')).not.toContain('unknown')
+  })
+
+  it('still cuts off genuinely deep inline nesting', () => {
+    // The case the guard is actually for: anonymous levels really do nest in
+    // the emitted text, so something has to stop them.
+    let t = '{ v: string }'
+    for (let i = 0; i < 15; i++) t = `{ v: string; next: ${t} }`
+
+    const warnings: string[] = []
+    const out = expand(`type Target = ${t}`, { onWarn: (m) => warnings.push(m) })
+
+    expect(warnings.length).toBeGreaterThan(0)
+    expect(out.text).toContain('unknown')
   })
 
   it('cuts off runaway depth rather than hanging', () => {

--- a/packages/cli/__tests__/client-plugin-skips.test.ts
+++ b/packages/cli/__tests__/client-plugin-skips.test.ts
@@ -37,13 +37,80 @@ function makeCtx(over: Partial<TypegenContext> = {}) {
 
 describe('kick/client plugin', () => {
   it('emits nothing under watch, and says why', async () => {
-    const { ctx, log, getScanResult } = makeCtx({ watch: true })
+    // Opted in, so the watch check is what this exercises — the wanted/not
+    // gate runs first and would otherwise skip for a different reason.
+    const { ctx, log, getScanResult } = makeCtx({
+      watch: true,
+      config: { typegen: { client: true } },
+    })
 
     expect(await kickClientTypegen().generate(ctx)).toBeNull()
 
     expect(log.info.mock.calls.flat().join(' ')).toContain('watch')
     // The expensive part must not even be reached.
     expect(getScanResult).not.toHaveBeenCalled()
+  })
+
+  it('does nothing at all for a project that never asked for the map', async () => {
+    // The reason this gate exists: producing the map builds a TypeScript
+    // program over the server. Measured on a 1,940-route API, the whole
+    // typegen pass goes 7.50s / 1127 MB with the map to 0.59s / 182 MB
+    // without. An API with no frontend should not pay that for a file nothing
+    // reads — and most projects have no frontend.
+    const { ctx, getScanResult } = makeCtx()
+
+    expect(await kickClientTypegen().generate(ctx)).toBeNull()
+    // Not even the scan: the gate is checked before any work.
+    expect(getScanResult).not.toHaveBeenCalled()
+  })
+
+  it('runs when the config asks for it', async () => {
+    const { ctx, getScanResult } = makeCtx({ config: { typegen: { client: true } } })
+
+    await kickClientTypegen().generate(ctx)
+
+    expect(getScanResult).toHaveBeenCalled()
+  })
+
+  it('does not infer "on" from the file being there, but says so', async () => {
+    // Inferring from disk would put the switch somewhere nobody looks: a
+    // project paying seconds and a gigabyte per typegen because of a file,
+    // with nothing in its config explaining why. Config is the switch.
+    //
+    // A map left to rot is still worth a word — that is how a frontend ends
+    // up type-checking against routes the server no longer serves.
+    const dir = mkdtempSync(join(tmpdir(), 'kick-gate-'))
+    try {
+      mkdirSync(join(dir, '.kickjs/types'), { recursive: true })
+      writeFileSync(join(dir, '.kickjs/types/kick__client.d.ts'), 'export {}\n')
+
+      const { ctx, log, getScanResult } = makeCtx({ cwd: dir })
+      expect(await kickClientTypegen().generate(ctx)).toBeNull()
+
+      expect(getScanResult).not.toHaveBeenCalled()
+      const warned = log.warn.mock.calls.flat().join(' ')
+      expect(warned).toContain('typegen.client')
+      expect(warned).toContain('NOT')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('stays off when explicitly disabled, even with the map on disk', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kick-gate-'))
+    try {
+      mkdirSync(join(dir, '.kickjs/types'), { recursive: true })
+      writeFileSync(join(dir, '.kickjs/types/kick__client.d.ts'), 'export {}\n')
+
+      const { ctx, getScanResult } = makeCtx({
+        cwd: dir,
+        config: { typegen: { client: false } },
+      })
+      expect(await kickClientTypegen().generate(ctx)).toBeNull()
+      expect(getScanResult).not.toHaveBeenCalled()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 
   it('stays quiet when the project never had a client map', async () => {
@@ -66,7 +133,7 @@ describe('kick/client plugin', () => {
       const out = join(dir, '.kickjs/types/kick__client.d.ts')
       writeFileSync(out, 'export interface KickApi {}\n')
 
-      const { ctx, log } = makeCtx({ cwd: dir })
+      const { ctx, log } = makeCtx({ cwd: dir, config: { typegen: { client: true } } })
       expect(await kickClientTypegen().generate(ctx)).toBeNull()
 
       const warnings = log.warn.mock.calls.flat().join(' ')
@@ -84,7 +151,7 @@ describe('kick/client plugin', () => {
   it('runs the resolution when not watching', async () => {
     // Guards against "skipped" becoming the only path: the watch check must
     // be the reason for the skip above, not an unconditional return.
-    const { ctx, getScanResult } = makeCtx()
+    const { ctx, getScanResult } = makeCtx({ config: { typegen: { client: true } } })
 
     await kickClientTypegen().generate(ctx)
 
@@ -101,7 +168,7 @@ describe('kick/client plugin', () => {
       const out = join(dir, '.kickjs/types/kick__client.d.ts')
       writeFileSync(out, 'export interface KickApi { "GET /gone": never }\n')
 
-      const { ctx, log } = makeCtx({ cwd: dir })
+      const { ctx, log } = makeCtx({ cwd: dir, config: { typegen: { client: true } } })
       expect(await kickClientTypegen().generate(ctx)).toBeNull()
 
       expect(existsSync(out)).toBe(false)

--- a/packages/cli/__tests__/client-plugin-skips.test.ts
+++ b/packages/cli/__tests__/client-plugin-skips.test.ts
@@ -46,16 +46,39 @@ describe('kick/client plugin', () => {
     expect(getScanResult).not.toHaveBeenCalled()
   })
 
-  it('warns and skips on any resolution failure, instead of failing typegen', async () => {
+  it('stays quiet when the project never had a client map', async () => {
+    // This plugin runs for every adopter, and most do not consume the map:
+    // the fullstack template's web app is wired to the ambient KickRoutes.Api,
+    // and rest/minimal have no frontend at all. Warning on every
+    // `kick typegen` about a file they do not use is pure noise — and the
+    // compiler API it needs pulls a second TypeScript, so "just install it"
+    // is not a free answer either.
     const { ctx, log } = makeCtx()
 
-    // An unusable project — no tsconfig, no routes file, possibly no compiler
-    // API. Every one of those means "skip this file", never "fail the pass":
-    // this plugin runs for every adopter, and an additive feature must not
-    // turn into a hard break. (The compiler-API message itself is asserted in
-    // client-ts-compiler.test.ts, where the decision lives.)
     expect(await kickClientTypegen().generate(ctx)).toBeNull()
-    expect(log.warn.mock.calls.flat().join(' ')).toContain('kick/client: skipped')
+    expect(log.warn).not.toHaveBeenCalled()
+  })
+
+  it('warns loudly when a map WAS on disk, because that is a regression', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kick-skip-'))
+    try {
+      mkdirSync(join(dir, '.kickjs/types'), { recursive: true })
+      const out = join(dir, '.kickjs/types/kick__client.d.ts')
+      writeFileSync(out, 'export interface KickApi {}\n')
+
+      const { ctx, log } = makeCtx({ cwd: dir })
+      expect(await kickClientTypegen().generate(ctx)).toBeNull()
+
+      const warnings = log.warn.mock.calls.flat().join(' ')
+      expect(warnings).toContain('kick/client: skipped')
+      // Missing beats stale: a frontend importing a deleted file fails to
+      // compile immediately, where an obsolete map type-checks cleanly
+      // against routes the server no longer serves.
+      expect(warnings).toContain('removed the previously generated')
+      expect(existsSync(out)).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 
   it('runs the resolution when not watching', async () => {

--- a/packages/cli/__tests__/client-render.test.ts
+++ b/packages/cli/__tests__/client-render.test.ts
@@ -18,7 +18,7 @@ const code = (out: string) =>
     .join('\n')
 
 describe('renderClient', () => {
-  it('emits a module-scoped interface with no imports', () => {
+  it('emits no imports, and exposes only the namespace globally', () => {
     const out = renderClient(
       {
         entries: new Map([['GET /terms', '{ params: {}; response: __T0[] }']]),
@@ -27,22 +27,31 @@ describe('renderClient', () => {
       ['GET /terms'],
     )
 
-    expect(out).toContain('export interface KickApi {')
+    expect(out).toContain('namespace KickClientApi {')
+    // Module-local, so the 86 hoisted shapes of a real app do not land in the
+    // consuming frontend's global scope.
+    expect(out).toContain('interface Api {')
+    expect(out).toContain('export type { Api }')
+    // NOT a global `KickApi`: kick__routes.ts already declares one, and both
+    // files sit in .kickjs/types which the server's own tsconfig includes.
+    expect(out).not.toContain('type KickApi')
     expect(out).toContain('"GET /terms": { params: {}; response: __T0[] }')
     expect(out).toContain('interface __T0 {')
     expect(code(out)).not.toContain('import ')
-    expect(code(out)).not.toContain('declare global')
+    // One global namespace, and nothing else ambient: the hoisted `__T<n>`
+    // shapes must not reach the consuming frontend's global scope.
+    expect(out.match(/declare global/g)).toHaveLength(1)
   })
 
   it('still emits a usable empty map before the first route exists', () => {
     const out = renderClient({ entries: new Map(), hoisted: [] }, [])
-    expect(out).toContain('export interface KickApi {}')
+    expect(out).toContain('interface Api {}')
   })
 
   it('emits the empty map rather than a broken one when every key was skipped', () => {
     // Keys with no resolved entry would otherwise render as `'K': undefined`.
     const out = renderClient({ entries: new Map(), hoisted: [] }, ['GET /ghost'])
-    expect(out).toContain('export interface KickApi {}')
+    expect(out).toContain('interface Api {}')
     expect(out).not.toContain('ghost')
   })
 

--- a/packages/cli/__tests__/client-resolve-entries.test.ts
+++ b/packages/cli/__tests__/client-resolve-entries.test.ts
@@ -96,6 +96,51 @@ describe('resolveClientMap', () => {
     expect(out.hoisted.join('\n')).not.toContain('src/term')
   })
 
+  it('does not load project files no route can reach', async () => {
+    // The probe imports the route map, which imports the controllers, so
+    // everything that can contribute to a route type arrives transitively.
+    // Passing the whole tsconfig on top of that loaded files no route can
+    // reference — on a 1,940-route app, 686 of 2,851 roots were tests.
+    writeFileSync(join(dir, 'src/unreachable.ts'), 'export const NOT_A_ROUTE = 1\n')
+
+    const out = await resolveClientMap({
+      projectDir: dir,
+      compilerFrom: process.cwd(),
+      routesFile,
+      keys: ['GET /terms'],
+    })
+
+    // Still resolves — the reduction must not cost fidelity.
+    expect(out.entries.get('GET /terms')).toContain('response: __T0[]')
+  })
+
+  it('keeps ambient declarations, which nothing imports', async () => {
+    // A `declare global` file is unreachable by definition: no import points
+    // at it. Dropping one silently removes the globals it declares, and a
+    // controller depending on those would resolve differently — the quiet
+    // divergence this generator must never produce. `kick__env.ts` is exactly
+    // this shape, and is a `.ts`, not a `.d.ts`.
+    writeFileSync(
+      join(dir, '.kickjs/types/kick__env.ts'),
+      'declare global {\n  interface KickAmbientProbe {\n    marker: string\n  }\n}\nexport {}\n',
+    )
+    writeFileSync(
+      join(dir, 'src/term.ts'),
+      'export interface Term { id: string; name: string; startsAt: Date; probe: KickAmbientProbe }\n',
+    )
+
+    const out = await resolveClientMap({
+      projectDir: dir,
+      compilerFrom: process.cwd(),
+      routesFile,
+      keys: ['GET /terms'],
+    })
+
+    // If the ambient file were dropped from the roots, KickAmbientProbe would
+    // be an error type and this property would degrade.
+    expect(out.hoisted.join('\n')).toContain('marker: string')
+  })
+
   it('warns and skips a key the program does not have', async () => {
     const warnings: string[] = []
     const out = await resolveClientMap({

--- a/packages/cli/__tests__/dev-debug-inspector.test.ts
+++ b/packages/cli/__tests__/dev-debug-inspector.test.ts
@@ -1,0 +1,45 @@
+/**
+ * `kick dev:debug` advertised a debugger that was never attached.
+ *
+ * It set `process.env.NODE_OPTIONS = '--inspect=…'` and then started the dev
+ * server in-process. Node reads NODE_OPTIONS once, at startup, so the flag did
+ * nothing — the server booted normally, printed `Debugger: ws://0.0.0.0:9229`,
+ * and port 9229 was closed. Nothing failed, which is why it survived.
+ *
+ * @module @forinda/kickjs-cli/__tests__/dev-debug-inspector.test
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { openInspector } from '../src/commands/run'
+
+afterEach(async () => {
+  const inspector = await import('node:inspector')
+  inspector.close()
+})
+
+describe('openInspector', () => {
+  it('actually opens the port, and returns a connectable URL', async () => {
+    // A high port, so a developer's own 9229 session cannot make this flaky.
+    const url = await openInspector(39229, '127.0.0.1')
+
+    // The session id is the part a hand-built ws://host:port URL lacks — and
+    // without it a debugger client cannot attach even to an open port.
+    expect(url).toMatch(/^ws:\/\/127\.0\.0\.1:39229\/[0-9a-f-]{36}$/)
+
+    // The port is genuinely listening: the inspector's own HTTP endpoint answers.
+    const res = await fetch('http://127.0.0.1:39229/json/version')
+    expect(res.ok).toBe(true)
+    expect(await res.json()).toHaveProperty('Protocol-Version')
+  })
+
+  it('throws rather than reporting a URL it did not open', async () => {
+    await openInspector(39230, '127.0.0.1')
+
+    // Node refuses a second activation. Surfacing that beats returning the
+    // still-valid URL of the FIRST port, which would tell the developer to
+    // attach somewhere they did not ask for. `dev:debug` catches this and
+    // suggests --inspect-port.
+    await expect(openInspector(39231, '127.0.0.1')).rejects.toThrow(/already activated/i)
+  })
+})

--- a/packages/cli/__tests__/dev-debug-inspector.test.ts
+++ b/packages/cli/__tests__/dev-debug-inspector.test.ts
@@ -33,6 +33,19 @@ describe('openInspector', () => {
     expect(await res.json()).toHaveProperty('Protocol-Version')
   })
 
+  it('binds to loopback by default', async () => {
+    // An attached inspector evaluates arbitrary code in the process, so the
+    // bind address is a security boundary, not a convenience. `node --inspect`
+    // defaults to loopback for this reason; `dev:debug` used to hardcode
+    // 0.0.0.0, which on a laptop means the café wifi.
+    //
+    // No host argument — the default is what this pins.
+    const url = await openInspector(39232)
+
+    expect(url).toContain('127.0.0.1')
+    expect(url).not.toContain('0.0.0.0')
+  })
+
   it('throws rather than reporting a URL it did not open', async () => {
     await openInspector(39230, '127.0.0.1')
 

--- a/packages/cli/__tests__/fullstack-client-map-wiring.test.ts
+++ b/packages/cli/__tests__/fullstack-client-map-wiring.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The fullstack template's web app reads the route map from the ambient
+ * `KickClientApi` namespace. Nothing pinned that wiring before: deleting the
+ * old `src/types/kick-routes.d.ts` bridge from the generator broke no test,
+ * which is exactly the kind of silent template regression a scaffold user
+ * finds instead of CI.
+ *
+ * @module @forinda/kickjs-cli/__tests__/fullstack-client-map-wiring.test
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { webApi, webTsConfig } from '../src/generators/fullstack'
+
+/** Statements only — the file comments the explicit-import alternative. */
+const code = (out: string) =>
+  out
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n')
+
+describe('fullstack web wiring', () => {
+  it('reads the map from the ambient namespace, with no import', () => {
+    const api = webApi()
+
+    expect(api).toContain('createClient<KickClientApi.Api>')
+    // The bridge is gone: no import of the server's generated route types.
+    expect(code(api)).not.toContain('kick__routes')
+    expect(code(api)).not.toContain("from '../../server")
+    // The only import is the client package itself.
+    expect(code(api).match(/^import /gm)).toHaveLength(1)
+  })
+
+  it('registers the map as a global type package', () => {
+    const cfg = JSON.parse(webTsConfig())
+
+    expect(cfg.compilerOptions.types).toContain('../server/.kickjs/types/kick__client')
+    // Extension omitted — a `types` entry is a package specifier, not a path
+    // to a file, and including `.d.ts` makes it unresolvable.
+    expect(cfg.compilerOptions.types.join()).not.toContain('.d.ts')
+  })
+
+  it('needs none of the settings the ambient bridge forced on it', () => {
+    // The bridge dragged decorated server source into the web program; the
+    // resolved map carries no reference to it, so these must not come back.
+    const cfg = JSON.parse(webTsConfig())
+
+    expect(cfg.compilerOptions.experimentalDecorators).toBeUndefined()
+    expect(cfg.compilerOptions.emitDecoratorMetadata).toBeUndefined()
+    expect(cfg.compilerOptions.paths).toBeUndefined()
+  })
+})

--- a/packages/cli/__tests__/scaffold-dev-script.test.ts
+++ b/packages/cli/__tests__/scaffold-dev-script.test.ts
@@ -9,19 +9,42 @@ import { describe, it, expect } from 'vitest'
 
 import { generatePackageJson } from '../src/generators/templates/project-config'
 
+const versions = () => ({
+  '@forinda/kickjs': '^5.16.0',
+  '@forinda/kickjs-schema': '^0.1.2',
+  '@forinda/kickjs-cli': '^6.0.1',
+  '@forinda/kickjs-testing': '^7.0.0',
+  '@forinda/kickjs-vite': '^6.0.1',
+})
+
 describe('scaffolded package.json scripts', () => {
   it('dev runs kick dev (typegen watcher), not bare vite', () => {
-    const versions = {
-      '@forinda/kickjs': '^5.16.0',
-      '@forinda/kickjs-schema': '^0.1.2',
-      '@forinda/kickjs-cli': '^6.0.1',
-      '@forinda/kickjs-testing': '^7.0.0',
-      '@forinda/kickjs-vite': '^6.0.1',
-    }
-    const pkg = JSON.parse(generatePackageJson('demo-app', 'minimal', versions))
+    const fixture = versions()
+    const pkg = JSON.parse(generatePackageJson('demo-app', 'minimal', fixture))
     expect(pkg.scripts.dev).toBe('kick dev')
-    expect(pkg.scripts['dev:debug']).toBe('kick dev:debug')
     expect(pkg.scripts.build).toBe('kick build')
-    expect(pkg.scripts.typegen).toBe('kick typegen')
+  })
+
+  it('ships four scripts, and no script it cannot run', () => {
+    const pkg = JSON.parse(generatePackageJson('demo-app', 'minimal', versions()))
+
+    expect(Object.keys(pkg.scripts).toSorted()).toEqual(['build', 'dev', 'start', 'test'])
+
+    // Every command a script invokes has to be installed. `lint: 'eslint src/'`
+    // shipped for a long time with eslint in no dependency list, so `lint`
+    // failed with "command not found" in every generated project.
+    const devDeps = Object.keys(pkg.devDependencies)
+    expect(devDeps).toContain('vitest')
+    expect(devDeps).not.toContain('eslint')
+    expect(devDeps).not.toContain('prettier')
+  })
+
+  it('formats with the tool the framework itself uses', () => {
+    const pkg = JSON.parse(generatePackageJson('demo-app', 'minimal', versions()))
+
+    // A scaffold arriving with prettier, from a repo formatted by oxfmt, makes
+    // the generated project disagree with the framework it came from.
+    expect(pkg.devDependencies).toHaveProperty('oxfmt')
+    expect(pkg.devDependencies).not.toHaveProperty('prettier')
   })
 })

--- a/packages/cli/src/commands/custom.ts
+++ b/packages/cli/src/commands/custom.ts
@@ -1,5 +1,7 @@
 import type { Command } from 'commander'
 import type { KickConfig, KickCommandDefinition } from '../config'
+import { join, delimiter } from 'node:path'
+
 import { runShellCommand } from '../utils/shell'
 
 /**
@@ -83,6 +85,25 @@ function registerSingleCommand(program: Command, def: KickCommandDefinition): vo
   command.allowUnknownOption(true)
   command.argument('[args...]', 'Additional arguments passed to the command')
 
+  /**
+   * PATH with the project's `node_modules/.bin` in front.
+   *
+   * Steps inherit the PATH of whatever launched `kick`. Run through a package
+   * script that already includes local binaries; run from a shell with a
+   * global `kick`, it does not — which is why these steps used to be written
+   * `npx <tool>`, and npx resolves an ABSENT binary by fetching whatever the
+   * registry has under that name. For a bin whose package is named differently
+   * that is a stranger's code: `kick` on npm is an AngularJS scaffolder.
+   *
+   * Putting the project's own binaries on PATH means steps can name tools
+   * plainly, and a missing one fails as "command not found" rather than
+   * downloading something.
+   */
+  function binPathEnv(): NodeJS.ProcessEnv {
+    const bin = join(process.cwd(), 'node_modules', '.bin')
+    return { PATH: `${bin}${delimiter}${process.env.PATH ?? ''}` }
+  }
+
   command.action((args: string[]) => {
     const extraArgs = args.join(' ')
     const steps = Array.isArray(def.steps) ? def.steps : [def.steps]
@@ -92,7 +113,7 @@ function registerSingleCommand(program: Command, def: KickCommandDefinition): vo
       const finalCmd = extraArgs ? `${step} ${extraArgs}` : step
       console.log(`  $ ${finalCmd}`)
       try {
-        runShellCommand(finalCmd)
+        runShellCommand(finalCmd, undefined, binPathEnv())
       } catch {
         console.error(`  Command failed: ${def.name}`)
         process.exitCode = 1

--- a/packages/cli/src/commands/dev-typecheck.ts
+++ b/packages/cli/src/commands/dev-typecheck.ts
@@ -21,13 +21,13 @@ export interface TypecheckBin {
   args: string[]
   /** `.CMD` shims require a shell on Windows. */
   shell: boolean
-  kind: 'tsgo' | 'tsc'
+  kind: 'vue-tsc' | 'tsgo' | 'tsc'
 }
 
 /**
  * Locate the project's checker binary under `node_modules/.bin`,
  * preferring tsgo (`@typescript/native-preview`) over tsc. Returns
- * null when neither is installed — callers print a one-time notice
+ * null when none is installed — callers print a one-time notice
  * and skip checking rather than failing the dev server.
  *
  * On Windows the runnable shim is `<name>.CMD` / `<name>.cmd`; the
@@ -36,7 +36,11 @@ export interface TypecheckBin {
 export function resolveTypecheckBin(projectDir: string): TypecheckBin | null {
   const binDir = join(projectDir, 'node_modules', '.bin')
   const isWin = process.platform === 'win32'
-  for (const kind of ['tsgo', 'tsc'] as const) {
+  // `vue-tsc` first, and it being installed is the signal: plain tsc does not
+  // understand `.vue`, so in a Vue project it matches no inputs and reports
+  // TS18003 "No inputs were found" while real errors sit unchecked in the
+  // SFCs. vue-tsc checks plain `.ts` too, so preferring it costs nothing.
+  for (const kind of ['vue-tsc', 'tsgo', 'tsc'] as const) {
     const names = isWin ? [`${kind}.CMD`, `${kind}.cmd`, `${kind}.exe`] : [kind]
     for (const name of names) {
       const candidate = join(binDir, name)
@@ -53,7 +57,7 @@ export interface TypecheckResult {
   /** Combined stdout+stderr of the checker run. */
   output: string
   durationMs: number
-  kind: 'tsgo' | 'tsc'
+  kind: 'vue-tsc' | 'tsgo' | 'tsc'
 }
 
 export interface DevTypechecker {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process'
 import { cpSync, existsSync, mkdirSync } from 'node:fs'
 import { resolve, join } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -367,6 +368,34 @@ export function registerRunCommands(program: Command): void {
       const env: NodeJS.ProcessEnv = { NODE_ENV: 'production' }
       if (opts.port) env.PORT = String(opts.port)
       runNodeWithEnv(opts.entry, env)
+    })
+
+  program
+    .command('typecheck')
+    .description('Type-check the project with its own tsgo/tsc')
+    .option('--cwd <dir>', 'Directory to type-check', '.')
+    .action((opts: any) => {
+      // The point of routing this through `kick` is that a scaffold should not
+      // have to spell the package manager. `pnpm -r exec tsc --noEmit` and
+      // `cd server && npx tsc --noEmit` do the same job in two incompatible
+      // dialects, and the fullstack template had to branch on the manager to
+      // write them. `kick typecheck` is the same command everywhere.
+      //
+      // Same resolver `kick dev --typecheck` uses, so it prefers tsgo and
+      // handles Windows' .CMD shims.
+      const dir = resolve(process.cwd(), opts.cwd ?? '.')
+      const bin = resolveTypecheckBin(dir)
+      if (!bin) {
+        console.error(
+          '\n  No type-checker found. Install one in this project:' +
+            '\n    pnpm add -D typescript        (tsc)' +
+            '\n    pnpm add -D @typescript/native-preview   (tsgo, faster)\n',
+        )
+        process.exit(1)
+        return
+      }
+      const result = spawnSync(bin.cmd, bin.args, { stdio: 'inherit', shell: bin.shell, cwd: dir })
+      process.exit(result.status ?? 1)
     })
 
   program

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -53,7 +53,7 @@ function resolvePolling(flag: boolean | undefined): boolean {
  * The returned URL carries the session id. A hand-built `ws://host:port`
  * cannot be connected to even when the port is open.
  */
-export async function openInspector(port: number, host = '0.0.0.0'): Promise<string> {
+export async function openInspector(port: number, host = '127.0.0.1'): Promise<string> {
   const inspector = await import('node:inspector')
   inspector.open(port, host, false)
   const url = inspector.url()
@@ -375,8 +375,25 @@ export function registerRunCommands(program: Command): void {
     .option('-e, --entry <file>', 'Entry file', 'src/index.ts')
     .option('-p, --port <port>', 'Port number')
     .option('--inspect-port <port>', 'Inspector port', '9229')
+    .option(
+      '--inspect-host <host>',
+      'Inspector bind address (use 0.0.0.0 to reach it from outside a container)',
+      '127.0.0.1',
+    )
     .action(async (opts: any) => {
       const inspectPort = Number(opts.inspectPort ?? '9229')
+      const inspectHost = opts.inspectHost ?? '127.0.0.1'
+
+      // Anyone who reaches an open inspector can evaluate code in this
+      // process. Loopback keeps that to this machine; a wildcard bind is a
+      // real choice a container makes, not a default to inherit silently.
+      if (!['127.0.0.1', 'localhost', '::1'].includes(inspectHost)) {
+        console.warn(
+          `  WARNING: the debugger is bound to ${inspectHost}, not loopback. Anyone who can` +
+            `\n  reach port ${inspectPort} can run code in this process. Use it on a trusted` +
+            `\n  network only, and prefer publishing the port from your container instead.`,
+        )
+      }
 
       // Attach the inspector to THIS process. Setting NODE_OPTIONS here does
       // nothing: Node reads it once, at startup, and the dev server runs
@@ -389,7 +406,7 @@ export function registerRunCommands(program: Command): void {
       // running process. `false` means do not block waiting for a client.
       let url: string
       try {
-        url = await openInspector(inspectPort)
+        url = await openInspector(inspectPort, inspectHost)
       } catch (err: any) {
         console.error(
           `\n  Could not open the inspector on ${inspectPort}: ${err.message ?? err}` +

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -41,6 +41,26 @@ function resolvePolling(flag: boolean | undefined): boolean {
   return env === '1' || env === 'true'
 }
 
+/**
+ * Attach a Node inspector to the CURRENT process and return its real URL.
+ *
+ * Not `NODE_OPTIONS`: Node reads that once, at startup, and the dev server
+ * runs in-process — `startDevServer` calls Vite's `createServer` directly
+ * rather than spawning. Setting it here printed a debugger URL that nothing
+ * was listening on, which is how this went unnoticed: the server booted
+ * normally and only the port was missing.
+ *
+ * The returned URL carries the session id. A hand-built `ws://host:port`
+ * cannot be connected to even when the port is open.
+ */
+export async function openInspector(port: number, host = '0.0.0.0'): Promise<string> {
+  const inspector = await import('node:inspector')
+  inspector.open(port, host, false)
+  const url = inspector.url()
+  if (!url) throw new Error('inspector.open() reported no URL')
+  return url
+}
+
 async function startDevServer(
   _entry: string,
   port?: string,
@@ -356,11 +376,29 @@ export function registerRunCommands(program: Command): void {
     .option('-p, --port <port>', 'Port number')
     .option('--inspect-port <port>', 'Inspector port', '9229')
     .action(async (opts: any) => {
-      // For debug mode, we need --inspect on the Node.js process itself.
-      // Re-launch the dev command with NODE_OPTIONS=--inspect
-      const inspectPort = opts.inspectPort ?? '9229'
-      process.env.NODE_OPTIONS = `--inspect=0.0.0.0:${inspectPort}`
-      console.log(`  Debugger: ws://0.0.0.0:${inspectPort}`)
+      const inspectPort = Number(opts.inspectPort ?? '9229')
+
+      // Attach the inspector to THIS process. Setting NODE_OPTIONS here does
+      // nothing: Node reads it once, at startup, and the dev server runs
+      // in-process (`startDevServer` calls Vite's `createServer` directly, it
+      // does not spawn). So the previous version printed a debugger URL that
+      // nothing was listening on — the server came up fine and port 9229 was
+      // closed.
+      //
+      // `inspector.open` is the supported way in: it opens the port on the
+      // running process. `false` means do not block waiting for a client.
+      let url: string
+      try {
+        url = await openInspector(inspectPort)
+      } catch (err: any) {
+        console.error(
+          `\n  Could not open the inspector on ${inspectPort}: ${err.message ?? err}` +
+            `\n  Another process may already hold it — try --inspect-port <port>.`,
+        )
+        process.exit(1)
+        return
+      }
+      console.log(`  Debugger: ${url}`)
 
       try {
         await startDevServer(opts.entry, opts.port)

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -240,6 +240,25 @@ export interface TypegenConfig {
    * not a strict registry.
    */
   disable?: string[]
+
+  /**
+   * Generate `.kickjs/types/kick__client.d.ts`, the self-contained route map
+   * a frontend consumes without compiling the server.
+   *
+   * Producing it means building a whole TypeScript program over the server —
+   * measured at 1.1 GB and ~7.6s on a 1,940-route app, against ~130ms for
+   * every other typegen plugin combined. An API with no frontend should not
+   * pay that for a file nothing reads, so this is not on for everyone.
+   *
+   * Off unless set. `kick new --template fullstack` writes `true`, since its
+   * web app reads the map; anything else opts in here.
+   *
+   * A map already on disk does NOT turn this on — that would put the switch
+   * somewhere nobody looks. It does get a warning, since a map left to rot is
+   * how a frontend ends up type-checking against routes the server no longer
+   * serves.
+   */
+  client?: boolean
 }
 
 /** Module generation settings — controls how `kick g module` produces code */

--- a/packages/cli/src/generators/config.ts
+++ b/packages/cli/src/generators/config.ts
@@ -64,7 +64,7 @@ export default defineConfig({
     },
     {
       name: 'ci:check',
-      description: 'Run typecheck + format check',
+      description: 'Run typecheck + lint + format check',
       steps: ['kick typecheck', 'oxlint src/', 'oxfmt --check src/'],
       aliases: ['verify'],
     },

--- a/packages/cli/src/generators/config.ts
+++ b/packages/cli/src/generators/config.ts
@@ -49,18 +49,18 @@ export default defineConfig({
     },
     {
       name: 'format',
-      description: 'Format code with Prettier',
-      steps: 'npx prettier --write src/',
+      description: 'Format code with oxfmt',
+      steps: 'npx oxfmt src/',
     },
     {
       name: 'format:check',
       description: 'Check formatting without writing',
-      steps: 'npx prettier --check src/',
+      steps: 'npx oxfmt --check src/',
     },
     {
       name: 'ci:check',
       description: 'Run typecheck + format check',
-      steps: ['npx tsc --noEmit', 'npx prettier --check src/'],
+      steps: ['npx tsc --noEmit', 'npx oxfmt --check src/'],
       aliases: ['verify'],
     },
   ],

--- a/packages/cli/src/generators/config.ts
+++ b/packages/cli/src/generators/config.ts
@@ -45,22 +45,27 @@ export default defineConfig({
     {
       name: 'test',
       description: 'Run tests with Vitest',
-      steps: 'npx vitest run',
+      steps: 'vitest run',
+    },
+    {
+      name: 'lint',
+      description: 'Lint with oxlint',
+      steps: 'oxlint src/',
     },
     {
       name: 'format',
       description: 'Format code with oxfmt',
-      steps: 'npx oxfmt src/',
+      steps: 'oxfmt src/',
     },
     {
       name: 'format:check',
       description: 'Check formatting without writing',
-      steps: 'npx oxfmt --check src/',
+      steps: 'oxfmt --check src/',
     },
     {
       name: 'ci:check',
       description: 'Run typecheck + format check',
-      steps: ['npx tsc --noEmit', 'npx oxfmt --check src/'],
+      steps: ['kick typecheck', 'oxlint src/', 'oxfmt --check src/'],
       aliases: ['verify'],
     },
   ],

--- a/packages/cli/src/generators/fullstack.ts
+++ b/packages/cli/src/generators/fullstack.ts
@@ -418,6 +418,15 @@ It stops being invisible when the frontend grows or moves. \`kick typegen\` also
 emits \`server/.kickjs/types/kick__client.d.ts\` — the same routes with every
 type resolved to a literal shape and **no imports at all**:
 
+On TypeScript 7 the resolver needs a compiler API, which TS 7 does not ship:
+
+\`\`\`bash
+cd server && ${pm} add -D @typescript/typescript6
+\`\`\`
+
+It is not installed by default — it pulls a second TypeScript, and this
+template's \`web\` does not use the map.
+
 \`\`\`ts
 // web/src/api.ts
 import type { KickApi } from '../../server/.kickjs/types/kick__client'

--- a/packages/cli/src/generators/fullstack.ts
+++ b/packages/cli/src/generators/fullstack.ts
@@ -406,6 +406,36 @@ Server: http://localhost:3000 · Web: http://localhost:5173 (Vite proxies \`/api
 Rename a field in \`server/src/modules/hello/hello.service.ts\` → \`web/src/App.tsx\`
 stops compiling. That's the point.
 
+### When to switch to \`kick__client.d.ts\`
+
+Step 3 works because \`web\` compiles the server's route types — which reference
+controller classes, so the server's source graph is pulled into \`web\`'s own
+\`tsc\` run. That is why \`web/tsconfig.json\` carries \`experimentalDecorators\`.
+In one workspace of this size the cost is invisible, and the payoff is the live
+loop above.
+
+It stops being invisible when the frontend grows or moves. \`kick typegen\` also
+emits \`server/.kickjs/types/kick__client.d.ts\` — the same routes with every
+type resolved to a literal shape and **no imports at all**:
+
+\`\`\`ts
+// web/src/api.ts
+import type { KickApi } from '../../server/.kickjs/types/kick__client'
+
+export const api = createClient<KickApi>({ baseUrl: '/api/v1' })
+\`\`\`
+
+Then delete \`web/src/types/kick-routes.d.ts\` and drop \`experimentalDecorators\`
+from \`web/tsconfig.json\`. Call sites do not change: both maps carry the same
+types, because the second is produced by resolving the first.
+
+Switch when the frontend lives in its own repo, when it sets
+\`verbatimModuleSyntax\`, or when its typecheck starts paying for the server's.
+The trade is that this file is **not** refreshed by \`kick dev\` — resolving it
+builds a whole TypeScript program — so a renamed field surfaces on the next
+\`kick typegen\` rather than on save. \`kick typegen --check\` catches a stale one
+in CI.
+
 Docs: https://kickjs.app/guide/typed-client.html
 `
 }

--- a/packages/cli/src/generators/fullstack.ts
+++ b/packages/cli/src/generators/fullstack.ts
@@ -84,11 +84,26 @@ export async function initFullstackProject(options: InitFullstackOptions): Promi
   await writeFileSafe(join(dir, 'web/src/api.ts'), webApi())
 
   // ── workspace root ──────────────────────────────────────────────────
-  await writeFileSafe(join(dir, 'package.json'), rootPackageJson(name, packageManager))
+  await writeFileSafe(
+    join(dir, 'package.json'),
+    rootPackageJson(name, packageManager, versions['@forinda/kickjs-cli']),
+  )
   // Only pnpm reads this file. npm / yarn / bun declare workspaces via the
   // `workspaces` field in the root package.json instead — see rootPackageJson.
   if (packageManager === 'pnpm') {
-    await writeFileSafe(join(dir, 'pnpm-workspace.yaml'), `packages:\n  - server\n  - web\n`)
+    // `allowBuilds` is answered here, not left to pnpm. This scaffold installs
+    // non-interactively, so pnpm cannot prompt — it writes
+    // `'@swc/core': set this to true or false` and then refuses to run ANY
+    // script with ERR_PNPM_IGNORED_BUILDS, leaving a fresh project unable to
+    // run `pnpm typecheck` or `pnpm dev` until someone edits this file.
+    //
+    // Both are build tools this template chose: swc compiles the decorators,
+    // esbuild is Vite's. Approving their install scripts is the same decision
+    // as depending on them.
+    await writeFileSafe(
+      join(dir, 'pnpm-workspace.yaml'),
+      `packages:\n  - server\n  - web\n\nallowBuilds:\n  '@swc/core': true\n  esbuild: true\n`,
+    )
   }
   await writeFileSafe(join(dir, '.gitignore'), rootGitignore())
   await writeFileSafe(join(dir, 'README.md'), rootReadme(name, packageManager))
@@ -278,8 +293,9 @@ function webApp(): string {
 import { api } from './api'
 
 // The response types below are INFERRED from the server's handlers —
-// change server/src/modules/hello/hello.service.ts and these types follow
-// on the next \`kick typegen\` (automatic under \`kick dev\`).
+// change server/src/modules/hello/hello.service.ts and these types follow on
+// the next \`kick typegen\`. Not under \`kick dev\`: resolving the client map
+// builds a whole TypeScript program, so it is a build step, not a per-save one.
 type Greeting = Awaited<ReturnType<typeof fetchGreeting>>
 
 function fetchGreeting() {
@@ -339,7 +355,7 @@ export const api = createClient<KickClientApi.Api>({ baseUrl: '/api/v1' })
 
 // ── root templates ────────────────────────────────────────────────────
 
-function rootPackageJson(name: string, pm: string): string {
+function rootPackageJson(name: string, pm: string, cliVersion: string): string {
   const scripts: Record<string, string> =
     pm === 'pnpm'
       ? {
@@ -349,7 +365,16 @@ function rootPackageJson(name: string, pm: string): string {
           'dev:server': 'pnpm --filter ./server dev',
           'dev:web': 'pnpm --filter ./web dev',
           build: 'pnpm -r run build',
-          typecheck: 'pnpm -r run typecheck',
+          // No `npx`: the binary is `kick` but the package is
+          // `@forinda/kickjs-cli`, so npx cannot map one to the other and
+          // falls back to the REGISTRY — where `kick` is an unrelated
+          // AngularJS scaffolder. It runs, prints its own help, and exits 0,
+          // so this script would pass without type-checking anything.
+          //
+          // Every package manager puts `node_modules/.bin` on PATH for
+          // scripts, so the bare name resolves locally, and a missing install
+          // fails loudly instead of fetching a stranger.
+          typecheck: 'kick typecheck --cwd server && kick typecheck --cwd web',
         }
       : {
           // cd-based scripts — the one form npm, yarn (classic AND berry),
@@ -361,7 +386,16 @@ function rootPackageJson(name: string, pm: string): string {
           build: `${pm} run build:server && ${pm} run build:web`,
           'build:server': `cd server && ${pm} run build`,
           'build:web': `cd web && ${pm} run build`,
-          typecheck: `cd web && ${pm} run typecheck`,
+          // No `npx`: the binary is `kick` but the package is
+          // `@forinda/kickjs-cli`, so npx cannot map one to the other and
+          // falls back to the REGISTRY — where `kick` is an unrelated
+          // AngularJS scaffolder. It runs, prints its own help, and exits 0,
+          // so this script would pass without type-checking anything.
+          //
+          // Every package manager puts `node_modules/.bin` on PATH for
+          // scripts, so the bare name resolves locally, and a missing install
+          // fails loudly instead of fetching a stranger.
+          typecheck: 'kick typecheck --cwd server && kick typecheck --cwd web',
         }
   return `${JSON.stringify(
     {
@@ -370,6 +404,10 @@ function rootPackageJson(name: string, pm: string): string {
       version: '0.0.0',
       type: 'module',
       scripts,
+      // The CLI is a ROOT dependency so the bare `kick` in the scripts above
+      // resolves: package managers put `node_modules/.bin` on PATH for
+      // scripts, and the CLI otherwise lives only in `server/node_modules`.
+      devDependencies: { '@forinda/kickjs-cli': cliVersion },
       workspaces: ['server', 'web'],
     },
     null,

--- a/packages/cli/src/generators/fullstack.ts
+++ b/packages/cli/src/generators/fullstack.ts
@@ -7,7 +7,7 @@
 //
 // The type loop: server controllers use return-value handlers → `kick
 // typegen` (run here once, re-run by `kick dev`) emits
-// server/.kickjs/types/kick__routes.ts → web/src/types/kick-routes.d.ts
+// server/.kickjs/types/kick__client.d.ts → web tsconfig `types` (ambient)
 // side-effect-imports that file (type-only, erased at runtime) → the web
 // client calls `api.get('/hello')` with the handler's actual response type.
 
@@ -57,6 +57,9 @@ export async function initFullstackProject(options: InitFullstackOptions): Promi
     template: 'minimal',
     schemaLib,
     runtime,
+    // web/ reads the resolved route map from the ambient KickClientApi
+    // namespace, which needs the TS 7 compiler API to produce.
+    withClientMap: true,
     // Root owns install + git so the lockfile/commit cover the workspace.
     initGit: false,
     installDeps: false,
@@ -79,7 +82,6 @@ export async function initFullstackProject(options: InitFullstackOptions): Promi
   await writeFileSafe(join(dir, 'web/src/main.tsx'), webMain())
   await writeFileSafe(join(dir, 'web/src/App.tsx'), webApp())
   await writeFileSafe(join(dir, 'web/src/api.ts'), webApi())
-  await writeFileSafe(join(dir, 'web/src/types/kick-routes.d.ts'), webRouteTypes())
 
   // ── workspace root ──────────────────────────────────────────────────
   await writeFileSafe(join(dir, 'package.json'), rootPackageJson(name, packageManager))
@@ -206,7 +208,7 @@ export default defineConfig({
 `
 }
 
-function webTsConfig(): string {
+export function webTsConfig(): string {
   return `${JSON.stringify(
     {
       compilerOptions: {
@@ -219,12 +221,21 @@ function webTsConfig(): string {
         skipLibCheck: true,
         noEmit: true,
         isolatedModules: true,
-        // The type bridge pulls server controller sources into this
-        // program — they use legacy TS decorators.
-        experimentalDecorators: true,
-        // The KickRoutes ambient types come from the server's generated
-        // typegen output via src/types/kick-routes.d.ts.
-        types: [],
+        // The resolved client route map, as an ambient global type package —
+        // the same mechanism as "node" or "vitest/globals". It makes
+        // `KickClientApi.Api` available with no import and no bridge file.
+        //
+        // Note this is a `types` ENTRY, not an `include`: the map is a global
+        // type package, not source of this app. It also means the file must
+        // exist — `kick new` runs typegen for you, and `kick typegen` in
+        // server/ refreshes it. (An `include` entry tolerates the file being
+        // absent; a `types` entry reports TS2688, which is the louder and
+        // more useful failure for something the app depends on.)
+        //
+        // No `experimentalDecorators` here: unlike the ambient
+        // `KickRoutes.Api` bridge, this map carries no reference to the
+        // server's decorated controller sources.
+        types: ['../server/.kickjs/types/kick__client'],
       },
       include: ['src'],
     },
@@ -308,22 +319,21 @@ export function App() {
 `
 }
 
-function webApi(): string {
+export function webApi(): string {
   return `import { createClient } from '@forinda/kickjs-client'
 
-// KickApi (alias of KickRoutes.Api) is ambient — populated by server/.kickjs/types (see
-// src/types/kick-routes.d.ts). Keys are module-mount-relative paths;
-// the bootstrap-level '/api/v1' prefix lives here in baseUrl, and the
-// Vite dev proxy forwards it to the KickJS server.
-export const api = createClient<KickApi>({ baseUrl: '/api/v1' })
-`
-}
-
-function webRouteTypes(): string {
-  return `// Type-only bridge to the server's generated route types. The import is
-// erased at build time — no server code ever enters the web bundle.
-// Regenerate with \`kick typegen\` in server/ (automatic under \`kick dev\`).
-import '../../../server/.kickjs/types/kick__routes'
+// KickClientApi is ambient — the resolved route map from
+// server/.kickjs/types/kick__client.d.ts, wired in tsconfig's \`types\`. Every
+// response type is a literal shape, so nothing from the server's source graph
+// enters this program.
+//
+// Keys are module-mount-relative paths; the bootstrap-level '/api/v1' prefix
+// lives here in baseUrl, and the Vite dev proxy forwards it to the KickJS
+// server.
+//
+// Prefer an explicit import? The same file exports the type:
+//   import type { Api } from '../../server/.kickjs/types/kick__client'
+export const api = createClient<KickClientApi.Api>({ baseUrl: '/api/v1' })
 `
 }
 
@@ -398,52 +408,57 @@ Server: http://localhost:3000 · Web: http://localhost:5173 (Vite proxies \`/api
 ## The type loop
 
 1. Server handlers **return** their payloads (\`return this.service.greet(...)\`).
-2. \`kick typegen\` (auto under \`kick dev\`) emits \`server/.kickjs/types/kick__routes.ts\` —
-   including the flat \`KickRoutes.Api\` map with inferred response types.
-3. \`web/src/types/kick-routes.d.ts\` imports that file type-only.
-4. \`web/src/api.ts\`'s \`createClient<KickRoutes.Api>\` types every call site.
+2. \`kick typegen\` emits \`server/.kickjs/types/kick__client.d.ts\` — the flat
+   route map with every response type resolved to a literal shape.
+3. \`web/tsconfig.json\` lists that file in \`types\`, so \`KickClientApi\` is
+   ambient — no import, no bridge file.
+4. \`web/src/api.ts\`'s \`createClient<KickClientApi.Api>\` types every call site.
+
+Because the map holds resolved types rather than references to controllers,
+\`web\` never compiles server source: no \`experimentalDecorators\`, no path
+aliases into \`server/src\`.
 
 Rename a field in \`server/src/modules/hello/hello.service.ts\` → \`web/src/App.tsx\`
 stops compiling. That's the point.
 
-### When to switch to \`kick__client.d.ts\`
+### Keeping the map fresh
 
-Step 3 works because \`web\` compiles the server's route types — which reference
-controller classes, so the server's source graph is pulled into \`web\`'s own
-\`tsc\` run. That is why \`web/tsconfig.json\` carries \`experimentalDecorators\`.
-In one workspace of this size the cost is invisible, and the payoff is the live
-loop above.
+\`server/.kickjs/types/kick__client.d.ts\` is generated, and \`web\` reads it as
+an ambient type package. Two things follow.
 
-It stops being invisible when the frontend grows or moves. \`kick typegen\` also
-emits \`server/.kickjs/types/kick__client.d.ts\` — the same routes with every
-type resolved to a literal shape and **no imports at all**:
+**It is not refreshed by \`kick dev\`.** Resolving it builds a whole TypeScript
+program over the server, which is a build-step cost rather than a per-save one,
+so a renamed response field surfaces on the next \`kick typegen\` rather than on
+save. Everything else in \`.kickjs/types\` still updates on save. Add
+\`kick typegen --check\` to CI and a stale map fails the build.
 
-On TypeScript 7 the resolver needs a compiler API, which TS 7 does not ship:
+**It needs a compiler API.** TypeScript 7 ships none, so \`server\` depends on
+\`@typescript/typescript6\`. Remove it and typegen skips this one file, saying
+so; \`web\` then reports \`TS2688\` because the file it lists in \`types\` is gone.
 
-\`\`\`bash
-cd server && ${pm} add -D @typescript/typescript6
+### The other way to wire it
+
+A \`types\` entry says "this is a global type package", which is what the map is,
+and it fails loudly when the file is missing. If you would rather it be quiet
+when absent — say, a repo where the map is not always generated — use
+\`include\` instead:
+
+\`\`\`json
+{ "include": ["src", "../server/.kickjs/types/kick__client.d.ts"] }
 \`\`\`
 
-It is not installed by default — it pulls a second TypeScript, and this
-template's \`web\` does not use the map.
+That tolerates the file not existing, at the cost of \`KickClientApi\` silently
+not resolving. Note \`types\` replaces TypeScript's automatic \`@types\`
+inclusion, so if you add entries there, list the ones you rely on too
+(\`"types": ["node", "../server/.kickjs/types/kick__client"]\`).
+
+Or skip the global entirely — the same file exports the type:
 
 \`\`\`ts
-// web/src/api.ts
-import type { KickApi } from '../../server/.kickjs/types/kick__client'
+import type { Api } from '../../server/.kickjs/types/kick__client'
 
-export const api = createClient<KickApi>({ baseUrl: '/api/v1' })
+export const api = createClient<Api>({ baseUrl: '/api/v1' })
 \`\`\`
-
-Then delete \`web/src/types/kick-routes.d.ts\` and drop \`experimentalDecorators\`
-from \`web/tsconfig.json\`. Call sites do not change: both maps carry the same
-types, because the second is produced by resolving the first.
-
-Switch when the frontend lives in its own repo, when it sets
-\`verbatimModuleSyntax\`, or when its typecheck starts paying for the server's.
-The trade is that this file is **not** refreshed by \`kick dev\` — resolving it
-builds a whole TypeScript program — so a renamed field surfaces on the next
-\`kick typegen\` rather than on save. \`kick typegen --check\` catches a stale one
-in CI.
 
 Docs: https://kickjs.app/guide/typed-client.html
 `

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -353,7 +353,7 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
   // ── kick.config.ts — CLI configuration ─────────────────────────────
   await writeFileSafe(
     join(dir, 'kick.config.ts'),
-    generateKickConfig(template, defaultRepo, packageManager, runtime),
+    generateKickConfig(template, defaultRepo, packageManager, runtime, options.withClientMap),
   )
 
   // ── vitest.config.ts ────────────────────────────────────────────────

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -199,6 +199,8 @@ interface InitProjectOptions {
   runtime?: 'express' | 'fastify' | 'h3'
   /** Wire `SpaAdapter` at this clientDir (fullstack template). */
   spaClientDir?: string
+  /** Pin the compiler API + generate the client route map (fullstack). */
+  withClientMap?: boolean
 }
 
 /** Scaffold a new KickJS project */
@@ -287,7 +289,15 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
   // ── package.json — template-aware deps ────────────────────────────
   await writeFileSafe(
     join(dir, 'package.json'),
-    generatePackageJson(name, template, versions, packages, schemaLib, runtime),
+    generatePackageJson(
+      name,
+      template,
+      versions,
+      packages,
+      schemaLib,
+      runtime,
+      options.withClientMap,
+    ),
   )
 
   // ── vite.config.ts — enables HMR + SWC for decorators ──────────────

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -8,7 +8,7 @@ import {
   generatePackageJson,
   generateViteConfig,
   generateTsConfig,
-  generatePrettierConfig,
+  generateFormatterConfig,
   generateEditorConfig,
   generateGitIgnore,
   generateGitAttributes,
@@ -306,8 +306,8 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
   // ── tsconfig.json ───────────────────────────────────────────────────
   await writeFileSafe(join(dir, 'tsconfig.json'), generateTsConfig())
 
-  // ── .prettierrc ─────────────────────────────────────────────────────
-  await writeFileSafe(join(dir, '.prettierrc'), generatePrettierConfig())
+  // ── .oxfmtrc.json ───────────────────────────────────────────────────
+  await writeFileSafe(join(dir, '.oxfmtrc.json'), generateFormatterConfig())
 
   // ── .editorconfig ─────────────────────────────────────────────────────
   await writeFileSafe(join(dir, '.editorconfig'), generateEditorConfig())

--- a/packages/cli/src/generators/templates/controller.ts
+++ b/packages/cli/src/generators/templates/controller.ts
@@ -3,8 +3,8 @@ import type { TemplateContext } from './types'
 /** DDD controller — injects use-cases, nested import paths */
 export function generateController(ctx: TemplateContext): string {
   const { pascal, kebab, plural = '', pluralPascal = '' } = ctx
-  // Wrapped exactly as Prettier would at the scaffold's printWidth of 100 —
-  // a single-line import is 112 chars, so `pnpm format` on a fresh project
+  // Wrapped exactly as oxfmt would at the scaffold's printWidth of 100 —
+  // a single-line import is 112 chars, so `kick format` on a fresh project
   // would otherwise rewrite this file on the adopter's first run.
   return `import {
   Controller,
@@ -98,8 +98,8 @@ export class ${pascal}Controller {
 export function generateRestController(ctx: TemplateContext): string {
   const { pascal, kebab } = ctx
   const camel = pascal.charAt(0).toLowerCase() + pascal.slice(1)
-  // Wrapped exactly as Prettier would at the scaffold's printWidth of 100 —
-  // a single-line import is 112 chars, so `pnpm format` on a fresh project
+  // Wrapped exactly as oxfmt would at the scaffold's printWidth of 100 —
+  // a single-line import is 112 chars, so `kick format` on a fresh project
   // would otherwise rewrite this file on the adopter's first run.
   return `import {
   Controller,

--- a/packages/cli/src/generators/templates/project-app.ts
+++ b/packages/cli/src/generators/templates/project-app.ts
@@ -428,22 +428,27 @@ export default defineConfig({
     {
       name: 'test',
       description: 'Run tests with Vitest',
-      steps: 'npx vitest run',
+      steps: 'vitest run',
+    },
+    {
+      name: 'lint',
+      description: 'Lint with oxlint',
+      steps: 'oxlint src/',
     },
     {
       name: 'format',
       description: 'Format code with Prettier',
-      steps: 'npx prettier --write src/',
+      steps: 'oxfmt src/',
     },
     {
       name: 'format:check',
       description: 'Check formatting without writing',
-      steps: 'npx prettier --check src/',
+      steps: 'oxfmt --check src/',
     },
     {
       name: 'ci:check',
       description: 'Run typecheck + format check',
-      steps: ['npx tsc --noEmit', 'npx prettier --check src/'],
+      steps: ['kick typecheck', 'oxlint src/', 'oxfmt --check src/'],
       aliases: ['verify'],
     },
   ],

--- a/packages/cli/src/generators/templates/project-app.ts
+++ b/packages/cli/src/generators/templates/project-app.ts
@@ -447,7 +447,7 @@ export default defineConfig({
     },
     {
       name: 'format',
-      description: 'Format code with Prettier',
+      description: 'Format code with oxfmt',
       steps: 'oxfmt src/',
     },
     {
@@ -457,7 +457,7 @@ export default defineConfig({
     },
     {
       name: 'ci:check',
-      description: 'Run typecheck + format check',
+      description: 'Run typecheck + lint + format check',
       steps: ['kick typecheck', 'oxlint src/', 'oxfmt --check src/'],
       aliases: ['verify'],
     },

--- a/packages/cli/src/generators/templates/project-app.ts
+++ b/packages/cli/src/generators/templates/project-app.ts
@@ -391,6 +391,8 @@ export function generateKickConfig(
   defaultRepo: string = 'inmemory',
   packageManager: 'pnpm' | 'npm' | 'yarn' | 'bun' = 'pnpm',
   runtime: 'express' | 'fastify' | 'h3' = 'express',
+  /** Emit the client route map — set for scaffolds whose frontend reads it. */
+  withClientMap = false,
 ): string {
   // `inmemory` is the only built-in; every other name (incl. the
   // deprecated prisma/drizzle) is emitted as a `{ name }` custom repo.
@@ -421,7 +423,15 @@ export default defineConfig({
   // to \`'zod'\` if you ship Zod schemas without \`fromZod()\` wrapping, or
   // set \`schemaValidator: false\` to skip schema-driven body typing.
   typegen: {
-    schemaValidator: 'kickjs-schema',
+    schemaValidator: 'kickjs-schema',${
+      withClientMap
+        ? `
+    // web/ reads this map from the ambient KickClientApi namespace. Producing
+    // it builds a TypeScript program over the server, so it stays off unless a
+    // project actually consumes it.
+    client: true,`
+        : ''
+    }
   },
 
   commands: [

--- a/packages/cli/src/generators/templates/project-config.ts
+++ b/packages/cli/src/generators/templates/project-config.ts
@@ -53,6 +53,16 @@ export function generatePackageJson(
   packages: string[] = [],
   schemaLib: SchemaLib = 'zod',
   runtime: 'express' | 'fastify' | 'h3' = 'express',
+  /**
+   * Pin the TypeScript 7 compiler API, needed to resolve the client route map
+   * (`.kickjs/types/kick__client.d.ts`). Set by the fullstack generator, whose
+   * web app reads that map from the ambient `KickClientApi` namespace.
+   *
+   * Deliberately a flag rather than `template === 'fullstack'`: the fullstack
+   * workspace scaffolds its SERVER with `template: 'minimal'`, so keying off
+   * the template name silently pinned nothing.
+   */
+  withClientMap = false,
 ): string {
   const schemaDep = SCHEMA_LIB_DEPS[schemaLib]
   const baseDeps: Record<string, string> = {
@@ -140,15 +150,12 @@ export function generatePackageJson(
         supertest: '^7.2.2',
         vitest: '^4.1.2',
         typescript: '^7.0.2',
-        // NOT pinned here: `@typescript/typescript6`, the compiler API
-        // `kick typegen` needs to resolve the self-contained client route map
-        // on TypeScript 7. It is a 10 kB shim over a 24 MB `typescript@6`, and
-        // no template consumes the map — the fullstack web app is wired to the
-        // ambient `KickRoutes.Api` so it stays live under `kick dev`, and the
-        // rest/minimal templates have no frontend at all. A second compiler in
-        // every scaffold, for a file nothing reads, is not a default worth
-        // shipping. Projects that adopt the map install it then; the README
-        // section that describes the swap says so.
+        // Only scaffolds that consume the client route map pin the TypeScript 7
+        // compiler API: it is a 10 kB shim over a 24 MB `typescript@6`, which is
+        // not something to put in every project. Today that means fullstack,
+        // whose web app reads the map from the ambient `KickClientApi`
+        // namespace. rest/minimal have no frontend and stay lean.
+        ...(withClientMap ? { '@typescript/typescript6': '^6.0.2' } : {}),
         prettier: '^3.8.1',
       },
     },

--- a/packages/cli/src/generators/templates/project-config.ts
+++ b/packages/cli/src/generators/templates/project-config.ts
@@ -119,16 +119,18 @@ export function generatePackageJson(
         // typegen-on-save watcher. Plain `vite` gives working HMR but
         // frozen `.kickjs/types` — new routes silently lose their typing
         // until a manual `kick typegen`.
+        // Four scripts, not ten. Everything dropped from here is still one
+        // command away — `kick dev:debug`, `kick typegen`, `pnpm exec vitest`,
+        // `pnpm exec tsc --noEmit` — and a scaffold that opens with a wall of
+        // aliases teaches less than one that shows the binary.
+        //
+        // `lint: 'eslint src/'` used to be here without eslint ever being a
+        // dependency, so `lint` failed with "command not found" in every
+        // generated project.
         dev: 'kick dev',
-        'dev:debug': 'kick dev:debug',
         build: 'kick build',
         start: 'kick start',
         test: 'vitest run',
-        'test:watch': 'vitest',
-        typecheck: 'tsc --noEmit',
-        typegen: 'kick typegen',
-        lint: 'eslint src/',
-        format: 'prettier --write src/',
       },
       dependencies: baseDeps,
       devDependencies: {
@@ -156,7 +158,7 @@ export function generatePackageJson(
         // whose web app reads the map from the ambient `KickClientApi`
         // namespace. rest/minimal have no frontend and stay lean.
         ...(withClientMap ? { '@typescript/typescript6': '^6.0.2' } : {}),
-        prettier: '^3.8.1',
+        oxfmt: '^0.65.0',
       },
     },
     null,
@@ -244,15 +246,28 @@ export function generateTsConfig(): string {
   )
 }
 
-/** Generate .prettierrc with project formatting rules */
-export function generatePrettierConfig(): string {
+/**
+ * Generate `.oxfmtrc.json`.
+ *
+ * oxfmt over prettier: same options, same output for these settings, one
+ * binary instead of a package plus plugins — and it is what the framework
+ * itself is formatted with, so a scaffold no longer arrives holding a
+ * different tool than the project it came from.
+ *
+ * There is no `format` script. `pnpm exec oxfmt` is the command, and a
+ * scaffold that opens with ten aliases teaches less than one that shows the
+ * tools.
+ */
+export function generateFormatterConfig(): string {
   return JSON.stringify(
     {
+      $schema: './node_modules/oxfmt/configuration_schema.json',
       semi: false,
       singleQuote: true,
       trailingComma: 'all',
       printWidth: 100,
       tabWidth: 2,
+      ignorePatterns: ['**/dist/', '**/.kickjs/', '**/node_modules/'],
     },
     null,
     2,

--- a/packages/cli/src/generators/templates/project-config.ts
+++ b/packages/cli/src/generators/templates/project-config.ts
@@ -159,6 +159,7 @@ export function generatePackageJson(
         // namespace. rest/minimal have no frontend and stay lean.
         ...(withClientMap ? { '@typescript/typescript6': '^6.0.2' } : {}),
         oxfmt: '^0.65.0',
+        oxlint: '^1.80.0',
       },
     },
     null,

--- a/packages/cli/src/generators/templates/project-config.ts
+++ b/packages/cli/src/generators/templates/project-config.ts
@@ -140,12 +140,15 @@ export function generatePackageJson(
         supertest: '^7.2.2',
         vitest: '^4.1.2',
         typescript: '^7.0.2',
-        // TypeScript 7 ships no JS compiler API, and `kick typegen` needs one
-        // to resolve the self-contained client route map
-        // (.kickjs/types/kick__client.d.ts). Without it every typegen run
-        // prints a skip warning and the file never appears — so a scaffold
-        // that pins TS 7 has to pin this too.
-        '@typescript/typescript6': '^6.0.2',
+        // NOT pinned here: `@typescript/typescript6`, the compiler API
+        // `kick typegen` needs to resolve the self-contained client route map
+        // on TypeScript 7. It is a 10 kB shim over a 24 MB `typescript@6`, and
+        // no template consumes the map — the fullstack web app is wired to the
+        // ambient `KickRoutes.Api` so it stays live under `kick dev`, and the
+        // rest/minimal templates have no frontend at all. A second compiler in
+        // every scaffold, for a file nothing reads, is not a default worth
+        // shipping. Projects that adopt the map install it then; the README
+        // section that describes the swap says so.
         prettier: '^3.8.1',
       },
     },

--- a/packages/cli/src/generators/templates/project-config.ts
+++ b/packages/cli/src/generators/templates/project-config.ts
@@ -140,6 +140,12 @@ export function generatePackageJson(
         supertest: '^7.2.2',
         vitest: '^4.1.2',
         typescript: '^7.0.2',
+        // TypeScript 7 ships no JS compiler API, and `kick typegen` needs one
+        // to resolve the self-contained client route map
+        // (.kickjs/types/kick__client.d.ts). Without it every typegen run
+        // prints a skip warning and the file never appears — so a scaffold
+        // that pins TS 7 has to pin this too.
+        '@typescript/typescript6': '^6.0.2',
         prettier: '^3.8.1',
       },
     },

--- a/packages/cli/src/generators/templates/project-docs.ts
+++ b/packages/cli/src/generators/templates/project-docs.ts
@@ -141,8 +141,8 @@ ${pm} install            # Install dependencies
 kick dev                 # Dev server with HMR + typegen
 kick build && kick start # Production
 ${pm} run test           # Vitest
-${pm} run typecheck      # tsc --noEmit
-${pm} run format         # Prettier
+kick typecheck           # tsc/tsgo, whichever the project has
+kick format              # oxfmt
 \`\`\`
 
 ## v4 framework reminders
@@ -652,7 +652,7 @@ function buildSkills(pm: string): KickJsSkill[] {
 2. Verify the new folder under \`src/modules/<name>/\` contains \`<name>.module.ts\` (filename suffix is mandatory for Vite HMR).
 3. Confirm the module appears in \`src/modules/index.ts\` exports — generator does this automatically; verify if you bypassed it.
 4. Open \`<name>.dto.ts\` and tighten the Zod schemas to real fields (the generator emits placeholders).
-5. Run \`${pm} run typecheck\` and \`${pm} run test\` before claiming done.
+5. Run \`kick typecheck\` and \`${pm} run test\` before claiming done.
 
 **Canonical module shape** — \`defineModule\` factory, never \`class implements AppModule\`:
 

--- a/packages/cli/src/generators/templates/project-docs.ts
+++ b/packages/cli/src/generators/templates/project-docs.ts
@@ -390,7 +390,7 @@ package additions, env access patterns, troubleshooting) is detailed below.
 | TypeScript config | \`tsconfig.json\` |
 | Vite config (HMR) | \`vite.config.ts\` |
 | Vitest config | \`vitest.config.ts\` |
-| Prettier config | \`.prettierrc\` |
+| Formatter config | \`.oxfmtrc.json\` (oxfmt) |
 | CLI config | \`kick.config.ts\` |
 
 ### Module Pattern (${template.toUpperCase()})

--- a/packages/cli/src/plugin/builtins.ts
+++ b/packages/cli/src/plugin/builtins.ts
@@ -74,6 +74,9 @@ export const builtinCliPlugins: readonly KickCliPlugin[] = [
   defineCliPlugin({ name: 'kick/routes', typegens: [kickRoutesTypegen()] }),
   // After kick/routes, and that IS load-bearing here: this plugin resolves
   // types out of the map that one emits.
+  // Registered always; the plugin itself decides whether to run — see
+  // `typegen.client`. Gating registration instead would hide the id from
+  // `kick typegen --list` and from the disable filter.
   defineCliPlugin({ name: 'kick/client', typegens: [kickClientTypegen()] }),
   defineCliPlugin({ name: 'kick/env', typegens: [kickEnvTypegen()] }),
   defineCliPlugin({ name: 'kick/runtime', typegens: [kickRuntimeTypegen()] }),

--- a/packages/cli/src/typegen/builtin/client.ts
+++ b/packages/cli/src/typegen/builtin/client.ts
@@ -22,11 +22,12 @@
  * @module @forinda/kickjs-cli/typegen/builtin/client
  */
 import path from 'node:path'
+import { existsSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 
 import { resolveClientMap } from '../client/resolve-entries'
 import { renderClient } from '../render/client'
-import type { TypegenLogger, TypegenPlugin } from '../plugin'
+import { isDebugLog, type TypegenLogger, type TypegenPlugin } from '../plugin'
 
 const OUT_FILE = '.kickjs/types/kick__client.d.ts'
 
@@ -37,8 +38,12 @@ const OUT_FILE = '.kickjs/types/kick__client.d.ts'
  * immediately and points straight here, while an obsolete map type-checks
  * cleanly against routes that no longer exist.
  */
-async function discardStaleOutput(ctx: { cwd: string; log: TypegenLogger }): Promise<void> {
+async function discardStaleOutput(ctx: { cwd: string; log: TypegenLogger }): Promise<boolean> {
   const outFile = path.resolve(ctx.cwd, OUT_FILE)
+  // Nothing to discard, and nothing to announce. `rm --force` succeeds either
+  // way, so without this check the run claimed to have "removed the previously
+  // generated" file in projects that never had one.
+  if (!existsSync(outFile)) return false
   try {
     await rm(outFile, { force: true })
   } catch (err) {
@@ -48,12 +53,13 @@ async function discardStaleOutput(ctx: { cwd: string; log: TypegenLogger }): Pro
       `  kick/client: could not remove the stale ${OUT_FILE} — treat it as out of date ` +
         `(${err instanceof Error ? err.message : String(err)})`,
     )
-    return
+    return true
   }
   ctx.log.warn(
     `  kick/client: removed the previously generated ${OUT_FILE} rather than leave a ` +
       `stale one — re-run \`kick typegen\` once the cause above is fixed.`,
   )
+  return true
 }
 
 export const kickClientTypegen = (): TypegenPlugin => ({
@@ -97,10 +103,23 @@ export const kickClientTypegen = (): TypegenPlugin => ({
       })
       return renderClient(map, keys)
     } catch (err) {
-      // loadCompilerApi's message already names the install command, and a
-      // missing tsconfig / unreadable routes file is equally recoverable —
-      // every one of them means "skip this file", never "fail the pass".
-      ctx.log.warn(`  kick/client: skipped — ${err instanceof Error ? err.message : String(err)}`)
+      // Order matters: discard first, because whether a map was on disk is
+      // what decides how loud this should be.
+      //
+      // A project that has one is USING it, so a skip is a regression and
+      // says so. A project that never had one — no frontend, or a TS 7 setup
+      // that never installed the compiler API — is not broken, and a warning
+      // on every single `kick typegen` would be pure noise for a file it
+      // does not consume. loadCompilerApi's message names the install command
+      // either way; it just belongs at debug level until someone asks.
+      const hadOutput = existsSync(path.resolve(ctx.cwd, OUT_FILE))
+      const message = `  kick/client: skipped — ${err instanceof Error ? err.message : String(err)}`
+      // Cause first: the removal notice below says "the cause above".
+      if (hadOutput) ctx.log.warn(message)
+      // `ctx.log` is `console`, whose `debug` still writes to stdout — so the
+      // level has to be gated here, on the same LOG_LEVEL convention the
+      // plugin runner uses for its per-plugin status list.
+      else if (isDebugLog()) ctx.log.info?.(message)
       // Skipping leaves whatever is already on disk, and on a one-shot run
       // that file is now a lie: the routes were rescanned, this map was not
       // rebuilt, and nothing downstream can tell. A MISSING map is a compile
@@ -110,7 +129,7 @@ export const kickClientTypegen = (): TypegenPlugin => ({
       //
       // Only here. The watch skip returns earlier precisely so the dev loop
       // keeps the last good map.
-      await discardStaleOutput(ctx)
+      if (hadOutput) await discardStaleOutput(ctx)
       return null
     }
   },

--- a/packages/cli/src/typegen/builtin/client.ts
+++ b/packages/cli/src/typegen/builtin/client.ts
@@ -28,6 +28,7 @@ import { rm } from 'node:fs/promises'
 import { resolveClientMap } from '../client/resolve-entries'
 import { renderClient } from '../render/client'
 import { isDebugLog, type TypegenLogger, type TypegenPlugin } from '../plugin'
+import type { KickConfig } from '../../config'
 
 const OUT_FILE = '.kickjs/types/kick__client.d.ts'
 
@@ -62,11 +63,50 @@ async function discardStaleOutput(ctx: { cwd: string; log: TypegenLogger }): Pro
   return true
 }
 
+/**
+ * Whether this project wants the client route map.
+ *
+ * Producing it builds a whole TypeScript program over the server — 1.1 GB and
+ * ~7.6s on a 1,940-route app, against ~130ms for every other typegen plugin
+ * combined. An API with no frontend should not pay that for a file nothing
+ * reads, and most projects have no frontend.
+ *
+ * So: `typegen.client` decides when set. Otherwise the existing file decides,
+ * which makes the common cases right without anyone configuring anything —
+ * a project that has the map keeps it fresh (a stale map is worse than a slow
+ * pass), and a project that has never had one never starts paying.
+ * `kick new --template fullstack` writes `client: true`, so its web app has
+ * the map from the first run.
+ */
+function clientMapWanted(ctx: { cwd: string; config: KickConfig; log: TypegenLogger }): boolean {
+  const configured = ctx.config?.typegen?.client
+  if (typeof configured === 'boolean') return configured
+
+  // Unset means off. Inferring "on" from the file being there would work, but
+  // it puts the switch somewhere nobody looks — a project would be paying
+  // seconds and a gigabyte per typegen because of a file on disk, with nothing
+  // in its config to explain why.
+  //
+  // A map already on disk is still worth a word, though: silently leaving it
+  // to rot is how a frontend ends up type-checking against routes the server
+  // no longer serves.
+  if (existsSync(path.resolve(ctx.cwd, OUT_FILE))) {
+    ctx.log.warn(
+      `  kick/client: ${OUT_FILE} exists but typegen.client is not set, so it is NOT ` +
+        `being refreshed.\n  Add \`typegen: { client: true }\` to kick.config.ts to keep it ` +
+        `current, or delete the file if nothing reads it.`,
+    )
+  }
+  return false
+}
+
 export const kickClientTypegen = (): TypegenPlugin => ({
   id: 'kick/client',
   outExtension: '.d.ts',
   inputs: ['src/**/*.controller.ts', 'src/**/*.module.ts'],
   async generate(ctx) {
+    if (!clientMapWanted(ctx)) return null
+
     if (ctx.watch) {
       // Not a warning: this is the designed behaviour, and a warning per save
       // would be its own kind of noise.

--- a/packages/cli/src/typegen/client/expand-type.ts
+++ b/packages/cli/src/typegen/client/expand-type.ts
@@ -118,7 +118,14 @@ export class TypeExpander {
       this.hoistedByType.set(type, name)
       const index = this.blocks.length
       this.blocks.push('') // hold the slot so ordering matches creation order
-      this.blocks[index] = `interface ${name} {\n${this.members(type, depth, '  ')}\n}`
+      // Depth RESETS here. The counter bounds how deeply types nest *inline*,
+      // and a hoist ends that nesting: this body becomes its own top-level
+      // `interface __Tn { … }` block, referenced by name from wherever it
+      // appeared. Carrying the caller's depth in made a chain of named DTOs
+      // spend the budget on nothing — a 15-link chain emitted
+      // `interface __T12 { v: unknown }` where `v` was a plain `string`,
+      // degrading real types over a nesting the output does not contain.
+      this.blocks[index] = `interface ${name} {\n${this.members(type, 0, '  ')}\n}`
       return name
     }
 

--- a/packages/cli/src/typegen/client/resolve-entries.ts
+++ b/packages/cli/src/typegen/client/resolve-entries.ts
@@ -79,7 +79,14 @@ export async function resolveClientMap(opts: ResolveClientMapOptions): Promise<R
   // would confuse "missing route" with "route whose entry really is `any`".
   const broken = keysWithDiagnostics(t, program, probe, opts.keys)
 
-  const expander = new TypeExpander(t, checker, program, { onWarn: opts.onWarn })
+  // The expander is shared across routes so hoisted shapes are reused, but a
+  // warning from inside it is useless without knowing which route provoked it
+  // — "type nesting exceeded 12 levels" repeated 34 times names nothing to go
+  // and fix. Track the route being expanded and prefix on the way out.
+  let currentKey: string | null = null
+  const expander = new TypeExpander(t, checker, program, {
+    onWarn: (msg) => opts.onWarn?.(currentKey ? `route '${currentKey}': ${msg}` : msg),
+  })
   const entries = new Map<string, string>()
 
   for (const [index, key] of opts.keys.entries()) {
@@ -110,7 +117,9 @@ export async function resolveClientMap(opts: ResolveClientMapOptions): Promise<R
       )
       continue
     }
+    currentKey = key
     entries.set(key, expander.expand(type))
+    currentKey = null
   }
 
   return { entries, hoisted: expander.hoisted() }

--- a/packages/cli/src/typegen/client/resolve-entries.ts
+++ b/packages/cli/src/typegen/client/resolve-entries.ts
@@ -19,6 +19,7 @@
  *
  * @module @forinda/kickjs-cli/typegen/client/resolve-entries
  */
+import { readdirSync } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
 
 import type ts from '@typescript/typescript6'
@@ -200,6 +201,47 @@ function keysWithDiagnostics(
 }
 
 /**
+ * The roots this pass actually needs, out of everything the tsconfig lists.
+ *
+ * The probe imports the generated route map, which imports the controllers,
+ * which import their services and DTOs — so every file that can contribute to
+ * a route type is reachable and TypeScript pulls it in on its own. Handing it
+ * the whole project on top of that loads files no route can reference: on a
+ * 1,940-route app, 686 of the 2,851 roots were tests.
+ *
+ * Two kinds of file stay, because nothing imports them and dropping one
+ * silently removes the globals it declares — a controller depending on those
+ * would then resolve differently, which is exactly the quiet divergence this
+ * generator must not produce:
+ *
+ *   - every declaration file the tsconfig lists, wherever it lives;
+ *   - everything typegen itself emits, read from disk rather than taken from
+ *     the tsconfig.
+ *
+ * That second list is read from disk deliberately. TypeScript's `include`
+ * skips dot-directories, so `.kickjs/types` is absent from `fileNames` unless
+ * the adopter spelled out a glob for it — and `kick__env.ts` carries a
+ * `declare global` that nothing imports. Relying on the tsconfig meant those
+ * globals were simply missing for every project that did not happen to glob
+ * them, and a controller referencing one resolved against an error type.
+ */
+function clientRootNames(fileNames: readonly string[], typesDir: string): string[] {
+  const declarations = fileNames.filter((f) => /\.d\.(ts|mts|cts)$/.test(f))
+
+  let generated: string[] = []
+  try {
+    generated = readdirSync(typesDir)
+      .filter((f) => f.endsWith('.ts'))
+      .map((f) => join(typesDir, f))
+  } catch {
+    // No generated types yet — the probe still reaches the route map through
+    // its own import, and a missing map is reported by the caller.
+  }
+
+  return [...new Set([...declarations, ...generated])]
+}
+
+/**
  * Build a program over the project's tsconfig with the probe added as a root.
  *
  * The probe lives only in memory. Writing it would leave a stray file in
@@ -237,7 +279,7 @@ function createProbeProgram(
       : getSourceFile(name, languageVersion, onError, shouldCreate)
 
   return t.createProgram({
-    rootNames: [...parsed.fileNames, probePath],
+    rootNames: [...clientRootNames(parsed.fileNames, dirname(probePath)), probePath],
     options: parsed.options,
     host: compilerHost,
   })

--- a/packages/cli/src/typegen/plugin.ts
+++ b/packages/cli/src/typegen/plugin.ts
@@ -10,6 +10,19 @@
 import type { KickConfig } from '../config'
 import type { ScanOptions, ScanResult } from './scanner'
 
+/**
+ * True when verbose typegen output is requested via `LOG_LEVEL=debug` (the
+ * kickjs log-level convention).
+ *
+ * Lives here rather than in `run-plugins` because plugins need it too, and
+ * `run-plugins` → `plugin/builtins` → any builtin plugin is a cycle: importing
+ * it the other way left `kickClientTypegen` undefined at module-eval time.
+ */
+export function isDebugLog(): boolean {
+  const level = (process.env.LOG_LEVEL ?? process.env.KICKJS_LOG_LEVEL ?? '').toLowerCase()
+  return level === 'debug' || level === 'trace'
+}
+
 export interface TypegenLogger {
   info(msg: string): void
   warn(msg: string): void

--- a/packages/cli/src/typegen/render/client.ts
+++ b/packages/cli/src/typegen/render/client.ts
@@ -39,16 +39,16 @@ export function renderClient(map: ResolvedClientMap, keys: string[]): string {
     return `${HEADER}
 // (no routes discovered yet — annotate a controller method with
 //  @Get/@Post/@Put/@Delete/@Patch and re-run \`kick typegen\`)
+interface Api {}
+
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace KickClientApi {
-    interface Api {}
+    export { Api }
   }
 }
 
-export type { Api } from './kick__client'
-
-export {}
+export type { Api }
 `
   }
 

--- a/packages/cli/src/typegen/render/client.ts
+++ b/packages/cli/src/typegen/render/client.ts
@@ -22,8 +22,11 @@ const HEADER = `/* eslint-disable */
 // Self-contained: this file has no imports, so a frontend consumes it without
 // compiling the server, its decorators, or its path aliases.
 //
-//   import type { KickApi } from './path/to/kick__client'
-//   export const api = createClient<KickApi>({ baseUrl: '/api/v1' })
+//   // Ambient — add this file to the frontend's tsconfig "include", then:
+//   export const api = createClient<KickClientApi.Api>({ baseUrl: '/api/v1' })
+//
+//   // Or import it explicitly, if you prefer no globals:
+//   import type { Api } from './path/to/kick__client'
 //
 // Not refreshed by \`kick dev\` — resolving these types builds a full
 // TypeScript program over the server. Re-run \`kick typegen\`.
@@ -36,16 +39,43 @@ export function renderClient(map: ResolvedClientMap, keys: string[]): string {
     return `${HEADER}
 // (no routes discovered yet — annotate a controller method with
 //  @Get/@Post/@Put/@Delete/@Patch and re-run \`kick typegen\`)
-export interface KickApi {}
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace KickClientApi {
+    interface Api {}
+  }
+}
+
+export type { Api } from './kick__client'
+
+export {}
 `
   }
 
   const hoisted = map.hoisted.length > 0 ? map.hoisted.join('\n\n') + '\n\n' : ''
   const lines = emitted.map((key) => `  ${JSON.stringify(key)}: ${map.entries.get(key)!}`)
 
+  // The hoisted shapes stay MODULE-local while only the namespace is global.
+  // Emitting them at the top level instead would put all 86 `__T<n>` into the
+  // frontend's global scope, which was measurable: a file shaped that way let
+  // `type Leaked = __T0` compile in the consuming app.
+  //
+  // The name matters too. `kick__routes.ts` already declares a global
+  // `KickApi`, and both files live in `.kickjs/types`, which the server's own
+  // tsconfig includes — reusing that name made the SERVER fail to compile with
+  // `TS2300: Duplicate identifier 'KickApi'`.
   return `${HEADER}
-${hoisted}export interface KickApi {
+${hoisted}interface Api {
 ${lines.join('\n')}
 }
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace KickClientApi {
+    export { Api }
+  }
+}
+
+export type { Api }
 `
 }

--- a/packages/cli/src/typegen/run-plugins.ts
+++ b/packages/cli/src/typegen/run-plugins.ts
@@ -14,22 +14,12 @@ import { mergeCliPlugins } from '../plugin'
 import { builtinCliPlugins } from '../plugin/builtins'
 import { runTypegen as runPluginTypegens } from './runner'
 import type { ScanDelta } from './scanner'
-import { TypegenDriftError } from './plugin'
+import { isDebugLog, TypegenDriftError } from './plugin'
 import type { TypegenPluginResult } from './plugin'
 import { applyDisableFilter } from './disable-filter'
 
 // Re-export so the existing public surface (cli/index.ts) still resolves.
 export { applyDisableFilter } from './disable-filter'
-
-/**
- * True when verbose typegen output is requested via `LOG_LEVEL=debug`
- * (the kickjs log-level convention). Gates the per-plugin status list so
- * a normal `kick typegen` run only prints its one-line summary.
- */
-function isDebugLog(): boolean {
-  const level = (process.env.LOG_LEVEL ?? process.env.KICKJS_LOG_LEVEL ?? '').toLowerCase()
-  return level === 'debug' || level === 'trace'
-}
 
 export interface RunAllPluginTypegensOptions {
   cwd: string


### PR DESCRIPTION
Split out of #548, which had already merged when the first commit landed on its branch.

## What this is now

The first commit pinned `@typescript/typescript6` into every scaffold so the client route map would generate. **That was the wrong fix, and the second commit removes it.**

`@typescript/typescript6` is a 10 kB shim whose dependency is `typescript@6.0.3` — **24 MB**. And no template consumes the map:

- the fullstack `web` is deliberately wired to the ambient `KickRoutes.Api`, so it stays live under `kick dev` (the template's headline: rename a field, the web stops compiling)
- `rest` and `minimal` have no frontend at all

A second full TypeScript in every new project, for a file nothing reads, is not a default worth shipping.

## The actual problem was noise

`kick/client` warned on every `kick typegen` when no compiler API was present, and reported having "removed the previously generated `kick__client.d.ts`" even in projects that never had one — `rm --force` succeeds either way, so the claim was simply false.

The fix follows from who is affected:

| state | behaviour |
| --- | --- |
| no map on disk | **silent** — visible under `LOG_LEVEL=debug` |
| map on disk | **warn** — that project is using it and just lost it |

The removal notice now fires only when a file was actually removed, and prints *after* the cause it tells you to fix (it says "the cause above", and used to print first).

Verified both paths against real scaffolded projects: a fresh one is quiet and shows two lines under `LOG_LEVEL=debug`; one with a generated map warns and deletes it, cause first.

## Documentation instead of a dependency

The fullstack README's **"When to switch to `kick__client.d.ts`"** section now carries the install as part of the swap:

```bash
cd server && pnpm add -D @typescript/typescript6
```

with the note that it pulls a second TypeScript and this template's `web` does not need it — plus the one-line import change, the two lines to delete afterwards, the fact that call sites do not change (both maps carry the same types, the second produced by resolving the first), and the trade: no refresh under `kick dev`, `--check` as the CI backstop.

The documented import path is compiled inside a real scaffolded project rather than written from memory.

## One cycle found on the way

Reaching `isDebugLog` from `run-plugins` is a cycle — `run-plugins` → `plugin/builtins` → `builtin/client` — which left `kickClientTypegen` `undefined` at module-eval time and took the plugin's whole test file down with it. That is the same shape `typegen/index.ts` already lazy-imports around. The helper moves to `typegen/plugin.ts`, which imports only types; `run-plugins` now uses it from there, so there is one definition of "verbose" rather than two.


## 3. The depth guard was counting through hoists

Reported from a 1,940-route app: 34 copies of

```text
type nesting exceeded 12 levels — emitting 'unknown'. Declare a response schema on the route for an exact type.
```

The counter bounds how deeply types nest **inline**, and hoisting ends inline nesting — a named type becomes its own top-level `interface __Tn { … }` block, referenced by name. Carrying the caller's depth into that body made a chain of named DTOs spend the budget on a nesting the emitted file does not contain.

It corrupted rather than truncated. A 15-link chain produced:

```ts
interface __T12 { v: unknown; next: unknown }   // v was declared `string`
```

Degrading a declared type is the failure the guard exists to prevent.

Depth now resets at a hoist. On that app:

| | before | after |
| --- | --- | --- |
| nesting warnings | **34** | **0** |
| hoisted interfaces | 10 | **86** |
| `: any` | 0 | 0 |

The interface count rising is the fix visible — those chains now expand into their own blocks instead of being cut off. The regenerated 388 KB map type-checks clean under TypeScript 7. Genuinely deep inline nesting still degrades, which is what the guard is for; both directions are pinned and sabotage-verified.

**The warnings also name their route now** (`route 'GET /x': …`). Thirty-four identical lines with no route between them gave the reader nothing to act on — which is why this arrived as a bug report rather than as a fix.

## Verification

684 tests across 63 files in the CLI package. Four new ones pin both directions of the quiet/loud contract and of the depth guard. `tsc --noEmit`, lint, token lint and format clean.

Worth knowing when running the suite locally: the workspace `dist/` outputs must exist first (`pnpm build`), or 96 tests fail on `CLI binary not found` — unrelated to anything here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Fullstack projects now use generated ambient client route types through `KickClientApi.Api`.
  - Added the `kick typecheck` command, including Vue support.
  - `kick dev:debug` now opens a working inspector connection and displays the real debugger URL.
  - New projects use oxfmt, oxlint, local tooling, and streamlined development scripts.

- **Bug Fixes**
  - Reduced unnecessary client route-map warnings and improved stale-map removal messaging.
  - Preserved accurate types through deeply linked DTOs and added route context to warnings.
  - Improved generated type-map compatibility for projects without routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->