### PR TITLE
docs: purge references to the removed auth, Drizzle and Prisma packages

### DIFF
--- a/docs/guide/byo-recipes.md
+++ b/docs/guide/byo-recipes.md
@@ -22,7 +22,7 @@ layer it actually needs.
 
 This doc collects working recipes for the domains we've moved to BYO.
 
-## Deprecated packages → BYO targets
+## Removed packages → BYO targets
 
 The current BYO targets, with a recipe for each:
 
@@ -39,7 +39,7 @@ The framework keeps shipping the **primitives** that those packages wrapped (`de
 
 ## Auth
 
-The deprecated `@forinda/kickjs-auth` package shipped:
+`@forinda/kickjs-auth` was removed in v8. It shipped:
 
 - Decorators: `@Authenticated`, `@Public`, `@Roles`, `@Can`, `@CsrfExempt`, `@RateLimit`, `@Policy`
 - Adapter: `AuthAdapter({ strategies, defaultPolicy, onForbidden, … })`
@@ -320,12 +320,14 @@ parameterised contributor over the primitives the framework ships.
   if you need it; most apps just inline the check inside the
   handler.
 - **No `OAuthStrategy` / `SessionStrategy` / `PassportBridge` ready-made**
-  — they're 50–80 lines each. Copy from `@forinda/kickjs-auth@5.1.x`
-  source if you used them; they're unchanged in BYO form.
+  — they're 50–80 lines each. The last published version,
+  `@forinda/kickjs-auth@6.0.1`, still carries the source if you used them;
+  they're unchanged in BYO form.
 
 ### Migration checklist
 
-- [ ] Pin `@forinda/kickjs-auth` to `^5.1.x` until you migrate.
+- [ ] Pin `@forinda/kickjs-auth` to `6.0.1` — its last release — and stay on
+      kickjs 7 until you have migrated.
 - [ ] Copy the recipe above into `src/auth/` (or wherever).
 - [ ] Replace `import { JwtStrategy } from '@forinda/kickjs-auth'` with
       your local `jwtStrategy` (lowercase — it's a function, not a
@@ -336,6 +338,6 @@ parameterised contributor over the primitives the framework ships.
       (or the `Public` shim re-export).
 - [ ] Replace `@Roles('admin')` with `@RequireRole({ roles: ['admin'] })`.
 - [ ] Run your existing auth tests — they should pass without changes.
-- [ ] `pnpm remove @forinda/kickjs-auth`.
+- [ ] Remove `@forinda/kickjs-auth`, then upgrade to kickjs 8.
 - [ ] Open an issue if anything from the original surface isn't
       reachable from the recipe.

--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -560,7 +560,7 @@ export const TenantAdapter = defineAdapter({
 Three traps to avoid:
 
 - **`declare module` is the whole mechanism.** It is what makes `ctx.get('tenant')` typed; without it you cast at every read site. (`defineAugmentation` never typed anything and is deprecated — safe to drop.)
-- **Augmenting the wrong module** — `ContextMeta` lives in `@forinda/kickjs`. `AuthUser` lives in `@forinda/kickjs-auth`. The `declare module '...'` string must match the package the interface was originally declared in, or the augmentation is silently a no-op.
+- **Augmenting the wrong module** — the `declare module '...'` string must match the package the interface was originally declared in, or the augmentation is silently a no-op. `ContextMeta` lives in `@forinda/kickjs`; a type you declared yourself, like `AuthUser`, is augmented in your own module, not the framework's.
 
 ### When the same registration runs at multiple levels
 

--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -28,7 +28,7 @@ KickJS integrates with external services through **adapters** and **middleware**
 
 ## Authentication
 
-- [Authentication (BYO)](../authentication.md) — compose JWT / API-key / role checks with context decorators (the `@forinda/kickjs-auth` package is deprecated).
+- [Authentication (BYO)](../authentication.md) — compose JWT / API-key / role checks with context decorators. The framework ships no auth layer; `@forinda/kickjs-auth` was removed in v8.
 
 ## Observability
 

--- a/docs/guide/migration-runtimes.md
+++ b/docs/guide/migration-runtimes.md
@@ -77,10 +77,14 @@ default), but an adapter written against `ctx.http` works on every runtime.
 `Express` by default. If you build a **mock** `AdapterContext` in tests, it now
 needs an `http` entry alongside `app`.
 
-## Deprecated packages
+## Removed packages
 
-`@forinda/kickjs-auth`, `@forinda/kickjs-prisma`, `@forinda/kickjs-drizzle`, and
-the `@forinda/kickjs-db-{pg,mysql,sqlite}` shims are frozen — they stay installed
-and working at their last published version, but no longer receive updates. See
-their READMEs for the recommended replacements (BYO auth via context decorators,
-`@forinda/kickjs-db` with its `/pg` · `/mysql` · `/sqlite` subpaths).
+`@forinda/kickjs-auth`, `@forinda/kickjs-prisma` and `@forinda/kickjs-drizzle`
+were **removed in v8**, along with their `kick add` entries. The
+`@forinda/kickjs-db-{pg,mysql,sqlite}` shims are frozen at their last published
+version. Nothing uninstalls itself — an app pinned to one keeps working against
+the version it was built for — but none of them come with you to v8.
+
+Replacements: [BYO auth](./byo-recipes.md#auth) composed from context
+decorators, and `@forinda/kickjs-db` with its `/pg` · `/mysql` · `/sqlite`
+subpaths. See the [v8 migration guide](./migration-v7-to-v8.md).

--- a/docs/guide/socketio.md
+++ b/docs/guide/socketio.md
@@ -237,23 +237,36 @@ io.on('connection', (socket) => {
 })
 ```
 
-## With KickJS Auth
+## Sharing auth with your HTTP routes
 
-If you're using `@forinda/kickjs-auth`, you can reuse your JWT strategy:
+Auth is [bring-your-own](./byo-recipes.md#auth), so the piece to share is a plain function you own — not a framework strategy. Keep token verification separate from the transport, and both sides call it:
 
 ```ts
-import { JwtStrategy } from '@forinda/kickjs-auth'
+// src/auth/verify-token.ts — no HTTP, no socket, just the token
+import jwt from 'jsonwebtoken'
+import type { AuthUser } from './context'
 
-const jwtStrategy = JwtStrategy({ secret: JWT_SECRET })
-
-io.use(async (socket, next) => {
-  // Create a mock request object for the strategy
-  const mockReq = {
-    headers: { authorization: `Bearer ${socket.handshake.auth?.token}` },
+export function verifyToken(token: string | undefined): AuthUser | null {
+  if (!token) return null
+  try {
+    return mapPayload(jwt.verify(token, JWT_SECRET) as jwt.JwtPayload)
+  } catch {
+    return null
   }
-  const user = await jwtStrategy.validate(mockReq)
+}
+```
+
+The HTTP side calls it from the `user` contributor ([Step 3 of the recipe](./byo-recipes.md#auth)); the socket side calls it from `io.use`:
+
+```ts
+import { verifyToken } from './auth/verify-token'
+
+io.use((socket, next) => {
+  const user = verifyToken(socket.handshake.auth?.token)
   if (!user) return next(new Error('Unauthorized'))
   socket.data.user = user
   next()
 })
 ```
+
+Resist reusing a `RequestContext`-shaped strategy here by faking a request object. A handshake is not an HTTP request — it has no route, params or body — and the mock drifts the moment the strategy reads something the fake does not have.

--- a/docs/guide/swagger.md
+++ b/docs/guide/swagger.md
@@ -213,7 +213,7 @@ If your project uses a different auth library and wants its decorators to drive 
 ```typescript
 SwaggerAdapter({
   securityResolver: ({ controllerClass, handlerName }) => {
-    // Bridge `@forinda/kickjs-auth`'s metadata without coupling.
+    // Bridge your own auth decorators' metadata without coupling.
     const proto = controllerClass.prototype
     if (Reflect.getMetadata('kick:auth:public', proto, handlerName)) return null
     const secured =

--- a/docs/http/spec-http-runtimes.md
+++ b/docs/http/spec-http-runtimes.md
@@ -39,7 +39,8 @@ application rewrite.
 - No performance-parity promise on day one — Fastify behind the runtime
   seam initially routes through the shared pipeline, not Fastify's
   schema-compiled serializers (see §7 Risks).
-- No migration of the deprecated `@forinda/kickjs-auth` package (BYO auth
+- No migration of the `@forinda/kickjs-auth` package, deprecated at the time
+  of writing and since removed in v8 (BYO auth
   already composes from `ctx`, which is runtime-neutral by design here).
 
 ## 2. Where Express actually lives today


### PR DESCRIPTION
Stacked on #599.

Removing the packages fixed `authentication.md` and `authorization.md` but left **eight other pages** pointing at them. You spotted socketio; here is the full sweep.

| page | was | now |
| --- | --- | --- |
| `socketio.md` | **`import { JwtStrategy } from '@forinda/kickjs-auth'`** — code that cannot resolve | extract verification into a plain function your app owns; call it from both the `user` contributor and `io.use` |
| `context-decorators.md` | "`AuthUser` lives in `@forinda/kickjs-auth`" — augment that module | it is a type you declare yourself, augmented in your own module |
| `swagger.md` | stale `securityResolver` comment bridging kickjs-auth metadata | bridges your own auth decorators |
| `migration-runtimes.md` | all three "frozen — still installed and working" | removed in v8, with the replacement table and a link to the guide |
| `byo-recipes.md` | "deprecated"; pin `@forinda/kickjs-auth@^5.1.x` | removed; pin `6.0.1` (its actual last release) and note it cannot install alongside v8 |
| `integrations/index.md`, `spec-http-runtimes.md` | deprecated | removed |

The socketio one is the only page that handed out broken code. Its replacement also says **why** not to fake a `RequestContext` for a handshake — a handshake has no route, params or body, so the mock drifts the moment the strategy reads something the fake lacks. That was the shape of the original example.

`byo-recipes.md`'s pin was wrong twice over: `^5.1.x` predates the package's last release (6.0.1), so following it would have installed something older than necessary and still incompatible with v8.

Left alone deliberately: `changelog.md` and `migration-v3-to-v4.md` (historical records), and `migration-v7-to-v8.md` (documents the removal).

Docs build clean.
