### PR TITLE
docs: export the generator in the worked example so its test compiles

### DIFF
--- a/docs/guide/plugin-generators.md
+++ b/docs/guide/plugin-generators.md
@@ -179,7 +179,8 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { defineConfig, defineCliPlugin, defineGenerator } from '@forinda/kickjs-cli'
 
-const jobGenerator = defineGenerator({
+// Exported, so the test below can import it — see "Testing a generator".
+export const jobGenerator = defineGenerator({
   name: 'job',
   description: 'Generate a @Job queue processor with @Process handlers',
   args: [{ name: 'name', required: true }],


### PR DESCRIPTION
The worked `kick.config.ts` example declares `const jobGenerator`, while the testing section two headings below does:

```ts
import { jobGenerator } from '../kick.config'
```

So anyone following the page in order imports a name the module does not export. Now `export const jobGenerator`, with a comment saying why.

Audited the rest of the page rather than fixing only the reported line — the same class of defect had already appeared twice on this page (a worked example that ignored its own authoring rules, and a code span my line-wrap split across two lines). The test's context literal carries every required `GeneratorContext` field, and the example's imports match its usage.

Caught by CodeRabbit on #553 after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the plugin generator guide’s testing example to make the sample generator available for import.
  * Clarified the worked example so it can be reused directly in generator tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->