### PR TITLE
fix(kickjs): make h3 error handling match the other runtimes

### DIFF
--- a/.changeset/olive-moles-hunt.md
+++ b/.changeset/olive-moles-hunt.md
@@ -24,6 +24,14 @@ The runtime now only skips the read when nothing was sent, deciding on
 A body that is present but unparseable raises `HttpException.badRequest`, so all
 three runtimes answer 400.
 
+The content type has to be normalised for that to hold. `readBody` matches
+`application/json` **exactly**, so `application/json; charset=utf-8` — what most
+clients actually send — fell to its catch-all branch and parsed non-strictly,
+handing the handler a raw string rather than throwing. The runtime now strips
+parameters itself and asks for strict parsing when the media type is JSON.
+Deliberately not extended to `+json` types: Express does not parse those at all,
+so making h3 stricter there would be a different divergence rather than a fix.
+
 Covered by a matrix over all three: malformed JSON is rejected and the handler
 does not run, a well-formed body still works, and a request with no body at all
 still succeeds — that last one being why the original catch existed.

--- a/.changeset/olive-moles-hunt.md
+++ b/.changeset/olive-moles-hunt.md
@@ -1,0 +1,29 @@
+---
+'@forinda/kickjs': patch
+---
+
+Fix the h3 runtime answering 200 for a malformed request body.
+
+The h3 runtime read bodies with `readBody(event).catch(() => undefined)`. That
+catch was there for the legitimate absent-body case, but it swallowed a PARSE
+failure just as readily — so broken JSON produced a **200**, with the handler
+running against `undefined`:
+
+| runtime | malformed JSON                                   |
+| ------- | ------------------------------------------------ |
+| express | `400 {"message":"Unexpected end of JSON input"}` |
+| fastify | `400 {"message":"Body is not valid JSON…"}`      |
+| h3      | `200 {"got":null}`                               |
+
+Worse than the wrong status: the client was told it succeeded, and the handler
+executed on data that never parsed — a create endpoint would write whatever its
+defaults were.
+
+The runtime now only skips the read when nothing was sent, deciding on
+`content-length` / `transfer-encoding` rather than on whether parsing threw.
+A body that is present but unparseable raises `HttpException.badRequest`, so all
+three runtimes answer 400.
+
+Covered by a matrix over all three: malformed JSON is rejected and the handler
+does not run, a well-formed body still works, and a request with no body at all
+still succeeds — that last one being why the original catch existed.

--- a/.changeset/olive-moles-hunt.md
+++ b/.changeset/olive-moles-hunt.md
@@ -27,3 +27,24 @@ three runtimes answer 400.
 Covered by a matrix over all three: malformed JSON is rejected and the handler
 does not run, a well-formed body still works, and a request with no body at all
 still succeeds — that last one being why the original catch existed.
+
+The same comparison turned up a second h3 divergence, also fixed here. h3 routes
+every thrown value through `createError()`, which returns its own error with the
+original on `cause`, and that wrapper was handed to the shared error middleware.
+Express and Fastify hand it the original, so responses differed by runtime for
+the same thrown value:
+
+| thrown                                | express / fastify             | h3 (before)                                 |
+| ------------------------------------- | ----------------------------- | ------------------------------------------- |
+| `HttpException(418, 'I am a teapot')` | `{"message":"I am a teapot"}` | `{"message":"I am a teapot","requestId":…}` |
+| `new Error('kaboom')` → `error` field | `Error: kaboom`               | `Error: kaboom ← caused by Error: kaboom`   |
+
+`instanceof HttpException` failed against the wrapper, so an expected 4xx fell
+through to the generic branch and picked up a `requestId` the other runtimes
+omit for that case. The runtime now unwraps an `Error` cause before delegating.
+h3's own 404 carries no cause, so the not-found path is untouched.
+
+A parity suite pins the catch-all and error mapping on all three: unknown route
+under the prefix, unknown route at the root, known path with the wrong method,
+`HttpException` status and body, an unexpected throw naming the error once with
+a correlation id, and a working route.

--- a/packages/kickjs/src/http/runtimes/h3.ts
+++ b/packages/kickjs/src/http/runtimes/h3.ts
@@ -175,7 +175,17 @@ function makeEventHandler(entry: RouteEntry): (event: H3EventLike) => Promise<vo
       const sentBody = encoding !== undefined || (length !== undefined && length !== '0')
       if (sentBody) {
         try {
-          req.body = await readBody(event)
+          // `readBody` matches `application/json` EXACTLY, so
+          // `application/json; charset=utf-8` — what most clients actually send
+          // — fell to its catch-all branch and parsed non-strictly, handing the
+          // handler a raw string for malformed JSON instead of throwing. Decide
+          // on the normalised media type and ask for strict parsing ourselves.
+          // Only `application/json` — the type h3 itself special-cases. Widening
+          // this to `+json` would make h3 stricter than Express, which does not
+          // parse those at all: a different divergence, not a fix.
+          const mediaType = (req.headers['content-type'] ?? '').split(';')[0].trim().toLowerCase()
+          const strict = mediaType === 'application/json'
+          req.body = await readBody(event, strict ? { strict: true } : {})
         } catch (err) {
           throw HttpException.badRequest(
             err instanceof Error ? err.message : 'Request body could not be parsed',

--- a/packages/kickjs/src/http/runtimes/h3.ts
+++ b/packages/kickjs/src/http/runtimes/h3.ts
@@ -24,6 +24,7 @@ import { applyHandlerResult } from '../reply'
 import { requestStore } from '../request-store'
 import { createRequestStore, disposeRequestStore } from '../middleware/request-scope'
 import { validate } from '../middleware/validate'
+import { HttpException } from '../../core/errors'
 import { applyUploadConfig, type RawUploadPart } from '../middleware/upload'
 import type {
   ConnectMiddleware,
@@ -165,7 +166,22 @@ function makeEventHandler(entry: RouteEntry): (event: H3EventLike) => Promise<vo
       req.files = files
       req.body = fields
     } else if (BODY_METHODS.has(req.method ?? 'GET')) {
-      req.body = await readBody(event).catch(() => undefined)
+      // Swallow ONLY the absent-body case. `.catch(() => undefined)` also
+      // swallowed a malformed one, so h3 answered 200 with the handler running
+      // on `undefined` where Express and Fastify both answer 400 — a client
+      // sending broken JSON got a success response, and the handler executed
+      // against data that was never valid.
+      const { 'content-length': length, 'transfer-encoding': encoding } = req.headers
+      const sentBody = encoding !== undefined || (length !== undefined && length !== '0')
+      if (sentBody) {
+        try {
+          req.body = await readBody(event)
+        } catch (err) {
+          throw HttpException.badRequest(
+            err instanceof Error ? err.message : 'Request body could not be parsed',
+          )
+        }
+      }
     }
 
     const headerId = req.headers['x-request-id']

--- a/packages/kickjs/src/http/runtimes/h3.ts
+++ b/packages/kickjs/src/http/runtimes/h3.ts
@@ -227,6 +227,26 @@ function makeEventHandler(entry: RouteEntry): (event: H3EventLike) => Promise<vo
 }
 
 /**
+ * The original error h3 wrapped.
+ *
+ * h3 routes every thrown value through `createError()`, which returns its own
+ * error with the original on `cause`. Handing that wrapper to the shared error
+ * middleware means it sees something Express and Fastify never give it, and the
+ * responses diverge: `instanceof HttpException` fails, so a thrown
+ * `HttpException(418)` falls through to the generic branch and picks up a
+ * `requestId` the other two omit, and `describeError` walks the cause chain to
+ * report `kaboom ← caused by kaboom`.
+ *
+ * Only an `Error` cause is unwrapped. h3's own 404 carries no cause, so the
+ * not-found path above is unaffected.
+ */
+function unwrapH3Error(error: unknown): unknown {
+  if (!(error instanceof Error)) return error
+  const { cause } = error as { cause?: unknown }
+  return cause instanceof Error ? cause : error
+}
+
+/**
  * The h3 HTTP runtime. Pass to `bootstrap({ runtime: h3Runtime() })`.
  * h3 parses bodies itself (`readBody`), so the Application skips its default
  * `express.json()` (see `nativeBodyParsing`).
@@ -270,7 +290,7 @@ export function h3Runtime(): HttpRuntime<H3AppLike> {
           const mw = state[ERROR_MW]
           if (mw) {
             ;(mw as (e: unknown, req: unknown, res: unknown, next: () => void) => void)(
-              error,
+              unwrapH3Error(error),
               event.node.req,
               resDriver(res),
               NOOP_NEXT,

--- a/packages/testing/__tests__/body-parse-errors.test.ts
+++ b/packages/testing/__tests__/body-parse-errors.test.ts
@@ -58,8 +58,40 @@ describe.each(runtimes)('body parsing on $name', ({ make }) => {
     expect(res.body).not.toHaveProperty('got')
   })
 
+  it.each([['application/json'], ['application/json; charset=utf-8']])(
+    'rejects malformed JSON sent as %s',
+    async (contentType) => {
+      // The content type is normally parameterised — `; charset=utf-8` is what
+      // most clients send. h3's `readBody` matches `application/json` EXACTLY, so
+      // anything with a parameter took its non-strict branch and handed the
+      // handler a raw string. The first fix here only covered the bare form,
+      // because the test only sent the bare form.
+      const res = await (
+        await agent()
+      )
+        .post('/api/v1/echo')
+        .set('Content-Type', contentType)
+        .send('{"a":')
+
+      expect(res.status).toBe(400)
+      expect(res.body).not.toHaveProperty('got')
+    },
+  )
+
   it('accepts a well-formed body', async () => {
     const res = await (await agent()).post('/api/v1/echo').send({ a: 1 })
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ got: 1 })
+  })
+
+  it('accepts a well-formed body with a parameterised content type', async () => {
+    // The strict flag must not break the ordinary case it was added for.
+    const res = await (
+      await agent()
+    )
+      .post('/api/v1/echo')
+      .set('Content-Type', 'application/json; charset=utf-8')
+      .send('{"a":1}')
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ got: 1 })
   })

--- a/packages/testing/__tests__/body-parse-errors.test.ts
+++ b/packages/testing/__tests__/body-parse-errors.test.ts
@@ -1,0 +1,74 @@
+/**
+ * A malformed body is a client error on every runtime.
+ *
+ * The h3 runtime read the body with `.catch(() => undefined)`, which swallowed
+ * a PARSE failure as well as an absent body. So broken JSON produced a 200 and
+ * the handler ran against `undefined`, where Express and Fastify both answer
+ * 400. Worse than the wrong status: the handler executed on data that was
+ * never valid, and the client was told it succeeded.
+ *
+ * @module @forinda/kickjs-testing/__tests__/body-parse-errors.test
+ */
+
+import { describe, expect, it } from 'vitest'
+import request from 'supertest'
+import { Controller, Post, expressRuntime, type RequestContext } from '@forinda/kickjs'
+
+// Source paths: this package's vitest alias maps the bare specifier at src/index.ts.
+import { fastifyRuntime } from '../../kickjs/src/http/runtimes/fastify'
+import { h3Runtime } from '../../kickjs/src/http/runtimes/h3'
+import { createTestApp, createTestModule } from '../src/index'
+
+@Controller()
+class EchoController {
+  @Post('/')
+  create(ctx: RequestContext) {
+    return { got: (ctx.body as { a?: number })?.a ?? null }
+  }
+}
+
+const EchoModule = createTestModule({
+  register: () => {},
+  routes: () => ({ path: '/echo', controller: EchoController }),
+})
+
+const runtimes = [
+  { name: 'express', make: () => expressRuntime() },
+  { name: 'fastify', make: () => fastifyRuntime() },
+  { name: 'h3', make: () => h3Runtime() },
+] as const
+
+describe.each(runtimes)('body parsing on $name', ({ make }) => {
+  async function agent() {
+    const { app } = await createTestApp({ modules: [EchoModule], runtime: make(), isolated: true })
+    return request(app.handle.bind(app))
+  }
+
+  it('rejects malformed JSON with a client error', async () => {
+    const res = await (
+      await agent()
+    )
+      .post('/api/v1/echo')
+      .set('Content-Type', 'application/json')
+      .send('{"a":')
+
+    expect(res.status).toBe(400)
+    // The handler must not have run — a success body here means the request was
+    // accepted on data that never parsed.
+    expect(res.body).not.toHaveProperty('got')
+  })
+
+  it('accepts a well-formed body', async () => {
+    const res = await (await agent()).post('/api/v1/echo').send({ a: 1 })
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ got: 1 })
+  })
+
+  it('still allows a request with no body at all', async () => {
+    // The absent-body case is why the h3 catch existed; tightening it must not
+    // turn "nothing sent" into an error.
+    const res = await (await agent()).post('/api/v1/echo')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ got: null })
+  })
+})

--- a/packages/testing/__tests__/error-parity.test.ts
+++ b/packages/testing/__tests__/error-parity.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Catch-all and error handling must agree across runtimes.
+ *
+ * Express brings opinionated defaults — a 404 fall-through, an error middleware
+ * signature, `originalUrl` — and the framework was written against them. The
+ * other two engines reach the same shared middleware by a different road, so
+ * anything the road changes shows up as a response that differs by runtime for
+ * the same thrown value.
+ *
+ * h3 was the outlier: it routes every thrown value through `createError()`,
+ * which wraps the original on `cause`. The shared handler then failed
+ * `instanceof HttpException`, so a thrown `HttpException(418)` fell through to
+ * the generic branch and gained a `requestId` the other two omit, and
+ * `describeError` walked the chain to report `kaboom ← caused by kaboom`.
+ *
+ * @module @forinda/kickjs-testing/__tests__/error-parity.test
+ */
+
+import { describe, expect, it } from 'vitest'
+import request from 'supertest'
+import {
+  Controller,
+  Get,
+  HttpException,
+  expressRuntime,
+  type RequestContext,
+} from '@forinda/kickjs'
+
+// Source paths: this package's vitest alias maps the bare specifier at src/index.ts.
+import { fastifyRuntime } from '../../kickjs/src/http/runtimes/fastify'
+import { h3Runtime } from '../../kickjs/src/http/runtimes/h3'
+import { createTestApp, createTestModule } from '../src/index'
+
+@Controller()
+class ThingsController {
+  @Get('/ok')
+  ok(_ctx: RequestContext) {
+    return { ok: true }
+  }
+
+  @Get('/boom')
+  boom(_ctx: RequestContext): never {
+    throw new Error('kaboom')
+  }
+
+  @Get('/teapot')
+  teapot(_ctx: RequestContext): never {
+    throw new HttpException(418, 'I am a teapot')
+  }
+}
+
+const ThingsModule = createTestModule({
+  register: () => {},
+  routes: () => ({ path: '/things', controller: ThingsController }),
+})
+
+const runtimes = [
+  { name: 'express', make: () => expressRuntime() },
+  { name: 'fastify', make: () => fastifyRuntime() },
+  { name: 'h3', make: () => h3Runtime() },
+] as const
+
+describe.each(runtimes)('error handling on $name', ({ make }) => {
+  async function agent() {
+    const { app } = await createTestApp({
+      modules: [ThingsModule],
+      runtime: make(),
+      isolated: true,
+    })
+    return request(app.handle.bind(app))
+  }
+
+  it('404s an unknown route under the API prefix', async () => {
+    const res = await (await agent()).get('/api/v1/nope')
+    expect(res.status).toBe(404)
+    expect(res.body).toEqual({ message: 'Not Found' })
+  })
+
+  it('404s an unknown route at the root, outside the prefix', async () => {
+    // The catch-all has to cover paths the router never mounted at all, not
+    // just misses inside the API prefix.
+    const res = await (await agent()).get('/definitely-nothing')
+    expect(res.status).toBe(404)
+  })
+
+  it('404s a known path with the wrong method', async () => {
+    const res = await (await agent()).delete('/api/v1/things/ok')
+    expect(res.status).toBe(404)
+  })
+
+  it('maps a thrown HttpException to its own status and body', async () => {
+    // Identical on all three: no `requestId` on an expected 4xx. h3 used to add
+    // one because its wrapper defeated the `instanceof` check.
+    const res = await (await agent()).get('/api/v1/things/teapot')
+    expect(res.status).toBe(418)
+    expect(res.body).toEqual({ message: 'I am a teapot' })
+  })
+
+  it('maps an unexpected throw to a 500 that names the error once', async () => {
+    const res = await (await agent()).get('/api/v1/things/boom')
+    expect(res.status).toBe(500)
+    expect(res.body.message).toBe('Internal Server Error')
+    // Correlation id on unexpected errors, in every environment.
+    expect(res.body.requestId).toBeTruthy()
+    // Once — h3's wrapper produced `kaboom ← caused by kaboom`.
+    expect(res.body.error).toBe('Error: kaboom')
+  })
+
+  it('still serves a working route', async () => {
+    const res = await (await agent()).get('/api/v1/things/ok')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ ok: true })
+  })
+})


### PR DESCRIPTION
Reading the Fastify and h3 error docs you linked, I compared how each runtime turns a bad request body into a response. Express and Fastify agree; **h3 did not**.

## The divergence

Same request — `POST` with `Content-Type: application/json` and body `{"a":`

| runtime | status | body |
| --- | --- | --- |
| express | 400 | `{"message":"Unexpected end of JSON input"}` |
| fastify | 400 | `{"message":"Body is not valid JSON but content-type is set to 'application/json'"}` |
| **h3** | **200** | `{"got":null}` |

## Cause

```ts
req.body = await readBody(event).catch(() => undefined)
```

The catch was there for the legitimate absent-body case, but it swallowed a **parse** failure just as readily.

Worse than the wrong status: the client is told it succeeded, and the handler runs against `undefined`. A create endpoint would write whatever its defaults are, for a request that never parsed.

## Fix

Skip the read only when nothing was sent — decided on `content-length` / `transfer-encoding`, not on whether parsing threw. A body that is present but unparseable raises `HttpException.badRequest`, so all three runtimes now answer 400 and the handler does not run.

## Why this was invisible

The existing error tests covered Express and Fastify — the pair that already agreed. Extending the matrix to h3 is what surfaced it, which is the same shape as #571 (`/health/ready` 500ing on Fastify because nothing exercised a non-Express runtime).

`body-parse-errors.test.ts` runs all three: malformed JSON rejected with the handler not running, a well-formed body still parsed, and **a request with no body at all still succeeding** — that last case being why the original catch existed, and the one a naive fix breaks. Restoring the blanket catch fails the suite.

Monorepo green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViFD8FXyNzwnAd3ixx7biB

---

## Second divergence, from the same comparison

You framed this as catch-all and error handling across runtimes — Express having the opinionated defaults the framework was written against. Comparing all three on that basis turned up a second h3 outlier.

h3 routes every thrown value through `createError()`, which returns **its own** error with the original on `cause`. That wrapper was handed to the shared error middleware; Express and Fastify hand it the original. Same thrown value, different response per runtime:

| thrown | express / fastify | h3 (before) |
| --- | --- | --- |
| `HttpException(418, 'I am a teapot')` | `{"message":"I am a teapot"}` | `{"message":"I am a teapot",`**`"requestId"`**`:…}` |
| `new Error('kaboom')` → `error` | `Error: kaboom` | `Error: kaboom `**`← caused by Error: kaboom`** |

`instanceof HttpException` failed against the wrapper, so an expected 4xx fell through to the generic branch and gained a `requestId` the other two omit there. The duplicate text came from `describeError` walking the cause chain.

The runtime now unwraps an `Error` cause before delegating. Only an `Error` cause — h3's own 404 carries none, so the not-found path is untouched.

## What already agreed

Worth recording, since it bounds the problem: **404 handling was already consistent.** Unknown route under the prefix, unknown route at the root, and a known path with the wrong method all return `404 {"message":"Not Found"}` on all three. The catch-all seam is fine; the divergences were both in how a thrown value reached the handler.

`error-parity.test.ts` now pins all of it — six cases × three runtimes. Reverting the unwrap fails two of them.

Monorepo green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Malformed JSON request bodies now return HTTP 400 without invoking the request handler.
  - JSON content types with parameters such as `charset=utf-8` are parsed consistently.
  - Error responses from the h3 runtime now match behavior across supported runtimes.
  - Unknown routes, unsupported methods, and unexpected errors return consistent status codes and response details.

- **Tests**
  - Added cross-runtime coverage for body parsing and error-handling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->