### PR TITLE
feat(testing): let createTestApp run the engine you actually deploy

### DIFF
--- a/.changeset/spotty-apes-camp.md
+++ b/.changeset/spotty-apes-camp.md
@@ -1,0 +1,18 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+Stop generated docs and `kick explain` from teaching the Express-only test
+pattern.
+
+Every scaffolded sample drove `request(expressApp)`. The HTTP engine is
+pluggable, so under Fastify or h3 that is the wrong object — and generated docs
+are copied before anyone reads a guide, which propagates the pattern into
+projects that never see the corrected documentation.
+
+The project docs the CLI writes, and the `kick explain` known-issue snippets,
+now destructure `app` and drive `request(app.handle.bind(app))`, which follows
+whichever runtime the app is configured with. A test pins every CLI-emitting
+source so a sample cannot regress.
+
+Pairs with the `runtime` option on `createTestApp` in `@forinda/kickjs-testing`.

--- a/.changeset/tidy-eels-repeat.md
+++ b/.changeset/tidy-eels-repeat.md
@@ -1,0 +1,28 @@
+---
+'@forinda/kickjs-testing': minor
+---
+
+Let `createTestApp` run the engine you actually deploy.
+
+The harness hardcoded Express and returned `expressApp`, so a project running
+Fastify or h3 in production had its entire suite passing against a different
+engine. Routing, body parsing, status handling and error mapping all live in the
+runtime seam, so a green Express suite says nothing about any of them — the one
+thing an integration test exists to rule out.
+
+`createTestApp` now accepts `runtime`, the same value passed to `bootstrap()`:
+
+```ts
+import { fastifyRuntime } from '@forinda/kickjs/fastify'
+
+const { app } = await createTestApp({ modules: [UserModule], runtime: fastifyRuntime() })
+const res = await request(app.handle.bind(app)).get('/api/v1/users')
+```
+
+Drive the returned `app` rather than `expressApp`: `app.handle` is the
+Application's own Node request listener and follows whichever runtime is
+configured, so one suite can run against every engine.
+
+`expressApp` still works under the Express runtime. Under any other engine it
+now throws, instead of returning that engine's instance mistyped as
+`express.Express` — which is how a suite silently exercises the wrong runtime.

--- a/.changeset/tidy-eels-repeat.md
+++ b/.changeset/tidy-eels-repeat.md
@@ -23,6 +23,13 @@ Drive the returned `app` rather than `expressApp`: `app.handle` is the
 Application's own Node request listener and follows whichever runtime is
 configured, so one suite can run against every engine.
 
+The default middleware follows the runtime too. `createTestApp` defaulted to
+`[express.json()]` unconditionally, and passing it explicitly bypasses the
+Application's own native-body guard — under Fastify the connect parser then
+consumes the stream before Fastify reads it, and a JSON POST hangs until the
+test times out rather than failing. The default is now empty on a runtime that
+reports `nativeBodyParsing`.
+
 `expressApp` still works under the Express runtime. Under any other engine it
 now throws, instead of returning that engine's instance mistyped as
 `express.Express` — which is how a suite silently exercises the wrong runtime.

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -26,7 +26,7 @@ pnpm add -D @forinda/kickjs-testing supertest @types/supertest vitest
 
 ## createTestApp
 
-Creates an Application instance for testing — resets DI, runs `setup()`, returns the Express app for supertest:
+Creates an Application instance for testing — resets DI, runs `setup()`, and returns the app to drive with supertest:
 
 ```ts
 import { createTestApp } from '@forinda/kickjs-testing'
@@ -53,7 +53,45 @@ interface CreateTestAppOptions {
   defaultVersion?: number
   middleware?: express.RequestHandler[] // replaces default (express.json())
   isolated?: boolean // use Container.create() instead of reset()
+  runtime?: HttpRuntime // engine under test — defaults to Express
 }
+```
+
+### Testing the engine you deploy
+
+The HTTP engine is pluggable, and routing, body parsing and error mapping all
+live in the runtime seam. A suite that runs Express while production runs
+Fastify is not testing those at all.
+
+Pass the same `runtime` your `bootstrap()` uses, and drive the app rather than
+`expressApp` — `app.handle` is the Application's own Node listener and follows
+whichever engine is configured:
+
+```ts
+import request from 'supertest'
+import { fastifyRuntime } from '@forinda/kickjs/fastify'
+
+const { app } = await createTestApp({
+  modules: [UserModule],
+  runtime: fastifyRuntime(),
+})
+
+const res = await request(app.handle.bind(app)).get('/api/v1/users')
+```
+
+`expressApp` still works under the Express runtime, but throws under any other
+engine rather than handing back that engine's instance mistyped as
+`express.Express`.
+
+To run one suite across every engine you support:
+
+```ts
+describe.each([
+  { name: 'express', runtime: () => expressRuntime(), middleware: [express.json()] },
+  { name: 'fastify', runtime: () => fastifyRuntime(), middleware: [] },
+])('users on $name', ({ runtime, middleware }) => {
+  // Fastify parses JSON natively; Express needs the middleware.
+})
 ```
 
 ## Testing a Module

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -29,13 +29,20 @@ pnpm add -D @forinda/kickjs-testing supertest @types/supertest vitest
 Creates an Application instance for testing — resets DI, runs `setup()`, and returns the app to drive with supertest:
 
 ```ts
+import request from 'supertest'
 import { createTestApp } from '@forinda/kickjs-testing'
 import { UserModule } from '../src/modules/users'
 
-const { expressApp, container } = await createTestApp({
+const { app, container } = await createTestApp({
   modules: [UserModule],
 })
+
+const res = await request(app.handle.bind(app)).get('/api/v1/users')
 ```
+
+`app.handle` is the Application's own Node request listener, so this works
+whichever runtime the app is configured with. See
+[Testing the engine you deploy](#testing-the-engine-you-deploy).
 
 ::: tip
 `createTestApp` is **async** — always `await` it.
@@ -192,20 +199,20 @@ describe('UserController', () => {
   }
 
   it('GET /api/v1/users returns user list', async () => {
-    const { expressApp } = await createTestApp({ modules: [buildTestModule()] })
-    const res = await request(expressApp).get('/api/v1/users').expect(200)
+    const { app } = await createTestApp({ modules: [buildTestModule()] })
+    const res = await request(app.handle.bind(app)).get('/api/v1/users').expect(200)
     expect(res.body.data).toHaveLength(1)
   })
 
   it('GET /api/v1/users/:id returns 404 for unknown', async () => {
-    const { expressApp } = await createTestApp({ modules: [buildTestModule()] })
-    await request(expressApp).get('/api/v1/users/unknown').expect(404)
+    const { app } = await createTestApp({ modules: [buildTestModule()] })
+    await request(app.handle.bind(app)).get('/api/v1/users/unknown').expect(404)
   })
 
   it('DELETE removes and reduces count', async () => {
-    const { expressApp } = await createTestApp({ modules: [buildTestModule()] })
-    await request(expressApp).delete('/api/v1/users/u1').expect(204)
-    const res = await request(expressApp).get('/api/v1/users').expect(200)
+    const { app } = await createTestApp({ modules: [buildTestModule()] })
+    await request(app.handle.bind(app)).delete('/api/v1/users/u1').expect(204)
+    const res = await request(app.handle.bind(app)).get('/api/v1/users').expect(200)
     expect(res.body.data).toHaveLength(0)
   })
 })
@@ -248,15 +255,15 @@ class ProtectedController {
 
 // Tests
 it('rejects requests without token', async () => {
-  const { expressApp } = await createTestApp({ modules: [buildProtectedModule()] })
-  await request(expressApp).get('/api/v1/protected/me').expect(401)
+  const { app } = await createTestApp({ modules: [buildProtectedModule()] })
+  await request(app.handle.bind(app)).get('/api/v1/protected/me').expect(401)
 })
 
 it('accepts valid JWT', async () => {
-  const { expressApp } = await createTestApp({ modules: [buildProtectedModule()] })
+  const { app } = await createTestApp({ modules: [buildProtectedModule()] })
   const token = jwt.sign({ sub: 'u1', email: 'alice@test.com' }, TEST_SECRET, { expiresIn: '1h' })
 
-  const res = await request(expressApp)
+  const res = await request(app.handle.bind(app))
     .get('/api/v1/protected/me')
     .set('Authorization', `Bearer ${token}`)
     .expect(200)
@@ -265,10 +272,10 @@ it('accepts valid JWT', async () => {
 })
 
 it('rejects expired tokens', async () => {
-  const { expressApp } = await createTestApp({ modules: [buildProtectedModule()] })
+  const { app } = await createTestApp({ modules: [buildProtectedModule()] })
   const token = jwt.sign({ sub: 'u1' }, TEST_SECRET, { expiresIn: '-1s' })
 
-  await request(expressApp)
+  await request(app.handle.bind(app))
     .get('/api/v1/protected/me')
     .set('Authorization', `Bearer ${token}`)
     .expect(401)
@@ -314,9 +321,9 @@ class UploadController {
 
 // Test
 it('accepts file upload', async () => {
-  const { expressApp } = await createTestApp({ modules: [buildUploadModule()] })
+  const { app } = await createTestApp({ modules: [buildUploadModule()] })
 
-  const res = await request(expressApp)
+  const res = await request(app.handle.bind(app))
     .post('/api/v1/uploads')
     .attach('file', Buffer.from('hello world'), 'test.txt')
     .expect(200)
@@ -326,10 +333,10 @@ it('accepts file upload', async () => {
 })
 
 it('rejects files exceeding size limit', async () => {
-  const { expressApp } = await createTestApp({ modules: [buildUploadModule()] })
+  const { app } = await createTestApp({ modules: [buildUploadModule()] })
   const largeBuffer = Buffer.alloc(6 * 1024 * 1024) // 6MB > 5MB limit
 
-  await request(expressApp)
+  await request(app.handle.bind(app))
     .post('/api/v1/uploads')
     .attach('file', largeBuffer, 'big.bin')
     .expect(413)
@@ -535,7 +542,7 @@ directly.
 For concurrent test environments (`--pool threads`), use isolated containers:
 
 ```ts
-const { expressApp } = await createTestApp({
+const { app } = await createTestApp({
   modules: [UserModule],
   isolated: true, // uses Container.create() instead of Container.reset()
 })
@@ -572,6 +579,6 @@ The generated tests are scaffolds with real assertions. Customize them for your 
 - Test controllers without auth by creating test-only controllers
 - Put test env in `.env.test` — it wins outright and never falls back to `.env`
 - `vi.stubEnv()` after import needs `resetEnvCache()` + `loadEnv()` to reach `ConfigService`
-- The `expressApp` works directly with supertest — no server needed
+- The returned `app` works directly with supertest via `app.handle.bind(app)` — no server needed, on any runtime
 - Adapter lifecycle hooks (`beforeMount`, `beforeStart`) still run during setup
 - Generated tests work out of the box — `kick g module user && npx vitest run`

--- a/packages/cli/__tests__/generated-docs-runtime-neutral.test.ts
+++ b/packages/cli/__tests__/generated-docs-runtime-neutral.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Nothing the CLI writes should teach the Express-only test pattern.
+ *
+ * The HTTP engine is pluggable, but every generated sample drove
+ * `request(expressApp)`. Scaffolded docs are copied before anyone reads a
+ * guide, so a stale sample there propagates into projects that never see the
+ * corrected documentation — and under Fastify or h3 `expressApp` is the wrong
+ * object entirely.
+ *
+ * @module @forinda/kickjs-cli/__tests__/generated-docs-runtime-neutral.test
+ */
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/** Sources whose string literals end up in a generated project or in CLI output. */
+const EMITTERS = [
+  'src/generators/templates/project-docs.ts',
+  'src/generators/templates/project-config.ts',
+  'src/generators/templates/tests.ts',
+  'src/explain/known-issues.ts',
+]
+
+const ROOT = join(__dirname, '..')
+
+describe('CLI-emitted samples', () => {
+  it.each(EMITTERS)('%s does not hand out expressApp', (file) => {
+    const source = readFileSync(join(ROOT, file), 'utf8')
+    // Prose explaining why NOT to use it is fine; a sample destructuring or
+    // calling it is not.
+    expect(source).not.toMatch(/const \{[^}]*\bexpressApp\b[^}]*\}\s*=/)
+    expect(source).not.toMatch(/request\(\s*expressApp\s*\)/)
+  })
+})

--- a/packages/cli/src/explain/known-issues.ts
+++ b/packages/cli/src/explain/known-issues.ts
@@ -110,12 +110,12 @@ const envSchemaNotRegistered: KnownIssue = {
           codeBefore:
             "import { createTestApp } from '@forinda/kickjs-testing'\n" +
             '\n' +
-            'const { expressApp } = await createTestApp({ modules: [UserModule] })\n',
+            'const { app } = await createTestApp({ modules: [UserModule] })\n',
           codeAfter:
             "import { createTestApp } from '@forinda/kickjs-testing'\n" +
             "import '@/config'  // ← registers the env schema, as src/index.ts does\n" +
             '\n' +
-            'const { expressApp } = await createTestApp({ modules: [UserModule] })\n',
+            'const { app } = await createTestApp({ modules: [UserModule] })\n',
           docs: 'https://kickjs.app/guide/configuration.html#wiring-the-schema-at-startup',
         },
       }

--- a/packages/cli/src/generators/templates/project-docs.ts
+++ b/packages/cli/src/generators/templates/project-docs.ts
@@ -844,12 +844,16 @@ describe('UserController', () => {
 
   it('returns users', async () => {
     // \`createTestApp\` takes an OPTIONS OBJECT and returns
-    // \`{ app, expressApp, container }\`. Passing a bare array throws
+    // \`{ app, container }\`. Passing a bare array throws
     // "this.options.modules is not iterable"; the result has no \`.get()\`.
-    const { expressApp } = await createTestApp({
+    //
+    // Drive \`app.handle\` rather than \`expressApp\`: it is the Application's
+    // own Node listener, so the test runs on whichever runtime the app is
+    // configured with. Pass \`runtime\` to \`createTestApp\` to match production.
+    const { app } = await createTestApp({
       modules: [UserModule],
     })
-    const res = await request(expressApp).get('/api/v1/users')
+    const res = await request(app.handle.bind(app)).get('/api/v1/users')
     expect(res.status).toBe(200)
   })
 })

--- a/packages/testing/__tests__/runtime-parity.test.ts
+++ b/packages/testing/__tests__/runtime-parity.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The harness must exercise the engine the app actually deploys on.
+ *
+ * `createTestApp` hardcoded Express and returned `expressApp`, so a project
+ * running Fastify or h3 in production had its whole suite passing against a
+ * different engine — the one thing an integration test exists to rule out.
+ * Routing, body parsing, status handling and error mapping all live in the
+ * runtime seam, so a green Express suite says nothing about them.
+ *
+ * @module @forinda/kickjs-testing/__tests__/runtime-parity.test
+ */
+
+import { describe, expect, it } from 'vitest'
+import request from 'supertest'
+import express from 'express'
+import { Controller, Get, Post, type RequestContext } from '@forinda/kickjs'
+import { expressRuntime } from '@forinda/kickjs'
+// Source path, not the '@forinda/kickjs/fastify' subpath: this package's
+// vitest alias maps the bare specifier straight at src/index.ts.
+import { fastifyRuntime } from '../../kickjs/src/http/runtimes/fastify'
+
+import { createTestApp, createTestModule } from '../src/index'
+
+@Controller('/things')
+class ThingsController {
+  @Get('/')
+  list(_ctx: RequestContext) {
+    return [{ id: '1' }]
+  }
+
+  @Post('/')
+  create(ctx: RequestContext) {
+    return { received: (ctx.body as { name?: string })?.name ?? null }
+  }
+}
+
+const ThingsModule = createTestModule({
+  register: () => {},
+  routes: () => ({ path: '/things', controller: ThingsController }),
+})
+
+const runtimes = [
+  { name: 'express', make: () => expressRuntime(), middleware: [express.json()] },
+  { name: 'fastify', make: () => fastifyRuntime(), middleware: [] },
+] as const
+
+describe.each(runtimes)('createTestApp on $name', ({ make, middleware }) => {
+  async function boot() {
+    const { app, container } = await createTestApp({
+      modules: [ThingsModule],
+      runtime: make(),
+      middleware: [...middleware],
+      isolated: true,
+    })
+    return { app, container, agent: request(app.handle.bind(app)) }
+  }
+
+  it('reports the runtime it was actually given', async () => {
+    const { app } = await boot()
+    expect(app.getActiveRuntime().name).toBe(make().name)
+  })
+
+  it('routes a GET through the real engine', async () => {
+    const { agent } = await boot()
+    const res = await agent.get('/api/v1/things')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual([{ id: '1' }])
+  })
+
+  it('parses a JSON body through the real engine', async () => {
+    // Body parsing is runtime-specific — Fastify parses natively, Express
+    // needs the middleware. Exactly the class of thing an Express-only suite
+    // could never have caught.
+    const { agent } = await boot()
+    const res = await agent.post('/api/v1/things').send({ name: 'widget' })
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ received: 'widget' })
+  })
+
+  it('404s an unknown route through the real engine', async () => {
+    const { agent } = await boot()
+    expect((await agent.get('/api/v1/nope')).status).toBe(404)
+  })
+})
+
+describe('expressApp escape hatch', () => {
+  it('still works under Express', async () => {
+    const { expressApp } = await createTestApp({
+      modules: [ThingsModule],
+      middleware: [express.json()],
+      isolated: true,
+    })
+    expect((await request(expressApp).get('/api/v1/things')).status).toBe(200)
+  })
+
+  it('refuses to hand back another engine mistyped as Express', async () => {
+    // It used to return the Fastify instance cast to `express.Express`, which
+    // is how a suite silently exercises the wrong runtime.
+    const result = await createTestApp({
+      modules: [ThingsModule],
+      runtime: fastifyRuntime(),
+      isolated: true,
+    })
+    expect(() => result.expressApp).toThrow(/only available under the Express runtime/)
+  })
+})

--- a/packages/testing/__tests__/runtime-parity.test.ts
+++ b/packages/testing/__tests__/runtime-parity.test.ts
@@ -12,7 +12,6 @@
 
 import { describe, expect, it } from 'vitest'
 import request from 'supertest'
-import express from 'express'
 import { Controller, Get, Post, type RequestContext } from '@forinda/kickjs'
 import { expressRuntime } from '@forinda/kickjs'
 // Source path, not the '@forinda/kickjs/fastify' subpath: this package's
@@ -21,7 +20,7 @@ import { fastifyRuntime } from '../../kickjs/src/http/runtimes/fastify'
 
 import { createTestApp, createTestModule } from '../src/index'
 
-@Controller('/things')
+@Controller()
 class ThingsController {
   @Get('/')
   list(_ctx: RequestContext) {
@@ -40,16 +39,20 @@ const ThingsModule = createTestModule({
 })
 
 const runtimes = [
-  { name: 'express', make: () => expressRuntime(), middleware: [express.json()] },
-  { name: 'fastify', make: () => fastifyRuntime(), middleware: [] },
+  { name: 'express', make: () => expressRuntime() },
+  { name: 'fastify', make: () => fastifyRuntime() },
 ] as const
 
-describe.each(runtimes)('createTestApp on $name', ({ make, middleware }) => {
+describe.each(runtimes)('createTestApp on $name', ({ make }) => {
+  // No `middleware` — the default path is the one that matters. Passing
+  // `express.json()` explicitly bypasses the Application's native-body guard,
+  // and under Fastify the connect parser then eats the stream before Fastify
+  // reads it, so a JSON POST hangs. An earlier revision of this suite passed
+  // `middleware: []` for Fastify and never exercised it.
   async function boot() {
     const { app, container } = await createTestApp({
       modules: [ThingsModule],
       runtime: make(),
-      middleware: [...middleware],
       isolated: true,
     })
     return { app, container, agent: request(app.handle.bind(app)) }
@@ -67,10 +70,9 @@ describe.each(runtimes)('createTestApp on $name', ({ make, middleware }) => {
     expect(res.body).toEqual([{ id: '1' }])
   })
 
-  it('parses a JSON body through the real engine', async () => {
-    // Body parsing is runtime-specific — Fastify parses natively, Express
-    // needs the middleware. Exactly the class of thing an Express-only suite
-    // could never have caught.
+  it('parses a JSON body with the DEFAULT middleware', async () => {
+    // Body parsing is runtime-specific: Fastify parses natively, Express needs
+    // `express.json()`. Getting the default wrong does not fail — it hangs.
     const { agent } = await boot()
     const res = await agent.post('/api/v1/things').send({ name: 'widget' })
     expect(res.status).toBe(200)
@@ -85,11 +87,7 @@ describe.each(runtimes)('createTestApp on $name', ({ make, middleware }) => {
 
 describe('expressApp escape hatch', () => {
   it('still works under Express', async () => {
-    const { expressApp } = await createTestApp({
-      modules: [ThingsModule],
-      middleware: [express.json()],
-      isolated: true,
-    })
+    const { expressApp } = await createTestApp({ modules: [ThingsModule], isolated: true })
     expect((await request(expressApp).get('/api/v1/things')).status).toBe(200)
   })
 

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -37,6 +37,10 @@ type BootstrapPassthroughOptions = Pick<
   | 'security'
   | 'contributors'
   | 'contextStore'
+  // The engine under test. Without this every test ran Express while
+  // production ran Fastify or h3 — the one thing an integration test exists
+  // to rule out.
+  | 'runtime'
 >
 
 /**
@@ -66,19 +70,38 @@ export interface CreateTestAppOptions extends BootstrapPassthroughOptions {
 /**
  * Create an Application instance configured for testing.
  * Resets the DI container, registers modules, applies overrides,
- * and returns both the Application and its Express app.
+ * and returns the Application, which drives whichever runtime is configured.
+ *
+ * Drive it through `app` — `app.handle` is the Application's own Node request
+ * listener and follows whichever runtime is configured, so the same test runs
+ * against the engine you actually deploy.
  *
  * @example
  * ```ts
- * const { expressApp, container } = await createTestApp({
+ * const { app, container } = await createTestApp({
  *   modules: [UserModule],
  *   overrides: { [USER_REPO]: new InMemoryUserRepo() },
  * })
- * const res = await request(expressApp).get('/api/v1/users')
+ * const res = await request(app.handle.bind(app)).get('/api/v1/users')
+ * ```
+ *
+ * @example Test the engine you actually deploy
+ * ```ts
+ * import { fastifyRuntime } from '@forinda/kickjs/fastify'
+ *
+ * const { app } = await createTestApp({ modules: [UserModule], runtime: fastifyRuntime() })
+ * const res = await request(app.handle.bind(app)).get('/api/v1/users')
  * ```
  */
 export async function createTestApp(options: CreateTestAppOptions): Promise<{
   app: Application
+  /**
+   * @deprecated Use `app.handle.bind(app)`. Only valid under the Express
+   * runtime — under
+   * any other engine this throws rather than handing back that engine's
+   * instance mistyped as `express.Express`, which is how a suite ends up
+   * silently exercising the wrong runtime.
+   */
   expressApp: express.Express
   container: Container
 }> {
@@ -108,6 +131,9 @@ export async function createTestApp(options: CreateTestAppOptions): Promise<{
     security: options.security,
     contributors: options.contributors,
     contextStore: options.contextStore,
+    // Without this the option is accepted and ignored, which is worse than
+    // not offering it: the suite reports Express while claiming Fastify.
+    runtime: options.runtime,
   })
 
   // Run setup — mounts routes, registers modules, initializes adapters.
@@ -137,9 +163,20 @@ export async function createTestApp(options: CreateTestAppOptions): Promise<{
     }
   }
 
+  const runtimeName = app.getActiveRuntime().name
+
   return {
     app,
-    expressApp: app.getExpressApp(),
+    get expressApp(): express.Express {
+      if (runtimeName !== 'express') {
+        throw new Error(
+          `createTestApp: 'expressApp' is only available under the Express runtime — ` +
+            `this app is running '${runtimeName}'. Drive the app instead, which follows ` +
+            `whichever engine is configured: request(app.handle.bind(app)).get('/...').`,
+        )
+      }
+      return app.getExpressApp()
+    },
     container,
   }
 }

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -121,8 +121,15 @@ export async function createTestApp(options: CreateTestAppOptions): Promise<{
     port: options.port,
     apiPrefix: options.apiPrefix,
     defaultVersion: options.defaultVersion,
-    // Use provided middleware, or default to JSON body parsing only
-    middleware: options.middleware ?? [express.json()],
+    // Default to JSON body parsing only — but NOT on a runtime that parses
+    // bodies itself. Passing `express.json()` explicitly bypasses the
+    // Application's own native-body guard, and under Fastify the connect
+    // parser then consumes the stream before Fastify reads it: a JSON POST
+    // hangs until the test times out. `RuntimeCapabilities.nativeBodyParsing`
+    // is the same flag the Application guards on.
+    middleware:
+      options.middleware ??
+      (options.runtime?.capabilities.nativeBodyParsing ? [] : [express.json()]),
     onError: options.onError,
     onNotFound: options.onNotFound,
     plugins: options.plugins,


### PR DESCRIPTION
## The gap

> `createTestApp` returns `expressApp` and has no `runtime` option — tests run Express while production runs Fastify.

Confirmed. The harness hardcoded Express, and `getExpressApp()` returns `this.app` cast to `express.Express` — so under Fastify it hands back the **Fastify instance mistyped as Express**. Silent at the type level, silent at runtime.

That matters because routing, body parsing, status handling and error mapping all live in the runtime seam (`src/http/runtimes/{express,fastify,h3}.ts`). A green Express suite says nothing about any of them, which is the one thing an integration test exists to rule out.

## The fix

`createTestApp` takes `runtime`, the same value `bootstrap()` takes:

```ts
import { fastifyRuntime } from '@forinda/kickjs/fastify'

const { app } = await createTestApp({ modules: [UserModule], runtime: fastifyRuntime() })
const res = await request(app.handle.bind(app)).get('/api/v1/users')
```

No new return key: `app` was already returned and is already runtime-agnostic. `app.handle` is the Application's own Node request listener and follows whichever engine is configured, so supertest drives the real one.

`expressApp` still works under Express. Under any other engine it now **throws** with a message pointing at `app.handle`, rather than returning the wrong engine mistyped.

## Tests

`packages/testing/__tests__/runtime-parity.test.ts` runs the same module on Express and Fastify:

- reports the runtime it was actually given
- routes a GET through the real engine
- **parses a JSON body** — native on Fastify, middleware on Express; precisely the class of difference an Express-only suite could never catch
- 404s an unknown route
- `expressApp` works under Express, throws under Fastify

Testing package: 42 → 52 tests. Monorepo green.

## One thing worth flagging

Writing that suite caught a bug in my own first pass: I added `runtime` to the options **type** but never passed it to `Application`, so it was accepted and silently ignored — the app still reported `express`. That is worse than not offering the option at all, and only the parity test surfaced it. The passthrough is now covered: reverting it fails three tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViFD8FXyNzwnAd3ixx7biB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Test applications can now run against the configured HTTP runtime, including Express and Fastify.
  - Added support for driving tests through the application’s standard request handler.
  - Added guidance and examples for testing across multiple runtimes.

- **Bug Fixes**
  - Prevented non-Express runtimes from being incorrectly exposed as Express applications.
  - Improved runtime parity for routing, JSON body handling, and unknown-route responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->