### PR TITLE
fix(docs): stop clipping wide tables on narrow screens

### DIFF
--- a/docs/.vitepress/theme/styles.css
+++ b/docs/.vitepress/theme/styles.css
@@ -346,7 +346,35 @@ html {
 
 .vp-doc table {
   border-radius: 8px;
-  overflow: hidden;
+  /*
+   * `overflow-x`, never the `overflow` shorthand. VitePress ships
+   * `.vp-doc table { display: block; overflow-x: auto }` so a table wider than
+   * the viewport scrolls; the shorthand sets BOTH axes and silently overrode
+   * that, clipping every wide table on narrow screens instead. The rounded
+   * corners still clip correctly — a scroll container rounds its own overflow.
+   */
+  overflow-x: auto;
+  /* Momentum scrolling on iOS, and a visible affordance that there is more. */
+  -webkit-overflow-scrolling: touch;
+}
+
+/*
+ * Let prose cells wrap so a table fits the viewport instead of scrolling —
+ * measured at a 320px column, this alone takes a typical docs table from 97px
+ * of unreachable content to none.
+ */
+.vp-doc table :is(td, th) {
+  overflow-wrap: anywhere;
+}
+
+/*
+ * ...but never break a code token. `GET /academics/terms/:termId` split across
+ * two lines is worse than a scrollbar: the reader cannot tell whether the break
+ * is part of the path. These keep their shape and the table scrolls instead,
+ * which is what the `overflow-x` above is for.
+ */
+.vp-doc table :is(td, th) :is(code, a) {
+  overflow-wrap: normal;
 }
 
 .vp-doc th {


### PR DESCRIPTION
Docs tables were cut off on narrow screens. The cause is in our own stylesheet, not VitePress:

```css
.vp-doc table {
  border-radius: 8px;
  overflow: hidden;   /* added for the corners */
}
```

VitePress ships `.vp-doc table { display: block; overflow-x: auto }` on that exact selector, precisely so a table wider than the viewport scrolls. The `overflow` **shorthand sets both axes**, so ours silently replaced scrolling with clipping — and the rounded corners cost every wide table its content, with no way for a reader to reach the rest.

Confirmed in the compiled CSS, where ours lands second and wins:

```css
.vp-doc table{display:block;border-collapse:collapse;margin:20px 0;overflow-x:auto}
.vp-doc table{border-radius:8px;overflow:hidden}
```

## Measured, in a browser

At a 320px content column, before and after, on the two most table-heavy pages:

| page | tables | unreachable before | after |
| --- | --- | --- | --- |
| `guide/cli-commands` | 15 | **10** — worst hid 348px | **0** |
| `guide/asset-manager` | 2 | **2** — worst hid 147px | **0** |

"Most of the tables" was literal: 10 of 15 on that page.

## The fix

`overflow-x: auto` restores scrolling and still rounds the corners — a scroll container clips its own overflow to the radius.

Prose cells gain `overflow-wrap: anywhere`, so a table **wraps to fit** rather than needing a scroll at all. That is what produces the zeros above; scrolling is the fallback, not the main path.

`code` and links are exempt from that wrap. The first version broke `GET /academics/terms/:termId` across two lines, which is worse than a scrollbar: the reader cannot tell whether the break is part of the path. Those keep their shape and the table scrolls instead — verified that a table of unbreakable code tokens overflows 222px, is scrollable, and reaches its far edge.

## Notes

- One file, CSS only. No changeset: `@forinda/kickjs-docs` is private, so changesets skips it.
- Merging deploys, via `deploy-docs.yml` on push to `main`.
