### PR TITLE
fix(cli): terminate recursive response types instead of expanding them forever

### DIFF
--- a/.changeset/curly-moons-repeat.md
+++ b/.changeset/curly-moons-repeat.md
@@ -1,0 +1,40 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+Fix unbounded expansion of recursive response types in the client route map.
+
+A type alias to an object literal (`type Node = { … }`) carries TypeScript's
+anonymous `__type` symbol rather than the alias name, so the expander did not
+consider it nameable and re-expanded it inline at every occurrence. For a
+_recursive_ alias — zod v4's `JSONSchema`, whose `$defs` is
+`Record<string, JSONSchema>`, or any condition tree — inlining cannot
+terminate, and the walk fanned out exponentially.
+
+Measured on a 1,940-route app: one route produced 8.1 million depth-guard
+warnings and exhausted a 24 GB heap without emitting a map. A second route
+emitted a single 7,000-character property that duplicated its subtree at every
+level and still bottomed out in `unknown`. Neither is a scaling problem — both
+came from individual routes.
+
+An anonymous object type that reaches itself while being rendered now claims a
+name and hoists, so the cycle terminates on that name. Recursive types are
+emitted exactly, as mutually-referencing interfaces, instead of degrading:
+
+```ts
+interface __T638 { readonly all: readonly (__T638 | __T639 | __T640 | …)[] }
+interface __T639 { readonly any: readonly (__T638 | __T639 | __T640 | …)[] }
+interface __T640 { readonly not: __T638 | __T639 | __T640 | … }
+```
+
+On that same app: 130s / 15.5 GB / V8 abort with no output → 13.4s / 1.66 GB,
+all 1,940 routes emitted, 325 depth-guard warnings → 0, longest line 7,000 →
+1,644 characters. Route count, typed-response count and `any` count are
+unchanged, so the fidelity is identical — only the pathological expansion is
+gone.
+
+Expansion is now also bounded as a backstop: a route that hits the depth guard
+more than 1,000 times abandons its expansion, emits `unknown`, and says so
+once. The depth guard was firing correctly on every one of those 8.1 million
+warnings — it just never stopped, so the cost was unbounded. Finding that
+meant counting the warnings to notice a single route was responsible.

--- a/.changeset/olive-pandas-invent.md
+++ b/.changeset/olive-pandas-invent.md
@@ -1,0 +1,30 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+Let `typegen.client` take `{ maxDepth }` to tune client-map expansion depth.
+
+A response type is expanded inline up to 12 levels before it is emitted as
+`unknown`. That limit was hardcoded, so a project whose types were genuinely
+deeper had no way to recover the lost fidelity — the only ceiling in the map an
+adopter could not lift.
+
+```ts
+typegen: {
+  client: {
+    maxDepth: 24
+  }
+}
+```
+
+The object form is on unless it says otherwise, so `{ maxDepth: 24 }` alone also
+enables the map; `{ enabled: false }` disables it. `client: true` is unchanged.
+
+The default is rarely reached: recursive and named types both hoist into their
+own interface, which costs one level rather than the whole budget, so only deep
+anonymous nesting spends it. On a 1,940-route app the emitted map is
+byte-identical at 12, 24, 48 and 96 — the knob exists for the project where it
+is not, not because the default is wrong.
+
+The depth is part of the map's fingerprint, so changing it rebuilds rather than
+serving the cached map.

--- a/docs/guide/typed-client.md
+++ b/docs/guide/typed-client.md
@@ -123,6 +123,31 @@ The record lives in `.kickjs/cache/client-map.sha1`, inside the already-ignored
 never writes it — that flag is read-only.
 :::
 
+### Expansion depth
+
+A response is expanded inline up to 12 levels; past that it is emitted as
+`unknown` and the route is named in a warning. Truncation is loud and safe —
+`unknown` has to be narrowed by the consumer, so it can never be mistaken for a
+type the server does not return.
+
+The default is rarely reached. Recursive types and named types both hoist into
+their own `interface __Tn`, which costs one level instead of the whole budget,
+so only deep _anonymous_ nesting spends it. On a 1,940-route app the emitted map
+is byte-identical at 12, 24, 48 and 96.
+
+Raise it if a route tells you it hit the limit:
+
+```ts
+// kick.config.ts
+export default defineConfig({
+  typegen: { client: { maxDepth: 24 } },
+})
+```
+
+The object form is on unless you say otherwise, so `{ maxDepth: 24 }` on its own
+also enables the map; `{ enabled: false }` turns it off. Changing the depth
+changes what is emitted, so it invalidates the cache and rebuilds.
+
 ::: warning `types` replaces automatic `@types` inclusion
 Listing anything in `types` switches off TypeScript's automatic inclusion of
 every `@types/*` package. If your frontend relies on that, name what it needs

--- a/packages/cli/__tests__/client-expand-type.test.ts
+++ b/packages/cli/__tests__/client-expand-type.test.ts
@@ -338,3 +338,34 @@ describe('TypeExpander', () => {
     expect(out.text).not.toContain('Term')
   })
 })
+
+describe('TypeExpander — expansion budget', () => {
+  it('abandons an expansion that keeps hitting the depth guard', () => {
+    // Depth alone was never the danger — unbounded *work* was. The guard fired
+    // correctly every time on a recursive type and never bailed, so one route
+    // emitted 1.66M warnings and exhausted the heap. Past the budget the walk
+    // stops and says so once.
+    const deep = Array.from(
+      { length: 6 },
+      (_, i) => `type L${i} = { a: L${i + 1}; b: L${i + 1}; c: L${i + 1} }`,
+    ).join('\n')
+    const warnings: string[] = []
+    const out = expand(`${deep}\ntype L6 = { end: string }\ntype Target = L0`, {
+      maxDepth: 2,
+      truncationBudget: 3,
+      onWarn: (m) => warnings.push(m),
+    })
+    expect(out.text).toBe('unknown')
+    expect(warnings.at(-1)).toMatch(/expansion abandoned after 3/)
+  })
+
+  it('leaves an ordinary deep type alone', () => {
+    const warnings: string[] = []
+    const out = expand(`type Target = { a: { b: { c: string } } }`, {
+      truncationBudget: 3,
+      onWarn: (m) => warnings.push(m),
+    })
+    expect(out.text).toBe('{ a: { b: { c: string } } }')
+    expect(warnings).toEqual([])
+  })
+})

--- a/packages/cli/__tests__/client-fingerprint.test.ts
+++ b/packages/cli/__tests__/client-fingerprint.test.ts
@@ -152,3 +152,17 @@ describe('client map fingerprint', () => {
     )
   })
 })
+
+describe('client map fingerprint — expansion depth', () => {
+  // The depth changes what is emitted, so a project that raises it must get a
+  // rebuilt map rather than the cached one.
+  it('changes when maxDepth changes', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kick-fp-depth-'))
+    const src = join(dir, 'a.ts')
+    writeFileSync(src, 'export const a = 1')
+    const base = { projectDir: dir, fileNames: [src], keys: [], cliVersion: '1.0.0' }
+    expect(fingerprint({ ...base, options: { __kickMaxDepth: 12 } })).not.toBe(
+      fingerprint({ ...base, options: { __kickMaxDepth: 24 } }),
+    )
+  })
+})

--- a/packages/cli/__tests__/client-plugin-skips.test.ts
+++ b/packages/cli/__tests__/client-plugin-skips.test.ts
@@ -196,3 +196,19 @@ describe('kick/client plugin', () => {
     }
   })
 })
+
+describe('kick/client depth configuration', () => {
+  it('treats an object config as on, so { maxDepth } alone reads the way it looks', async () => {
+    const { ctx, getScanResult } = makeCtx({ config: { typegen: { client: { maxDepth: 24 } } } })
+    await kickClientTypegen().generate(ctx)
+    expect(getScanResult).toHaveBeenCalled()
+  })
+
+  it('still honours an explicit opt-out on the object form', async () => {
+    const { ctx, getScanResult } = makeCtx({
+      config: { typegen: { client: { enabled: false, maxDepth: 24 } } },
+    })
+    expect(await kickClientTypegen().generate(ctx)).toBeNull()
+    expect(getScanResult).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/__tests__/client-recursive-types.test.ts
+++ b/packages/cli/__tests__/client-recursive-types.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Recursive response types, through the real resolution path.
+ *
+ * The unit-level expander harness does not reproduce this: it hands the
+ * expander a type read straight off its own alias declaration, which renders
+ * by name. The bug only appears once a type arrives the way a route's response
+ * does — instantiated, with the alias stripped — so this test drives
+ * `resolveClientMap` over a real project, like `client-e2e.test.ts` does.
+ *
+ * What it protects: a recursive type alias (zod v4's `JSONSchema`, or a
+ * condition tree) is anonymous — a type alias to an object literal carries the
+ * `__type` symbol, not the alias name — so nothing was hoistable and the walk
+ * re-expanded it inline at every occurrence. Measured on a real app: one route
+ * produced 1.66M depth-guard warnings, 4.4 GB, and a V8 abort; another emitted
+ * a single 7,000-character line that bottomed out in `unknown` anyway.
+ *
+ * @module @forinda/kickjs-cli/__tests__/client-recursive-types.test
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { resolveClientMap } from '../src/typegen/client/resolve-entries'
+import type { ResolvedClientMap } from '../src/typegen/client/resolve-entries'
+
+let dir: string
+let map: ResolvedClientMap
+let warnings: string[]
+
+const KEY = 'GET /policies'
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'kick-recursive-'))
+  mkdirSync(join(dir, '.kickjs/types'), { recursive: true })
+  mkdirSync(join(dir, 'src'), { recursive: true })
+
+  writeFileSync(
+    join(dir, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        target: 'ES2022',
+        module: 'ESNext',
+        moduleResolution: 'bundler',
+        strict: true,
+        noEmit: true,
+      },
+      include: ['.kickjs', 'src'],
+    }),
+  )
+
+  // A condition tree: mutually recursive, and every member anonymous.
+  writeFileSync(
+    join(dir, 'src/policy.ts'),
+    `export type Node =
+  | { readonly all: readonly Node[] }
+  | { readonly any: readonly Node[] }
+  | { readonly not: Node }
+  | { readonly p: string; readonly v: string }
+
+export interface Policy {
+  readonly id: string
+  readonly when: Node
+}
+`,
+  )
+
+  const routesFile = join(dir, '.kickjs/types/kick__routes.ts')
+  writeFileSync(
+    routesFile,
+    `import type { Policy } from '../../src/policy'
+
+declare global {
+  namespace KickRoutes {
+    interface Api {
+      '${KEY}': {
+        params: {}
+        body: unknown
+        query: unknown
+        response: Policy[]
+        contextKeys: never
+      }
+    }
+  }
+}
+
+export const kickRpc = {} as const
+`,
+  )
+
+  warnings = []
+  map = await resolveClientMap({
+    projectDir: dir,
+    compilerFrom: process.cwd(),
+    routesFile,
+    keys: [KEY],
+    onWarn: (m) => warnings.push(m),
+  })
+})
+
+afterAll(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('recursive response types', () => {
+  it('resolves without tripping the depth guard', () => {
+    // 325 identical warnings for one route was the symptom that this had
+    // degraded; 1.66M was the symptom that it had run away.
+    expect(warnings).toEqual([])
+  })
+
+  it('hoists the recursive members instead of inlining them', () => {
+    expect(map.hoisted.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('represents the recursion as a self-reference', () => {
+    // This is the whole fix: the cycle terminates on a name. Without it the
+    // walk duplicates the subtree at every level until it runs out of budget.
+    const blocks = map.hoisted.join('\n')
+    expect(blocks).toMatch(/interface __T\d+ \{[^}]*readonly all: readonly \(__T\d+/)
+    expect(blocks).toMatch(/__T\d+ \| __T\d+/)
+  })
+
+  it('keeps the type exact rather than degrading it', () => {
+    // `Policy` itself hoists, so the entry references it by name; the fields
+    // live in the block. `unknown` anywhere in the response is the degradation
+    // this guards against — the entry's own body/query are unknown by design,
+    // so check the response and the blocks.
+    const response = /response: ([^;]+);/.exec(map.entries.get(KEY)!)?.[1]
+    expect(response).toMatch(/__T\d+\[\]/)
+    const blocks = map.hoisted.join('\n')
+    expect(blocks).toContain('readonly id: string')
+    expect(blocks).not.toContain('unknown')
+  })
+
+  it('stays small — the failure mode was a duplicated blob', () => {
+    // The real app emitted 7,000 characters for one such property.
+    const longest = Math.max(...[...map.hoisted, map.entries.get(KEY)!].map((s) => s.length))
+    expect(longest).toBeLessThan(1000)
+  })
+})

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -259,8 +259,35 @@ export interface TypegenConfig {
    * somewhere nobody looks. It does get a warning, since a map left to rot is
    * how a frontend ends up type-checking against routes the server no longer
    * serves.
+   *
+   * Pass an object to tune the expansion. `{ maxDepth }` raises the limit on
+   * how deeply a response type is expanded inline before it is emitted as
+   * `unknown`:
+   *
+   * ```ts
+   * typegen: { client: { maxDepth: 24 } }
+   * ```
+   *
+   * The default of 12 truncates nothing on a 1,940-route app — recursion and
+   * named types both hoist, which costs one level rather than the whole
+   * budget, so only deep *anonymous* nesting spends it. Raise it if a route
+   * warns that it exceeded the limit; the warning names the route.
    */
-  client?: boolean
+  client?: boolean | ClientTypegenConfig
+}
+
+/** Tuning for the client route map — see `TypegenConfig.client`. */
+export interface ClientTypegenConfig {
+  /** On, unless explicitly false. Lets `{ maxDepth }` alone mean "on". */
+  enabled?: boolean
+  /**
+   * Levels of inline nesting expanded before a type is emitted as `unknown`.
+   *
+   * Truncation is loud and safe — it warns naming the route, and `unknown`
+   * cannot be mistaken for a wrong type — so this is a knob for fidelity, not
+   * correctness. Default 12.
+   */
+  maxDepth?: number
 }
 
 /** Module generation settings — controls how `kick g module` produces code */

--- a/packages/cli/src/typegen/builtin/client.ts
+++ b/packages/cli/src/typegen/builtin/client.ts
@@ -127,9 +127,18 @@ async function discardStaleOutput(ctx: { cwd: string; log: TypegenLogger }): Pro
  * `kick new --template fullstack` writes `client: true`, so its web app has
  * the map from the first run.
  */
+/** The configured expansion depth, or undefined for the expander's default. */
+function clientMaxDepth(config: KickConfig): number | undefined {
+  const configured = config?.typegen?.client
+  return typeof configured === 'object' ? configured.maxDepth : undefined
+}
+
 function clientMapWanted(ctx: { cwd: string; config: KickConfig; log: TypegenLogger }): boolean {
   const configured = ctx.config?.typegen?.client
   if (typeof configured === 'boolean') return configured
+  // An object means on unless it says otherwise, so `{ maxDepth: 24 }` alone
+  // reads the way it looks.
+  if (configured && typeof configured === 'object') return configured.enabled !== false
 
   // Unset means off. Inferring "on" from the file being there would work, but
   // it puts the switch somewhere nobody looks — a project would be paying
@@ -187,9 +196,11 @@ export const kickClientTypegen = (): TypegenPlugin => ({
     // 1,940-route app. Fingerprinting what the map depends on costs ~35ms, so
     // an unchanged project skips two orders of magnitude of work. Returning
     // null leaves the existing file in place.
+    const maxDepth = clientMaxDepth(ctx.config)
     const stamp = await fingerprintClientMap({
       projectDir: ctx.cwd,
       keys,
+      maxDepth,
       cliVersion: CLI_VERSION,
     })
     const recorded = readStamp(path.resolve(ctx.cwd, STAMP_FILE))
@@ -210,6 +221,7 @@ export const kickClientTypegen = (): TypegenPlugin => ({
         projectDir: ctx.cwd,
         routesFile: path.resolve(ctx.cwd, '.kickjs/types/kick__routes.ts'),
         keys,
+        maxDepth,
         onWarn: (msg) => ctx.log.warn(msg),
       })
       const rendered = renderClient(map, keys)

--- a/packages/cli/src/typegen/client/expand-type.ts
+++ b/packages/cli/src/typegen/client/expand-type.ts
@@ -26,13 +26,41 @@ import type { TsApi } from './ts-compiler'
 export interface TypeExpanderOptions {
   /** Depth beyond which a type degrades to `unknown`. Default 12. */
   maxDepth?: number
+  /** Depth-guard hits tolerated per route before the expansion is abandoned. */
+  truncationBudget?: number
   onWarn?: (msg: string) => void
 }
 
+/**
+ * Depth-guard hits tolerated in one route before the expansion is abandoned.
+ *
+ * A genuinely deep response trips the guard a handful of times. Hundreds of
+ * thousands means the type is recursive and the walk is exponential — that is
+ * an OOM, not a slow render, so it has to stop rather than warn its way there.
+ */
+const TRUNCATION_BUDGET = 1000
+const BUDGET_EXHAUSTED = Symbol('kick/client: expansion budget exhausted')
+
 export class TypeExpander {
   private readonly hoistedByType = new Map<ts.Type, string>()
+  /**
+   * Anonymous object types currently being rendered inline.
+   *
+   * A type alias to an object literal (`type J = { … }`) carries the anonymous
+   * `__type` symbol, so it is not "named" and renders inline. That is right
+   * until it reaches itself — zod v4's `JSONSchema` has
+   * `properties?: Record<string, JSONSchema>` — at which point inlining cannot
+   * terminate. Recording the render in progress lets a self-reference claim a
+   * name, which promotes the type to a hoisted interface and ends the walk.
+   * Without it, one such route produced 1.66M warnings, 4.4 GB and a V8 abort.
+   */
+  private readonly inProgress = new Map<ts.Type, { name: string | null }>()
+  private nextName = 0
   private readonly blocks: string[] = []
   private readonly maxDepth: number
+  /** Depth-guard hits for the route being expanded; reset per `expand()`. */
+  private truncations = 0
+  private readonly budget: number
 
   constructor(
     private readonly ts: TsApi,
@@ -41,6 +69,7 @@ export class TypeExpander {
     private readonly opts: TypeExpanderOptions = {},
   ) {
     this.maxDepth = opts.maxDepth ?? 12
+    this.budget = opts.truncationBudget ?? TRUNCATION_BUDGET
   }
 
   /** Hoisted `interface __T<n> { … }` blocks, in creation order. */
@@ -49,13 +78,30 @@ export class TypeExpander {
   }
 
   expand(type: ts.Type): string {
-    return this.render(type, 0)
+    this.truncations = 0
+    try {
+      return this.render(type, 0)
+    } catch (err) {
+      if (err !== BUDGET_EXHAUSTED) throw err
+      // One clear line beats a flood. A type that hits the depth guard this
+      // many times in a single route is pathological, not merely deep, and
+      // expanding the rest of it buys nothing: the output is already mostly
+      // `unknown`. Finding the last one of these meant counting 8.1 million
+      // warnings to notice a single route was responsible.
+      this.opts.onWarn?.(
+        `expansion abandoned after ${this.budget} truncations — emitting 'unknown'. ` +
+          `This usually means a recursive type. Declare a response schema on the route ` +
+          `for an exact type.`,
+      )
+      return 'unknown'
+    }
   }
 
   private render(type: ts.Type, depth: number): string {
     const F = this.ts.TypeFlags
 
     if (depth > this.maxDepth) {
+      if (++this.truncations > this.budget) throw BUDGET_EXHAUSTED
       this.opts.onWarn?.(
         `type nesting exceeded ${this.maxDepth} levels — emitting 'unknown'. ` +
           `Declare a response schema on the route for an exact type.`,
@@ -114,7 +160,7 @@ export class TypeExpander {
     if (this.isNamed(type)) {
       // Reserve the name BEFORE expanding the body: a self-referencing type
       // must find its own name already in the map.
-      const name = `__T${this.hoistedByType.size}`
+      const name = this.allocName()
       this.hoistedByType.set(type, name)
       const index = this.blocks.length
       this.blocks.push('') // hold the slot so ordering matches creation order
@@ -129,8 +175,36 @@ export class TypeExpander {
       return name
     }
 
-    const inline = this.members(type, depth, '', '; ')
+    // Anonymous. Render inline, but stay reachable: a self-reference during
+    // this render claims a name, and a named type must be hoisted.
+    const active = this.inProgress.get(type)
+    if (active) return (active.name ??= this.allocName())
+
+    const marker: { name: string | null } = { name: null }
+    this.inProgress.set(type, marker)
+    let inline: string
+    try {
+      inline = this.members(type, depth, '', '; ')
+    } finally {
+      this.inProgress.delete(type)
+    }
+
+    if (marker.name) {
+      // Recursive after all. Bind the name first so the re-render terminates
+      // on the memo, then emit the body as its own block. Re-rendering from
+      // depth 0 also recovers whatever the first pass truncated on the way in.
+      this.hoistedByType.set(type, marker.name)
+      const index = this.blocks.length
+      this.blocks.push('')
+      this.blocks[index] = `interface ${marker.name} {\n${this.members(type, 0, '  ')}\n}`
+      return marker.name
+    }
+
     return inline.length > 0 ? `{ ${inline} }` : '{}'
+  }
+
+  private allocName(): string {
+    return `__T${this.nextName++}`
   }
 
   private members(type: ts.Type, depth: number, indent: string, join = '\n'): string {

--- a/packages/cli/src/typegen/client/resolve-entries.ts
+++ b/packages/cli/src/typegen/client/resolve-entries.ts
@@ -36,6 +36,8 @@ export interface ResolvedClientMap {
 }
 
 export interface ResolveClientMapOptions {
+  /** Inline nesting expanded before a type becomes `unknown`. Default 12. */
+  maxDepth?: number
   /** Project root — holds `tsconfig.json`, and is where the program is built. */
   projectDir: string
   /**
@@ -62,6 +64,8 @@ const PROBE = '__kick_client_probe__.ts'
 export async function fingerprintClientMap(opts: {
   projectDir: string
   compilerFrom?: string
+  /** Part of the fingerprint: changing it changes the emitted map. */
+  maxDepth?: number
   /** Route keys the map is built for — see `FingerprintInput.keys`. */
   keys: readonly string[]
   cliVersion: string
@@ -82,7 +86,7 @@ export async function fingerprintClientMap(opts: {
       projectDir: opts.projectDir,
       fileNames: parsed.fileNames,
       keys: opts.keys,
-      options: parsed.options,
+      options: { ...parsed.options, __kickMaxDepth: opts.maxDepth ?? null },
       cliVersion: opts.cliVersion,
     })
   } catch {
@@ -124,6 +128,7 @@ export async function resolveClientMap(opts: ResolveClientMapOptions): Promise<R
   // and fix. Track the route being expanded and prefix on the way out.
   let currentKey: string | null = null
   const expander = new TypeExpander(t, checker, program, {
+    maxDepth: opts.maxDepth,
     onWarn: (msg) => opts.onWarn?.(currentKey ? `route '${currentKey}': ${msg}` : msg),
   })
   const entries = new Map<string, string>()


### PR DESCRIPTION
## What this actually was

Diagnosed — by me, and independently in the consuming app — as superlinear memory scaling in the client route map, needing >12 GB and blocking a migration. It was neither superlinear nor scaling. **Two individual routes.**

A type alias to an object literal (`type Node = { … }`) carries TypeScript's anonymous `__type` symbol rather than the alias name, so `isNamed` returned false, the type was never hoisted, and it was re-expanded inline at every occurrence. For a **recursive** alias — zod v4's `JSONSchema` (`$defs?: Record<string, JSONSchema>`), or a condition tree — inlining cannot terminate, so the walk fanned out exponentially.

An `interface` in the same position was always fine: it hoists, the hoist keys the memo, and the memo ends the recursion. Only the alias form was affected, which is why this went unnoticed.

## Measured, on a 1,940-route app

| | before | after |
| --- | --- | --- |
| whole pass | 130 s, 15.5 GB, **V8 abort, no map** | 13.4 s, 1.66 GB, map emitted |
| depth-guard warnings | 325 (8.1 M on the worst route) | **0** |
| longest emitted line | ~7,000 chars | 1,644 |
| routes / typed responses / bare `any` | 1940 / 1195 / 7 | 1940 / 1195 / 7 |

Fidelity is identical — same routes, same typed-response count, same `any` count. Only the pathological expansion is gone.

## What it emits now

The recursion is represented exactly, as mutually-referencing interfaces, instead of a duplicated blob that bottomed out in `unknown` anyway:

```ts
interface __T638 { readonly all: readonly (__T638 | __T639 | __T640 | { readonly p: string; readonly v: unknown })[] }
interface __T639 { readonly any: readonly (__T638 | __T639 | __T640 | { readonly p: string; readonly v: unknown })[] }
interface __T640 { readonly not: __T638 | __T639 | __T640 | { readonly p: string; readonly v: unknown } }
```

An anonymous object type that reaches itself mid-render claims a name and is promoted to a hoisted interface; the body is then re-rendered from depth 0, which also recovers whatever the first inline pass truncated on the way in. Non-recursive anonymous types are untouched and still render inline — there's a test pinning that.

## Backstop

Past 1,000 depth-guard hits in one route, the expansion is abandoned, emits `unknown`, and says so **once**.

The guard was firing correctly on every one of those 8.1 M warnings. It just never stopped, so the cost was unbounded — a correct guard with no bail is still an OOM. Diagnosing it meant counting warnings to notice one route was responsible.

## Testing

`packages/cli/__tests__/client-recursive-types.test.ts` drives `resolveClientMap` over a real project. The existing expander harness does **not** reproduce this — it reads the type off its own alias declaration, where it still renders by name, so tests written there passed with the fix reverted and were worthless. All five assertions in the new file fail with the fix reverted.

Also two budget tests (`truncationBudget` is injectable so they're load-bearing). Full suite green: 732 CLI tests, 2,254 across the monorepo.

## Note

Chunked resolution was prototyped against the wrong diagnosis and is **not** in this PR — with the actual cause fixed, 1.66 GB needs no chunking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViFD8FXyNzwnAd3ixx7biB

---

## Follow-up commit: `typegen.client: { maxDepth }`

The depth limit was the one ceiling in the map an adopter could not lift — hardcoded at 12, no config path. Now:

```ts
typegen: { client: { maxDepth: 24 } }
```

The object form is on unless it says otherwise, so `{ maxDepth: 24 }` alone also enables the map; `{ enabled: false }` disables it. `client: true` is unchanged.

Depth joins the map's fingerprint — without that, raising it would serve the cached map built at the old depth. Verified by flipping to 6: cache misses, 41 truncation warnings, smaller map.

**The default is not wrong, and this isn't an admission that it is.** Recursive and named types both hoist into their own interface, costing one level rather than the whole budget, so only deep *anonymous* nesting spends it. On the 1,940-route app the emitted map is **byte-identical at 12, 24, 48 and 96** — measured cold each time. The knob is for the project where that isn't true.

Changesets: `patch` for the fix, `minor` for this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configure client response-type expansion depth with `typegen.client.maxDepth`.
  - Support object-based client configuration, including explicit enable/disable controls.
  - Preserve recursive response types by generating reusable named interfaces.
  - Safely fall back to `unknown` with a single warning when expansion limits are exceeded.
  - Configuration changes now trigger client-map regeneration instead of using stale cached output.

- **Documentation**
  - Added guidance for configuring expansion depth and understanding generated recursive types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->