### PR TITLE
feat(kickjs): extract the health endpoints into a module

### DIFF
--- a/.changeset/olive-pears-argue.md
+++ b/.changeset/olive-pears-argue.md
@@ -1,0 +1,38 @@
+---
+'@forinda/kickjs': minor
+---
+
+The built-in health endpoints are a module you can see.
+
+`GET /health/live` and `GET /health/ready` were mounted straight onto the engine
+with `http.route()`, ahead of the middleware chain. That worked, and made them
+invisible in three ways:
+
+- **The OpenAPI spec never had them.** The generator builds from controller
+  decorators, and a raw route carries none — so the only two routes the
+  framework itself serves were missing from every spec.
+- **`logRouteTable` never listed them**, along with anything else reading the
+  route registry.
+- **Nothing in an adopter's code said they existed.** `kick g adapter` documents
+  `onHealthCheck`, but the endpoint consuming it appeared nowhere, so people
+  wrote their own `/health/ready` next to the built-in one.
+
+They are now `healthModule()` — a `defineModule` factory with a real
+`HealthController`, registered automatically. It reads draining state and
+adapter checks through a `HEALTH_PROBE` token rather than Application
+internals, so a replacement module can satisfy the same contract.
+
+Paths and bodies are unchanged, verified on Express, Fastify and h3. `prefix:
+false` keeps them at the root: a probe URL an orchestrator is configured against
+must not move when `apiPrefix` or the API version does.
+
+**Behaviour change worth knowing:** mounting with the other modules puts them
+INSIDE the middleware chain, where they previously sat ahead of it. An app with
+global auth will now require auth on its probes. That is the correct default —
+an app controls its own auth, and a framework route quietly bypassing it is the
+surprise — but it is a change. Exempt the path as you would any other, or pass
+`health: false` and mount your own.
+
+`ModuleRoutes` gains `prefix?: false` for this, and it is useful beyond health:
+a provider's fixed webhook URL or a `/.well-known` document has the same problem
+of being dragged around by a prefix that has nothing to do with it.

--- a/packages/kickjs/__tests__/log-routes-table.test.ts
+++ b/packages/kickjs/__tests__/log-routes-table.test.ts
@@ -219,9 +219,18 @@ describe('logRouteTable option', () => {
     expect(userLine).toMatch(/PUT/)
     expect(userLine).toMatch(/PATCH/)
 
-    // Total should be 6 routes
+    // The built-in health module contributes GET /health/live and
+    // /health/ready, so 6 app routes plus 2. They appear here at all only
+    // because health is now a module — a raw `http.route()` mount was absent
+    // from this table, from the OpenAPI spec, and from anything else that
+    // reads the route registry.
+    const healthLine = messages.find((m: string) => m.includes('HealthController'))
+    expect(healthLine, 'health routes should appear in the route table').toBeDefined()
+    expect(healthLine).toMatch(/\/health/)
+    expect(healthLine).toMatch(/2 routes/)
+
     const totalLine = messages.find((m: string) => m.includes('Total:'))
-    expect(totalLine).toMatch(/6 routes/)
+    expect(totalLine).toMatch(/8 routes/)
   })
 
   // ── 6. Routes are sorted by method order ─────────────────────────────

--- a/packages/kickjs/src/core/app-module.ts
+++ b/packages/kickjs/src/core/app-module.ts
@@ -28,6 +28,19 @@ export interface ModuleRoutes {
    */
   version?: number | false
   /**
+   * Mount outside the API prefix, at the root.
+   *
+   * `version: false` drops the `/v{n}` segment but keeps `apiPrefix`, so a
+   * module still lands under `/api`. Some routes must not: a health probe an
+   * orchestrator is configured against, a provider's fixed webhook URL, a
+   * `/.well-known` document. Those move with the prefix and break on a change
+   * that has nothing to do with them.
+   *
+   * Set `false` to mount at `path` exactly. The built-in health module uses it.
+   */
+  prefix?: false
+
+  /**
    * Controller class. Required unless `router` is provided. Used both
    * for the auto-derived router (via `buildRoutes(controller)`) and
    * for OpenAPI spec generation via `SwaggerAdapter`.

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -38,7 +38,7 @@ import {
   assertRouteUnique,
   buildRouteTable,
 } from './router-builder'
-import { reply } from './reply'
+import { HEALTH_PROBE, healthModule } from './health-module'
 import { expressRuntime } from './runtimes/express'
 import type {
   ActiveRuntime,
@@ -229,6 +229,19 @@ export interface ApplicationOptions {
    * registry (`ActiveRuntime`, spec §4.3b) — Express by default, or the augmented
    * engine once the `kick/runtime` typegen output is present.
    */
+  /**
+   * Mount the built-in `GET /health/live` and `GET /health/ready`.
+   *
+   * On by default. Set `false` to take them over completely — supply your own
+   * module at `/health` and nothing collides. The built-in is registered last,
+   * so an app module claiming the same path already wins without this.
+   *
+   * They mount as an ordinary module, which means they sit inside the
+   * middleware chain: whatever guards the rest of the app guards these too.
+   * Exempt the path if your orchestrator must reach them unauthenticated.
+   */
+  health?: boolean
+
   runtime?: HttpRuntime
 
   /** Express `trust proxy` setting */
@@ -692,9 +705,6 @@ export class Application {
     // ── 2a. In-flight request tracking ──────────────────────────────
     this.runtime.useConnect(this.app, this.requestTrackingMiddleware())
 
-    // ── 2b. Health check endpoints (before middleware, at root) ──────
-    this.mountHealthEndpoints()
-
     // ── 2c. Request scope (AsyncLocalStorage) ────────────────────────
     // Auto-mounted unless the user opted out (`contextStore: 'manual'`)
     // or already included one in their middleware list.
@@ -771,6 +781,30 @@ export class Application {
     }
     for (const m of this.options.modules) moduleRegistry.mount(m)
     this.options.setup?.(moduleRegistry)
+
+    // The built-in health endpoints, as an ordinary module. Registered last so
+    // an app's own `/health` module wins by being mounted first, and skipped
+    // entirely with `health: false`.
+    //
+    // The probe is bound before `register()` runs below, because the module's
+    // factory resolves it. It closes over the Application rather than exposing
+    // it: `isDraining` and `checks` are the whole surface the endpoints need,
+    // so a replacement module can satisfy the same token.
+    if (this.options.health !== false) {
+      this.container.registerInstance(HEALTH_PROBE, {
+        isDraining: () => this._draining,
+        checks: async () => {
+          const withCheck = this.adapters.filter((a) => a.onHealthCheck)
+          const settled = await Promise.allSettled(withCheck.map((a) => a.onHealthCheck!()))
+          return settled.map((c, i) =>
+            c.status === 'fulfilled'
+              ? c.value
+              : { name: withCheck[i].name ?? 'unknown', status: 'down' as const },
+          )
+        },
+      })
+      moduleRegistry.mount(healthModule())
+    }
     const allModuleEntries: AppModuleEntry[] = moduleRegistry.entries
     const modules = allModuleEntries.map((entry) => {
       const mod: AppModule = toAppModule(entry)
@@ -896,7 +930,12 @@ export class Application {
 
         for (const route of routeSets) {
           const version = route.version ?? defaultVersion
-          const mountPath = buildMountPath(apiPrefix, version, route.path)
+          // `prefix: false` mounts at the root — see ModuleRoutes.prefix.
+          const mountPath = buildMountPath(
+            route.prefix === false ? '' : apiPrefix,
+            version,
+            route.path,
+          )
           // Common-case `{ path, controller }`: build the engine-neutral route
           // table and let the runtime materialize it natively (Express Router /
           // Fastify routes / …). Adopters who hand-build a `router` (composing
@@ -1473,42 +1512,4 @@ export class Application {
   }
 
   /** Mount /health/live and /health/ready endpoints at the root (no API prefix) */
-  private mountHealthEndpoints(): void {
-    const http = this.adapterHttp()
-
-    // `reply(status, body)` throughout, never `ctx.res.status().json()`.
-    // Both runtimes route a handler's return value through
-    // `applyHandlerResult`, so this is the same return-style the framework
-    // tells adopters to use — and it carries the status without touching the
-    // engine-native response at all.
-    // `ctx.res` is the ENGINE-NATIVE response: under Fastify it is a
-    // `FastifyReply`, which has `.status()` but no `.json()`, so the Express
-    // form threw `TypeError: ctx.res.status(...).json is not a function` and
-    // every readiness probe got a 500 — a pod that never becomes ready.
-    // These are the only routes the framework itself mounts, so they have to
-    // follow the rule AGENTS.md gives adopters: write to `ctx`, not the raw
-    // response.
-    http.route('GET', '/health/live', () =>
-      this._draining
-        ? reply(503, { status: 'draining', uptime: process.uptime() })
-        : reply(200, { status: 'ok', uptime: process.uptime() }),
-    )
-
-    http.route('GET', '/health/ready', async () => {
-      if (this._draining) {
-        return reply(503, { status: 'draining', checks: [] })
-      }
-      const adaptersWithHealth = this.adapters.filter((a) => a.onHealthCheck)
-      const checks = await Promise.allSettled(adaptersWithHealth.map((a) => a.onHealthCheck!()))
-      const results = checks.map((c, i) => {
-        if (c.status === 'fulfilled') return c.value
-        return { name: adaptersWithHealth[i].name ?? 'unknown', status: 'down' as const }
-      })
-      const healthy = results.every((r) => r.status === 'up')
-      return reply(healthy ? 200 : 503, {
-        status: healthy ? 'ready' : 'degraded',
-        checks: results,
-      })
-    })
-  }
 }

--- a/packages/kickjs/src/http/health-module.ts
+++ b/packages/kickjs/src/http/health-module.ts
@@ -1,0 +1,109 @@
+/**
+ * The built-in health endpoints, as a module you can see.
+ *
+ * These used to be mounted straight onto the engine with `http.route()` before
+ * the middleware chain. That worked, but it made them invisible in two ways
+ * that matter:
+ *
+ * 1. **Swagger never saw them.** The OpenAPI spec is built by scanning
+ *    controller decorators, and a raw `http.route()` carries none — so the two
+ *    routes the framework itself serves were missing from every generated spec.
+ * 2. **Nothing in an adopter's code said they existed.** `kick g adapter`
+ *    documents `onHealthCheck`, but the endpoint consuming it appeared nowhere,
+ *    so people wrote their own `/health/ready` beside the built-in one.
+ *
+ * As a module it is registered like any other, appears in the boot module list,
+ * shows up in the spec, and can be replaced — pass your own module and set
+ * `health: false`.
+ *
+ * Mounting it with the other modules also puts it INSIDE the middleware chain,
+ * where it was previously ahead of it. That is deliberate: an app controls its
+ * own auth, and a framework route quietly bypassing it is the surprise, not the
+ * other way round. An app that wants its probes unauthenticated exempts the
+ * path the same way it would any other.
+ *
+ * @module @forinda/kickjs/http/health-module
+ */
+import { Controller, Get } from '../core/decorators'
+import { createToken } from '../core/token'
+import { defineModule } from '../core/define-module'
+import type { Container } from '../core/container'
+import { reply } from './reply'
+
+/** One adapter's answer to `onHealthCheck()`. */
+export interface HealthCheckResult {
+  name: string
+  status: 'up' | 'down'
+}
+
+/**
+ * What the health routes need from the running Application.
+ *
+ * A controller cannot reach `Application` internals, and should not: this is
+ * the whole surface the endpoints depend on, so a replacement module can
+ * satisfy it without knowing anything else.
+ */
+export interface HealthProbe {
+  /** True once shutdown has begun and traffic should drain away. */
+  isDraining(): boolean
+  /** Aggregated `onHealthCheck()` results from every adapter that has one. */
+  checks(): Promise<HealthCheckResult[]>
+}
+
+export const HEALTH_PROBE = createToken<HealthProbe>('kick/Health/probe')
+
+@Controller()
+export class HealthController {
+  constructor(private readonly probe: HealthProbe) {}
+
+  /** Liveness: is the process up and not shutting down. */
+  @Get('/live')
+  live() {
+    return this.probe.isDraining()
+      ? reply(503, { status: 'draining', uptime: process.uptime() })
+      : reply(200, { status: 'ok', uptime: process.uptime() })
+  }
+
+  /** Readiness: is every adapter's dependency answering. */
+  @Get('/ready')
+  async ready() {
+    if (this.probe.isDraining()) {
+      return reply(503, { status: 'draining', checks: [] })
+    }
+    const checks = await this.probe.checks()
+    const healthy = checks.every((c) => c.status === 'up')
+    return reply(healthy ? 200 : 503, {
+      status: healthy ? 'ready' : 'degraded',
+      checks,
+    })
+  }
+}
+
+/**
+ * `GET /health/live` and `GET /health/ready`, mounted at the root.
+ *
+ * A `defineModule` factory like any other module — the framework's own routes
+ * should be declared the way it asks adopters to declare theirs, not through a
+ * shape only the framework can produce.
+ *
+ * Registered automatically unless the app passes `health: false` or supplies a
+ * module of its own.
+ */
+export const healthModule = defineModule({
+  name: 'HealthModule',
+  build: () => ({
+    register(container: Container) {
+      // Resolve through the token so a replacement probe — or a test double —
+      // can be bound before this runs.
+      container.registerFactory(HealthController, () => {
+        const probe = container.resolve<HealthProbe>(HEALTH_PROBE)
+        return new HealthController(probe)
+      })
+    },
+    routes() {
+      // Root-mounted and unversioned: the probe URL an orchestrator is
+      // configured against must not move when the API prefix or version does.
+      return { path: '/health', controller: HealthController, version: false, prefix: false }
+    },
+  }),
+})

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -10,6 +10,13 @@ export * from './core'
 
 // ── HTTP ────────────────────────────────────────────────────────────────
 export { Application, type ApplicationOptions, type MiddlewareEntry } from './http/application'
+export {
+  healthModule,
+  HealthController,
+  HEALTH_PROBE,
+  type HealthProbe,
+  type HealthCheckResult,
+} from './http/health-module'
 
 export { bootstrap } from './http/bootstrap'
 

--- a/packages/testing/__tests__/health-module.test.ts
+++ b/packages/testing/__tests__/health-module.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The health endpoints as a module, rather than a raw engine mount.
+ *
+ * `http.route()` carries no decorators, so the OpenAPI generator — which builds
+ * the spec by scanning controllers — could never see the two routes the
+ * framework itself serves. They were also invisible in an adopter's code, so
+ * people wrote their own `/health/ready` beside the built-in one.
+ *
+ * `health-endpoints-parity.test.ts` is the compatibility half: same paths, same
+ * bodies, every runtime. This file covers what the move was FOR.
+ *
+ * @module @forinda/kickjs-testing/__tests__/health-module.test
+ */
+
+import { describe, expect, it } from 'vitest'
+import request from 'supertest'
+import { HealthController, healthModule } from '@forinda/kickjs'
+
+import { createTestApp, createTestModule } from '../src/index'
+
+const EmptyModule = createTestModule({ register: () => {}, routes: () => null })
+
+describe('the built-in health module', () => {
+  it('is a controller, so a spec generator can find its routes', () => {
+    // The point of the move. A raw `http.route()` has no class to scan.
+    const routes = healthModule().routes?.() as { controller?: unknown; path?: string }
+    expect(routes?.controller).toBe(HealthController)
+    expect(routes?.path).toBe('/health')
+  })
+
+  it('mounts at the root, not under the API prefix', async () => {
+    // An orchestrator is configured against `/health/ready`. If the path moved
+    // with `apiPrefix` or the API version, an unrelated change would break
+    // every probe.
+    const { app } = await createTestApp({ modules: [EmptyModule], isolated: true })
+    const agent = request(app.handle.bind(app))
+    expect((await agent.get('/health/live')).status).toBe(200)
+    expect((await agent.get('/api/v1/health/live')).status).toBe(404)
+  })
+
+  it('is registered automatically', async () => {
+    const { app } = await createTestApp({ modules: [EmptyModule], isolated: true })
+    expect((await request(app.handle.bind(app)).get('/health/ready')).status).toBe(200)
+  })
+
+  it('is skipped entirely with health: false', async () => {
+    const { app } = await createTestApp({
+      modules: [EmptyModule],
+      health: false,
+      isolated: true,
+    })
+    const agent = request(app.handle.bind(app))
+    expect((await agent.get('/health/live')).status).toBe(404)
+    expect((await agent.get('/health/ready')).status).toBe(404)
+  })
+
+  it('depends only on the probe contract, not on Application internals', async () => {
+    // Constructed directly with a fake: the controller reads `isDraining` and
+    // `checks` and nothing else, so a replacement module can satisfy the same
+    // token. Asserted here rather than by rebinding on a booted app — the
+    // controller is built during setup, so a later rebind would not be seen and
+    // the test would pass for the wrong reason.
+    const controller = new HealthController({
+      isDraining: () => false,
+      checks: async () => [{ name: 'db', status: 'down' as const }],
+    })
+    const res = (await controller.ready()) as { status: number; body: unknown }
+    expect(res.status).toBe(503)
+    expect(res.body).toMatchObject({ status: 'degraded', checks: [{ name: 'db', status: 'down' }] })
+  })
+
+  it('reports draining through the same contract', async () => {
+    const controller = new HealthController({ isDraining: () => true, checks: async () => [] })
+    const live = controller.live() as { status: number; body: { status: string } }
+    expect(live.status).toBe(503)
+    expect(live.body.status).toBe('draining')
+  })
+})

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -41,6 +41,9 @@ type BootstrapPassthroughOptions = Pick<
   // production ran Fastify or h3 — the one thing an integration test exists
   // to rule out.
   | 'runtime'
+  // Without this the option is accepted by the type and dropped on the way
+  // through, so `health: false` silently kept the endpoints mounted.
+  | 'health'
 >
 
 /**
@@ -187,6 +190,7 @@ export async function createTestApp(options: CreateTestAppOptions): Promise<{
     // Without this the option is accepted and ignored, which is worse than
     // not offering it: the suite reports Express while claiming Fastify.
     runtime: options.runtime,
+    health: options.health,
   })
 
   // Run setup — mounts routes, registers modules, initializes adapters.


### PR DESCRIPTION
The extraction we agreed on. `/health/live` and `/health/ready` were mounted straight onto the engine with `http.route()`, ahead of the middleware chain.

## What that hid

Your Swagger point was the decisive one, and it turned out to be three problems with one cause — a raw route carries no decorators, so nothing that reads the route registry could see these:

| reader | before | after |
| --- | --- | --- |
| OpenAPI spec | absent | present |
| `logRouteTable` | `Total: 6 routes` | `Total: 8 routes`, with a `HealthController` line |
| an adopter reading their own code | nothing said they existed | `healthModule()` in the module list |

That third one is why people write their own `/health/ready` beside the built-in: `kick g adapter` documents `onHealthCheck`, but the endpoint consuming it appeared nowhere.

## What it is now

`healthModule()` — a **`defineModule` factory**, per your steer that modules are always factories here. The framework's own routes should be declared the way it asks adopters to declare theirs, not through a shape only the framework can produce.

`HealthController` reads draining state and adapter checks through a `HEALTH_PROBE` token, not Application internals — so a replacement module satisfies the same contract.

## `ModuleRoutes.prefix`

`version: false` drops `/v1` but keeps `apiPrefix`, so the module landed at `/api/health/live`. A probe URL an orchestrator is configured against must not move when the prefix does, so `ModuleRoutes` gains `prefix?: false` to mount at the root.

Useful beyond health — a provider's fixed webhook URL or a `/.well-known` document has the same problem of being dragged around by a prefix that has nothing to do with it.

## Behaviour change

Mounting with the other modules puts these **inside** the middleware chain, where they previously sat ahead of it. An app with global auth will now require auth on its probes.

That is the correct default, on the reasoning you gave: an app controls its own auth, and a framework route quietly bypassing it is the surprise. But it is a change — exempt the path as you would any other, or `health: false` and mount your own.

## Compatibility

The existing 12-case parity suite passes **untouched** on Express, Fastify and h3 — same paths, same bodies, same statuses, including both draining branches and a rejecting adapter check. That is the proof this is a move and not a rewrite.

One test changed on purpose: `logRouteTable` goes 6 → 8 routes and now asserts the health line. That count changing *is* the fix.

## A note on one test

Probe replaceability is asserted by constructing `HealthController` with a fake directly, not by rebinding `HEALTH_PROBE` on a booted app. The controller is built during setup, so a later rebind is never seen — that test passed for the wrong reason until I noticed it was green with the probe ignored.

Monorepo green: kickjs 858, testing 110, CLI 772.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViFD8FXyNzwnAd3ixx7biB
