### PR TITLE
refactor(kickjs)!: drop the deprecated `middleware` option

### DIFF
--- a/.changeset/tidy-moons-divide.md
+++ b/.changeset/tidy-moons-divide.md
@@ -1,0 +1,38 @@
+---
+'@forinda/kickjs': major
+'@forinda/kickjs-testing': major
+'@forinda/kickjs-cli': patch
+---
+
+`middleware` is gone; the option is `middlewares`.
+
+`bootstrap()` took both — `middlewares` as the real name and `middleware` as a
+deprecated alias, with the plural winning when both were set. The alias has
+carried a `@deprecated` tag for several releases, and v8 is the window to drop
+it, so there is one name for one thing:
+
+```ts
+bootstrap({
+  modules,
+  middlewares: [helmet(), cors(), requestId()],
+})
+```
+
+The rename is mechanical and the compiler finds every site: `middleware` is no
+longer a key on `ApplicationOptions`, so passing it is a type error rather than
+a silently ignored object.
+
+Renamed in the same place, for the same reason:
+
+- **`createTestApp({ middlewares })`** — the harness passes the option straight
+  through to `bootstrap()`, and a test harness whose option name disagreed with
+  the thing it configures is the inconsistency this change exists to remove.
+  This is why `@forinda/kickjs-testing` takes a major too.
+- **`createWebApp({ middlewares })`** — the web/edge entry had its own
+  `middleware`, ctx-style rather than connect-style, but the same name.
+
+**`AppAdapter.middleware()` and `Plugin.middleware()` are unchanged.** They are a
+different API — a hook returning entries, not an option taking them — and
+nothing about them was ambiguous.
+
+Generated projects emit `middlewares` from the CLI's `rest` template.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ import { bootstrap, helmet, cors, requestId, requestLogger, csrf, rateLimit } fr
 
 bootstrap({
   modules: [/* your modules */],
-  middleware: [
+  middlewares: [
     helmet(), // Security headers (X-Frame-Options, HSTS, etc.)
     cors({ origin: ['https://app.example.com'] }), // CORS with spec-correct behavior
     requestId(), // X-Request-Id generation/propagation

--- a/docs/guide/edge-deployment.md
+++ b/docs/guide/edge-deployment.md
@@ -121,7 +121,7 @@ export default {
       h3,
       modules,
       env,
-      middleware: [
+      middlewares: [
         rateLimitGuard({
           max: 60,
           windowMs: 60_000,

--- a/docs/guide/migration-v7-to-v8.md
+++ b/docs/guide/migration-v7-to-v8.md
@@ -9,10 +9,10 @@ pnpm add @forinda/kickjs@8
 ```
 
 ::: tip Only the framework goes to 8
-Versions are per-package and independent. This release is `@forinda/kickjs` **8.0.0**, `@forinda/kickjs-cli` **7.2.0** and `@forinda/kickjs-testing` **7.1.0** — the CLI and the test harness carry no breaking change, so they do not follow the framework's major. Upgrade them with `@latest`, not `@8`:
+Versions are per-package and independent. This release is `@forinda/kickjs` **8.0.0**, `@forinda/kickjs-testing` **8.0.0** and `@forinda/kickjs-cli` **7.2.0**. The harness follows the framework to 8 because it renames an option alongside it (below); the CLI carries no breaking change and stays on 7:
 
 ```bash
-pnpm add -D @forinda/kickjs-cli@latest @forinda/kickjs-testing@latest
+pnpm add -D @forinda/kickjs-testing@8 @forinda/kickjs-cli@latest
 ```
 
 :::
@@ -21,6 +21,7 @@ pnpm add -D @forinda/kickjs-cli@latest @forinda/kickjs-testing@latest
 
 | Change                                          | Affects                     | Action                                              |
 | ----------------------------------------------- | --------------------------- | --------------------------------------------------- |
+| `middleware` option renamed to `middlewares`    | Any app setting it          | Rename the key — the compiler finds every one       |
 | 404 body is now problem details                 | Any app                     | Read `title`/`status`, or restore with `onNotFound` |
 | Wrong verb answers 405, not 404                 | Any app                     | Move the case to the 405 branch                     |
 | Health probes moved inside the middleware chain | Apps with global auth       | Exempt the path, or `health: false`                 |
@@ -30,6 +31,31 @@ pnpm add -D @forinda/kickjs-cli@latest @forinda/kickjs-testing@latest
 | `csrf`, `rateLimit`, `session` now work         | Fastify / h3                | Re-test — they used to throw                        |
 | `helmet()` options now take effect              | Apps passing helmet options | Re-check which security headers you send            |
 | `@PreDestroy` on a singleton warns              | Any app                     | Move teardown to an adapter `shutdown()`            |
+
+## Breaking: `middleware` is now `middlewares`
+
+`bootstrap()` took both — `middlewares` as the real name, `middleware` as a deprecated alias that the plural beat when both were set. v8 drops the alias, so there is one name for one thing:
+
+```ts
+bootstrap({
+  modules,
+  middlewares: [helmet(), cors(), requestId()], // was: middleware
+})
+```
+
+This is the least dangerous change in the release: `middleware` is no longer a key on `ApplicationOptions`, so passing it is a **type error**, not a silently ignored object. Rename and the compiler confirms you got them all.
+
+Renamed for the same reason, in the same release:
+
+| call            | was          | now           |
+| --------------- | ------------ | ------------- |
+| `bootstrap`     | `middleware` | `middlewares` |
+| `createTestApp` | `middleware` | `middlewares` |
+| `createWebApp`  | `middleware` | `middlewares` |
+
+`createTestApp` passes the option straight through to `bootstrap()`, so a harness whose option name disagreed with the thing it configures was exactly the inconsistency being removed — that is why `@forinda/kickjs-testing` takes a major too.
+
+**`AppAdapter.middleware()` and `Plugin.middleware()` are unchanged.** Those are a different API — a hook that returns entries, not an option that takes them — and nothing about them was ambiguous. If you write adapters, nothing there moves.
 
 ## Breaking: the catch-all
 
@@ -177,7 +203,7 @@ If you mounted any of these on Fastify or h3, they now do what they always claim
 `bootstrap()` auto-injects `helmet()` with defaults, and it did so _ahead of_ your middleware array. So an app declaring its own helmet ran two — and the second can only overwrite a header, never drop one:
 
 ```ts
-bootstrap({ middleware: [helmet({ frameguard: false })] })
+bootstrap({ middlewares: [helmet({ frameguard: false })] })
 // v7: still X-Frame-Options: DENY
 // v8: header absent, as asked
 ```
@@ -258,14 +284,15 @@ const { app } = await createTestApp({
 
 ## Upgrade checklist
 
-1. `pnpm add @forinda/kickjs@8` and `pnpm add -D @forinda/kickjs-cli@latest @forinda/kickjs-testing@latest` — only the framework goes to 8.
-2. Grep your tests and clients for `'Not Found'` — assert on `title`/`status`, or pass `onNotFound`.
-3. Grep for 404 handling that covers the wrong-verb case; split out 405.
-4. If you have global auth, exempt `/health` or pass `health: false`.
-5. Boot the app and read the startup log for a `@PreDestroy` warning.
-6. On Fastify or h3: re-test anything that mounted `csrf`, `rateLimit` or `session`.
-7. If you pass options to `helmet()`, re-read them — they take effect now, and a header you disabled in v7 was still being sent.
-8. Point `createTestApp` at your production runtime and run the suite again — that is the check that catches everything above at once.
+1. `pnpm add @forinda/kickjs@8` and `pnpm add -D @forinda/kickjs-testing@8 @forinda/kickjs-cli@latest` — the CLI stays on 7.
+2. Rename `middleware:` to `middlewares:` at every `bootstrap`, `createTestApp` and `createWebApp` call — then typecheck; anything missed is an error, not a silent no-op.
+3. Grep your tests and clients for `'Not Found'` — assert on `title`/`status`, or pass `onNotFound`.
+4. Grep for 404 handling that covers the wrong-verb case; split out 405.
+5. If you have global auth, exempt `/health` or pass `health: false`.
+6. Boot the app and read the startup log for a `@PreDestroy` warning.
+7. On Fastify or h3: re-test anything that mounted `csrf`, `rateLimit` or `session`.
+8. If you pass options to `helmet()`, re-read them — they take effect now, and a header you disabled in v7 was still being sent.
+9. Point `createTestApp` at your production runtime and run the suite again — that is the check that catches everything above at once.
 
 ## Older migrations
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -121,8 +121,8 @@ To run one suite across every engine you support:
 
 ```ts
 describe.each([
-  { name: 'express', runtime: () => expressRuntime(), middleware: [express.json()] },
-  { name: 'fastify', runtime: () => fastifyRuntime(), middleware: [] },
+  { name: 'express', runtime: () => expressRuntime(), middlewares: [express.json()] },
+  { name: 'fastify', runtime: () => fastifyRuntime(), middlewares: [] },
 ])('users on $name', ({ runtime, middleware }) => {
   // Fastify parses JSON natively; Express needs the middleware.
 })

--- a/packages/auth/src/strategies/session.strategy.ts
+++ b/packages/auth/src/strategies/session.strategy.ts
@@ -35,7 +35,7 @@ export interface SessionStrategyOptions {
  * Requires the session middleware from `@forinda/kickjs`:
  * ```ts
  * import { session } from '@forinda/kickjs'
- * middleware: [session({ secret: process.env.SESSION_SECRET! })]
+ * middlewares: [session({ secret: process.env.SESSION_SECRET! })]
  * ```
  *
  * @example

--- a/packages/cli/src/generators/middleware.ts
+++ b/packages/cli/src/generators/middleware.ts
@@ -69,7 +69,7 @@ export interface ${toPascalCase(name)}Options {
  * ${toPascalCase(name)} middleware.
  *
  * Usage in bootstrap (fires on every request):
- *   middleware: [${camel}()]
+ *   middlewares: [${camel}()]
  *
  * Usage with adapter — phase controls *when* the handler runs:
  *

--- a/packages/cli/src/generators/templates/project-app.ts
+++ b/packages/cli/src/generators/templates/project-app.ts
@@ -128,7 +128,7 @@ ${restImportsBlock}import { modules } from './modules'
 export const app = await bootstrap({
   modules,
   runtime: ${factory.name}(),${restAdaptersBlock}
-  middleware: [
+  middlewares: [
     // Security headers. The framework injects helmet() with these defaults
     // anyway — declaring it here is what lets you CHANGE them, e.g.
     // helmet({ frameguard: 'SAMEORIGIN' }) or helmet({ hsts: false }).

--- a/packages/kickjs/__tests__/edge-stores.test.ts
+++ b/packages/kickjs/__tests__/edge-stores.test.ts
@@ -121,7 +121,7 @@ describe('rateLimitGuard on the web entry', () => {
       name: 'PingModule',
       build: () => ({ routes: () => ({ path: '/p', controller: PingController }) }),
     })()
-    return createWebApp({ h3: h3v2, modules: [mod], middleware: [guard] })
+    return createWebApp({ h3: h3v2, modules: [mod], middlewares: [guard] })
   }
 
   const req = (ip = '1.2.3.4') =>

--- a/packages/kickjs/__tests__/exports.test.ts
+++ b/packages/kickjs/__tests__/exports.test.ts
@@ -216,7 +216,7 @@ describe('Custom error handlers (onNotFound, onError)', () => {
 
     const app = new Application({
       modules: [],
-      middleware: [express.json()],
+      middlewares: [express.json()],
       onNotFound: (req: any, res: any) => {
         res.status(404).json({ custom: true, path: req.originalUrl })
       },
@@ -235,7 +235,7 @@ describe('Custom error handlers (onNotFound, onError)', () => {
 
     const app = new Application({
       modules: [],
-      middleware: [
+      middlewares: [
         express.json(),
         // Middleware that always throws
         (_req: any, _res: any, _next: any) => {
@@ -260,7 +260,7 @@ describe('Custom error handlers (onNotFound, onError)', () => {
 
     const app = new Application({
       modules: [],
-      middleware: [express.json()],
+      middlewares: [express.json()],
     })
     await app.setup()
 

--- a/packages/kickjs/__tests__/lifecycle-mount-order.test.ts
+++ b/packages/kickjs/__tests__/lifecycle-mount-order.test.ts
@@ -196,7 +196,7 @@ describe('Application lifecycle mount order', () => {
       modules: [buildTracingModule(trace)],
       adapters: [buildTracingAdapter(trace, 'A')],
       plugins: [buildTracingPlugin(trace, 'P')],
-      middleware: [userMiddleware(trace, 'user-global-mw')],
+      middlewares: [userMiddleware(trace, 'user-global-mw')],
       apiPrefix: '/api',
       defaultVersion: 1,
     })
@@ -227,7 +227,7 @@ describe('Application lifecycle mount order', () => {
     const app = new Application({
       modules: [buildTracingModule(trace)],
       adapters: [buildTracingAdapter(trace, 'A')],
-      middleware: [],
+      middlewares: [],
       apiPrefix: '/api',
       defaultVersion: 1,
     })
@@ -288,7 +288,7 @@ describe('Application lifecycle mount order', () => {
     const app = new Application({
       modules: [buildTracingModule(trace)],
       plugins: [buildTracingPlugin(trace, 'P')],
-      middleware: [userMiddleware(trace, 'user-mw')],
+      middlewares: [userMiddleware(trace, 'user-mw')],
       apiPrefix: '/api',
       defaultVersion: 1,
     })

--- a/packages/kickjs/__tests__/log-routes-table.test.ts
+++ b/packages/kickjs/__tests__/log-routes-table.test.ts
@@ -114,7 +114,7 @@ async function buildApp(options: {
 
   const app = new Application({
     modules: [TestModule],
-    middleware: [express.json()],
+    middlewares: [express.json()],
     logRouteTable: options.logRouteTable,
     logRoutesTable: options.logRoutesTable,
   })

--- a/packages/kickjs/__tests__/request-scope.test.ts
+++ b/packages/kickjs/__tests__/request-scope.test.ts
@@ -357,7 +357,7 @@ describe('REQUEST scope — HTTP integration', () => {
 
     const { expressApp } = await createTestApp({
       modules: [TestModule],
-      middleware: [express.json(), requestScopeMiddleware()],
+      middlewares: [express.json(), requestScopeMiddleware()],
     })
 
     const res1 = await request(expressApp).get('/api/v1/counter/')
@@ -403,7 +403,7 @@ describe('REQUEST scope — HTTP integration', () => {
 
     const { expressApp } = await createTestApp({
       modules: [TestModule],
-      middleware: [express.json(), requestScopeMiddleware()],
+      middlewares: [express.json(), requestScopeMiddleware()],
     })
 
     const res = await request(expressApp).get('/api/v1/shared/')
@@ -446,7 +446,7 @@ describe('REQUEST scope — HTTP integration', () => {
 
     const { expressApp } = await createTestApp({
       modules: [TestModule],
-      middleware: [express.json(), requestScopeMiddleware()],
+      middlewares: [express.json(), requestScopeMiddleware()],
     })
 
     const responses = await Promise.all(
@@ -481,7 +481,7 @@ describe('REQUEST scope — HTTP integration', () => {
 
     const { expressApp } = await createTestApp({
       modules: [TestModule],
-      middleware: [express.json(), requestScopeMiddleware()],
+      middlewares: [express.json(), requestScopeMiddleware()],
     })
 
     const res = await request(expressApp).get('/api/v1/reqid/').set('x-request-id', 'trace-abc-123')

--- a/packages/kickjs/__tests__/shutdown.test.ts
+++ b/packages/kickjs/__tests__/shutdown.test.ts
@@ -64,7 +64,7 @@ describe('Graceful shutdown with request draining', () => {
   it('shutdown waits for in-flight requests to complete', async () => {
     const app = new Application({
       modules: [createSlowModule()],
-      middleware: [express.json()],
+      middlewares: [express.json()],
       shutdownTimeout: 5000,
     })
     await app.setup()
@@ -113,7 +113,7 @@ describe('Graceful shutdown with request draining', () => {
 
     const app = new Application({
       modules: [HangModule],
-      middleware: [
+      middlewares: [
         express.json(),
         // Add a route inline that will never finish
         ((_req: any, res: any, next: any) => {
@@ -166,7 +166,7 @@ describe('Graceful shutdown with request draining', () => {
     const app = new Application({
       modules: [],
       adapters: [adapter],
-      middleware: [express.json()],
+      middlewares: [express.json()],
     })
     await app.setup()
 
@@ -186,7 +186,7 @@ describe('Graceful shutdown with request draining', () => {
     const app = new Application({
       modules: [],
       adapters: [adapter1, adapter2],
-      middleware: [express.json()],
+      middlewares: [express.json()],
     })
     await app.setup()
 
@@ -208,7 +208,7 @@ describe('Graceful shutdown with request draining', () => {
     const app = new Application({
       modules: [],
       adapters: [adapter],
-      middleware: [express.json()],
+      middlewares: [express.json()],
     })
     await app.setup()
 
@@ -223,7 +223,7 @@ describe('Graceful shutdown with request draining', () => {
     Container.reset()
     const app = new Application({
       modules: [],
-      middleware: [express.json()],
+      middlewares: [express.json()],
     })
     await app.setup()
 
@@ -287,7 +287,7 @@ describe('Graceful shutdown with request draining', () => {
     const { bootstrap } = await import('../src/http/bootstrap')
     const app = await bootstrap({
       modules: [],
-      middleware: [express.json()],
+      middlewares: [express.json()],
       port: 0,
     })
 

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -139,12 +139,6 @@ export interface ApplicationOptions {
    *   requestId(), express.json({ limit: '100kb' })
    */
   middlewares?: MiddlewareEntry[]
-  /**
-   * @deprecated Use {@link ApplicationOptions.middlewares} (plural).
-   * Kept as an alias for back-compat; `middlewares` wins when both are
-   * set.
-   */
-  middleware?: MiddlewareEntry[]
 
   /** Plugins that bundle modules, adapters, middleware, and DI bindings */
   plugins?: KickPlugin[]
@@ -742,7 +736,7 @@ export class Application {
     // does not replace the app-wide pass — standing down for it would strip
     // security headers from every OTHER path.
     // `Symbol.for` registry lookup, so the dynamic import() below stays intact.
-    const declaredHelmet = (this.options.middlewares ?? this.options.middleware ?? []).some(
+    const declaredHelmet = (this.options.middlewares ?? []).some(
       (entry) => typeof entry === 'function' && Symbol.for('kick/http/helmet') in entry,
     )
     const autoHelmet = this.options.security?.helmet !== false && !declaredHelmet
@@ -755,7 +749,7 @@ export class Application {
       }
     }
 
-    const userMiddlewares = this.options.middlewares ?? this.options.middleware
+    const userMiddlewares = this.options.middlewares
     if (userMiddlewares) {
       // User-declared pipeline — full control
       for (const entry of userMiddlewares) {
@@ -1455,7 +1449,7 @@ export class Application {
   private shouldAutoMountRequestScope(): boolean {
     if (this.options.contextStore === 'manual') return false
 
-    const userEntries = this.options.middlewares ?? this.options.middleware ?? []
+    const userEntries = this.options.middlewares ?? []
     for (const entry of userEntries) {
       const handler = typeof entry === 'function' ? entry : entry.handler
       if (isRequestScopeMiddleware(handler)) return false

--- a/packages/kickjs/src/http/middleware/cors.ts
+++ b/packages/kickjs/src/http/middleware/cors.ts
@@ -41,11 +41,11 @@ function isOriginAllowed(requestOrigin: string, allowed: CorsOptions['origin']):
  * @example
  * ```ts
  * // Allow all origins
- * bootstrap({ middleware: [cors(), express.json()] })
+ * bootstrap({ middlewares: [cors(), express.json()] })
  *
  * // Allowlist specific origins
  * bootstrap({
- *   middleware: [
+ *   middlewares: [
  *     cors({
  *       origin: ['https://app.example.com', /\.example\.com$/],
  *       credentials: true,

--- a/packages/kickjs/src/http/middleware/csrf.ts
+++ b/packages/kickjs/src/http/middleware/csrf.ts
@@ -37,7 +37,7 @@ export interface CsrfOptions {
  *
  * bootstrap({
  *   modules,
- *   middleware: [
+ *   middlewares: [
  *     cookieParser(),
  *     csrf(),
  *     // ... other middleware

--- a/packages/kickjs/src/http/middleware/helmet.ts
+++ b/packages/kickjs/src/http/middleware/helmet.ts
@@ -29,7 +29,7 @@ export interface HelmetOptions {
  * @example
  * ```ts
  * bootstrap({
- *   middleware: [helmet(), requestId(), express.json()],
+ *   middlewares: [helmet(), requestId(), express.json()],
  * })
  * ```
  */

--- a/packages/kickjs/src/http/middleware/rate-limit-guard.ts
+++ b/packages/kickjs/src/http/middleware/rate-limit-guard.ts
@@ -81,7 +81,7 @@ function defaultKey(ctx: RequestContext): string {
  * // Edge (Cloudflare Workers) — app-wide:
  * const app = createWebApp({
  *   h3, modules,
- *   middleware: [rateLimitGuard({ max: 60, windowMs: 60_000, store: new KvRateLimitStore(env.KV, { windowMs: 60_000 }) })],
+ *   middlewares: [rateLimitGuard({ max: 60, windowMs: 60_000, store: new KvRateLimitStore(env.KV, { windowMs: 60_000 }) })],
  * })
  *
  * // Any runtime — per controller/route:

--- a/packages/kickjs/src/http/middleware/rate-limit.ts
+++ b/packages/kickjs/src/http/middleware/rate-limit.ts
@@ -107,7 +107,7 @@ class MemoryStore implements RateLimitStore {
  *
  * bootstrap({
  *   modules,
- *   middleware: [
+ *   middlewares: [
  *     rateLimit({ max: 100, windowMs: 60_000 }),
  *     // ... other middleware
  *   ],

--- a/packages/kickjs/src/http/middleware/request-logger.ts
+++ b/packages/kickjs/src/http/middleware/request-logger.ts
@@ -55,7 +55,7 @@ export interface RequestLoggerOptions {
  * @example
  * ```ts
  * bootstrap({
- *   middleware: [requestId(), requestLogger(), express.json()],
+ *   middlewares: [requestId(), requestLogger(), express.json()],
  * })
  * ```
  *

--- a/packages/kickjs/src/http/middleware/session.ts
+++ b/packages/kickjs/src/http/middleware/session.ts
@@ -149,7 +149,7 @@ function unsign(signed: string, secret: string): string | false {
  *
  * bootstrap({
  *   modules,
- *   middleware: [
+ *   middlewares: [
  *     session({ secret: process.env.SESSION_SECRET! }),
  *     // ... other middleware
  *   ],

--- a/packages/kickjs/src/http/middleware/trace-context.ts
+++ b/packages/kickjs/src/http/middleware/trace-context.ts
@@ -85,7 +85,7 @@ export function parseTraceparent(header: string): TraceContext | null {
  * @example
  * ```ts
  * bootstrap({
- *   middleware: [
+ *   middlewares: [
  *     requestScopeMiddleware(),
  *     traceContext(),          // extracts or generates traceId
  *     requestLogger(),

--- a/packages/kickjs/src/web.ts
+++ b/packages/kickjs/src/web.ts
@@ -90,10 +90,10 @@ export interface CreateWebAppOptions {
   env?: Record<string, string | undefined>
   /**
    * Global `(ctx, next)` middlewares, run before route middlewares on every
-   * route — the web-entry counterpart of `bootstrap({ middleware })`. Only
+   * route — the web-entry counterpart of `bootstrap({ middlewares })`. Only
    * ctx-style handlers are accepted (no connect/express middleware here).
    */
-  middleware?: MiddlewareHandler[]
+  middlewares?: MiddlewareHandler[]
 }
 
 export interface WebApp {
@@ -144,7 +144,7 @@ export function createWebApp(options: CreateWebAppOptions): WebApp {
   const app = new h3mod.H3()
   const apiPrefix = options.apiPrefix ?? '/api'
   const defaultVersion = options.defaultVersion ?? 1
-  const globalMiddleware = options.middleware ?? []
+  const globalMiddleware = options.middlewares ?? []
 
   const globalSources: SourcedRegistration[] = (options.contributors ?? []).map(
     (registration): SourcedRegistration => ({

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -532,7 +532,7 @@ The MCP SDK's `StreamableHTTPServerTransport` allows **one active session per se
 Browser-based MCP clients (Inspector, web UIs) require CORS with the session header exposed:
 
 ```ts
-middleware: [cors({ origin: '*', exposedHeaders: ['mcp-session-id'] }), express.json()]
+middlewares: [cors({ origin: '*', exposedHeaders: ['mcp-session-id'] }), express.json()]
 ```
 
 Without `exposedHeaders`, the Inspector can't read the session ID and every request after `initialize` fails. Stdio transport doesn't need CORS.

--- a/packages/testing/__tests__/helmet-opt-out.test.ts
+++ b/packages/testing/__tests__/helmet-opt-out.test.ts
@@ -24,15 +24,15 @@ describe('helmet opt-out via user middleware', () => {
   it('an explicit frameguard: false actually removes X-Frame-Options', async () => {
     const { app } = await createTestApp({
       modules: [PingModule()],
-      middleware: [helmet({ frameguard: false })],
+      middlewares: [helmet({ frameguard: false })],
     })
     const res = await request(app.handle.bind(app)).get('/ping')
     expect(res.headers['x-frame-options']).toBeUndefined()
   })
 
   it('scaffolded helmet() adds nothing over the auto-injected one', async () => {
-    const bare = await createTestApp({ modules: [PingModule()], middleware: [] })
-    const withHelmet = await createTestApp({ modules: [PingModule()], middleware: [helmet()] })
+    const bare = await createTestApp({ modules: [PingModule()], middlewares: [] })
+    const withHelmet = await createTestApp({ modules: [PingModule()], middlewares: [helmet()] })
     const a = await request(bare.app.handle.bind(bare.app)).get('/ping')
     const b = await request(withHelmet.app.handle.bind(withHelmet.app)).get('/ping')
     const names = (r: any) => Object.keys(r.headers).toSorted().join(',')
@@ -44,7 +44,7 @@ describe('a path-scoped helmet', () => {
   it('does not strip security headers from other paths', async () => {
     const { app } = await createTestApp({
       modules: [PingModule()],
-      middleware: [{ path: '/admin', handler: helmet({ frameguard: 'SAMEORIGIN' }) }],
+      middlewares: [{ path: '/admin', handler: helmet({ frameguard: 'SAMEORIGIN' }) }],
     })
     const res = await request(app.handle.bind(app)).get('/ping')
     // auto-helmet must still cover /ping

--- a/packages/testing/__tests__/middleware-runtime-matrix.test.ts
+++ b/packages/testing/__tests__/middleware-runtime-matrix.test.ts
@@ -74,7 +74,7 @@ describe.each(runtimes)('middleware on $name', ({ make }) => {
     const { app } = await createTestApp({
       modules: [ProbeModule],
       runtime: make(),
-      middleware: middleware as never,
+      middlewares: middleware as never,
       isolated: true,
     })
     return request(app.handle.bind(app))
@@ -141,7 +141,7 @@ describe.each(runtimes)('middleware on $name', ({ make }) => {
       const { app } = await createTestApp({
         modules: [ProbeModule],
         runtime: make(),
-        middleware: [session({ secret: 'test-secret-value' })] as never,
+        middlewares: [session({ secret: 'test-secret-value' })] as never,
         isolated: true,
       })
       // A supertest *agent* keeps the cookie jar between requests, which is the
@@ -178,7 +178,7 @@ describe.each(runtimes)('middleware on $name', ({ make }) => {
       const { app } = await createTestApp({
         modules: [ProbeModule],
         runtime: make(),
-        middleware: [csrf()] as never,
+        middlewares: [csrf()] as never,
         isolated: true,
       })
       const agent = request.agent(app.handle.bind(app))

--- a/packages/testing/__tests__/runtime-parity.test.ts
+++ b/packages/testing/__tests__/runtime-parity.test.ts
@@ -48,7 +48,7 @@ describe.each(runtimes)('createTestApp on $name', ({ make }) => {
   // `express.json()` explicitly bypasses the Application's native-body guard,
   // and under Fastify the connect parser then eats the stream before Fastify
   // reads it, so a JSON POST hangs. An earlier revision of this suite passed
-  // `middleware: []` for Fastify and never exercised it.
+  // `middlewares: []` for Fastify and never exercised it.
   async function boot() {
     const { app, container } = await createTestApp({
       modules: [ThingsModule],

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -28,7 +28,7 @@ type BootstrapPassthroughOptions = Pick<
   | 'port'
   | 'apiPrefix'
   | 'defaultVersion'
-  | 'middleware'
+  | 'middlewares'
   | 'onError'
   | 'onNotFound'
   | 'plugins'
@@ -176,8 +176,8 @@ export async function createTestApp(options: CreateTestAppOptions): Promise<{
     // parser then consumes the stream before Fastify reads it: a JSON POST
     // hangs until the test times out. `RuntimeCapabilities.nativeBodyParsing`
     // is the same flag the Application guards on.
-    middleware:
-      options.middleware ??
+    middlewares:
+      options.middlewares ??
       (options.runtime?.capabilities.nativeBodyParsing ? [] : [express.json()]),
     onError: options.onError,
     onNotFound: options.onNotFound,

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -31,7 +31,7 @@
  * // Export the Express app — Vite serves it in dev, you start it in prod
  * export const app = bootstrap({
  *   modules: [UserModule],
- *   middleware: [express.json()],
+ *   middlewares: [express.json()],
  * })
  *
  * // Production: start the server directly


### PR DESCRIPTION
Stacked on #594 — that branch is its base, because both touch the same expression in `application.ts`. Merge #594 first.

## What

`bootstrap()` took both `middlewares` and `middleware`, the latter a deprecated alias the plural beat when both were set. The tag has been on it for several releases; v8 is the window to drop it.

```ts
bootstrap({
  modules,
  middlewares: [helmet(), cors(), requestId()], // was: middleware
})
```

Removing the key rather than ignoring it means the compiler finds every site — passing `middleware` is a **type error**, not a silently dropped object.

Renamed alongside, for the same reason:

| call | was | now |
| --- | --- | --- |
| `bootstrap` | `middleware` | `middlewares` |
| `createTestApp` | `middleware` | `middlewares` |
| `createWebApp` | `middleware` | `middlewares` |

`createTestApp` passes the option straight through to `bootstrap()`, so a harness whose option name disagreed with the thing it configures was exactly the inconsistency being removed. That takes `@forinda/kickjs-testing` to a major: **kickjs 8.0.0, testing 8.0.0, cli 7.2.0.**

**`AppAdapter.middleware()` and `Plugin.middleware()` are untouched** — a hook returning entries is a different API from an option taking them, and neither was ambiguous.

## Scope

45 call sites across docs, doc comments, templates and tests. Two `middleware:` keys deliberately left alone: the devtools route table and the vscode route-provider test both name a *route's* middleware list, not an option.

Guide updated — new breaking section, at-a-glance row, checklist step, and the corrected version note.

## Verification

Suite green, 44/44 tasks.

Worth recording how the one miss was caught: the rename pattern keyed on `middleware: [`, and the matrix helper reads `middleware: middleware as never` — no `[` after the colon. Every shipped middleware silently stopped being mounted, and 18 assertions in `middleware-runtime-matrix` failed. A narrower test set would have shipped it green.
