### PR TITLE
fix(kickjs): report a rejected upload as 413/415 on Express too

### DIFF
--- a/.changeset/eighty-jars-smile.md
+++ b/.changeset/eighty-jars-smile.md
@@ -1,0 +1,30 @@
+---
+'@forinda/kickjs': patch
+---
+
+Answer 413 / 415 for a rejected upload on Express, matching the other runtimes.
+
+`@FileUpload` enforces `maxSize` and `allowedTypes` through a different backend
+per engine — Multer under Express, `@fastify/multipart` under Fastify,
+`readMultipartFormData` under h3 — and only two of the three reported a
+violation as the client's:
+
+| upload          | express                                                                | fastify / h3                                   |
+| --------------- | ---------------------------------------------------------------------- | ---------------------------------------------- |
+| over `maxSize`  | **500** `MulterError: File too large`, with a Multer stack in the body | `413` `File big.txt exceeds the 16-byte limit` |
+| disallowed type | **500** `Error: File type text/plain is not allowed`                   | `415` `File type text/plain is not allowed`    |
+
+So an Express app told the client it had itself failed, for a file the client
+chose — and leaked a Multer stack trace doing it.
+
+Multer's `LIMIT_FILE_SIZE` is now translated to `HttpException(413)` and the
+type filter raises `HttpException(415)` directly, matching the messages
+`applyUploadConfig` already produced on the other engines.
+
+One difference remains and is documented rather than papered over: on a 413
+Express names the form **field** where the others name the **file**, because
+Multer's error carries no filename. Status and limit are identical.
+
+Found by running `@FileUpload` and route validation as a runtime matrix.
+Validation was already consistent across all three, including that the schema's
+transform reaches the handler and not just its check.

--- a/docs/guide/file-uploads.md
+++ b/docs/guide/file-uploads.md
@@ -153,6 +153,26 @@ All middleware methods accept an `UploadOptions` object:
 | `storage`       | Multer `StorageEngine`     | memory                   | Custom Multer storage engine (Express only) |
 | `dest`          | `string`                   | —                        | Disk storage destination dir, Express only  |
 
+## What a rejected upload returns
+
+A violation is the client's, so it answers 4xx — identically on every runtime,
+even though each engine detects it in its own backend:
+
+| Violation                  | Status                       | Body                                               |
+| -------------------------- | ---------------------------- | -------------------------------------------------- |
+| Larger than `maxSize`      | `413 Payload Too Large`      | `{ "message": "File … exceeds the N-byte limit" }` |
+| Type not in `allowedTypes` | `415 Unsupported Media Type` | `{ "message": "File type … is not allowed" }`      |
+
+::: tip Express names the field, the others name the file
+On a `413`, Express reports the form **field** (`doc`) where Fastify and h3
+report the **filename** (`big.txt`) — Multer's `LIMIT_FILE_SIZE` error carries
+no filename to pass on. The status and the limit are identical, so branch on
+those rather than parsing the message.
+:::
+
+Both are `HttpException`s, so `onError` sees them like any other and can reshape
+the body.
+
 ## Allowed Types — Value or Function
 
 `allowedTypes` follows a Vue-style pattern: pass a **value** (string array) or a **function** for full control.

--- a/packages/kickjs/src/http/middleware/upload.ts
+++ b/packages/kickjs/src/http/middleware/upload.ts
@@ -1,3 +1,4 @@
+import { HttpException, HttpStatus } from '../../core/errors'
 import { unlink } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import type { Request, Response, NextFunction, RequestHandler } from 'express'
@@ -54,6 +55,32 @@ export interface UploadOptions extends BaseUploadOptions {
   dest?: string
 }
 
+/**
+ * Turn multer's own errors into the exceptions the other runtimes raise.
+ *
+ * multer reports a file over the limit as `MulterError: File too large`, a
+ * plain error the handler maps to 500 — so an oversized upload was reported as
+ * a server fault on Express while Fastify and h3 answered 413. The message is
+ * matched to `applyUploadConfig` so the response does not depend on the engine.
+ */
+function translateMulterErrors(mw: RequestHandler, options: UploadOptions): RequestHandler {
+  const maxSize = options.maxSize ?? 5 * 1024 * 1024
+  return (req, res, next) => {
+    mw(req, res, (err?: unknown) => {
+      if (err && (err as { code?: string }).code === 'LIMIT_FILE_SIZE') {
+        const name = (err as { field?: string }).field ?? 'file'
+        return next(
+          new HttpException(
+            HttpStatus.PAYLOAD_TOO_LARGE,
+            `File ${name} exceeds the ${maxSize}-byte limit`,
+          ),
+        )
+      }
+      next(err as never)
+    })
+  }
+}
+
 function createMulter(options: UploadOptions) {
   const limits: MulterOptions['limits'] = {
     fileSize: options.maxSize ?? 5 * 1024 * 1024,
@@ -66,7 +93,16 @@ function createMulter(options: UploadOptions) {
       if (typeAllowed(file.mimetype, file.originalname)) {
         cb(null, true)
       } else {
-        cb(new Error(`File type ${file.mimetype} is not allowed`))
+        // Same exception the Fastify and h3 path raises from
+        // `applyUploadConfig`. A plain Error here reached the handler as a 500,
+        // so Express blamed itself for the client's file — and leaked a multer
+        // stack doing it.
+        cb(
+          new HttpException(
+            HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+            `File type ${file.mimetype} is not allowed`,
+          ),
+        )
       }
     }
   }
@@ -95,7 +131,7 @@ function createMulter(options: UploadOptions) {
  */
 function single(fieldName: string, options: UploadOptions = {}): RequestHandler {
   const m = createMulter(options)
-  return m.single(fieldName) as RequestHandler
+  return translateMulterErrors(m.single(fieldName) as RequestHandler, options)
 }
 
 /**
@@ -103,7 +139,7 @@ function single(fieldName: string, options: UploadOptions = {}): RequestHandler 
  */
 function array(fieldName: string, maxCount = 10, options: UploadOptions = {}): RequestHandler {
   const m = createMulter(options)
-  return m.array(fieldName, maxCount) as RequestHandler
+  return translateMulterErrors(m.array(fieldName, maxCount) as RequestHandler, options)
 }
 
 /**
@@ -111,7 +147,7 @@ function array(fieldName: string, maxCount = 10, options: UploadOptions = {}): R
  */
 function none(options: UploadOptions = {}): RequestHandler {
   const m = createMulter(options)
-  return m.none() as RequestHandler
+  return translateMulterErrors(m.none() as RequestHandler, options)
 }
 
 /**

--- a/packages/testing/__tests__/upload-validate-matrix.test.ts
+++ b/packages/testing/__tests__/upload-validate-matrix.test.ts
@@ -1,0 +1,213 @@
+/**
+ * `@FileUpload` and route validation, on every runtime.
+ *
+ * These two diverge the most by construction. Uploads use a different backend
+ * per engine — multer under Express, `@fastify/multipart` under Fastify,
+ * `readMultipartFormData` under h3 — so `ctx.file` / `ctx.files` are assembled
+ * three separate ways and only end-to-end tests compare the results. Validation
+ * runs before the handler on every engine but reads a body each one parsed
+ * differently.
+ *
+ * @module @forinda/kickjs-testing/__tests__/upload-validate-matrix.test
+ */
+
+import { describe, expect, it } from 'vitest'
+import request from 'supertest'
+import { z } from 'zod'
+import { Controller, FileUpload, Post, expressRuntime, type RequestContext } from '@forinda/kickjs'
+
+// Source paths: this package's vitest alias maps the bare specifier at src/index.ts.
+import { fastifyRuntime } from '../../kickjs/src/http/runtimes/fastify'
+import { h3Runtime } from '../../kickjs/src/http/runtimes/h3'
+import { createTestApp, createTestModule } from '../src/index'
+
+const createBody = z.object({ name: z.string().min(2), age: z.coerce.number().int().min(0) })
+
+@Controller()
+class UploadController {
+  @Post('/one')
+  @FileUpload({ mode: 'single', fieldName: 'doc' })
+  one(ctx: RequestContext) {
+    const file = ctx.file as { originalname?: string; size?: number; mimetype?: string } | undefined
+    return {
+      name: file?.originalname ?? null,
+      size: file?.size ?? null,
+      type: file?.mimetype ?? null,
+      // Text fields sent alongside the file must survive too.
+      title: (ctx.body as { title?: string } | undefined)?.title ?? null,
+    }
+  }
+
+  @Post('/many')
+  @FileUpload({ mode: 'array', fieldName: 'docs', maxCount: 3 })
+  many(ctx: RequestContext) {
+    const files = (ctx.files ?? []) as Array<{ originalname?: string }>
+    return { count: files.length, names: files.map((f) => f.originalname ?? null) }
+  }
+
+  @Post('/limited')
+  @FileUpload({ mode: 'single', fieldName: 'doc', maxSize: 16 })
+  limited(ctx: RequestContext) {
+    return { name: (ctx.file as { originalname?: string } | undefined)?.originalname ?? null }
+  }
+
+  @Post('/images')
+  @FileUpload({ mode: 'single', fieldName: 'doc', allowedTypes: ['png'] })
+  images(ctx: RequestContext) {
+    return { name: (ctx.file as { originalname?: string } | undefined)?.originalname ?? null }
+  }
+
+  @Post('/validated', { body: createBody })
+  validated(ctx: RequestContext) {
+    return { received: ctx.body }
+  }
+}
+
+const UploadModule = createTestModule({
+  register: () => {},
+  routes: () => ({ path: '/files', controller: UploadController }),
+})
+
+const runtimes = [
+  { name: 'express', make: () => expressRuntime() },
+  { name: 'fastify', make: () => fastifyRuntime() },
+  { name: 'h3', make: () => h3Runtime() },
+] as const
+
+describe.each(runtimes)('uploads and validation on $name', ({ make }) => {
+  async function agent() {
+    const { app } = await createTestApp({
+      modules: [UploadModule],
+      runtime: make(),
+      isolated: true,
+    })
+    return request(app.handle.bind(app))
+  }
+
+  describe('@FileUpload single', () => {
+    it('exposes the file with its name, size and type', async () => {
+      const res = await (
+        await agent()
+      )
+        .post('/api/v1/files/one')
+        .attach('doc', Buffer.from('hello world'), {
+          filename: 'note.txt',
+          contentType: 'text/plain',
+        })
+
+      expect(res.status).toBe(200)
+      expect(res.body.name).toBe('note.txt')
+      expect(res.body.size).toBe(11)
+      expect(res.body.type).toContain('text/plain')
+    })
+
+    it('keeps text fields sent alongside the file', async () => {
+      // Multipart carries both; an engine that reads only the file loses these.
+      const res = await (
+        await agent()
+      )
+        .post('/api/v1/files/one')
+        .field('title', 'my upload')
+        .attach('doc', Buffer.from('x'), { filename: 'a.txt', contentType: 'text/plain' })
+
+      expect(res.status).toBe(200)
+      expect(res.body.title).toBe('my upload')
+    })
+
+    it('leaves ctx.file empty when no file is sent', async () => {
+      const res = await (await agent()).post('/api/v1/files/one').field('title', 'no file')
+      expect(res.status).toBe(200)
+      expect(res.body.name).toBeNull()
+    })
+  })
+
+  describe('@FileUpload array', () => {
+    it('collects every file under the field', async () => {
+      const res = await (
+        await agent()
+      )
+        .post('/api/v1/files/many')
+        .attach('docs', Buffer.from('a'), { filename: 'a.txt', contentType: 'text/plain' })
+        .attach('docs', Buffer.from('b'), { filename: 'b.txt', contentType: 'text/plain' })
+
+      expect(res.status).toBe(200)
+      expect(res.body.count).toBe(2)
+      expect(res.body.names).toEqual(['a.txt', 'b.txt'])
+    })
+  })
+
+  describe('@FileUpload limits', () => {
+    it('rejects a file over maxSize with the same status everywhere', async () => {
+      // multer, @fastify/multipart and readMultipartFormData each enforce this
+      // differently; the response an adopter sees must not depend on that.
+      const res = await (
+        await agent()
+      )
+        .post('/api/v1/files/limited')
+        .attach('doc', Buffer.alloc(64, 'x'), { filename: 'big.txt', contentType: 'text/plain' })
+
+      // 413, not 500: an oversized upload is the client's doing. Express used
+      // to surface multer's raw `MulterError: File too large` as a server
+      // fault, stack included, while the other two answered 413.
+      expect(res.status).toBe(413)
+      // Express names the FIELD here and the others the filename — multer's
+      // LIMIT_FILE_SIZE error carries no filename to report. The status and the
+      // limit are what a client acts on, so those are what this pins.
+      expect(res.body.message).toContain('exceeds the 16-byte limit')
+    })
+
+    it('accepts a file under maxSize', async () => {
+      const res = await (
+        await agent()
+      )
+        .post('/api/v1/files/limited')
+        .attach('doc', Buffer.from('small'), { filename: 'ok.txt', contentType: 'text/plain' })
+      expect(res.status).toBe(200)
+      expect(res.body.name).toBe('ok.txt')
+    })
+
+    it('rejects a disallowed file type with the same status everywhere', async () => {
+      const res = await (
+        await agent()
+      )
+        .post('/api/v1/files/images')
+        .attach('doc', Buffer.from('not-an-image'), {
+          filename: 'note.txt',
+          contentType: 'text/plain',
+        })
+
+      expect(res.status).toBe(415)
+      expect(res.body.message).toBe('File type text/plain is not allowed')
+    })
+  })
+
+  describe('validation', () => {
+    it('accepts a valid body', async () => {
+      const res = await (
+        await agent()
+      )
+        .post('/api/v1/files/validated')
+        .send({ name: 'kim', age: 30 })
+      expect(res.status).toBe(200)
+      expect(res.body.received).toMatchObject({ name: 'kim', age: 30 })
+    })
+
+    it('rejects an invalid body with 422', async () => {
+      const res = await (await agent()).post('/api/v1/files/validated').send({ name: 'k', age: -1 })
+      expect(res.status).toBe(422)
+    })
+
+    it('applies the schema transform, not just the check', async () => {
+      // `z.coerce.number()` means the handler must see a number, not the "30"
+      // that arrived. An engine that validates a parsed copy but hands the
+      // handler the raw body would pass the check and fail here.
+      const res = await (
+        await agent()
+      )
+        .post('/api/v1/files/validated')
+        .send({ name: 'kim', age: '30' })
+      expect(res.status).toBe(200)
+      expect(res.body.received.age).toBe(30)
+    })
+  })
+})


### PR DESCRIPTION
Continues the runtime-matrix sweep with the two remaining middlewares. Uploads diverge most by construction — a different backend per engine — and validation reads a body each one parsed differently.

## Validation was already consistent

Worth stating first, since it bounds the result: all three runtimes agree on accepting a valid body, rejecting an invalid one with 422, and — the case I expected to break — **applying the schema's transform rather than only its check**. `z.coerce.number()` means the handler must see `30`, not the `"30"` that arrived; an engine validating a parsed copy while handing the handler the raw body would pass the check and fail there. None do.

## Uploads: Express was the outlier

| upload | express | fastify / h3 |
| --- | --- | --- |
| over `maxSize` | **500** `MulterError: File too large`, with a Multer stack in the body | `413` `File big.txt exceeds the 16-byte limit` |
| disallowed type | **500** `Error: File type text/plain is not allowed` | `415` `File type text/plain is not allowed` |

An Express app told the client **it** had failed, for a file the client chose, and leaked a Multer stack doing it.

`applyUploadConfig` already raised `HttpException(413/415)` on the Fastify and h3 path. The Express path let Multer's own errors through: `LIMIT_FILE_SIZE` is now translated to `HttpException(413)` and the type filter raises `HttpException(415)` directly, reusing the same messages.

## One difference left, documented rather than faked

On a 413, Express names the form **field** (`doc`) where the others name the **file** (`big.txt`) — Multer's error carries no filename to pass on. Status and limit are identical, so the tests pin those and the guide says to branch on them rather than parse the message.

## Docs

You asked whether the docs explain the per-runtime variation. They do, and well — `docs/guide/file-uploads.md` already has the backend table, states that `upload` / `cleanupFiles()` are Multer-specific and therefore Express-only, and explains why `@FileUpload` deliberately has no `storage` / `dest` so the decorator behaves identically everywhere.

What it lacked was **what a violation returns**. Added: the 413/415 contract, the field-vs-filename caveat, and that both are `HttpException`s so `onError` can reshape them.

## Matrix

30 cases × 3 runtimes: single upload (name/size/type), text fields alongside a file, no file sent, array collection, `maxSize`, `allowedTypes`, and validation accept / reject / transform.

Verified load-bearing by sabotage: dropping h3's multipart field collection fails the text-fields case; removing validation's write-back fails the transform case on all three; reverting the Multer translation fails both Express limit cases.

Monorepo green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViFD8FXyNzwnAd3ixx7biB
