### PR TITLE
fix(cli): keep non-JSON members out of the client route map

### DIFF
--- a/.changeset/proud-crabs-shave.md
+++ b/.changeset/proud-crabs-shave.md
@@ -29,6 +29,14 @@ which let `response.createdAt.getFullYear()` compile against a string. This
 assumes the default JSON transport; a client that revives values will have
 richer runtime types than the map claims.
 
+Optional methods and optional callbacks are covered too. The checker adds
+`undefined` to every optional property, so `save?(): void` arrives as
+`(() => void) | undefined`; requiring every union member to be callable kept
+those, which then rendered as `onDone?: {}` — and an optional method earned its
+own empty hoisted interface. A callable member inside any union is dropped as
+well, since `(() => void) | Foo` reaches the client as `Foo` or not at all,
+never as an empty object.
+
 Every `typeToString` call now passes `NoTruncation`. Truncated output is never
 valid type syntax, so this is unconditional rather than a heuristic.
 

--- a/.changeset/proud-crabs-shave.md
+++ b/.changeset/proud-crabs-shave.md
@@ -21,6 +21,14 @@ omitted, as are well-known symbol keys — the checker prints those as
 anything a client could index by, and which would also churn the map's
 fingerprint between compiler versions.
 
+The same rule covers what JSON _transforms_, not only what it drops: a type
+declaring `toJSON()` is emitted as that method's return type. `Date` becomes
+`string` and `Buffer` becomes `{ type: 'Buffer'; data: number[] }` — what the
+client actually receives. One app's map carried 496 bare `Date`s, every one of
+which let `response.createdAt.getFullYear()` compile against a string. This
+assumes the default JSON transport; a client that revives values will have
+richer runtime types than the map claims.
+
 Every `typeToString` call now passes `NoTruncation`. Truncated output is never
 valid type syntax, so this is unconditional rather than a heuristic.
 

--- a/.changeset/proud-crabs-shave.md
+++ b/.changeset/proud-crabs-shave.md
@@ -37,6 +37,12 @@ own empty hoisted interface. A callable member inside any union is dropped as
 well, since `(() => void) | Foo` reaches the client as `Foo` or not at all,
 never as an empty object.
 
+A cycle through `toJSON()` — `A.toJSON(): B` and `B.toJSON(): A` — is emitted
+as `unknown` with a warning. That hop is not structural nesting, so it spends no
+depth, and a direct self-return check cannot see a two-type cycle; nothing
+bounded it but the call stack, which overflowed. Such a value has no
+serializable form, so `unknown` is the honest answer.
+
 Every `typeToString` call now passes `NoTruncation`. Truncated output is never
 valid type syntax, so this is unconditional rather than a heuristic.
 

--- a/.changeset/proud-crabs-shave.md
+++ b/.changeset/proud-crabs-shave.md
@@ -1,0 +1,33 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+Stop emitting methods, symbol keys and truncated types into the client route map.
+
+A response containing a `Buffer` produced a map that would not parse: 34
+`TS1110: Type expected` errors, and nothing downstream could consume it.
+
+Two causes, one symptom. `Buffer` was expanded structurally into a 107-member
+interface — `slice`, `write`, `toJSON`, `reduce` and the rest, each hoisted into
+its own interface. The overloaded ones fell through to `checker.typeToString`,
+which elides long types with `...` by default, and `...` is not type syntax, so
+it landed in the `.d.ts` verbatim.
+
+The map describes a JSON response, and `JSON.stringify` drops functions and
+symbol keys. A method in this map therefore describes a field the client can
+never receive. Properties whose type has call or construct signatures are now
+omitted, as are well-known symbol keys — the checker prints those as
+`__@toStringTag@138`, whose numeric suffix is compiler state rather than
+anything a client could index by, and which would also churn the map's
+fingerprint between compiler versions.
+
+Every `typeToString` call now passes `NoTruncation`. Truncated output is never
+valid type syntax, so this is unconditional rather than a heuristic.
+
+Data-only types are unaffected — getters are properties, not callables, so they
+still serialize and are still emitted; lib types like `Date` were already
+emitted by name rather than expanded.
+
+On a 1,940-route app: 34 type errors in the emitted map become 0, hoisted
+interfaces drop from 769 to 691, and the `Buffer` case shrinks from 6,850 bytes
+of unusable output to 1,280 that type-checks.

--- a/docs/guide/typed-client.md
+++ b/docs/guide/typed-client.md
@@ -123,6 +123,27 @@ The record lives in `.kickjs/cache/client-map.sha1`, inside the already-ignored
 never writes it — that flag is read-only.
 :::
 
+### The map describes JSON, not the server's objects
+
+The types are the shape the client _receives_, which is not always the shape the
+handler returned. `JSON.stringify` is applied on the way out, so the map applies
+the same rules:
+
+| in the handler         | in the map                           | why                                           |
+| ---------------------- | ------------------------------------ | --------------------------------------------- |
+| `Date`                 | `string`                             | `Date.prototype.toJSON` returns an ISO string |
+| `Buffer`               | `{ type: 'Buffer'; data: number[] }` | its `toJSON`                                  |
+| a method               | omitted                              | functions do not serialize                    |
+| `[Symbol.toStringTag]` | omitted                              | symbol keys do not serialize                  |
+
+Any type declaring `toJSON()` is emitted as that method's return type. Without
+this the map type-checks and then lies — `response.createdAt.getFullYear()`
+compiles against a value that is a string at runtime.
+
+This assumes the default transport: JSON over `fetch`, parsed with `JSON.parse`.
+If your client revives values (`superjson`, a `JSON.parse` reviver that rebuilds
+dates), the runtime types will be richer than the map claims.
+
 ### Expansion depth
 
 A response is expanded inline up to 12 levels; past that it is emitted as

--- a/packages/cli/__tests__/client-expand-type.test.ts
+++ b/packages/cli/__tests__/client-expand-type.test.ts
@@ -451,3 +451,33 @@ describe('TypeExpander — what JSON transforms', () => {
     expect(out.text).toBe('{ a: { b: string } }')
   })
 })
+
+describe('TypeExpander — optional and unioned callables', () => {
+  // The checker adds `undefined` to every optional property, so `save?(): void`
+  // arrives as `(() => void) | undefined`. Requiring every union member to be
+  // callable therefore kept optional methods: they rendered as `onDone?: {}`,
+  // and an optional *method* even earned its own empty hoisted interface.
+  it('drops optional methods and optional callbacks', () => {
+    const out = expand(`
+      type Target = {
+        keep: string
+        save?(): void
+        onDone?: () => void
+      }
+    `)
+    expect(out.text).toBe('{ keep: string }')
+    expect(out.hoisted).toEqual([])
+  })
+
+  it('drops a callable member from a union rather than emitting {}', () => {
+    // `(() => void) | Foo` arrives as `Foo` or not at all — never as the
+    // function, and never as an empty object.
+    const out = expand(`type Target = { mixed: (() => void) | { value: string } }`)
+    expect(out.text).toBe('{ mixed: { value: string } }')
+  })
+
+  it('keeps an optional data property optional', () => {
+    const out = expand(`type Target = { a?: string; b: number }`)
+    expect(out.text).toBe('{ a?: string; b: number }')
+  })
+})

--- a/packages/cli/__tests__/client-expand-type.test.ts
+++ b/packages/cli/__tests__/client-expand-type.test.ts
@@ -481,3 +481,39 @@ describe('TypeExpander — optional and unioned callables', () => {
     expect(out.text).toBe('{ a?: string; b: number }')
   })
 })
+
+describe('TypeExpander — cyclic toJSON', () => {
+  // `A.toJSON(): B` and `B.toJSON(): A` alternate forever. The direct
+  // self-return check does not see it, and the hop is not structural nesting
+  // so it spends no depth — nothing stopped it but the call stack, which
+  // overflowed with `RangeError: Maximum call stack size exceeded`.
+  it('emits unknown rather than overflowing the stack', () => {
+    const warnings: string[] = []
+    const out = expand(
+      `
+      declare class A { toJSON(): B }
+      declare class B { toJSON(): A }
+      type Target = { x: A }
+    `,
+      { onWarn: (m) => warnings.push(m) },
+    )
+    expect(out.text).toBe('{ x: unknown }')
+    expect(warnings.join('\n')).toMatch(/cyclic toJSON/)
+  })
+
+  it('still resolves a toJSON that returns a plain shape', () => {
+    // The guard must not break the ordinary single hop it sits in front of.
+    const out = expand(`
+      declare class Money { toJSON(): { cents: number } }
+      type Target = { total: Money; when: Date }
+    `)
+    expect(out.text).toBe('{ total: { cents: number }; when: string }')
+  })
+
+  it('allows the same toJSON type twice in one shape', () => {
+    // Sequential use is not a cycle — the guard is scoped to the walk, not a
+    // permanent blocklist.
+    const out = expand(`type Target = { a: Date; b: Date }`)
+    expect(out.text).toBe('{ a: string; b: string }')
+  })
+})

--- a/packages/cli/__tests__/client-expand-type.test.ts
+++ b/packages/cli/__tests__/client-expand-type.test.ts
@@ -106,8 +106,11 @@ describe('TypeExpander', () => {
   })
 
   it('keeps lib types by name — every frontend already has them', () => {
-    // Expanding Date would emit hundreds of methods AND be wrong.
-    expect(expand('type Target = { at: Date }').text).toBe('{ at: Date }')
+    // Expanding one of these would emit hundreds of methods AND be wrong.
+    // Deliberately not `Date`: it declares `toJSON()`, so it is transformed to
+    // a string on the wire and has its own test below. This case is about lib
+    // types that survive as themselves.
+    expect(expand('type Target = { at: ArrayBuffer }').text).toBe('{ at: ArrayBuffer }')
   })
 
   it('hoists a named project interface instead of inlining it everywhere', () => {
@@ -334,7 +337,8 @@ describe('TypeExpander', () => {
       type Target = { params: {}; response: Term[] }
     `)
     expect(out.text).toBe('{ params: {}; response: __T0[] }')
-    expect(out.hoisted.join('\n')).toContain('startsAt: Date')
+    // `string`, not `Date` — that is what arrives over the wire.
+    expect(out.hoisted.join('\n')).toContain('startsAt: string')
     expect(out.text).not.toContain('Term')
   })
 })
@@ -419,5 +423,31 @@ describe('TypeExpander — what cannot survive JSON', () => {
   it('keeps a data-only object untouched', () => {
     const out = expand(`type Target = { a: string; b: { c: number } }`)
     expect(out.text).toBe('{ a: string; b: { c: number } }')
+  })
+})
+
+describe('TypeExpander — what JSON transforms', () => {
+  // Dropping what JSON drops is only half the rule. `JSON.stringify` also
+  // *calls* `toJSON()`, so for those types the wire shape is that method's
+  // return type. Emitting the type itself type-checks and then lies: a map
+  // saying `Date` lets `r.createdAt.getFullYear()` compile against a value
+  // that is a string at runtime. One app had 496 of them.
+  it('emits Date as the string the client actually receives', () => {
+    const out = expand(`type Target = { createdAt: Date; deletedAt: Date | null }`)
+    expect(out.text).toBe('{ createdAt: string; deletedAt: null | string }')
+  })
+
+  it('uses a custom toJSON return type over the object itself', () => {
+    const out = expand(`
+      declare class Money { amount: number; currency: string; toJSON(): { cents: number } }
+      type Target = { total: Money }
+    `)
+    expect(out.text).toContain('cents: number')
+    expect(out.text).not.toContain('currency')
+  })
+
+  it('leaves a type without toJSON alone', () => {
+    const out = expand(`type Target = { a: { b: string } }`)
+    expect(out.text).toBe('{ a: { b: string } }')
   })
 })

--- a/packages/cli/__tests__/client-expand-type.test.ts
+++ b/packages/cli/__tests__/client-expand-type.test.ts
@@ -369,3 +369,55 @@ describe('TypeExpander — expansion budget', () => {
     expect(warnings).toEqual([])
   })
 })
+
+describe('TypeExpander — what cannot survive JSON', () => {
+  // A response is JSON. `JSON.stringify` drops functions and symbol keys, so a
+  // method in this map describes a field the client never receives. Expanding
+  // them turned one `Buffer` into a 107-member interface of `slice`/`write`/
+  // `reduce` overloads — and the overloads printed through `typeToString`,
+  // which elides with `...`, which is not type syntax. 34 syntax errors, and
+  // the whole map stopped parsing.
+  it('drops methods and function-valued properties', () => {
+    const out = expand(`
+      type Target = {
+        name: string
+        save(): void
+        onDone: (x: number) => void
+        nested: { id: string; run(): number }
+      }
+    `)
+    expect(out.text).toContain('name: string')
+    expect(out.text).toContain('id: string')
+    expect(out.text).not.toContain('save')
+    expect(out.text).not.toContain('onDone')
+    expect(out.text).not.toContain('run')
+    expect(out.text).not.toContain('=>')
+  })
+
+  it('drops well-known symbol keys, whose printed name is compiler state', () => {
+    // The checker prints these as `__@toStringTag@138` — the suffix is an
+    // internal id, so it is neither indexable by a client nor stable to hash.
+    const out = expand(`
+      type Target = { readonly [Symbol.toStringTag]: 'Thing'; a: string }
+    `)
+    expect(out.text).toContain('a: string')
+    expect(out.text).not.toContain('__@')
+  })
+
+  // Smoke check, not a regression test: dropping methods removes the only path
+  // that reached `typeToString` with something long enough to elide, so this
+  // passes with the NoTruncation flag off. The flag stays because the invariant
+  // is unconditional — truncated output is never valid type syntax — and
+  // because it is the last line of defence if a long type reaches the printer
+  // by some route this suite does not model.
+  it('never emits an elision, whatever the type', () => {
+    const out = expand(`type Target = { d: Uint8Array; b: ArrayBuffer }`)
+    expect(out.text).not.toContain('...')
+    for (const block of out.hoisted) expect(block).not.toContain('...')
+  })
+
+  it('keeps a data-only object untouched', () => {
+    const out = expand(`type Target = { a: string; b: { c: number } }`)
+    expect(out.text).toBe('{ a: string; b: { c: number } }')
+  })
+})

--- a/packages/cli/__tests__/client-resolve-entries.test.ts
+++ b/packages/cli/__tests__/client-resolve-entries.test.ts
@@ -88,7 +88,9 @@ describe('resolveClientMap', () => {
 
     const entry = out.entries.get('GET /terms')!
     expect(entry).toContain('response: __T0[]')
-    expect(out.hoisted.join('\n')).toContain('startsAt: Date')
+    // `string`, not `Date`: JSON.stringify calls Date.toJSON, so an ISO
+    // string is what the client receives. See client-expand-type.test.ts.
+    expect(out.hoisted.join('\n')).toContain('startsAt: string')
 
     // The point of the whole feature: nothing reaches back into src/.
     expect(entry).not.toContain('import')

--- a/packages/cli/src/typegen/client/expand-type.ts
+++ b/packages/cli/src/typegen/client/expand-type.ts
@@ -133,7 +133,14 @@ export class TypeExpander {
     }
 
     if (type.isUnion()) {
-      return type.types.map((m) => this.render(m, depth + 1)).join(' | ')
+      // A callable member cannot appear in JSON either — `(() => void) | Foo`
+      // arrives as `Foo` or not at all, never as the function. Dropping the
+      // member beats rendering it as `{}`, which claims an empty object is a
+      // possible value.
+      const members = type.types.filter((m) => !this.isCallable(m))
+      return (members.length > 0 ? members : type.types)
+        .map((m) => this.render(m, depth + 1))
+        .join(' | ')
     }
     if (type.isIntersection()) {
       return type.types.map((m) => this.render(m, depth + 1)).join(' & ')
@@ -446,7 +453,17 @@ export class TypeExpander {
 
   /** Has call or construct signatures — a method or function, never JSON. */
   private isCallable(type: ts.Type): boolean {
-    if (type.isUnion()) return type.types.every((m) => this.isCallable(m))
+    if (type.isUnion()) {
+      // The checker adds `undefined` to every optional property, so
+      // `save?(): void` arrives as `(() => void) | undefined`. Requiring
+      // *every* member to be callable therefore kept optional methods, which
+      // then rendered as `{}` — or, for a method, as a hoisted interface with
+      // no members. Decide on what is actually there.
+      const present = type.types.filter(
+        (m) => !(m.flags & (this.ts.TypeFlags.Undefined | this.ts.TypeFlags.Null)),
+      )
+      return present.length > 0 && present.every((m) => this.isCallable(m))
+    }
     return (
       this.checker.getSignaturesOfType(type, this.ts.SignatureKind.Call).length > 0 ||
       this.checker.getSignaturesOfType(type, this.ts.SignatureKind.Construct).length > 0

--- a/packages/cli/src/typegen/client/expand-type.ts
+++ b/packages/cli/src/typegen/client/expand-type.ts
@@ -152,6 +152,15 @@ export class TypeExpander {
       return array.readonly ? `readonly ${body}` : body
     }
 
+    // `JSON.stringify` calls `toJSON()` when a value has one, so the wire
+    // shape is that method's return type — not the type itself. `Date` becomes
+    // an ISO `string`, `Buffer` becomes `{ type: 'Buffer'; data: number[] }`.
+    // Emitting `Date` here type-checks and then lies: the client gets a string,
+    // so `r.createdAt.getFullYear()` compiles and throws at runtime. This runs
+    // before the lib-type branch, which would otherwise print `Date` by name.
+    const json = this.toJsonType(type)
+    if (json) return this.render(json, depth)
+
     // A type the frontend already has — emit the name, expand nothing.
     if (this.isLibType(type)) return this.renderLibType(type, depth)
 
@@ -417,6 +426,24 @@ export class TypeExpander {
   }
 
   /** Has a declared name worth hoisting (interface / class / named alias). */
+  /**
+   * The type `JSON.stringify` would actually produce for this value, when it
+   * declares `toJSON()`. Null when it does not, which is the common case.
+   */
+  private toJsonType(type: ts.Type): ts.Type | null {
+    if (!(type.flags & this.ts.TypeFlags.Object)) return null
+    const prop = this.checker.getPropertyOfType(type, 'toJSON')
+    if (!prop) return null
+    const [signature] = this.checker.getSignaturesOfType(
+      this.typeOfProperty(prop),
+      this.ts.SignatureKind.Call,
+    )
+    if (!signature) return null
+    const returned = this.checker.getReturnTypeOfSignature(signature)
+    // A `toJSON` returning the same type would spin; let the normal path run.
+    return returned === type ? null : returned
+  }
+
   /** Has call or construct signatures — a method or function, never JSON. */
   private isCallable(type: ts.Type): boolean {
     if (type.isUnion()) return type.types.every((m) => this.isCallable(m))

--- a/packages/cli/src/typegen/client/expand-type.ts
+++ b/packages/cli/src/typegen/client/expand-type.ts
@@ -66,6 +66,8 @@ export class TypeExpander {
    * Without it, one such route produced 1.66M warnings, 4.4 GB and a V8 abort.
    */
   private readonly inProgress = new Map<ts.Type, { name: string | null }>()
+  /** Types whose `toJSON()` result is being rendered — see the guard in `render`. */
+  private readonly jsonInProgress = new Set<ts.Type>()
   private nextName = 0
   private readonly blocks: string[] = []
   private readonly maxDepth: number
@@ -166,7 +168,27 @@ export class TypeExpander {
     // so `r.createdAt.getFullYear()` compiles and throws at runtime. This runs
     // before the lib-type branch, which would otherwise print `Date` by name.
     const json = this.toJsonType(type)
-    if (json) return this.render(json, depth)
+    if (json) {
+      // `A.toJSON(): B` and `B.toJSON(): A` alternate between two distinct
+      // types forever. The `returned === type` check in `toJsonType` only
+      // catches a direct self-return, and this hop is not structural nesting
+      // so it does not spend depth — leaving nothing to stop it but the call
+      // stack. A cycle here has no serializable fixpoint, so `unknown` is the
+      // honest answer rather than a guess at which side to stop on.
+      if (this.jsonInProgress.has(type)) {
+        this.opts.onWarn?.(
+          `'${this.checker.typeToString(type, undefined, this.printFlags)}' has a ` +
+            `cyclic toJSON() — emitting 'unknown', since it has no serializable form.`,
+        )
+        return 'unknown'
+      }
+      this.jsonInProgress.add(type)
+      try {
+        return this.render(json, depth)
+      } finally {
+        this.jsonInProgress.delete(type)
+      }
+    }
 
     // A type the frontend already has — emit the name, expand nothing.
     if (this.isLibType(type)) return this.renderLibType(type, depth)

--- a/packages/cli/src/typegen/client/expand-type.ts
+++ b/packages/cli/src/typegen/client/expand-type.ts
@@ -42,6 +42,17 @@ const TRUNCATION_BUDGET = 1000
 const BUDGET_EXHAUSTED = Symbol('kick/client: expansion budget exhausted')
 
 export class TypeExpander {
+  /**
+   * `typeToString` elides long types with `...` by default — and that `...` is
+   * not valid type syntax, so it lands in the emitted `.d.ts` and the whole
+   * map stops parsing. One `Buffer` in a response produced 34 syntax errors
+   * (`TS1110: Type expected`) and made the file unusable. Truncated output is
+   * never correct here, whatever the type.
+   */
+  private get printFlags(): ts.TypeFormatFlags {
+    return this.ts.TypeFormatFlags.NoTruncation
+  }
+
   private readonly hoistedByType = new Map<ts.Type, string>()
   /**
    * Anonymous object types currently being rendered inline.
@@ -112,13 +123,13 @@ export class TypeExpander {
     // Primitives and keywords — typeToString is exactly right for these and
     // carries no names from the program.
     if (type.flags & (F.String | F.Number | F.Boolean | F.BigInt | F.ESSymbol)) {
-      return this.checker.typeToString(type)
+      return this.checker.typeToString(type, undefined, this.printFlags)
     }
     if (type.flags & (F.Any | F.Unknown | F.Never | F.Void | F.Undefined | F.Null)) {
-      return this.checker.typeToString(type)
+      return this.checker.typeToString(type, undefined, this.printFlags)
     }
     if (type.isLiteral() || type.flags & F.BooleanLiteral) {
-      return this.checker.typeToString(type)
+      return this.checker.typeToString(type, undefined, this.printFlags)
     }
 
     if (type.isUnion()) {
@@ -211,12 +222,22 @@ export class TypeExpander {
     const lines: string[] = []
 
     for (const info of this.checker.getIndexInfosOfType(type)) {
-      const key = this.checker.typeToString(info.keyType)
+      const key = this.checker.typeToString(info.keyType, undefined, this.printFlags)
       lines.push(`${indent}[key: ${key}]: ${this.render(info.type, depth + 1)}`)
     }
 
     for (const prop of this.checker.getPropertiesOfType(type)) {
       const propType = this.typeOfProperty(prop)
+      // A response is JSON, and JSON has no functions: `JSON.stringify` drops
+      // every method, so a method in this map describes a field the client
+      // will never receive. Expanding them is how one `Buffer` became a
+      // 107-member interface of `slice`/`write`/`reduce` overloads.
+      if (this.isCallable(propType)) continue
+      // Same reasoning for symbol keys: `JSON.stringify` ignores them, and the
+      // checker prints them with an internal mangled name
+      // (`__@toStringTag@138`) whose numeric suffix is compiler state, not
+      // anything the client could index by.
+      if (prop.getName().startsWith('__@')) continue
       const optional = (prop.flags & this.ts.SymbolFlags.Optional) !== 0
       const rendered = this.renderPropertyType(propType, optional, prop, depth + 1)
       const readonly = this.isReadonlyProp(prop) ? 'readonly ' : ''
@@ -383,7 +404,8 @@ export class TypeExpander {
   private renderLibType(type: ts.Type, depth: number): string {
     const name = (type.aliasSymbol ?? type.getSymbol())?.getName()
     const args = type.aliasTypeArguments ?? this.typeArguments(type)
-    if (!name || args.length === 0) return this.checker.typeToString(type)
+    if (!name || args.length === 0)
+      return this.checker.typeToString(type, undefined, this.printFlags)
     return `${name}<${args.map((a) => this.render(a, depth + 1)).join(', ')}>`
   }
 
@@ -395,6 +417,15 @@ export class TypeExpander {
   }
 
   /** Has a declared name worth hoisting (interface / class / named alias). */
+  /** Has call or construct signatures — a method or function, never JSON. */
+  private isCallable(type: ts.Type): boolean {
+    if (type.isUnion()) return type.types.every((m) => this.isCallable(m))
+    return (
+      this.checker.getSignaturesOfType(type, this.ts.SignatureKind.Call).length > 0 ||
+      this.checker.getSignaturesOfType(type, this.ts.SignatureKind.Construct).length > 0
+    )
+  }
+
   private isNamed(type: ts.Type): boolean {
     const symbol = type.getSymbol()
     if (!symbol) return false


### PR DESCRIPTION

---

## Follow-up: what JSON *transforms*, not only what it drops

Dropping methods was half the rule. `JSON.stringify` also **calls** `toJSON()`, so for those types the wire shape is that method's return type.

Found while checking the fix against a 1,940-route app: **496 bare `Date`s in the emitted map.** Every one lets this compile —

```ts
const r = await api.get('/report-distributions/:id')
r.distributedAt.getFullYear()   // ✅ compiles · 💥 throws: it is a string
```

— because `Date.prototype.toJSON` returns an ISO string. Silent, type-checked, wrong. Worse than the parse error this PR started with, which at least failed loudly.

The surviving `Buffer` case was the same shape: a JSON response with an optional `pdf?: Buffer` field, emitted as `{ BYTES_PER_ELEMENT; buffer; byteLength; … }` — the server-side object, not what the client gets.

A type declaring `toJSON()` is now emitted as that method's return type:

| in the handler | in the map |
| --- | --- |
| `Date` | `string` |
| `Buffer` | `{ type: 'Buffer'; data: number[] }` |

| | before | after |
| --- | --- | --- |
| bare `Date` in the map | 496 | **0** |
| `BYTES_PER_ELEMENT` shapes | 1 | **0** |
| routes / typed | 1940 / 1884 | 1940 / 1884 |
| map typecheck errors | 0 | 0 |

**Two existing tests asserted `Date` by name and now assert otherwise.** Their intent — don't expand lib types, don't leak program names — still holds; `Date` was simply the wrong exemplar, so they use `ArrayBuffer` and `string`. Calling that out rather than quietly rewriting assertions.

**Assumption, now documented:** the default transport — JSON over `fetch`, parsed with `JSON.parse`. A client that revives values (`superjson`, a reviver that rebuilds dates) will have richer runtime types than the map claims.

Streaming handlers are unaffected and stay `unknown`: they return void, so there is no response type to get wrong.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved client route-map generation by excluding methods, callable properties, and unsupported symbol keys that cannot be represented in JSON.
  - Prevented long generated types from being truncated with invalid ellipsis syntax.
  - Represented types with `toJSON()` using their serialized return types, such as `Date` as `string`.
  - Preserved data-only properties and named library types for more accurate emitted declarations.

- **Documentation**
  - Clarified that typed client maps describe JSON responses rather than server-side objects.

- **Tests**
  - Added coverage for serialization, JSON compatibility, symbol-key filtering, and complete type output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->