### PR TITLE
feat(testing): accept InjectionToken keys in createTestApp overrides

### DIFF
--- a/.changeset/brave-frogs-repeat.md
+++ b/.changeset/brave-frogs-repeat.md
@@ -1,0 +1,39 @@
+---
+'@forinda/kickjs-testing': minor
+---
+
+`createTestApp` overrides accept an `InjectionToken` key.
+
+`overrides` was typed `Record<symbol | string, any>`, but the framework's own
+recommended DI key is `createToken()` — a frozen OBJECT identified by reference.
+TypeScript rejects an object as a computed property key, so the natural call did
+not compile:
+
+```
+error TS2464: A computed property name must be of type 'string', 'number',
+'symbol', or 'any'.
+```
+
+Tokens are the documented way to bind an interface to an implementation, and the
+generator emits one per repository, so the one key type most worth overriding in
+a test was the one shape `overrides` could not take.
+
+The obvious workaround is worse than the error: `[TOKEN.name]` is a string, so
+it compiles — and the container keys tokens by reference, so the override is
+accepted and silently never applied.
+
+`overrides` now also accepts entries or a `Map`, both of which preserve the
+token's identity:
+
+```ts
+const DATABASE = createToken<Database>('app/Db/connection')
+
+await createTestApp({
+  modules: [UserModule()],
+  overrides: [[DATABASE, fakeDb()]],
+})
+```
+
+The object form is unchanged for string and symbol keys. A test pins the
+silent-failure case too, so the by-name behaviour cannot drift into looking like
+it works.

--- a/packages/testing/__tests__/overrides-token-keys.test.ts
+++ b/packages/testing/__tests__/overrides-token-keys.test.ts
@@ -1,0 +1,84 @@
+/**
+ * `overrides` has to accept a `createToken()` key.
+ *
+ * A token is a frozen OBJECT identified by reference, and TypeScript rejects an
+ * object as a computed property key, so `{ [DATABASE]: fake }` did not compile
+ * (`TS2464`). Tokens are the documented way to bind an interface to an
+ * implementation — the generator emits one per repository — so the one key type
+ * most worth overriding in a test was the one shape `overrides` could not take.
+ *
+ * The obvious workaround is worse than the error: `[TOKEN.name]` is a string,
+ * it compiles, and the container keys tokens by reference — so the override is
+ * silently never applied.
+ *
+ * @module @forinda/kickjs-testing/__tests__/overrides-token-keys.test
+ */
+
+import { describe, expect, it } from 'vitest'
+import { createToken, Service } from '@forinda/kickjs'
+
+import { createTestApp, createTestModule } from '../src/index'
+
+interface Clock {
+  now(): string
+}
+const CLOCK = createToken<Clock>('app/Clock/default')
+
+@Service()
+class RealClock implements Clock {
+  now() {
+    return 'real'
+  }
+}
+
+const ClockModule = createTestModule({
+  register: (c) => c.registerFactory(CLOCK, () => new RealClock()),
+  routes: () => null,
+})
+
+const fake: Clock = { now: () => 'faked' }
+
+describe('createTestApp overrides', () => {
+  it('accepts a token via entries and actually rebinds it', async () => {
+    const { container } = await createTestApp({
+      modules: [ClockModule],
+      overrides: [[CLOCK, fake]],
+      isolated: true,
+    })
+    expect(container.resolve<Clock>(CLOCK).now()).toBe('faked')
+  })
+
+  it('accepts a Map for the same reason', async () => {
+    const { container } = await createTestApp({
+      modules: [ClockModule],
+      overrides: new Map<unknown, unknown>([[CLOCK, fake]]),
+      isolated: true,
+    })
+    expect(container.resolve<Clock>(CLOCK).now()).toBe('faked')
+  })
+
+  it('still accepts the object form for string and symbol keys', async () => {
+    const STRING_KEY = 'app/legacy/clock'
+    const Mod = createTestModule({
+      register: (c) => c.registerFactory(STRING_KEY, () => new RealClock()),
+      routes: () => null,
+    })
+    const { container } = await createTestApp({
+      modules: [Mod],
+      overrides: { [STRING_KEY]: fake },
+      isolated: true,
+    })
+    expect(container.resolve<Clock>(STRING_KEY).now()).toBe('faked')
+  })
+
+  it('does NOT rebind when a token is passed by name — the silent-failure case', async () => {
+    // Pinning the behaviour the docs now warn about: this compiles and looks
+    // right, and the real binding survives untouched.
+    const { container } = await createTestApp({
+      modules: [ClockModule],
+      overrides: { [CLOCK.name]: fake },
+      isolated: true,
+    })
+    expect(container.resolve<Clock>(CLOCK).now()).toBe('real')
+  })
+})

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -57,8 +57,38 @@ export interface CreateTestAppOptions extends BootstrapPassthroughOptions {
   modules: AppModuleEntry[]
   /** Adapters to attach (auth, queue, devtools, etc.) */
   adapters?: AppAdapter[]
-  /** DI overrides applied after module registration. Supports both string and symbol keys. */
-  overrides?: Record<symbol | string, any>
+  /**
+   * DI overrides applied after module registration.
+   *
+   * An object literal covers string and symbol keys. It cannot cover
+   * `createToken()`, though — a token is a frozen OBJECT identified by
+   * reference, and TypeScript rejects an object as a computed key
+   * (`TS2464: A computed property name must be of type 'string', 'number',
+   * 'symbol', or 'any'`). Since tokens are the documented way to bind an
+   * interface to an implementation, that excluded exactly the key type most
+   * worth overriding in a test.
+   *
+   * Worse, the obvious workaround compiles and does nothing: `[TOKEN.name]` is
+   * a string, and the container keys tokens by reference, so the override is
+   * accepted and never applied.
+   *
+   * Pass entries to override a token:
+   *
+   * ```ts
+   * const DATABASE = createToken<Database>('app/Db/connection')
+   *
+   * await createTestApp({
+   *   modules: [UserModule()],
+   *   overrides: [[DATABASE, fakeDb()]],
+   * })
+   * ```
+   *
+   * A `Map` works too. The object form is unchanged.
+   */
+  overrides?:
+    | Record<symbol | string, any>
+    | ReadonlyArray<readonly [token: unknown, value: unknown]>
+    | ReadonlyMap<unknown, unknown>
   /**
    * Use an isolated container instead of the global singleton.
    * Prevents concurrent tests from interfering with each other's DI state.
@@ -93,6 +123,22 @@ export interface CreateTestAppOptions extends BootstrapPassthroughOptions {
  * const res = await request(app.handle.bind(app)).get('/api/v1/users')
  * ```
  */
+/**
+ * Normalize every accepted `overrides` shape to `[token, value]` pairs.
+ *
+ * An array or Map keeps the token's identity, which is what the container
+ * matches on; an object literal is limited to string and symbol keys by the
+ * language itself.
+ */
+function overrideEntries(
+  overrides: NonNullable<CreateTestAppOptions['overrides']>,
+): Array<[unknown, unknown]> {
+  if (Array.isArray(overrides)) return overrides.map(([token, value]) => [token, value])
+  if (overrides instanceof Map) return [...overrides.entries()]
+  const record = overrides as Record<symbol | string, unknown>
+  return Reflect.ownKeys(record).map((key) => [key, record[key as never]])
+}
+
 export async function createTestApp(options: CreateTestAppOptions): Promise<{
   app: Application
   /**
@@ -165,8 +211,8 @@ export async function createTestApp(options: CreateTestAppOptions): Promise<{
   // Apply DI overrides AFTER setup so they take precedence over
   // bindings registered by modules during register().
   if (options.overrides) {
-    for (const token of Reflect.ownKeys(options.overrides)) {
-      container.registerInstance(token, options.overrides[token as any])
+    for (const [token, value] of overrideEntries(options.overrides)) {
+      container.registerInstance(token, value)
     }
   }
 


### PR DESCRIPTION
Closes #574.

## Reproduced

```
probe.ts(7,51): error TS2464: A computed property name must be of type
'string', 'number', 'symbol', or 'any'.
```

Exactly as reported, and the runtime side is fine — `registerInstance` keys `this.registrations` by the token object itself. This was purely the `Record<symbol | string, any>` type excluding the framework's own recommended key.

## Fix

`overrides` also accepts entries or a `Map`, both of which preserve the token's identity:

```ts
const DATABASE = createToken<Database>('app/Db/connection')

await createTestApp({
  modules: [UserModule()],
  overrides: [[DATABASE, fakeDb()]],
})
```

The object form is unchanged for string and symbol keys. There is no way to make `{ [DATABASE]: … }` itself compile — TypeScript does not permit an object as a computed key, whatever the value type — so entries are the closest honest shape.

## The part worth pinning

Your note that `[DATABASE.name]` "compiles but does not bind" is the more dangerous half: it looks correct, type-checks, and leaves the real binding in place. There is now a test asserting exactly that outcome, so the by-name behaviour cannot quietly drift into looking like it works, and the docs on `overrides` call it out.

Four tests: entries, `Map`, the object form for string keys, and the silent-failure case.

Monorepo green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViFD8FXyNzwnAd3ixx7biB
