### PR TITLE
fix(cli): run typegen before kick typecheck

### DIFF
--- a/.changeset/olive-bugs-smash.md
+++ b/.changeset/olive-bugs-smash.md
@@ -1,0 +1,28 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+`kick typecheck` refreshes generated types before checking.
+
+`kick dev` runs typegen on startup; `kick typecheck` did not. So the moment a
+handler was renamed or a module deleted without the dev server running, the
+check failed against `.kickjs/types` describing routes that no longer exist:
+
+```
+.kickjs/types/kick__routes.ts(12,45): error TS2307: Cannot find module
+  '../../src/modules/hello/hello.controller'
+src/modules/health/health.controller.ts(11,46): error TS2339: Property 'live'
+  does not exist on type 'HealthController'
+```
+
+The second one is the trap: it points at correct, current source and claims a
+method that does exist is missing, because the stale `KickRoutes` namespace has
+no entry for it. The cause is a generated file the developer never edited and
+may not know about. A pre-commit hook or a fresh clone hits this every time,
+since neither has run the dev server — and a fresh clone has no generated types
+at all.
+
+Typegen failures are reported and swallowed rather than aborting: a typegen
+problem must not masquerade as a type error, and must not stop the check that
+was asked for. `--no-typegen` skips the refresh for a caller that has just run
+typegen itself.

--- a/packages/cli/__tests__/typecheck-refreshes-types.test.ts
+++ b/packages/cli/__tests__/typecheck-refreshes-types.test.ts
@@ -1,0 +1,161 @@
+/**
+ * `kick typecheck` must not report errors from stale generated types.
+ *
+ * `kick dev` runs typegen on startup; `kick typecheck` did not. So the moment a
+ * handler is renamed or a module deleted without the dev server running, the
+ * check fails against `.kickjs/types` describing routes that no longer exist —
+ * and the most confusing of those errors point at correct, current source and
+ * claim a method that does exist is missing, because the stale `KickRoutes`
+ * namespace has no entry for it. A pre-commit hook or a fresh clone hits this
+ * every time, since neither has run the dev server.
+ *
+ * Spawns the real CLI against a real project, because the bug lives in the
+ * ordering of two commands rather than in any single function.
+ *
+ * @module @forinda/kickjs-cli/__tests__/typecheck-refreshes-types.test
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const CLI = resolve(__dirname, '..', 'bin.js')
+const REPO = resolve(__dirname, '..', '..', '..')
+
+let dir: string
+/**
+ * Set once the fixture actually reproduces the bug.
+ *
+ * Asserted rather than used to skip: an unmet prerequisite used to leave both
+ * tests passing while exercising nothing, which is the failure mode this file
+ * exists to prevent elsewhere.
+ */
+let ready = false
+let why = 'not initialised'
+
+function kick(args: string[]) {
+  const r = spawnSync(process.execPath, [CLI, ...args], {
+    cwd: dir,
+    encoding: 'utf8',
+    timeout: 120_000,
+  })
+  return `${r.stdout ?? ''}${r.stderr ?? ''}`
+}
+
+beforeAll(() => {
+  // The package directory, not the `.bin` shim: pnpm's shim computes its base
+  // from `$0` and so cannot be symlinked into another tree.
+  const tsPkg = join(REPO, 'node_modules', 'typescript')
+  const tsc = existsSync(tsPkg) ? realpathSync(tsPkg) : ''
+  // The workspace package itself, not a root node_modules link — pnpm does not
+  // create one, and guarding on a path that never exists made both tests below
+  // pass vacuously while asserting nothing.
+  const kickjs = join(REPO, 'packages', 'kickjs')
+  if (!tsc || !existsSync(join(tsc, 'bin', 'tsc')) || !existsSync(kickjs)) {
+    why = `missing prerequisite: typescript at ${tsc || '(unresolved)'} or ${kickjs}`
+    return
+  }
+
+  dir = mkdtempSync(join(tmpdir(), 'kick-stale-'))
+  mkdirSync(join(dir, 'src', 'modules', 'hello'), { recursive: true })
+  mkdirSync(join(dir, 'node_modules', '.bin'), { recursive: true })
+  mkdirSync(join(dir, 'node_modules', '@forinda'), { recursive: true })
+  // realpath, not the .bin shim: that shim is itself a relative symlink into
+  // .pnpm, which resolves to nothing from a temp directory.
+  // A one-line shim with an absolute require, so it works wherever the fixture
+  // lives. `resolveTypecheckBin` looks for `node_modules/.bin/tsc`.
+  const shim = join(dir, 'node_modules', '.bin', 'tsc')
+  writeFileSync(shim, `#!/usr/bin/env node\nrequire(${JSON.stringify(join(tsc, 'bin', 'tsc'))})\n`)
+  chmodSync(shim, 0o755)
+  symlinkSync(realpathSync(kickjs), join(dir, 'node_modules', '@forinda', 'kickjs'))
+
+  writeFileSync(
+    join(dir, 'src', 'modules', 'hello', 'hello.controller.ts'),
+    `import { Controller, Get } from '@forinda/kickjs'
+import type { RequestContext } from '@forinda/kickjs'
+
+@Controller()
+export class HelloController {
+  @Get('/hello/list')
+  list(_ctx: RequestContext) {
+    return [{ id: '1' }]
+  }
+}
+`,
+  )
+  writeFileSync(
+    join(dir, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        target: 'ES2022',
+        module: 'ESNext',
+        moduleResolution: 'bundler',
+        lib: ['ES2022'],
+        strict: true,
+        esModuleInterop: true,
+        skipLibCheck: true,
+        experimentalDecorators: true,
+        emitDecoratorMetadata: true,
+        noEmit: true,
+      },
+      include: ['src', '.kickjs/types/**/*.d.ts', '.kickjs/types/**/*.ts'],
+    }),
+  )
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({ name: 'stale-fx', private: true, type: 'module' }),
+  )
+
+  const generated = kick(['typegen'])
+  const routes = join(dir, '.kickjs', 'types', 'kick__routes.ts')
+  if (!existsSync(routes)) {
+    why = `kick typegen emitted no routes file. Output:\n${generated}`
+    return
+  }
+  if (!readFileSync(routes, 'utf8').includes("['list']")) {
+    why = `routes file does not reference the handler:\n${readFileSync(routes, 'utf8').slice(0, 400)}`
+    return
+  }
+
+  // Rename the handler WITHOUT regenerating: the generated types are now stale.
+  const controller = join(dir, 'src', 'modules', 'hello', 'hello.controller.ts')
+  writeFileSync(controller, readFileSync(controller, 'utf8').replace('list(_ctx', 'index(_ctx'))
+  ready = true
+})
+
+afterAll(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('kick typecheck against stale generated types', () => {
+  it('has a fixture that actually reproduces staleness', () => {
+    expect(ready, why).toBe(true)
+  })
+
+  it('reports the stale error when typegen is skipped', () => {
+    // Proves the fixture actually reproduces the bug. Without this the test
+    // below passes for any reason at all, including tsc failing to launch.
+    const out = kick(['typecheck', '--no-typegen'])
+    expect(out, out).toContain("Property 'list' does not exist")
+  })
+
+  it('refreshes the types first, so the stale error never surfaces', () => {
+    const out = kick(['typecheck'])
+    expect(out).not.toContain("Property 'list' does not exist")
+    expect(out).not.toContain('error TS')
+  })
+})

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -247,6 +247,53 @@ async function startDevServer(
   process.on('SIGBREAK', shutdown)
 }
 
+/**
+ * Refresh `.kickjs/types` before type-checking.
+ *
+ * `kick dev` runs typegen on startup, `kick typecheck` did not — so the moment
+ * a controller method is renamed or a module deleted without the dev server
+ * running, typecheck fails against types describing routes that no longer
+ * exist:
+ *
+ *   .kickjs/types/kick__routes.ts(12,45): error TS2307: Cannot find module
+ *     '../../src/modules/hello/hello.controller'
+ *   src/modules/health/health.controller.ts(11,46): error TS2339: Property
+ *     'live' does not exist on type 'HealthController'
+ *
+ * The last one is the trap: it points at correct, current source and blames a
+ * method that does exist, because the stale `KickRoutes` namespace has no entry
+ * for it. The cause is a generated file the developer never edited and may not
+ * know about. A pre-commit hook or a fresh clone hits this every time, since
+ * neither has run the dev server.
+ *
+ * Failures here are reported and swallowed: a typegen problem must not
+ * masquerade as a type error, but it also must not stop the type-check the
+ * user asked for.
+ */
+async function refreshTypesForTypecheck(cwd: string): Promise<void> {
+  const config = await loadKickConfig(cwd)
+  try {
+    await runTypegen({
+      cwd,
+      allowDuplicates: true,
+      schemaValidator: config?.typegen?.schemaValidator ?? 'zod',
+      envFile: config?.typegen?.envFile,
+      srcDir: config?.typegen?.srcDir,
+      outDir: config?.typegen?.outDir,
+      assetMap: config?.assetMap,
+      runPlugins: false,
+    })
+    const outDir = resolve(cwd, config?.typegen?.outDir ?? '.kickjs/types')
+    const results = await runAllPluginTypegens({ cwd, config })
+    await writeTypegenArtifacts(outDir, results, false)
+  } catch (err: any) {
+    console.warn(
+      `  kick typegen: skipped before typecheck (${err?.message ?? err}).\n` +
+        '  Generated types may be stale — errors inside .kickjs/types are likely from that.',
+    )
+  }
+}
+
 export function registerRunCommands(program: Command): void {
   program
     .command('dev')
@@ -374,7 +421,8 @@ export function registerRunCommands(program: Command): void {
     .command('typecheck')
     .description('Type-check the project with its own tsgo/tsc')
     .option('--cwd <dir>', 'Directory to type-check', '.')
-    .action((opts: any) => {
+    .option('--no-typegen', 'Skip refreshing .kickjs/types first')
+    .action(async (opts: any) => {
       // The point of routing this through `kick` is that a scaffold should not
       // have to spell the package manager. `pnpm -r exec tsc --noEmit` and
       // `cd server && npx tsc --noEmit` do the same job in two incompatible
@@ -384,6 +432,13 @@ export function registerRunCommands(program: Command): void {
       // Same resolver `kick dev --typecheck` uses, so it prefers tsgo and
       // handles Windows' .CMD shims.
       const dir = resolve(process.cwd(), opts.cwd ?? '.')
+
+      // Refresh generated types first. Without this, typecheck reports errors
+      // from `.kickjs/types` describing routes that no longer exist — and the
+      // most confusing of them point at correct source files. `--no-typegen`
+      // opts out for a caller that has just run typegen itself.
+      if (opts.typegen !== false) await refreshTypesForTypecheck(dir)
+
       const bin = resolveTypecheckBin(dir)
       if (!bin) {
         console.error(


### PR DESCRIPTION
Closes #570.

## Reproduced, both directions

A project whose types were made stale by renaming a handler:

```
$ kick typecheck --no-typegen
.kickjs/types/kick__routes.ts(19,70): error TS2339: Property 'list' does not exist on type 'HelloController'

$ kick typecheck
  kick typegen → 0 services, 1 routes, 0 modules → .kickjs/types (6ms)
  (no errors)
```

## Fix

`kick typecheck` refreshes `.kickjs/types` first, the same way `kick dev` does on startup. `--no-typegen` skips it for a caller that has just run typegen.

Typegen failures are **reported and swallowed** rather than aborting: a typegen problem must not masquerade as a type error, and must not stop the check that was asked for.

Chose option 1 from the issue. Option 2 (detect staleness and name it) still leaves a fresh clone failing, since it has no generated types at all — and the pre-commit and fresh-clone cases are exactly the ones you identified.

## Two things went wrong writing the test — both worth naming

**The test passed while asserting nothing.** The prerequisite guard pointed at `node_modules/@forinda/kickjs`, which pnpm never creates in a workspace, so `ready` stayed false and both assertions silently no-opped. Sabotaging the fix still showed green — which is how I caught it. That is the same vacuous-pass trap `dts-consumer-emit.test.ts` documents in its own header, and I walked into it anyway. The guard is now an assertion carrying the reason, not a skip.

**The fixture symlinked pnpm's `.bin/tsc` shim**, which computes its base directory from `$0` and therefore cannot be relocated — it looked for `typescript` under the temp directory. It now writes a shim with an absolute require.

The test is verified load-bearing: with the refresh disabled and a confirmed rebuild, `refreshes the types first, so the stale error never surfaces` fails.

Monorepo suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViFD8FXyNzwnAd3ixx7biB
