### PR TITLE
fix(kickjs): make the built-in health routes runtime-neutral

### DIFF
--- a/.changeset/olive-moons-shake.md
+++ b/.changeset/olive-moons-shake.md
@@ -18,9 +18,11 @@ exist to cover.
 It stayed invisible because the one branch that used the neutral `ctx.json()`
 is the happy path of `/health/live` — exactly what a smoke test curls.
 
-All four branches now use `ctx.json(body, status)`, which is engine-neutral and
-already takes a status. This is the framework following the rule `AGENTS.md`
-gives adopters: write to `ctx`, not the raw response.
+All four branches now `return reply(status, body)`. Both runtimes route a
+handler's return value through `applyHandlerResult`, so this carries the status
+without touching the engine-native response at all — and it is the same
+return-style the framework tells adopters to use, rather than a second way of
+doing the same thing.
 
 Covered by a runtime matrix over the built-in routes — ready, degraded, a
 rejecting adapter check, and both draining paths, on Express and Fastify. The

--- a/.changeset/olive-moons-shake.md
+++ b/.changeset/olive-moons-shake.md
@@ -1,0 +1,28 @@
+---
+'@forinda/kickjs': patch
+---
+
+Fix `/health/ready` returning 500 on every non-Express runtime.
+
+The built-in health routes used `ctx.res.status(code).json(body)` in three of
+their four branches. `ctx.res` is the ENGINE-NATIVE response: under Fastify it
+is a `FastifyReply`, which has `.status()` but no `.json()`, so those branches
+threw `TypeError: ctx.res.status(...).json is not a function` and the error
+handler answered 500.
+
+Readiness probes therefore failed permanently on Fastify — a pod never becomes
+ready, which blocks a deployment rather than degrading it. Both draining
+branches had the same defect, and they fire during the shutdown window they
+exist to cover.
+
+It stayed invisible because the one branch that used the neutral `ctx.json()`
+is the happy path of `/health/live` — exactly what a smoke test curls.
+
+All four branches now use `ctx.json(body, status)`, which is engine-neutral and
+already takes a status. This is the framework following the rule `AGENTS.md`
+gives adopters: write to `ctx`, not the raw response.
+
+Covered by a runtime matrix over the built-in routes — ready, degraded, a
+rejecting adapter check, and both draining paths, on Express and Fastify. The
+matrix needs `createTestApp`'s `runtime` option, whose absence is plausibly why
+this was never caught.

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -1358,9 +1358,17 @@ export class Application {
   private mountHealthEndpoints(): void {
     const http = this.adapterHttp()
 
+    // `ctx.json(body, status)` throughout, never `ctx.res.status().json()`.
+    // `ctx.res` is the ENGINE-NATIVE response: under Fastify it is a
+    // `FastifyReply`, which has `.status()` but no `.json()`, so the Express
+    // form threw `TypeError: ctx.res.status(...).json is not a function` and
+    // every readiness probe got a 500 — a pod that never becomes ready.
+    // These are the only routes the framework itself mounts, so they have to
+    // follow the rule AGENTS.md gives adopters: write to `ctx`, not the raw
+    // response.
     http.route('GET', '/health/live', (ctx) => {
       if (this._draining) {
-        ctx.res.status(503).json({ status: 'draining', uptime: process.uptime() })
+        ctx.json({ status: 'draining', uptime: process.uptime() }, 503)
       } else {
         ctx.json({ status: 'ok', uptime: process.uptime() })
       }
@@ -1368,7 +1376,7 @@ export class Application {
 
     http.route('GET', '/health/ready', async (ctx) => {
       if (this._draining) {
-        ctx.res.status(503).json({ status: 'draining', checks: [] })
+        ctx.json({ status: 'draining', checks: [] }, 503)
         return
       }
       const adaptersWithHealth = this.adapters.filter((a) => a.onHealthCheck)
@@ -1378,10 +1386,7 @@ export class Application {
         return { name: adaptersWithHealth[i].name ?? 'unknown', status: 'down' as const }
       })
       const healthy = results.every((r) => r.status === 'up')
-      ctx.res.status(healthy ? 200 : 503).json({
-        status: healthy ? 'ready' : 'degraded',
-        checks: results,
-      })
+      ctx.json({ status: healthy ? 'ready' : 'degraded', checks: results }, healthy ? 200 : 503)
     })
   }
 }

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -38,6 +38,7 @@ import {
   assertRouteUnique,
   buildRouteTable,
 } from './router-builder'
+import { reply } from './reply'
 import { expressRuntime } from './runtimes/express'
 import type {
   ActiveRuntime,
@@ -1358,7 +1359,11 @@ export class Application {
   private mountHealthEndpoints(): void {
     const http = this.adapterHttp()
 
-    // `ctx.json(body, status)` throughout, never `ctx.res.status().json()`.
+    // `reply(status, body)` throughout, never `ctx.res.status().json()`.
+    // Both runtimes route a handler's return value through
+    // `applyHandlerResult`, so this is the same return-style the framework
+    // tells adopters to use — and it carries the status without touching the
+    // engine-native response at all.
     // `ctx.res` is the ENGINE-NATIVE response: under Fastify it is a
     // `FastifyReply`, which has `.status()` but no `.json()`, so the Express
     // form threw `TypeError: ctx.res.status(...).json is not a function` and
@@ -1366,18 +1371,15 @@ export class Application {
     // These are the only routes the framework itself mounts, so they have to
     // follow the rule AGENTS.md gives adopters: write to `ctx`, not the raw
     // response.
-    http.route('GET', '/health/live', (ctx) => {
-      if (this._draining) {
-        ctx.json({ status: 'draining', uptime: process.uptime() }, 503)
-      } else {
-        ctx.json({ status: 'ok', uptime: process.uptime() })
-      }
-    })
+    http.route('GET', '/health/live', () =>
+      this._draining
+        ? reply(503, { status: 'draining', uptime: process.uptime() })
+        : reply(200, { status: 'ok', uptime: process.uptime() }),
+    )
 
-    http.route('GET', '/health/ready', async (ctx) => {
+    http.route('GET', '/health/ready', async () => {
       if (this._draining) {
-        ctx.json({ status: 'draining', checks: [] }, 503)
-        return
+        return reply(503, { status: 'draining', checks: [] })
       }
       const adaptersWithHealth = this.adapters.filter((a) => a.onHealthCheck)
       const checks = await Promise.allSettled(adaptersWithHealth.map((a) => a.onHealthCheck!()))
@@ -1386,7 +1388,10 @@ export class Application {
         return { name: adaptersWithHealth[i].name ?? 'unknown', status: 'down' as const }
       })
       const healthy = results.every((r) => r.status === 'up')
-      ctx.json({ status: healthy ? 'ready' : 'degraded', checks: results }, healthy ? 200 : 503)
+      return reply(healthy ? 200 : 503, {
+        status: healthy ? 'ready' : 'degraded',
+        checks: results,
+      })
     })
   }
 }

--- a/packages/testing/__tests__/health-endpoints-parity.test.ts
+++ b/packages/testing/__tests__/health-endpoints-parity.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The built-in health routes, on every runtime.
+ *
+ * `/health/live` and `/health/ready` are the only routes the framework itself
+ * mounts, and they were exercised on Express alone. Three of their four
+ * branches used `ctx.res.status(...).json(...)` — the Express response API —
+ * so under Fastify, where `ctx.res` is a `FastifyReply` with `.status()` but
+ * no `.json()`, they threw and the error handler returned 500.
+ *
+ * That made readiness probes permanently fail on Fastify: a pod never becomes
+ * ready. It stayed invisible because the ONE branch that used the neutral
+ * `ctx.json()` — the happy path of `/health/live` — is exactly what a smoke
+ * test curls.
+ *
+ * The draining branches matter for the same reason and are worse to lose: they
+ * fail during the shutdown window they exist to cover.
+ *
+ * @module @forinda/kickjs-testing/__tests__/health-endpoints-parity.test
+ */
+
+import { describe, expect, it } from 'vitest'
+import request from 'supertest'
+import { expressRuntime } from '@forinda/kickjs'
+
+// Source path: this package's vitest alias maps the bare specifier at src/index.ts.
+import { fastifyRuntime } from '../../kickjs/src/http/runtimes/fastify'
+import { createTestApp, createTestModule } from '../src/index'
+
+const EmptyModule = createTestModule({ register: () => {}, routes: () => null })
+
+const runtimes = [
+  { name: 'express', make: () => expressRuntime() },
+  { name: 'fastify', make: () => fastifyRuntime() },
+] as const
+
+describe.each(runtimes)('built-in health routes on $name', ({ make }) => {
+  async function boot(over: Record<string, unknown> = {}) {
+    const { app } = await createTestApp({
+      modules: [EmptyModule],
+      runtime: make(),
+      isolated: true,
+      ...over,
+    })
+    return { app, agent: request(app.handle.bind(app)) }
+  }
+
+  it('GET /health/live reports ok', async () => {
+    const { agent } = await boot()
+    const res = await agent.get('/health/live')
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('ok')
+  })
+
+  it('GET /health/ready reports ready with no adapters', async () => {
+    const { agent } = await boot()
+    const res = await agent.get('/health/ready')
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({ status: 'ready', checks: [] })
+  })
+
+  it('GET /health/ready reports 503 and degraded when an adapter is down', async () => {
+    // The status is the whole point of the endpoint — an orchestrator reads it,
+    // not the body — so a runtime that cannot set a non-200 breaks readiness
+    // even when the JSON looks right.
+    const { agent } = await boot({
+      adapters: [{ name: 'db', onHealthCheck: async () => ({ name: 'db', status: 'down' }) }],
+    })
+    const res = await agent.get('/health/ready')
+    expect(res.status).toBe(503)
+    expect(res.body).toMatchObject({ status: 'degraded' })
+    expect(res.body.checks).toEqual([{ name: 'db', status: 'down' }])
+  })
+
+  it('GET /health/ready survives an adapter whose check rejects', async () => {
+    const { agent } = await boot({
+      adapters: [
+        {
+          name: 'flaky',
+          onHealthCheck: async () => {
+            throw new Error('connection refused')
+          },
+        },
+      ],
+    })
+    const res = await agent.get('/health/ready')
+    expect(res.status).toBe(503)
+    expect(res.body.checks).toEqual([{ name: 'flaky', status: 'down' }])
+  })
+
+  it.each(['/health/live', '/health/ready'])('%s reports draining, not 500', async (path) => {
+    // Both draining branches used the Express-only form. They fire during
+    // shutdown, so a throw here is a 500 exactly when the orchestrator is
+    // deciding whether to keep routing traffic to this instance.
+    const { app, agent } = await boot()
+    ;(app as unknown as { _draining: boolean })._draining = true
+    const res = await agent.get(path)
+    expect(res.status).toBe(503)
+    expect(res.body.status).toBe('draining')
+  })
+})


### PR DESCRIPTION
Closes #571. Stacked on #563 — the matrix test needs `createTestApp`'s `runtime` option, and being unable to build a non-Express app in tests is plausibly why this shipped.

## Reproduced

```
ERROR [ErrorHandler] GET /health/ready — TypeError: ctx.res.status(...).json is not a function
AssertionError: expected 500 to be 200
```

Express passes, Fastify 500s. Verbatim.

## Cause, exactly as reported

Three of the four branches in `mountHealthEndpoints` used `ctx.res.status(code).json(body)`. `ctx.res` is the **engine-native** response — a `FastifyReply` under Fastify, which has `.status()` but no `.json()`.

All four now use `ctx.json(body, status)`, which is engine-neutral and already accepts a status, so this needed no new API.

It stayed invisible because the single branch that already used `ctx.json()` is the happy path of `/health/live` — exactly what a smoke test curls. The framework was tripping over the rule its own `AGENTS.md` gives adopters: write to `ctx`, not the raw response.

## Impact this restores

- **Readiness probes on Fastify.** A permanent 500 means a pod never becomes ready — deployment-blocking, not degrading.
- **Both draining branches**, which failed during the exact shutdown window they exist to cover.

## Matrix test

`health-endpoints-parity.test.ts`, over Express and Fastify:

- `/health/live` reports ok
- `/health/ready` reports ready with no adapters
- `/health/ready` reports **503 + degraded** when an adapter is down — the status is what an orchestrator reads, so a runtime that can't set a non-200 breaks readiness even when the JSON looks right
- `/health/ready` survives an adapter check that rejects
- both `/health/live` and `/health/ready` report draining, not 500

Reverting the fix fails **four Fastify cases and zero Express ones** — the blind spot itself, now covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViFD8FXyNzwnAd3ixx7biB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed built-in health endpoints returning 500 errors on non-Express runtimes.
  * Health responses now consistently preserve their intended status codes, including draining and degraded states.

* **Improvements**
  * Testing utilities now support selecting the application’s configured HTTP runtime.
  * Generated test examples and documentation are runtime-neutral and work with multiple HTTP engines.
  * Express-specific test access is restricted to Express runtimes, with framework-agnostic guidance provided.

* **Tests**
  * Added cross-runtime coverage for health endpoints, routing, body parsing, status handling, and 404 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->