### PR TITLE
feat(kickjs): problem details from the catch-all, and 405 for a wrong verb

### DIFF
--- a/.changeset/brave-lions-shout.md
+++ b/.changeset/brave-lions-shout.md
@@ -1,0 +1,43 @@
+---
+'@forinda/kickjs': minor
+---
+
+The catch-all answers problem details, and 405 when the verb is the problem.
+
+**Breaking: the default 404 body changed.** It was `{ "message": "Not Found" }`
+and is now RFC 9457 problem details with `Content-Type:
+application/problem+json`:
+
+```json
+{ "type": "about:blank", "title": "Not Found", "status": 404 }
+```
+
+The catch-all was the last response still emitting a bare `{ message }`, so a
+client parsing `application/problem+json` — which the framework already returns
+for every `ProblemException` — had to special-case exactly one path. Pass
+`bootstrap({ onNotFound })` to restore the old shape or supply any other.
+
+**A known path with the wrong method is now 405, not 404**, carrying `Allow` as
+RFC 9110 §15.5.6 requires:
+
+```
+DELETE /api/v1/things/1     405   Allow: GET, PATCH
+{ "type": "about:blank", "title": "Method Not Allowed", "status": 405,
+  "detail": "DELETE is not supported for this resource. Allowed: GET, PATCH." }
+```
+
+A 404 there tells a client to stop looking for a resource that is present. The
+handler takes the mounted route table — the Application is the only place that
+knows the full path, prefix and version joined — and an app that supplies its
+own `onNotFound` is unaffected.
+
+Also fixes a related h3 bug found while testing this: `NodeResDriver.json()` set
+`application/json` unconditionally, clobbering a content-type the caller had
+already chosen. Every `application/problem+json` response went out mislabelled
+on that runtime alone — not only the new catch-all, but every `ProblemException`
+the error handler has ever emitted there.
+
+Covered by a runtime matrix over Express, Fastify and h3: unknown path under the
+prefix, unknown path at the root, wrong method with `Allow`, a sibling path that
+matches no route, problem+json content type, `HttpException` mapping, and an
+unexpected throw.

--- a/.changeset/brave-lions-shout.md
+++ b/.changeset/brave-lions-shout.md
@@ -1,12 +1,26 @@
 ---
-'@forinda/kickjs': minor
+'@forinda/kickjs': major
 ---
 
 The catch-all answers problem details, and 405 when the verb is the problem.
 
-**Breaking: the default 404 body changed.** It was `{ "message": "Not Found" }`
-and is now RFC 9457 problem details with `Content-Type:
-application/problem+json`:
+Two breaking changes to responses an app produces without asking for them, which
+is why this is a major rather than a minor. Both are reachable through the
+existing bootstrap options: `onNotFound` and `onError` still win, so an app that
+supplies either is unaffected.
+
+## Migrating
+
+- A client asserting `body.message === 'Not Found'` reads `body.title` or
+  `body.status` instead, or passes `bootstrap({ onNotFound })` to restore the
+  old shape.
+- A client treating "known path, wrong verb" as 404 now sees 405. That is the
+  correct answer, but it moves the case from one branch to another.
+
+## The 404 body
+
+It was `{ "message": "Not Found" }` and is now RFC 9457 problem details with
+`Content-Type: application/problem+json`:
 
 ```json
 { "type": "about:blank", "title": "Not Found", "status": 404 }
@@ -17,8 +31,9 @@ client parsing `application/problem+json` — which the framework already return
 for every `ProblemException` — had to special-case exactly one path. Pass
 `bootstrap({ onNotFound })` to restore the old shape or supply any other.
 
-**A known path with the wrong method is now 405, not 404**, carrying `Allow` as
-RFC 9110 §15.5.6 requires:
+## Wrong verb on a known path
+
+Now 405, not 404, carrying `Allow` as RFC 9110 §15.5.6 requires:
 
 ```
 DELETE /api/v1/things/1     405   Allow: GET, PATCH
@@ -31,7 +46,9 @@ handler takes the mounted route table — the Application is the only place that
 knows the full path, prefix and version joined — and an app that supplies its
 own `onNotFound` is unaffected.
 
-Also fixes a related h3 bug found while testing this: `NodeResDriver.json()` set
+## An h3 bug this surfaced
+
+Not breaking — it makes h3 agree with the other two. `NodeResDriver.json()` set
 `application/json` unconditionally, clobbering a content-type the caller had
 already chosen. Every `application/problem+json` response went out mislabelled
 on that runtime alone — not only the new catch-all, but every `ProblemException`

--- a/.changeset/olive-moles-hunt.md
+++ b/.changeset/olive-moles-hunt.md
@@ -1,0 +1,29 @@
+---
+'@forinda/kickjs': patch
+---
+
+Fix the h3 runtime answering 200 for a malformed request body.
+
+The h3 runtime read bodies with `readBody(event).catch(() => undefined)`. That
+catch was there for the legitimate absent-body case, but it swallowed a PARSE
+failure just as readily — so broken JSON produced a **200**, with the handler
+running against `undefined`:
+
+| runtime | malformed JSON                                   |
+| ------- | ------------------------------------------------ |
+| express | `400 {"message":"Unexpected end of JSON input"}` |
+| fastify | `400 {"message":"Body is not valid JSON…"}`      |
+| h3      | `200 {"got":null}`                               |
+
+Worse than the wrong status: the client was told it succeeded, and the handler
+executed on data that never parsed — a create endpoint would write whatever its
+defaults were.
+
+The runtime now only skips the read when nothing was sent, deciding on
+`content-length` / `transfer-encoding` rather than on whether parsing threw.
+A body that is present but unparseable raises `HttpException.badRequest`, so all
+three runtimes answer 400.
+
+Covered by a matrix over all three: malformed JSON is rejected and the handler
+does not run, a well-formed body still works, and a request with no body at all
+still succeeds — that last one being why the original catch existed.

--- a/.changeset/olive-moles-hunt.md
+++ b/.changeset/olive-moles-hunt.md
@@ -27,3 +27,24 @@ three runtimes answer 400.
 Covered by a matrix over all three: malformed JSON is rejected and the handler
 does not run, a well-formed body still works, and a request with no body at all
 still succeeds — that last one being why the original catch existed.
+
+The same comparison turned up a second h3 divergence, also fixed here. h3 routes
+every thrown value through `createError()`, which returns its own error with the
+original on `cause`, and that wrapper was handed to the shared error middleware.
+Express and Fastify hand it the original, so responses differed by runtime for
+the same thrown value:
+
+| thrown                                | express / fastify             | h3 (before)                                 |
+| ------------------------------------- | ----------------------------- | ------------------------------------------- |
+| `HttpException(418, 'I am a teapot')` | `{"message":"I am a teapot"}` | `{"message":"I am a teapot","requestId":…}` |
+| `new Error('kaboom')` → `error` field | `Error: kaboom`               | `Error: kaboom ← caused by Error: kaboom`   |
+
+`instanceof HttpException` failed against the wrapper, so an expected 4xx fell
+through to the generic branch and picked up a `requestId` the other runtimes
+omit for that case. The runtime now unwraps an `Error` cause before delegating.
+h3's own 404 carries no cause, so the not-found path is untouched.
+
+A parity suite pins the catch-all and error mapping on all three: unknown route
+under the prefix, unknown route at the root, known path with the wrong method,
+`HttpException` status and body, an unexpected throw naming the error once with
+a correlation id, and a working route.

--- a/packages/kickjs/__tests__/error-handler-engine-neutral.test.ts
+++ b/packages/kickjs/__tests__/error-handler-engine-neutral.test.ts
@@ -64,6 +64,30 @@ describe('errorHandler — engine neutrality', () => {
   it('notFoundHandler answers through the runtime response surface', () => {
     const { res, calls } = makeRes()
     notFoundHandler()({ method: 'GET', url: '/nope', headers: {} } as never, res as never, () => {})
-    expect(calls[0]).toEqual({ status: 404, body: { message: 'Not Found' } })
+    expect(calls[0]).toEqual({
+      status: 404,
+      body: { type: 'about:blank', title: 'Not Found', status: 404 },
+    })
+  })
+
+  it('notFoundHandler answers 405 when the path exists under another method', () => {
+    // Given the mounted table, a matching path with a different verb is a 405,
+    // not a 404 — the resource is there and a 404 says otherwise.
+    const { res, calls } = makeRes()
+    notFoundHandler([
+      { method: 'GET', path: '/things/:id' },
+      { method: 'PATCH', path: '/things/:id' },
+    ])({ method: 'DELETE', url: '/things/7', headers: {} } as never, res as never, () => {})
+    expect(calls[0]).toMatchObject({ status: 405, body: { status: 405 } })
+  })
+
+  it('notFoundHandler still 404s a path no route matches', () => {
+    const { res, calls } = makeRes()
+    notFoundHandler([{ method: 'GET', path: '/things/:id' }])(
+      { method: 'GET', url: '/elsewhere', headers: {} } as never,
+      res as never,
+      () => {},
+    )
+    expect(calls[0]).toMatchObject({ status: 404 })
   })
 })

--- a/packages/kickjs/__tests__/exports.test.ts
+++ b/packages/kickjs/__tests__/exports.test.ts
@@ -266,6 +266,7 @@ describe('Custom error handlers (onNotFound, onError)', () => {
 
     const res = await request(app.getExpressApp()).get('/nonexistent')
     expect(res.status).toBe(404)
-    expect(res.body.message).toBe('Not Found')
+    // RFC 9457 problem details, matching every other error the framework emits.
+    expect(res.body).toEqual({ type: 'about:blank', title: 'Not Found', status: 404 })
   })
 })

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -31,7 +31,7 @@ import {
 } from '../core/disposables'
 import { getClassMeta } from '../core/metadata'
 import { requestId } from './middleware/request-id'
-import { notFoundHandler, errorHandler } from './middleware/error-handler'
+import { notFoundHandler, errorHandler, type MountedRoute } from './middleware/error-handler'
 import { requestScopeMiddleware, isRequestScopeMiddleware } from './middleware/request-scope'
 import {
   _setExternalContributorSources,
@@ -842,6 +842,12 @@ export class Application {
     // silently losing the dispatch race.
     const seenRoutes = new Map<string, string>()
 
+    // Every path this app mounts, for the catch-all: a request that matches a
+    // path but not its method is a 405, not a 404. Collected here because this
+    // is the only place that knows the FULL mounted path — prefix, version and
+    // controller route joined.
+    const mountedPaths: MountedRoute[] = []
+
     for (const mod of modules) {
       // Prefer the declared `name` field (set by `defineModule({ name: 'X', ... })`)
       // over `constructor.name`. Factory-built modules are plain objects whose
@@ -904,7 +910,9 @@ export class Application {
             for (const entry of routeTable) {
               // Per-handler owner so intra-controller duplicates name both methods.
               const owner = `${ctrl}.${String(entry.meta.handlerName ?? '?')}`
-              assertRouteUnique(seenRoutes, entry.method, joinPaths(mountPath, entry.path), owner)
+              const fullPath = joinPaths(mountPath, entry.path)
+              assertRouteUnique(seenRoutes, entry.method, fullPath, owner)
+              mountedPaths.push({ method: entry.method, path: fullPath })
             }
             this.runtime.mountRoutes(this.app, [{ mountPath, routes: routeTable }])
           } else {
@@ -983,7 +991,9 @@ export class Application {
     // ── 11. Error handlers ───────────────────────────────────────────
     // Last in the chain so any adapter-mounted route (step 10) gets
     // a chance to match before the catch-all 404 fires.
-    this.runtime.setNotFound(this.app, this.options.onNotFound ?? notFoundHandler())
+    // `onNotFound` / `onError` still win — the route table only sharpens the
+    // DEFAULT, so an app that supplies its own catch-all is unaffected.
+    this.runtime.setNotFound(this.app, this.options.onNotFound ?? notFoundHandler(mountedPaths))
     this.runtime.setErrorHandler(this.app, this.options.onError ?? errorHandler())
   }
 

--- a/packages/kickjs/src/http/middleware/error-handler.ts
+++ b/packages/kickjs/src/http/middleware/error-handler.ts
@@ -25,10 +25,71 @@ import {
 
 const log = createLogger('ErrorHandler')
 
-/** Catch-all for unmatched routes */
-export function notFoundHandler() {
-  return (_req: ErrorRequest, res: RuntimeResponse, _next: () => void) => {
-    res.status(404).json({ message: 'Not Found' })
+/** A mounted route, as the catch-all needs to see it. */
+export interface MountedRoute {
+  method: string
+  /** Full path as mounted, `:param` segments included. */
+  path: string
+}
+
+/** `/things/:id` → `^/things/[^/]+$`, so a concrete path can be matched. */
+function patternToRegExp(pattern: string): RegExp {
+  const source = pattern
+    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\/:[^/]+/g, '/[^/]+')
+    .replace(/\*/g, '.*')
+  return new RegExp(`^${source}/?$`)
+}
+
+/** Path without query string or hash. */
+function pathOf(req: ErrorRequest): string {
+  const url = req.originalUrl ?? req.url ?? '/'
+  const cut = url.search(/[?#]/)
+  return cut === -1 ? url : url.slice(0, cut)
+}
+
+/**
+ * Catch-all for unmatched routes.
+ *
+ * Answers RFC 9457 problem details, like every other error the framework
+ * produces — the catch-all was the one path still emitting a bare
+ * `{ message }`, so a client parsing `application/problem+json` had to special
+ * case it.
+ *
+ * Distinguishes a path that does not exist from a path that does not accept
+ * this method. `DELETE /things/1` where only `GET` is mounted is a **405** with
+ * an `Allow` header, not a 404: the resource is there, the verb is not, and
+ * 404 tells a client to stop looking for something that exists. Requires the
+ * mounted route table, so an app that does not pass one keeps answering 404.
+ */
+export function notFoundHandler(routes: readonly MountedRoute[] = []) {
+  const matchers = routes.map((route) => ({
+    method: route.method.toUpperCase(),
+    matches: patternToRegExp(route.path),
+  }))
+
+  return (req: ErrorRequest, res: RuntimeResponse, _next: () => void) => {
+    const path = pathOf(req)
+    const method = (req.method ?? 'GET').toUpperCase()
+    const allowed = [...new Set(matchers.filter((m) => m.matches.test(path)).map((m) => m.method))]
+
+    if (allowed.length > 0 && !allowed.includes(method)) {
+      // Sorted once: the header and the detail must list the same verbs in the
+      // same order, and `sort()` would mutate `allowed` under the second read.
+      const verbs = allowed.toSorted().join(', ')
+      // RFC 9110 §15.5.6 requires Allow on a 405.
+      res.setHeader('Allow', verbs)
+      res.setHeader('Content-Type', 'application/problem+json')
+      return res.status(405).json(
+        normalizeProblem({
+          status: 405,
+          detail: `${method} is not supported for this resource. Allowed: ${verbs}.`,
+        }),
+      )
+    }
+
+    res.setHeader('Content-Type', 'application/problem+json')
+    return res.status(404).json(normalizeProblem({ status: 404 }))
   }
 }
 

--- a/packages/kickjs/src/http/runtimes/h3.ts
+++ b/packages/kickjs/src/http/runtimes/h3.ts
@@ -24,6 +24,7 @@ import { applyHandlerResult } from '../reply'
 import { requestStore } from '../request-store'
 import { createRequestStore, disposeRequestStore } from '../middleware/request-scope'
 import { validate } from '../middleware/validate'
+import { HttpException } from '../../core/errors'
 import { applyUploadConfig, type RawUploadPart } from '../middleware/upload'
 import type {
   ConnectMiddleware,
@@ -165,7 +166,22 @@ function makeEventHandler(entry: RouteEntry): (event: H3EventLike) => Promise<vo
       req.files = files
       req.body = fields
     } else if (BODY_METHODS.has(req.method ?? 'GET')) {
-      req.body = await readBody(event).catch(() => undefined)
+      // Swallow ONLY the absent-body case. `.catch(() => undefined)` also
+      // swallowed a malformed one, so h3 answered 200 with the handler running
+      // on `undefined` where Express and Fastify both answer 400 — a client
+      // sending broken JSON got a success response, and the handler executed
+      // against data that was never valid.
+      const { 'content-length': length, 'transfer-encoding': encoding } = req.headers
+      const sentBody = encoding !== undefined || (length !== undefined && length !== '0')
+      if (sentBody) {
+        try {
+          req.body = await readBody(event)
+        } catch (err) {
+          throw HttpException.badRequest(
+            err instanceof Error ? err.message : 'Request body could not be parsed',
+          )
+        }
+      }
     }
 
     const headerId = req.headers['x-request-id']

--- a/packages/kickjs/src/http/runtimes/h3.ts
+++ b/packages/kickjs/src/http/runtimes/h3.ts
@@ -227,6 +227,26 @@ function makeEventHandler(entry: RouteEntry): (event: H3EventLike) => Promise<vo
 }
 
 /**
+ * The original error h3 wrapped.
+ *
+ * h3 routes every thrown value through `createError()`, which returns its own
+ * error with the original on `cause`. Handing that wrapper to the shared error
+ * middleware means it sees something Express and Fastify never give it, and the
+ * responses diverge: `instanceof HttpException` fails, so a thrown
+ * `HttpException(418)` falls through to the generic branch and picks up a
+ * `requestId` the other two omit, and `describeError` walks the cause chain to
+ * report `kaboom ← caused by kaboom`.
+ *
+ * Only an `Error` cause is unwrapped. h3's own 404 carries no cause, so the
+ * not-found path above is unaffected.
+ */
+function unwrapH3Error(error: unknown): unknown {
+  if (!(error instanceof Error)) return error
+  const { cause } = error as { cause?: unknown }
+  return cause instanceof Error ? cause : error
+}
+
+/**
  * The h3 HTTP runtime. Pass to `bootstrap({ runtime: h3Runtime() })`.
  * h3 parses bodies itself (`readBody`), so the Application skips its default
  * `express.json()` (see `nativeBodyParsing`).
@@ -270,7 +290,7 @@ export function h3Runtime(): HttpRuntime<H3AppLike> {
           const mw = state[ERROR_MW]
           if (mw) {
             ;(mw as (e: unknown, req: unknown, res: unknown, next: () => void) => void)(
-              error,
+              unwrapH3Error(error),
               event.node.req,
               resDriver(res),
               NOOP_NEXT,

--- a/packages/kickjs/src/http/runtimes/h3.ts
+++ b/packages/kickjs/src/http/runtimes/h3.ts
@@ -72,7 +72,14 @@ class NodeResDriver implements RuntimeResponse {
     return this
   }
   json(data: unknown): this {
-    if (!this.res.headersSent) this.res.setHeader('content-type', 'application/json; charset=utf-8')
+    // Do not clobber a content-type the caller already chose. This used to set
+    // `application/json` unconditionally, so every `application/problem+json`
+    // response — RFC 9457 problem details, which the error handler sets the
+    // header for before serialising — went out as plain JSON on this runtime
+    // alone. Express and Fastify both leave an existing value alone.
+    if (!this.res.headersSent && !this.res.getHeader('content-type')) {
+      this.res.setHeader('content-type', 'application/json; charset=utf-8')
+    }
     this.res.end(JSON.stringify(data))
     return this
   }

--- a/packages/testing/__tests__/body-parse-errors.test.ts
+++ b/packages/testing/__tests__/body-parse-errors.test.ts
@@ -1,0 +1,74 @@
+/**
+ * A malformed body is a client error on every runtime.
+ *
+ * The h3 runtime read the body with `.catch(() => undefined)`, which swallowed
+ * a PARSE failure as well as an absent body. So broken JSON produced a 200 and
+ * the handler ran against `undefined`, where Express and Fastify both answer
+ * 400. Worse than the wrong status: the handler executed on data that was
+ * never valid, and the client was told it succeeded.
+ *
+ * @module @forinda/kickjs-testing/__tests__/body-parse-errors.test
+ */
+
+import { describe, expect, it } from 'vitest'
+import request from 'supertest'
+import { Controller, Post, expressRuntime, type RequestContext } from '@forinda/kickjs'
+
+// Source paths: this package's vitest alias maps the bare specifier at src/index.ts.
+import { fastifyRuntime } from '../../kickjs/src/http/runtimes/fastify'
+import { h3Runtime } from '../../kickjs/src/http/runtimes/h3'
+import { createTestApp, createTestModule } from '../src/index'
+
+@Controller()
+class EchoController {
+  @Post('/')
+  create(ctx: RequestContext) {
+    return { got: (ctx.body as { a?: number })?.a ?? null }
+  }
+}
+
+const EchoModule = createTestModule({
+  register: () => {},
+  routes: () => ({ path: '/echo', controller: EchoController }),
+})
+
+const runtimes = [
+  { name: 'express', make: () => expressRuntime() },
+  { name: 'fastify', make: () => fastifyRuntime() },
+  { name: 'h3', make: () => h3Runtime() },
+] as const
+
+describe.each(runtimes)('body parsing on $name', ({ make }) => {
+  async function agent() {
+    const { app } = await createTestApp({ modules: [EchoModule], runtime: make(), isolated: true })
+    return request(app.handle.bind(app))
+  }
+
+  it('rejects malformed JSON with a client error', async () => {
+    const res = await (
+      await agent()
+    )
+      .post('/api/v1/echo')
+      .set('Content-Type', 'application/json')
+      .send('{"a":')
+
+    expect(res.status).toBe(400)
+    // The handler must not have run — a success body here means the request was
+    // accepted on data that never parsed.
+    expect(res.body).not.toHaveProperty('got')
+  })
+
+  it('accepts a well-formed body', async () => {
+    const res = await (await agent()).post('/api/v1/echo').send({ a: 1 })
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ got: 1 })
+  })
+
+  it('still allows a request with no body at all', async () => {
+    // The absent-body case is why the h3 catch existed; tightening it must not
+    // turn "nothing sent" into an error.
+    const res = await (await agent()).post('/api/v1/echo')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ got: null })
+  })
+})

--- a/packages/testing/__tests__/error-parity.test.ts
+++ b/packages/testing/__tests__/error-parity.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Catch-all and error handling must agree across runtimes.
+ *
+ * Express brings opinionated defaults — a 404 fall-through, an error middleware
+ * signature, `originalUrl` — and the framework was written against them. The
+ * other two engines reach the same shared middleware by a different road, so
+ * anything the road changes shows up as a response that differs by runtime for
+ * the same thrown value.
+ *
+ * h3 was the outlier: it routes every thrown value through `createError()`,
+ * which wraps the original on `cause`. The shared handler then failed
+ * `instanceof HttpException`, so a thrown `HttpException(418)` fell through to
+ * the generic branch and gained a `requestId` the other two omit, and
+ * `describeError` walked the chain to report `kaboom ← caused by kaboom`.
+ *
+ * @module @forinda/kickjs-testing/__tests__/error-parity.test
+ */
+
+import { describe, expect, it } from 'vitest'
+import request from 'supertest'
+import {
+  Controller,
+  Get,
+  HttpException,
+  expressRuntime,
+  type RequestContext,
+} from '@forinda/kickjs'
+
+// Source paths: this package's vitest alias maps the bare specifier at src/index.ts.
+import { fastifyRuntime } from '../../kickjs/src/http/runtimes/fastify'
+import { h3Runtime } from '../../kickjs/src/http/runtimes/h3'
+import { createTestApp, createTestModule } from '../src/index'
+
+@Controller()
+class ThingsController {
+  @Get('/ok')
+  ok(_ctx: RequestContext) {
+    return { ok: true }
+  }
+
+  @Get('/boom')
+  boom(_ctx: RequestContext): never {
+    throw new Error('kaboom')
+  }
+
+  @Get('/teapot')
+  teapot(_ctx: RequestContext): never {
+    throw new HttpException(418, 'I am a teapot')
+  }
+}
+
+const ThingsModule = createTestModule({
+  register: () => {},
+  routes: () => ({ path: '/things', controller: ThingsController }),
+})
+
+const runtimes = [
+  { name: 'express', make: () => expressRuntime() },
+  { name: 'fastify', make: () => fastifyRuntime() },
+  { name: 'h3', make: () => h3Runtime() },
+] as const
+
+describe.each(runtimes)('error handling on $name', ({ make }) => {
+  async function agent() {
+    const { app } = await createTestApp({
+      modules: [ThingsModule],
+      runtime: make(),
+      isolated: true,
+    })
+    return request(app.handle.bind(app))
+  }
+
+  it('404s an unknown route under the API prefix', async () => {
+    const res = await (await agent()).get('/api/v1/nope')
+    expect(res.status).toBe(404)
+    expect(res.body).toEqual({ message: 'Not Found' })
+  })
+
+  it('404s an unknown route at the root, outside the prefix', async () => {
+    // The catch-all has to cover paths the router never mounted at all, not
+    // just misses inside the API prefix.
+    const res = await (await agent()).get('/definitely-nothing')
+    expect(res.status).toBe(404)
+  })
+
+  it('404s a known path with the wrong method', async () => {
+    const res = await (await agent()).delete('/api/v1/things/ok')
+    expect(res.status).toBe(404)
+  })
+
+  it('maps a thrown HttpException to its own status and body', async () => {
+    // Identical on all three: no `requestId` on an expected 4xx. h3 used to add
+    // one because its wrapper defeated the `instanceof` check.
+    const res = await (await agent()).get('/api/v1/things/teapot')
+    expect(res.status).toBe(418)
+    expect(res.body).toEqual({ message: 'I am a teapot' })
+  })
+
+  it('maps an unexpected throw to a 500 that names the error once', async () => {
+    const res = await (await agent()).get('/api/v1/things/boom')
+    expect(res.status).toBe(500)
+    expect(res.body.message).toBe('Internal Server Error')
+    // Correlation id on unexpected errors, in every environment.
+    expect(res.body.requestId).toBeTruthy()
+    // Once — h3's wrapper produced `kaboom ← caused by kaboom`.
+    expect(res.body.error).toBe('Error: kaboom')
+  })
+
+  it('still serves a working route', async () => {
+    const res = await (await agent()).get('/api/v1/things/ok')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ ok: true })
+  })
+})

--- a/packages/testing/__tests__/error-parity.test.ts
+++ b/packages/testing/__tests__/error-parity.test.ts
@@ -70,10 +70,11 @@ describe.each(runtimes)('error handling on $name', ({ make }) => {
     return request(app.handle.bind(app))
   }
 
-  it('404s an unknown route under the API prefix', async () => {
+  it('404s an unknown route under the API prefix, as problem details', async () => {
     const res = await (await agent()).get('/api/v1/nope')
     expect(res.status).toBe(404)
-    expect(res.body).toEqual({ message: 'Not Found' })
+    expect(res.headers['content-type']).toContain('application/problem+json')
+    expect(res.body).toEqual({ type: 'about:blank', title: 'Not Found', status: 404 })
   })
 
   it('404s an unknown route at the root, outside the prefix', async () => {
@@ -83,8 +84,22 @@ describe.each(runtimes)('error handling on $name', ({ make }) => {
     expect(res.status).toBe(404)
   })
 
-  it('404s a known path with the wrong method', async () => {
+  it('405s a known path with the wrong method, and says what is allowed', async () => {
+    // The resource exists; the verb does not. A 404 here tells a client to stop
+    // looking for something that is right there.
     const res = await (await agent()).delete('/api/v1/things/ok')
+    expect(res.status).toBe(405)
+    // RFC 9110 §15.5.6 requires Allow on a 405.
+    expect(res.headers.allow).toBe('GET')
+    expect(res.headers['content-type']).toContain('application/problem+json')
+    expect(res.body).toMatchObject({ status: 405, title: 'Method Not Allowed' })
+    expect(res.body.detail).toContain('GET')
+  })
+
+  it('404s a path that does not exist at all, even with a mounted sibling', async () => {
+    // `/things/nope` shares a prefix with mounted routes but matches none, so
+    // it is genuinely absent — not a method problem.
+    const res = await (await agent()).get('/api/v1/things/nope')
     expect(res.status).toBe(404)
   })
 
@@ -104,6 +119,14 @@ describe.each(runtimes)('error handling on $name', ({ make }) => {
     expect(res.body.requestId).toBeTruthy()
     // Once — h3's wrapper produced `kaboom ← caused by kaboom`.
     expect(res.body.error).toBe('Error: kaboom')
+  })
+
+  it('sends problem details as problem+json, not plain JSON', async () => {
+    // The h3 driver used to set `application/json` unconditionally in `json()`,
+    // clobbering the content-type the error handler had already chosen — so
+    // every RFC 9457 response went out mislabelled on that runtime alone.
+    const res = await (await agent()).get('/api/v1/nope')
+    expect(res.headers['content-type']).toContain('application/problem+json')
   })
 
   it('still serves a working route', async () => {

--- a/packages/testing/__tests__/testing.test.ts
+++ b/packages/testing/__tests__/testing.test.ts
@@ -372,8 +372,10 @@ describe('createTestApp bootstrap option forwarding', () => {
 
     const res = await request(expressApp).get('/api/v1/missing')
     expect(res.status).toBe(404)
-    // Built-in handler returns { message: 'Not Found' }
-    expect(res.body).toHaveProperty('message')
+    // The built-in catch-all answers RFC 9457 problem details, like every other
+    // error the framework produces. It used to emit a bare `{ message }`, which
+    // made it the one response a problem+json client had to special case.
+    expect(res.body).toEqual({ type: 'about:blank', title: 'Not Found', status: 404 })
   })
 })
 


### PR DESCRIPTION
**Major — `@forinda/kickjs` 7.4.0 → 8.0.0.** Two responses change for apps that never asked for either.

### Migrating

- A client asserting `body.message === 'Not Found'` reads `body.title` or `body.status`, or restores the old shape with `bootstrap({ onNotFound })`.
- A client treating "known path, wrong verb" as 404 now sees **405**. Correct, but it moves the case from one branch to another.

The h3 content-type fix below is **not** breaking — it makes that runtime agree with Express and Fastify, which were already right.

---

Both defaults reached through the existing bootstrap options — `onNotFound` and `onError` still win, so this only sharpens what an app gets when it supplies neither.

## Problem details from the catch-all

**Breaking: the default 404 body changed.**

```diff
- { "message": "Not Found" }
+ { "type": "about:blank", "title": "Not Found", "status": 404 }
```
`Content-Type: application/problem+json`

The catch-all was the last response still emitting a bare `{ message }`, so a client parsing `application/problem+json` — which the framework already returns for every `ProblemException` — had to special-case exactly one path. `bootstrap({ onNotFound })` restores the old shape in a line.

## 405 for a wrong verb

```
DELETE /api/v1/things/1     405   Allow: GET, PATCH

{ "type": "about:blank", "title": "Method Not Allowed", "status": 405,
  "detail": "DELETE is not supported for this resource. Allowed: GET, PATCH." }
```

A 404 there tells a client to stop looking for a resource that is present. `Allow` is required on a 405 by RFC 9110 §15.5.6.

The handler takes the mounted route table, collected in `Application.setup()` — the only place that knows the full path with prefix, version and controller route joined. Called without one it still answers 404, so nothing regresses for another caller.

Path matching converts `:param` to a segment wildcard, so `/things/:id` matches `/things/7` but not `/things/7/extra`. A sibling path that matches no route is still a 404, not a 405 — there's a test for that, since it's the case a naive prefix check gets wrong.

## A third h3 divergence, found by testing this

`NodeResDriver.json()` set `application/json` unconditionally, clobbering a content-type the caller had already chosen:

```ts
if (!this.res.headersSent) this.res.setHeader('content-type', 'application/json; charset=utf-8')
```

So **every `application/problem+json` response went out mislabelled on h3** — not just the new catch-all, but every `ProblemException` the error handler has emitted there since problem support landed. Express and Fastify both leave an existing value alone.

That makes three h3-only divergences from this line of testing (malformed body → 200, error wrapper defeating `instanceof`, content-type clobbering), all of which were invisible while the tests compared Express with Fastify.

## Tests

Runtime matrix over all three: unknown path under the prefix, unknown path at the root, wrong method with `Allow`, a sibling path matching no route, problem+json content type, `HttpException` mapping, unexpected throw, and a working route. Plus unit coverage of the handler with and without a route table.

**Four existing tests asserted the old `{ message }` shape and were updated** — that's the breaking change, visible in the diff rather than described around.

Monorepo green: kickjs 858, testing 104, CLI 767.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViFD8FXyNzwnAd3ixx7biB
