### PR TITLE
fix(docs): stop overriding VitePress's table overflow

### DIFF
--- a/docs/.vitepress/theme/styles.css
+++ b/docs/.vitepress/theme/styles.css
@@ -344,37 +344,21 @@ html {
 
 /* ── Table Styling ───────────────────────────────────────────── */
 
+/*
+ * Only the corners. VitePress already ships
+ * `.vp-doc table { display: block; overflow-x: auto }`, so a table wider than
+ * the viewport scrolls on its own — and a scroll container clips its own
+ * rounded corners, so no `overflow` declaration is needed here.
+ *
+ * Both table bugs came from overriding that default. Pairing `border-radius`
+ * with the `overflow` shorthand set BOTH axes and clipped wide tables on narrow
+ * screens; replacing it with `overflow-wrap: anywhere` on cells then let the
+ * layout algorithm collapse a narrow column to a single character, stacking
+ * `dropped` vertically on a wide desktop screen. Neither was a VitePress
+ * problem. Wide tables scroll, which is the affordance readers already know.
+ */
 .vp-doc table {
   border-radius: 8px;
-  /*
-   * `overflow-x`, never the `overflow` shorthand. VitePress ships
-   * `.vp-doc table { display: block; overflow-x: auto }` so a table wider than
-   * the viewport scrolls; the shorthand sets BOTH axes and silently overrode
-   * that, clipping every wide table on narrow screens instead. The rounded
-   * corners still clip correctly — a scroll container rounds its own overflow.
-   */
-  overflow-x: auto;
-  /* Momentum scrolling on iOS, and a visible affordance that there is more. */
-  -webkit-overflow-scrolling: touch;
-}
-
-/*
- * Let prose cells wrap so a table fits the viewport instead of scrolling —
- * measured at a 320px column, this alone takes a typical docs table from 97px
- * of unreachable content to none.
- */
-.vp-doc table :is(td, th) {
-  overflow-wrap: anywhere;
-}
-
-/*
- * ...but never break a code token. `GET /academics/terms/:termId` split across
- * two lines is worse than a scrollbar: the reader cannot tell whether the break
- * is part of the path. These keep their shape and the table scrolls instead,
- * which is what the `overflow-x` above is for.
- */
-.vp-doc table :is(td, th) :is(code, a) {
-  overflow-wrap: normal;
 }
 
 .vp-doc th {


### PR DESCRIPTION
The `dropped` column stacking one letter per line, from your screenshot.

## Both table bugs were mine

VitePress already ships:

```css
.vp-doc table { display: block; border-collapse: collapse; margin: 20px 0; overflow-x: auto; }
```

Scrolling was handled from the start. The override caused it twice:

1. `border-radius` + the **`overflow` shorthand** set both axes, clipping wide tables on narrow screens. That was the mobile bug.
2. The fix for that replaced it with `overflow-wrap: anywhere` on cells. Unlike `break-word`, `anywhere` **feeds its break opportunities into min-content sizing** — so the layout algorithm is free to collapse a column to one character. That is the desktop bug: a narrow `v4 status` column stacking `dropped` vertically.

## Now

```css
.vp-doc table { border-radius: 8px; }
```

Nothing else. A scroll container clips its own rounded corners, so no overflow declaration is needed, and wide tables scroll — which, as you say, is what readers should just do. Better than any wrapping heuristic, and it cannot collapse a column.

Docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViFD8FXyNzwnAd3ixx7biB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated table styling to use rounded corners.
  * Preserved VitePress’s built-in wide-table scrolling behavior.
  * Removed custom wrapping and scrolling overrides for table cells, code, and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->