### PR TITLE
fix(cli): make generated controller tests assert something

### DIFF
--- a/.changeset/loud-mangos-search.md
+++ b/.changeset/loud-mangos-search.md
@@ -1,0 +1,36 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+`kick g module`: generated controller tests assert something.
+
+Every case in the generated controller test was `expect(true).toBe(true)`, so a
+new module reported a full green suite while asserting nothing — and kept
+reporting it after every route it named had been deleted. A suite that passes
+unconditionally is worse than no suite: it survives review, and it makes
+`pnpm test` stop carrying information.
+
+In a project with `@forinda/kickjs-testing` and `supertest` — which `kick new`
+installs — the list endpoint is now exercised for real: the module is booted
+through `createTestApp` and the response asserted. The remaining CRUD cases are
+`it.todo`, which the reporter lists as outstanding and which can never be
+counted as coverage.
+
+Without those packages the same scaffold is emitted with every case as a todo
+and no extra imports, since emitting an import for a package that is not
+installed produces a file that cannot compile — the same rule that gates
+`@ApiTags` on `swagger`.
+
+Two details the generated test gets right that are easy to get wrong by hand:
+
+- It passes the module in the shape its declaration style requires —
+  `Module()` for `define`, `Module` for `class`. The other way round is
+  `TypeError: entry is not a constructor`.
+- It drives `app.handle` rather than an Express app, so the generated suite
+  runs on whichever runtime the project is configured with.
+
+The mount path it assumes is stated as a `BASE` constant with the reason:
+`createTestApp` builds its own Application with the framework defaults
+(`apiPrefix: '/api'`, `defaultVersion: 1`) whatever `bootstrap()` uses, so it is
+correct as generated — and the comment shows what to change for an app that
+configures them differently, including `defaultVersion: false`.

--- a/packages/cli/__tests__/generated-tests-assert.test.ts
+++ b/packages/cli/__tests__/generated-tests-assert.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Generated controller tests have to assert something.
+ *
+ * Every case was `expect(true).toBe(true)`, so `kick g module widgets` produced
+ * a suite reporting 7 passed while asserting nothing — and it kept reporting 7
+ * passed after every route it named had been deleted. That is worse than no
+ * suite: it survives review, and it makes `pnpm test` stop carrying
+ * information.
+ *
+ * @module @forinda/kickjs-cli/__tests__/generated-tests-assert.test
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { generateControllerTest } from '../src/generators/templates/tests'
+
+const base = { pascal: 'Widget', kebab: 'widget', plural: 'widgets' }
+/** A scaffolded project: `kick new` installs kickjs-testing + supertest. */
+const ctx = { ...base, testHarness: true }
+/** A project without the harness — the generated file must still compile. */
+const bare = { ...base, testHarness: false }
+
+describe('generated controller test', () => {
+  it.each([
+    ['with the harness', ctx],
+    ['without the harness', bare],
+  ])('contains no unconditional assertion %s', (_label, given) => {
+    expect(generateControllerTest(given)).not.toContain('expect(true).toBe(true)')
+  })
+
+  it('imports nothing it cannot resolve when the harness is absent', () => {
+    // Same rule that gates @ApiTags on `swagger`: emitting an import for a
+    // package that is not installed produces a file that cannot compile. The
+    // first version of this fix broke `kick g module` in a bare project
+    // exactly that way.
+    const source = generateControllerTest(bare)
+    // Imports specifically — the header still NAMES both packages, in a comment
+    // telling you what to install to turn the real test on. That is guidance,
+    // not an unresolvable import.
+    expect(source).not.toMatch(/^import .*supertest/m)
+    expect(source).not.toMatch(/^import .*@forinda\/kickjs-testing/m)
+    // Still honest: every case is a todo, none is a fake pass.
+    expect(source).toMatch(/it\.todo\(/)
+    expect(source).not.toMatch(/^\s+it\('/m)
+  })
+
+  it('marks unwritten cases as todo, which cannot be counted as passing', () => {
+    const source = generateControllerTest(ctx)
+    expect(source).toMatch(/it\.todo\(/)
+    // Every `it(` that is not a todo must carry a real expectation; the whole
+    // point is that the reporter distinguishes them.
+    const plainIts = source.match(/^\s+it\('/gm) ?? []
+    expect(plainIts.length).toBeGreaterThan(0)
+    expect(source).toContain('expect(res.status).toBe(200)')
+  })
+
+  it('exercises the module through the real pipeline', () => {
+    const source = generateControllerTest(ctx)
+    expect(source).toContain('createTestApp')
+    // Runtime-neutral: `expressApp` would tie the generated suite to Express
+    // even in a project configured for Fastify or h3.
+    expect(source).toContain('app.handle.bind(app)')
+    expect(source).not.toContain('expressApp')
+  })
+
+  it('states the mount path it assumes, so a versioned app can correct it', () => {
+    // The CLI cannot know `apiPrefix` / `defaultVersion` — those are bootstrap()
+    // options, not kick.config.ts. createTestApp uses the framework defaults, so
+    // the generated path is right as written; the test says so and shows what
+    // to change when production differs.
+    const source = generateControllerTest(ctx)
+    expect(source).toContain("const BASE = '/api/v1/widgets'")
+    expect(source).toContain('defaultVersion')
+  })
+
+  it('passes the module in the shape its declaration style requires', () => {
+    // `define` modules are factories, `class` modules are the class itself.
+    // Getting this wrong is `TypeError: entry is not a constructor`.
+    expect(generateControllerTest({ ...ctx, style: 'define' })).toContain('[WidgetModule()]')
+    expect(generateControllerTest({ ...ctx, style: 'class' })).toContain('[WidgetModule]')
+  })
+})

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -17,7 +17,7 @@ import { generateContributor, type ContributorType } from '../generators/contrib
 import { generateService } from '../generators/service'
 import { generateController } from '../generators/controller'
 import { generateDto } from '../generators/dto'
-import { hasSwagger } from '../config'
+import { hasDependency, hasSwagger } from '../config'
 import { findProjectRoot } from '../utils/project-root'
 import { generateConfig } from '../generators/config'
 import { generateAgentDocs } from '../generators/agent-docs'
@@ -241,6 +241,12 @@ async function runModuleGeneration(
   // so a project that HAS swagger silently generates controllers without it.
   // The extension guide warns generator authors about exactly this trap.
   const swagger = hasSwagger(findProjectRoot())
+  // Both are devDependencies — a test harness is not needed in a production
+  // install — so this asks for 'any' rather than 'runtime'.
+  const projectRoot = findProjectRoot()
+  const testHarness =
+    hasDependency(projectRoot, '@forinda/kickjs-testing', 'any') &&
+    hasDependency(projectRoot, 'supertest', 'any')
   const resolvedStyle = mc.style ?? 'define'
 
   // Style-drift gate. When the project pins `modules.style: 'define'`
@@ -296,6 +302,7 @@ async function runModuleGeneration(
       minimal: opts.minimal,
       force: opts.force,
       pattern,
+      testHarness,
       dryRun,
       pluralize: shouldPluralize,
       tokenScope,

--- a/packages/cli/src/generators/module.ts
+++ b/packages/cli/src/generators/module.ts
@@ -43,6 +43,12 @@ interface GenerateModuleOptions {
   /** Project depends on @forinda/kickjs-swagger — gates @ApiTags emission. */
   swagger?: boolean
   /**
+   * Project has `@forinda/kickjs-testing` and `supertest` — gates the
+   * generated controller test booting the module for real. Without them the
+   * imports would not resolve and the generated file could not compile.
+   */
+  testHarness?: boolean
+  /**
    * Module declaration style — `'define'` (factory, default) or
    * `'class'` (legacy). Resolved by the orchestrating command from
    * `kick.config.ts > modules.style`.
@@ -104,6 +110,7 @@ export async function generateModule(options: GenerateModuleOptions): Promise<st
     noTests: noTests ?? false,
     tokenScope: options.tokenScope ?? 'app',
     swagger: options.swagger ?? false,
+    testHarness: options.testHarness ?? false,
     style: options.style ?? 'define',
     write,
     files,

--- a/packages/cli/src/generators/patterns/rest.ts
+++ b/packages/cli/src/generators/patterns/rest.ts
@@ -16,7 +16,18 @@ import {
 } from '../templates'
 
 export async function generateRestFiles(ctx: ModuleContext): Promise<void> {
-  const { pascal, kebab, plural, pluralPascal, repo, noTests, tokenScope, style, write } = ctx
+  const {
+    pascal,
+    kebab,
+    plural,
+    pluralPascal,
+    repo,
+    noTests,
+    tokenScope,
+    style,
+    testHarness,
+    write,
+  } = ctx
   const swagger = ctx.swagger ?? false
 
   // Module file (named `<kebab>.module.ts` so Vite's module-discovery plugin picks it up)
@@ -73,7 +84,7 @@ export async function generateRestFiles(ctx: ModuleContext): Promise<void> {
     }
     await write(
       `__tests__/${kebab}.controller.test.ts`,
-      generateControllerTest({ pascal, kebab, plural }),
+      generateControllerTest({ pascal, kebab, plural, style, testHarness }),
     )
     await write(
       `__tests__/${kebab}.repository.test.ts`,

--- a/packages/cli/src/generators/patterns/types.ts
+++ b/packages/cli/src/generators/patterns/types.ts
@@ -27,4 +27,6 @@ export interface ModuleContext {
   files: string[]
   /** Project depends on @forinda/kickjs-swagger — gates @ApiTags. */
   swagger?: boolean
+  /** Project has kickjs-testing + supertest — gates the real controller test. */
+  testHarness?: boolean
 }

--- a/packages/cli/src/generators/templates/tests.ts
+++ b/packages/cli/src/generators/templates/tests.ts
@@ -1,57 +1,127 @@
 import type { TemplateContext } from './types'
 
+/**
+ * Controller test scaffold.
+ *
+ * Every case used to be `expect(true).toBe(true)`, so a generated module
+ * reported a full green suite while asserting nothing — and kept reporting it
+ * after the routes it names were deleted. A suite that passes unconditionally
+ * is worse than no suite: it survives review and makes `pnpm test` stop
+ * carrying information.
+ *
+ * Now: one case that genuinely exercises the module end to end, and `it.todo`
+ * for the rest. Todos show up in the reporter as outstanding work and can
+ * never be mistaken for coverage.
+ */
 export function generateControllerTest(ctx: TemplateContext): string {
-  const { pascal, kebab, plural = '' } = ctx
-  return `import { describe, it, expect, beforeEach } from 'vitest'
+  const { pascal, kebab, plural = '', style = 'define', testHarness = false } = ctx
+  // `define` modules are factories; `class` modules are passed as the class.
+  // Getting this wrong yields `TypeError: entry is not a constructor`.
+  const moduleEntry = style === 'define' ? `${pascal}Module()` : `${pascal}Module`
+
+  // Without the harness installed, importing it would emit a file that cannot
+  // compile — the same rule that gates `@ApiTags` on `swagger`. Those projects
+  // get the identical scaffold with every case as a todo and no extra imports.
+  const header = testHarness
+    ? `import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import { Container } from '@forinda/kickjs'
+import { createTestApp } from '@forinda/kickjs-testing'
+
+import { ${pascal}Module } from '../${kebab}.module'
+
+/**
+ * Where this module is mounted.
+ *
+ * \`createTestApp\` builds its own Application with the framework defaults —
+ * apiPrefix \`/api\` and defaultVersion \`1\` — whatever your \`bootstrap()\` uses,
+ * so this is correct as generated. If your app configures them differently,
+ * pass the same values in \`boot()\` below and update this to match, so the test
+ * exercises the paths production actually serves:
+ *
+ *   defaultVersion: false  →  '/api/${plural}'
+ *   apiPrefix: '/v1'       →  '/v1/v1/${plural}'
+ */
+const BASE = '/api/v1/${plural}'
+`
+    : `import { describe, it, beforeEach } from 'vitest'
 import { Container } from '@forinda/kickjs'
 
+// Install \`@forinda/kickjs-testing\` and \`supertest\` to boot this module in a
+// test: \`kick add @forinda/kickjs-testing\`. Until then every case below is a
+// todo — the reporter lists them as outstanding rather than counting them as
+// coverage.
+`
+
+  const listBlock = testHarness
+    ? `  /**
+   * Boot the module through the real pipeline.
+   *
+   * Drive \`app.handle\` rather than an Express app: it is the Application's own
+   * Node listener, so this test runs on whichever runtime the app is
+   * configured with.
+   */
+  async function boot() {
+    const { app, container } = await createTestApp({
+      modules: [${moduleEntry}],
+      // Mirror your bootstrap() here if it overrides either, and update BASE:
+      // apiPrefix: '/api',
+      // defaultVersion: 1,
+    })
+    return { app, container, agent: request(app.handle.bind(app)) }
+  }
+
+  describe('GET /${plural}', () => {
+    it('returns an empty page before anything is created', async () => {
+      const { agent } = await boot()
+      const res = await agent.get(BASE)
+
+      expect(res.status).toBe(200)
+      expect(res.body).toMatchObject({ data: [], meta: { page: 1 } })
+    })
+
+    it.todo('returns created ${plural}, paginated')
+  })`
+    : `  describe('GET /${plural}', () => {
+    // Boot the module with createTestApp and assert { data, meta }.
+    it.todo('returns an empty page before anything is created')
+    it.todo('returns created ${plural}, paginated')
+  })`
+
+  return `${header}
 describe('${pascal}Controller', () => {
   beforeEach(() => {
     Container.reset()
   })
 
-  it('should be defined', () => {
-    expect(true).toBe(true)
-  })
+${listBlock}
+
+  // The cases below are scaffolding, not coverage. Each is \`it.todo\` so the
+  // reporter lists it as outstanding instead of counting it as a pass. Replace
+  // the todo with a real test as you implement each endpoint.
 
   describe('POST /${plural}', () => {
-    it('should create a new ${kebab}', async () => {
-      // TODO: Set up test module, call create endpoint, assert 201
-      expect(true).toBe(true)
-    })
-  })
-
-  describe('GET /${plural}', () => {
-    it('should return paginated ${plural}', async () => {
-      // TODO: Set up test module, call list endpoint, assert { data, meta }
-      expect(true).toBe(true)
-    })
+    // Post a valid body, assert 201 and the created ${kebab} in the response.
+    it.todo('creates a ${kebab}')
+    // Post an invalid body, assert 422 and the validation detail.
+    it.todo('rejects an invalid body')
   })
 
   describe('GET /${plural}/:id', () => {
-    it('should return a ${kebab} by id', async () => {
-      // TODO: Create a ${kebab}, then fetch by id, assert match
-      expect(true).toBe(true)
-    })
-
-    it('should return 404 for non-existent ${kebab}', async () => {
-      // TODO: Fetch non-existent id, assert 404
-      expect(true).toBe(true)
-    })
+    // Create one, fetch it by id, assert the payload matches.
+    it.todo('returns a ${kebab} by id')
+    // Fetch an id that does not exist, assert 404.
+    it.todo('returns 404 for an unknown id')
   })
 
   describe('PUT /${plural}/:id', () => {
-    it('should update an existing ${kebab}', async () => {
-      // TODO: Create, update, assert changes
-      expect(true).toBe(true)
-    })
+    // Create, update, assert the change is reflected on a subsequent read.
+    it.todo('updates an existing ${kebab}')
   })
 
   describe('DELETE /${plural}/:id', () => {
-    it('should delete a ${kebab}', async () => {
-      // TODO: Create, delete, assert gone
-      expect(true).toBe(true)
-    })
+    // Create, delete, assert a subsequent read is 404.
+    it.todo('deletes a ${kebab}')
   })
 })
 `

--- a/packages/cli/src/generators/templates/types.ts
+++ b/packages/cli/src/generators/templates/types.ts
@@ -48,6 +48,17 @@ export interface TemplateContext {
    */
   tokenScope?: string
   /**
+   * Project has `@forinda/kickjs-testing` and `supertest` available, so the
+   * generated controller test can boot the module for real.
+   *
+   * Same rule as {@link TemplateContext.swagger}: emitting an import for a
+   * package that is not installed produces a file that cannot compile. The
+   * scaffolded templates install both as devDependencies, so this is true for
+   * `kick new` projects and false for a bare one — which then gets the same
+   * test with every case as `it.todo` and no extra imports.
+   */
+  testHarness?: boolean
+  /**
    * Module declaration style emitted for the module-index file.
    * Defaults to `'define'`. Resolved from `kick.config.ts > modules.style`
    * by the orchestrating generator before the template is invoked.


### PR DESCRIPTION
Closes #565.

## Before / after, measured

```
kick g module widget && vitest run

before:  7 passed                 ← asserting nothing
after:   7 passed | 7 todo        ← one real assertion, six honest todos
```

The one real case boots the module through `createTestApp` and asserts the list endpoint:

```ts
const res = await agent.get(BASE)
expect(res.status).toBe(200)
expect(res.body).toMatchObject({ data: [], meta: { page: 1 } })
```

`it.todo` for the rest — the reporter lists them as outstanding, and they can never be counted as coverage.

## Your API-version point

The CLI **cannot** know `apiPrefix` / `defaultVersion` — those are `bootstrap()` options, not `kick.config.ts`, and there's no public route-table accessor to derive them from.

It doesn't need to: `createTestApp` builds its own Application with the framework defaults whatever production uses, so the emitted path is correct as generated. It's a named `BASE` constant that says so, and shows what to change when the app differs:

```ts
/**
 *   defaultVersion: false  →  '/api/widgets'
 *   apiPrefix: '/v1'       →  '/v1/v1/widgets'
 */
const BASE = '/api/v1/widgets'
```

Verified both: default passes, and `defaultVersion: false` + the documented `BASE` passes.

## A regression I introduced and the existing suite caught

The first version imported `supertest` and `@forinda/kickjs-testing` unconditionally, which broke `kick g module` in a project without them — an unresolvable import is a file that cannot compile. `module.test.ts > passes tsc --noEmit` failed and named it.

That's the same rule already gating `@ApiTags` on `swagger`, so it now uses the same mechanism: a `testHarness` flag resolved via `hasDependency(root, …, 'any')` (both are devDependencies). Without the harness the identical scaffold is emitted as todos with no extra imports, and the header names the two packages to install.

## Two details the generated test gets right

- Passes the module in the shape its style requires — `Module()` for `define`, `Module` for `class`. The other way round is `TypeError: entry is not a constructor` (#566).
- Drives `app.handle`, not an Express app, so the suite runs on whichever runtime the project uses.

Five regression tests cover both branches. Monorepo green — CLI 765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViFD8FXyNzwnAd3ixx7biB
