### PR TITLE
fix(kickjs): warn when @PreDestroy can never run

### DIFF
--- a/.changeset/lazy-owls-count.md
+++ b/.changeset/lazy-owls-count.md
@@ -1,0 +1,34 @@
+---
+'@forinda/kickjs': patch
+---
+
+Warn when `@PreDestroy` is applied to a service it will never run on.
+
+`@PreDestroy` fires when a REQUEST scope closes. On a SINGLETON — the default
+scope — nothing closes, so the hook is inert. It was silently inert: no type
+error, no log, no startup check. The reported case was a Postgres pool never
+closed on shutdown, invisible in development and surfacing as connection
+exhaustion under repeated restarts and HMR reloads.
+
+The asymmetry is what makes it a trap. `@PostConstruct` DOES run for singletons,
+so the pair reads as init/teardown while one half quietly opts out based on a
+scope the author may never have considered.
+
+Applying `@PreDestroy` to a non-REQUEST service now logs once, naming the class,
+its scope, and the seam that does work:
+
+```
+kickjs: @PreDestroy on DatabaseService (singleton) will never run — that hook
+fires only when a REQUEST scope closes.
+For application-lifetime resources, release them from an adapter's shutdown()
+hook instead.
+```
+
+The decorator's own documentation now says the same, since it previously
+described only the REQUEST case and left the singleton behaviour to be inferred.
+
+Deliberately a warning rather than running the hook on shutdown: making it fire
+is a behaviour change whose ordering, timeout and concurrency semantics have to
+match the adapter shutdown path, and an adapter's `shutdown()` already covers
+application-lifetime resources — the framework runs it on a real shutdown and on
+every HMR reload, time-boxed and concurrent.

--- a/.changeset/lazy-owls-count.md
+++ b/.changeset/lazy-owls-count.md
@@ -17,7 +17,7 @@ scope the author may never have considered.
 Applying `@PreDestroy` to a non-REQUEST service now logs once, naming the class,
 its scope, and the seam that does work:
 
-```
+```text
 kickjs: @PreDestroy on DatabaseService (singleton) will never run — that hook
 fires only when a REQUEST scope closes.
 For application-lifetime resources, release them from an adapter's shutdown()

--- a/packages/kickjs/__tests__/predestroy-scope-warning.test.ts
+++ b/packages/kickjs/__tests__/predestroy-scope-warning.test.ts
@@ -1,0 +1,65 @@
+/**
+ * `@PreDestroy` is inert on a SINGLETON, and used to be silently so.
+ *
+ * The request scope is what closes and triggers the hook, so on the default
+ * scope there is nothing to fire it. `@PostConstruct` DOES run for singletons,
+ * which is what makes this a trap: the pair reads as init/teardown while one
+ * half opts out on a scope the author may never have considered.
+ *
+ * Reported as a Postgres pool never closed on shutdown — invisible in
+ * development, surfacing as connection exhaustion under repeated restarts.
+ *
+ * @module @forinda/kickjs/__tests__/predestroy-scope-warning.test
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Container, PostConstruct, PreDestroy, Scope, Service } from '../src/index'
+
+let warn: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  Container.reset()
+  warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+afterEach(() => warn.mockRestore())
+
+const said = () => warn.mock.calls.map((c) => String(c[0])).join('\n')
+
+describe('@PreDestroy scope warning', () => {
+  it('warns, naming the class and the scope, on a singleton', () => {
+    @Service()
+    class PoolHolder {
+      @PreDestroy() close() {}
+    }
+    void PoolHolder
+    expect(said()).toContain('PoolHolder')
+    expect(said()).toMatch(/will never run/)
+  })
+
+  it('points at the adapter shutdown hook, since a warning without a fix is noise', () => {
+    @Service()
+    class Another {
+      @PreDestroy() close() {}
+    }
+    void Another
+    expect(said()).toMatch(/shutdown\(\)/)
+  })
+
+  it('stays quiet for a REQUEST-scoped service, where the hook does run', () => {
+    @Service({ scope: Scope.REQUEST })
+    class PerRequest {
+      @PreDestroy() close() {}
+    }
+    void PerRequest
+    expect(said()).not.toContain('PerRequest')
+  })
+
+  it('stays quiet for a singleton without the hook', () => {
+    @Service()
+    class Plain {
+      @PostConstruct() init() {}
+    }
+    void Plain
+    expect(said()).not.toContain('Plain')
+  })
+})

--- a/packages/kickjs/__tests__/predestroy-scope-warning.test.ts
+++ b/packages/kickjs/__tests__/predestroy-scope-warning.test.ts
@@ -54,6 +54,25 @@ describe('@PreDestroy scope warning', () => {
     expect(said()).not.toContain('PerRequest')
   })
 
+  it('warns for every offending class, even when two share a name', () => {
+    // Distinct constructors can share a `name` — two `DatabaseService` classes
+    // in different modules is ordinary. Deduping by name silently suppressed
+    // the second one's warning, which is the exact failure this exists to
+    // prevent.
+    function makeOne() {
+      @Service()
+      class DatabaseService {
+        @PreDestroy() close() {}
+      }
+      return DatabaseService
+    }
+    const a = makeOne()
+    const b = makeOne()
+    expect(a).not.toBe(b)
+    const hits = warn.mock.calls.filter((c) => String(c[0]).includes('DatabaseService'))
+    expect(hits).toHaveLength(2)
+  })
+
   it('stays quiet for a singleton without the hook', () => {
     @Service()
     class Plain {

--- a/packages/kickjs/src/core/decorators.ts
+++ b/packages/kickjs/src/core/decorators.ts
@@ -54,8 +54,19 @@ Container._onReset = (container: any) => {
 
 // ── Class Decorators ────────────────────────────────────────────────────
 
-/** Classes already warned about, so HMR replay does not repeat the notice. */
-const preDestroyWarned = new Set<string>()
+/**
+ * Classes already warned about.
+ *
+ * Keyed by the constructor, not its `name`: distinct classes can share a name —
+ * two `DatabaseService` classes in separate modules is ordinary — and deduping
+ * by name silently suppressed the second one's warning, which is precisely the
+ * failure this warning exists to prevent.
+ *
+ * A WeakSet means an HMR reload, which builds a NEW class object, warns again.
+ * That is correct rather than noisy: the reloaded code still has the problem,
+ * and the notice stops as soon as it is fixed.
+ */
+const preDestroyWarned = new WeakSet<object>()
 
 /**
  * `@PreDestroy` only runs for REQUEST-scoped services — the request scope is
@@ -79,9 +90,9 @@ function warnIfInertPreDestroy(target: any, scope: Scope): void {
   if (!proto) return
   const hook = Reflect.getMetadata?.(METADATA.PRE_DESTROY, proto)
   if (!hook) return
+  if (preDestroyWarned.has(target)) return
+  preDestroyWarned.add(target)
   const name = target.name || String(target)
-  if (preDestroyWarned.has(name)) return
-  preDestroyWarned.add(name)
   console.warn(
     `  kickjs: @PreDestroy on ${name} (${scope}) will never run — that hook fires ` +
       `only when a REQUEST scope closes.\n` +

--- a/packages/kickjs/src/core/decorators.ts
+++ b/packages/kickjs/src/core/decorators.ts
@@ -54,9 +54,48 @@ Container._onReset = (container: any) => {
 
 // ── Class Decorators ────────────────────────────────────────────────────
 
+/** Classes already warned about, so HMR replay does not repeat the notice. */
+const preDestroyWarned = new Set<string>()
+
+/**
+ * `@PreDestroy` only runs for REQUEST-scoped services — the request scope is
+ * what closes and triggers it. On a SINGLETON it is silently inert, which
+ * reads as a working teardown and is not: the reported case was a Postgres
+ * pool never closed on shutdown, invisible in development and surfacing as
+ * connection exhaustion under repeated restarts and HMR reloads.
+ *
+ * The asymmetry is the trap. `@PostConstruct` DOES run for singletons, so the
+ * pair looks like init/teardown while one half quietly opts out on a scope the
+ * author may never have considered.
+ *
+ * Warn rather than run it: making it fire on shutdown is a behaviour change
+ * whose ordering, timeout and concurrency semantics have to match the adapter
+ * shutdown path, and an adapter's `shutdown()` is already the seam for
+ * application-lifetime resources.
+ */
+function warnIfInertPreDestroy(target: any, scope: Scope): void {
+  if (scope === Scope.REQUEST) return
+  const proto = target?.prototype
+  if (!proto) return
+  const hook = Reflect.getMetadata?.(METADATA.PRE_DESTROY, proto)
+  if (!hook) return
+  const name = target.name || String(target)
+  if (preDestroyWarned.has(name)) return
+  preDestroyWarned.add(name)
+  console.warn(
+    `  kickjs: @PreDestroy on ${name} (${scope}) will never run — that hook fires ` +
+      `only when a REQUEST scope closes.\n` +
+      `  For application-lifetime resources, release them from an adapter's ` +
+      `shutdown() hook instead.`,
+  )
+}
+
 function registerInContainer(target: any, scope: Scope): void {
   setClassMeta(METADATA.INJECTABLE, true, target)
   setClassMeta(METADATA.SCOPE, scope, target)
+  // Method decorators run before the class decorator, so PRE_DESTROY metadata
+  // is already present by the time we get here.
+  warnIfInertPreDestroy(target, scope)
 
   // Track in persistent registry — survives Container.reset() for HMR replay.
   // Keyed by name so HMR class re-creation replaces the old entry.
@@ -138,6 +177,15 @@ export function PostConstruct(): MethodDecorator {
  * (response finished or aborted): release per-request resources there
  * (transactions, handles, subscriptions). May be async; errors are logged
  * and swallowed so one failing hook can't break request completion.
+ *
+ * It does NOT run on a SINGLETON — the default scope — because nothing closes
+ * a singleton's scope. Unlike {@link PostConstruct}, which does run for
+ * singletons, so the pair is not symmetric. Applying it to a singleton logs a
+ * warning naming the class rather than failing silently.
+ *
+ * For application-lifetime resources (a connection pool, a timer, a socket
+ * server) use an adapter's `shutdown()` hook, which the framework runs on a
+ * real shutdown AND on every HMR reload, time-boxed and concurrent.
  */
 export function PreDestroy(): MethodDecorator {
   return (target, propertyKey) => {


### PR DESCRIPTION
Closes #575.

## Reproduced

```
@Service()                         // SINGLETON by default
class Db {
  @PostConstruct() init() { this.ready = true }   // ✓ ran
  @PreDestroy() close() { closed() }              // ✗ never called
}
```

`AssertionError: expected "vi.fn()" to be called at least once`. Confirmed in the source too: `METADATA.PRE_DESTROY` has exactly one consumer, `http/middleware/request-scope.ts`. Nothing reads it for singletons.

## Fix — option 1 from the issue

Applying `@PreDestroy` to a non-REQUEST service now warns once, naming the class, its scope, and the seam that does work:

```
kickjs: @PreDestroy on DatabaseService (singleton) will never run — that hook
fires only when a REQUEST scope closes.
For application-lifetime resources, release them from an adapter's shutdown()
hook instead.
```

Method decorators run before the class decorator, so the metadata is already present at registration — no extra pass needed. Warned once per class name, so HMR replay doesn't repeat it.

Also took option 2: the decorator's JSDoc described only the REQUEST case and left the singleton behaviour to be inferred. It now states the asymmetry with `@PostConstruct` explicitly and points at `shutdown()`.

## Why not option 3

Running it on `app.shutdown()` is arguably what people expect, but it is a behaviour change whose ordering, timeout and concurrency semantics have to match the adapter shutdown path — and adapters already cover application-lifetime resources, running on a real exit *and* every HMR reload, time-boxed and concurrent.

You said (1) alone would have saved you the bug, so that is what this does. Happy to do (3) as a follow-up if you'd rather the hook actually fired.

## Tests

Four cases: warns naming the class, points at `shutdown()` (a warning without a fix is noise), stays quiet on REQUEST scope, stays quiet on a singleton without the hook.

Monorepo green — kickjs 847 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViFD8FXyNzwnAd3ixx7biB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a warning when `@PreDestroy` is used with a non-`REQUEST`-scoped service, clarifying that the hook will not run.
  - Warnings identify the affected service and direct developers to the appropriate shutdown mechanism.

- **Documentation**
  - Clarified `@PreDestroy` scope behavior and guidance for handling application-lifetime cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->