### PR TITLE
docs: catch up with the behaviour changes merged today

### DIFF
--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -83,6 +83,36 @@ interface AdapterContext {
 
 No need to import Express or http types — destructure only what you use.
 
+## Every hook, and what runs it
+
+All ten are optional. `kick g adapter <name>` scaffolds every one of them, so
+the generated file doubles as this reference — delete what you don't need.
+
+| Hook                       | Runs when                              | Consumed by                                                |
+| -------------------------- | -------------------------------------- | ---------------------------------------------------------- |
+| `middleware()`             | during setup                           | the pipeline, at the phase each entry names                |
+| `contributors()`           | during setup                           | the [context-contributor](./context-decorators.md) chain   |
+| `beforeMount(ctx)`         | before routes mount                    | you — early routes, docs, static assets                    |
+| `onRouteMount(ctrl, path)` | per controller mounted                 | you — route metadata, spec building                        |
+| `beforeStart(ctx)`         | inside `app.setup()`                   | you — also fires under `createTestApp`                     |
+| `afterStart(ctx)`          | once the server listens                | you — needs a live `server`; **not** under `createTestApp` |
+| `onHealthCheck()`          | on `GET /health/ready`                 | the built-in readiness endpoint                            |
+| `shutdown()`               | real shutdown **and** every HMR reload | the framework, time-boxed and concurrent                   |
+| `introspect()`             | DevTools topology poll                 | the `/_debug` dashboard                                    |
+| `devtoolsTabs()`           | DevTools panel discovery               | the `/_debug` dashboard                                    |
+
+Two are worth calling out because nothing else surfaces them:
+
+- **`onHealthCheck()`** is the only hook with a built-in consumer. The
+  Application aggregates every adapter's check through `Promise.allSettled`
+  and serves the result at `GET /health/ready`, so contributing one here is
+  what makes your dependency visible to readiness probes — you do not need a
+  route of your own.
+- **`introspect()`** must be cheap. The topology endpoint polls on a short
+  interval, so `state` and `metrics` should be counters and flags already in
+  memory. It may be async so a snapshot can be assembled, not so it can do
+  work.
+
 ## Middleware Phases
 
 The `middleware()` method returns entries that are inserted at a specific phase in the pipeline. Each entry has a `handler`, an optional `phase`, and an optional `path` for scoping:

--- a/docs/guide/cli-commands.md
+++ b/docs/guide/cli-commands.md
@@ -189,6 +189,39 @@ kick dev:debug -p 4000
 
 Same flags as `kick dev`. Opens a debug port so you can attach Chrome DevTools or your IDE's debugger.
 
+## kick typecheck
+
+Type-check the project with its own checker, without spelling out the package
+manager:
+
+```bash
+kick typecheck
+kick typecheck --cwd server
+kick typecheck --no-typegen
+```
+
+Routing this through `kick` is the point: `pnpm -r exec tsc --noEmit` and
+`cd server && npx tsc --noEmit` do the same job in two incompatible dialects.
+Same resolver `kick dev --typecheck` uses — `vue-tsc` first (plain `tsc`
+reports `TS18003` on `.vue`), then `tsgo`, then `tsc`.
+
+**Typegen runs first.** Otherwise the check reports errors from
+`.kickjs/types` describing routes that no longer exist — and the most confusing
+of them point at correct, current source:
+
+```text
+src/modules/health/health.controller.ts(11,46): error TS2339: Property 'live'
+  does not exist on type 'HealthController'
+```
+
+That method does exist; the stale `KickRoutes` namespace has no entry for it.
+A pre-commit hook or a fresh clone hits this every time, since neither has run
+the dev server — and a fresh clone has no generated types at all.
+
+Pass `--no-typegen` when the caller has just run typegen itself. A typegen
+failure is reported and does not abort the check, so a typegen problem never
+masquerades as a type error.
+
 ## kick build
 
 Build the project for production using Vite:

--- a/docs/guide/dependency-injection.md
+++ b/docs/guide/dependency-injection.md
@@ -222,6 +222,26 @@ class TxService {
 Hooks may be async; errors are logged and swallowed so one failing teardown
 can't break request completion.
 
+::: warning `@PreDestroy` does not run on a singleton
+The request scope is what closes and fires the hook, so on a SINGLETON — the
+default scope — there is nothing to trigger it. This is **not** symmetric with
+`@PostConstruct`, which does run for singletons, so the pair reads as
+init/teardown while one half quietly opts out.
+
+Applying it to a non-REQUEST service logs a warning naming the class rather
+than failing silently:
+
+```text
+kickjs: @PreDestroy on DatabaseService (singleton) will never run — that hook
+fires only when a REQUEST scope closes.
+```
+
+For application-lifetime resources — a connection pool, a timer, a socket
+server — release them from an adapter's [`shutdown()`](./adapters.md#shutdown-discipline)
+hook, which runs on a real shutdown **and** on every HMR reload, time-boxed and
+concurrent.
+:::
+
 ## Environment Injection
 
 Use `@Value` to inject environment variables. When `kick typegen` has populated the project's `KickEnv` global from `src/env.ts`, the key autocompletes and the `Env<K>` type alias resolves to the schema-inferred type — see [Configuration](configuration.md) and [Type Generation](typegen.md#how-env-vars-are-typed) for the full pipeline.

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -54,7 +54,11 @@ whichever runtime the app is configured with. See
 interface CreateTestAppOptions {
   modules: AppModuleEntry[]
   adapters?: AppAdapter[]
-  overrides?: Record<symbol | string, any>
+  // string / symbol keys, or entries / a Map for `createToken()` keys
+  overrides?:
+    | Record<symbol | string, any>
+    | ReadonlyArray<readonly [token: unknown, value: unknown]>
+    | ReadonlyMap<unknown, unknown>
   port?: number
   apiPrefix?: string
   defaultVersion?: number
@@ -63,6 +67,29 @@ interface CreateTestAppOptions {
   runtime?: HttpRuntime // engine under test — defaults to Express
 }
 ```
+
+### Overriding a token binding
+
+An object literal covers string and symbol keys. It cannot cover
+`createToken()` — a token is a frozen _object_ identified by reference, and
+TypeScript rejects an object as a computed key (`TS2464`). Pass entries instead:
+
+```ts
+const DATABASE = createToken<Database>('app/Db/connection')
+
+const { app } = await createTestApp({
+  modules: [UserModule()],
+  overrides: [[DATABASE, fakeDb()]],
+})
+```
+
+A `Map` works the same way.
+
+::: danger `[TOKEN.name]` compiles and does nothing
+`TOKEN.name` is a string, so it type-checks — but the container keys tokens by
+_reference_, so the override is accepted and never applied, leaving the real
+binding in place. Use the entries form.
+:::
 
 ### Testing the engine you deploy
 


### PR DESCRIPTION
Nine fixes merged today and **none of them updated the guides**. This closes the drift.

| Doc | Was | Now |
| --- | --- | --- |
| `guide/dependency-injection.md` | `@PreDestroy` documented only the REQUEST case | states it does **not** run on a singleton, that this is asymmetric with `@PostConstruct`, shows the warning, points at adapter `shutdown()` |
| `guide/testing.md` | `overrides?: Record<symbol \| string, any>` | entries / `Map` form for `createToken()` keys, plus a danger note that `[TOKEN.name]` compiles and silently doesn't bind |
| `guide/cli-commands.md` | `kick typecheck` not documented as a command at all | its own section: checker resolution order, why typegen runs first, `--no-typegen` |
| `guide/adapters.md` | no hook reference; `introspect()` and `devtoolsTabs()` absent entirely | table of all ten hooks with what runs each, matching what `kick g adapter` now scaffolds |

## Judgement calls

**`@PreDestroy`'s doc gap was the bug.** The guide said "for REQUEST-scoped services it runs when…" and left the singleton case to be inferred — which is exactly how #575 became a Postgres pool that was never closed. Documenting the negative is the point.

**For `overrides`, the silent failure is the part worth documenting.** `TS2464` at least fails loudly; `[TOKEN.name]` type-checks, looks right, and leaves the real binding in place. That gets a `::: danger`, the compile error gets a sentence.

**`api/core.md` needed nothing.** It already described the health endpoints' intended behaviour — #578 made that true on every runtime rather than only Express, so the docs were correct and the code was not.

Docs build clean (27.8s, no dead links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViFD8FXyNzwnAd3ixx7biB
