### PR TITLE
fix(kickjs): export LoggedRequest/LoggedResponse so the documented middleware layout compiles

### DIFF
--- a/.changeset/olive-pugs-relate.md
+++ b/.changeset/olive-pugs-relate.md
@@ -1,0 +1,28 @@
+---
+'@forinda/kickjs': patch
+---
+
+Export `LoggedRequest` / `LoggedResponse` so the documented middleware layout compiles.
+
+`requestLogger()` types its handler with these two interfaces, and they were
+module-private. The documented "keep `src/index.ts` thin" layout builds the
+middleware array in `src/middleware/index.ts` and exports it with an inferred
+type — which a dependant cannot name:
+
+```
+error TS4023: Exported variable 'middleware' has or is using name 'LoggedRequest'
+from external module ".../dist/request-logger-D_pf4xzE" but cannot be named.
+```
+
+So the recommended project layout walked straight into a compile error, and the
+workaround was to annotate with `MiddlewareEntry[]` rather than infer.
+
+Both interfaces are now exported from the package entry. They stay structural
+rather than Express's `Request`/`Response` on purpose: the Fastify and h3
+runtimes pass a raw Node request, which has `url` but no `path`.
+
+Sibling of the TS4058 leak in #235 — same class, different symbol. Guarded the
+same way, by emitting a declaration from a consumer that resolves the built
+`.d.mts` by name. That fixture now lives inside the package rather than
+`tmpdir()`: from `/tmp` the array trips `TS2883` on Express's own
+`ParamsDictionary` first, so the case under test was never reached.

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ examples/
 # Tutorials + generated thumbnails — authored locally, not tracked
 tutorials/
 .tmp-posters/
+
+# Throwaway consumer fixtures written inside the package by
+# dts-consumer-emit.test.ts (removed in `finally`; ignored in case a run dies).
+packages/kickjs/.dts-mw-*/

--- a/packages/kickjs/__tests__/dts-consumer-emit.test.ts
+++ b/packages/kickjs/__tests__/dts-consumer-emit.test.ts
@@ -65,6 +65,16 @@ export const Audit = defineContextDecorator.withParams<{ actorId: string }>()({
 })
 `
 
+// The documented \`src/middleware/index.ts\` layout: export the array and let
+// its type be inferred. \`requestLogger()\` typed its handler with private
+// \`LoggedRequest\`/\`LoggedResponse\` interfaces, so this could not be named
+// downstream — the recommended project layout walked straight into TS4023.
+const MIDDLEWARE_CONSUMER = `
+import { cors, helmet, requestId, requestLogger } from '@forinda/kickjs'
+
+export const middleware = [helmet(), cors({ origin: '*' }), requestId(), requestLogger()]
+`
+
 describe('a consumer can emit declarations for an exported contributor', () => {
   it('produces no TS4023 against the built package types', () => {
     expect(existsSync(DTS_ENTRY), 'dist/index.d.mts missing — run pnpm build first').toBe(true)
@@ -125,6 +135,66 @@ describe('a consumer can emit declarations for an exported contributor', () => {
       // Assert on TS4023 specifically rather than a clean exit: unrelated
       // config noise in a throwaway project should not fail this, but a
       // type that stopped being nameable must.
+      expect(output).not.toContain('TS4023')
+      expect(output).not.toContain('cannot be named')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('a consumer can emit declarations for an exported middleware array', () => {
+  // The documented "keep src/index.ts thin" layout: build the array in
+  // src/middleware/index.ts and export it with an inferred type. requestLogger()
+  // typed its handler with private LoggedRequest / LoggedResponse interfaces,
+  // so downstream that type had no importable name and the recommended layout
+  // failed to compile. Two teams hit it independently.
+  it('produces no TS4023 for the documented middleware/index.ts pattern', () => {
+    expect(existsSync(DTS_ENTRY), 'dist/index.d.mts missing — run pnpm build first').toBe(true)
+
+    // Inside the package, not tmpdir: a real dependant resolves `@types/express`
+    // through its own node_modules, and only then are Express's own symbols
+    // nameable. From /tmp the array trips TS2883 ("not portable") on
+    // `ParamsDictionary` long before it reaches the symbols this test is about.
+    const dir = mkdtempSync(join(PKG_ROOT, '.dts-mw-'))
+    try {
+      writeFileSync(join(dir, 'consumer.ts'), MIDDLEWARE_CONSUMER)
+      writeFileSync(
+        join(dir, 'tsconfig.json'),
+        JSON.stringify(
+          {
+            compilerOptions: {
+              declaration: true,
+              emitDeclarationOnly: true,
+              outDir: 'out',
+              strict: true,
+              module: 'esnext',
+              moduleResolution: 'bundler',
+              target: 'es2022',
+              skipLibCheck: true,
+              experimentalDecorators: true,
+              paths: { '@forinda/kickjs': [DTS_ENTRY] },
+            },
+            files: ['consumer.ts'],
+          },
+          null,
+          2,
+        ),
+      )
+
+      const tsc = resolve(PKG_ROOT, 'node_modules', 'typescript', 'bin', 'tsc')
+      const result = spawnSync(process.execPath, [tsc, '-p', dir], {
+        encoding: 'utf8',
+        timeout: 120_000,
+      })
+      const output = `${result.stdout ?? ''}${result.stderr ?? ''}`
+
+      // Same reasoning as the sibling test: prove it emitted before asserting
+      // on the absence of a diagnostic, or empty output passes trivially.
+      const emitted = join(dir, 'out', 'consumer.d.ts')
+      expect(existsSync(emitted), `tsc emitted nothing. Output:\n${output}`).toBe(true)
+      expect(readFileSync(emitted, 'utf8')).toContain('middleware')
+
       expect(output).not.toContain('TS4023')
       expect(output).not.toContain('cannot be named')
     } finally {

--- a/packages/kickjs/src/http/index.ts
+++ b/packages/kickjs/src/http/index.ts
@@ -48,7 +48,12 @@ export { requestId, REQUEST_ID_HEADER } from './middleware/request-id'
 export { validate } from './middleware/validate'
 export { notFoundHandler, errorHandler } from './middleware/error-handler'
 export { csrf, type CsrfOptions } from './middleware/csrf'
-export { requestLogger, type RequestLoggerOptions } from './middleware/request-logger'
+export {
+  requestLogger,
+  type RequestLoggerOptions,
+  type LoggedRequest,
+  type LoggedResponse,
+} from './middleware/request-logger'
 export { helmet, type HelmetOptions } from './middleware/helmet'
 export { cors, type CorsOptions } from './middleware/cors'
 export { rateLimit, type RateLimitOptions, type RateLimitStore } from './middleware/rate-limit'

--- a/packages/kickjs/src/http/middleware/request-logger.ts
+++ b/packages/kickjs/src/http/middleware/request-logger.ts
@@ -4,7 +4,19 @@
  * connect middleware the raw node objects — so anything Express-only is
  * `undefined` there.
  */
-interface LoggedRequest {
+/**
+ * The request shape this middleware reads.
+ *
+ * Exported because it appears in the returned handler's signature: a consumer
+ * following the documented `src/middleware/index.ts` layout exports the
+ * middleware array with an inferred type, and a type the entry does not
+ * re-export cannot be named there — `TS4023: Exported variable 'middleware'
+ * has or is using name 'LoggedRequest' … but cannot be named`.
+ *
+ * Deliberately structural rather than Express's `Request`: the Fastify and h3
+ * runtimes pass a raw Node request, which has `url` but no `path`.
+ */
+export interface LoggedRequest {
   method?: string
   url?: string
   /** Express-only convenience; the raw node request has only `url`. */
@@ -14,7 +26,8 @@ interface LoggedRequest {
   headers: Record<string, string | string[] | undefined>
 }
 
-interface LoggedResponse {
+/** The response shape this middleware reads. Exported for the same reason as {@link LoggedRequest}. */
+export interface LoggedResponse {
   statusCode: number
   on(event: 'finish', listener: () => void): unknown
 }

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -70,7 +70,12 @@ export { requestId, REQUEST_ID_HEADER } from './http/middleware/request-id'
 export { validate } from './http/middleware/validate'
 export { notFoundHandler, errorHandler } from './http/middleware/error-handler'
 export { csrf, type CsrfOptions } from './http/middleware/csrf'
-export { requestLogger, type RequestLoggerOptions } from './http/middleware/request-logger'
+export {
+  requestLogger,
+  type RequestLoggerOptions,
+  type LoggedRequest,
+  type LoggedResponse,
+} from './http/middleware/request-logger'
 export { helmet, type HelmetOptions } from './http/middleware/helmet'
 export { cors, type CorsOptions } from './http/middleware/cors'
 export { rateLimit, type RateLimitOptions, type RateLimitStore } from './http/middleware/rate-limit'


### PR DESCRIPTION
Closes #567.

## Reproduced first

Extended the existing declaration-emit harness (`dts-consumer-emit.test.ts`, built for the #235 TS4058 leak) with the documented `src/middleware/index.ts` pattern. It reproduces the reported error verbatim:

```
error TS4023: Exported variable 'middleware' has or is using name 'LoggedRequest'
from external module ".../dist/request-logger-D_pf4xzE" but cannot be named.
```

## Fix

`LoggedRequest` and `LoggedResponse` are now exported from the package entry.

Kept structural rather than widening `requestLogger()` to `ConnectMiddleware`, which was the issue's other suggestion: `ConnectMiddleware` is `RequestHandler | ErrorRequestHandler` from Express, and this middleware is deliberately runtime-agnostic — the Fastify and h3 runtimes pass a raw Node request, which has `url` but no `path`. Widening would tie it to Express to fix a naming problem.

## One thing worth knowing about the test

The first version of the fixture ran in `tmpdir()` like its sibling, and reproduced a **different** error:

```
TS2883: The inferred type of 'middleware' cannot be named without a reference to
'ParamsDictionary' ... This is likely not portable.
```

From `/tmp`, Express's own types aren't portably referenceable, so the array fails on `ParamsDictionary` long before reaching `LoggedRequest`. The fixture now lives inside the package, where `@types/express` resolves through normal `node_modules` lookup the way a real dependant's does — and only then does the actual reported error appear.

Worth flagging because a green test in `tmpdir()` would have "passed" while never exercising the case at all. `.gitignore` covers the fixture directory in case a run dies before its `finally`.

Fails with the exports reverted. Monorepo suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViFD8FXyNzwnAd3ixx7biB
