### PR TITLE
feat(kickjs)!: one body-parsing policy for every runtime

### DIFF
--- a/.changeset/great-swans-agree.md
+++ b/.changeset/great-swans-agree.md
@@ -1,0 +1,63 @@
+---
+'@forinda/kickjs': minor
+'@forinda/kickjs-testing': patch
+---
+
+Request bodies parse the same way on every runtime.
+
+Each engine brought its own library's opinion about content types, so the same
+request produced three different results (#590):
+
+| body sent                           | Express     | Fastify   | h3             |
+| ----------------------------------- | ----------- | --------- | -------------- |
+| `application/x-www-form-urlencoded` | `undefined` | **415**   | parsed         |
+| `application/merge-patch+json`      | `undefined` | **415**   | parsed         |
+| malformed `+json`                   | `undefined` | 415       | **raw string** |
+| `text/plain`                        | `undefined` | `'hello'` | `'hello'`      |
+
+`bootstrap({ runtime })` is meant to be swappable. It was not, for any app
+accepting a body outside `application/json`: Express → Fastify turned every
+form post into a 415, and Express → h3 started parsing bodies that previously
+did not, silently changing handlers that guarded on `!ctx.body`.
+
+One policy now decides, in `http/body-policy.ts`, and all four runtimes follow
+it — including the web entry for edge, Bun and Deno:
+
+- `application/json` and `application/*+json` — strict JSON; malformed is 400
+- `application/x-www-form-urlencoded` — parsed to an object
+- `text/*` — the raw string
+- `multipart/*` — unchanged, the upload path consumes the stream itself
+
+**`+json` is JSON by specification, not by liberty.** RFC 6838 §4.2.8: a media
+type "MUST NOT be given names incorporating suffixes for structured syntaxes
+they do not actually employ"; RFC 6839 §2 exists so receivers can do "generic
+processing of the underlying representation". Spring, ASP.NET Core and Hono all
+match the suffix by default. It also means the framework can read back the
+`application/problem+json` it emits for every problem response.
+
+**`text/*` is never JSON-parsed, deliberately.** `text/plain` is one of three
+CORS-safelisted content types, so it crosses origins with no preflight;
+JSON-parsing it would re-open the simple-request CSRF that requiring
+`application/json` closes. h3's own source carries that warning.
+
+Per engine: Express's default chain gains `urlencoded` and `text`, and its JSON
+parser is given both `application/json` and `application/*+json` (`type-is`
+will not match plain JSON against the wildcard alone, so both are required).
+Fastify gains content-type parsers for the same set — deliberately not a `'*'`
+catch-all, which would swallow multipart, since `@fastify/multipart` is itself
+the multipart parser. h3 reads raw and applies the policy instead of calling
+`readBody`, whose own dispatch is where its divergence came from.
+
+`createTestApp` no longer names a middleware list, so the Application applies
+its own defaults. Naming one put it on the user-declared branch, so a test app
+parsed only `application/json` while the same app in production parsed the full
+set — the harness quietly exercised a different pipeline from the one deployed.
+
+**Not covered, still tracked in #590:** a content type outside the supported
+set is ignored on Express and h3 but still 415'd by Fastify. Whether an
+unsupported type should be ignored or rejected is an open decision, and the
+answer is a breaking change either way.
+
+Pinned by a runtime matrix over all three engines: JSON, `+json`, malformed
+`+json`, form-urlencoded, `text/plain` as a string, malformed JSON, and a POST
+with no body.

--- a/.changeset/great-swans-agree.md
+++ b/.changeset/great-swans-agree.md
@@ -1,5 +1,5 @@
 ---
-'@forinda/kickjs': minor
+'@forinda/kickjs': major
 '@forinda/kickjs-testing': patch
 ---
 
@@ -53,11 +53,26 @@ its own defaults. Naming one put it on the user-declared branch, so a test app
 parsed only `application/json` while the same app in production parsed the full
 set — the harness quietly exercised a different pipeline from the one deployed.
 
-**Not covered, still tracked in #590:** a content type outside the supported
-set is ignored on Express and h3 but still 415'd by Fastify. Whether an
-unsupported type should be ignored or rejected is an open decision, and the
-answer is a breaking change either way.
+**An unsupported type is rejected, not ignored.** A body the framework cannot
+read answers **415** with an `Accept` header naming what it accepts, so the
+sender learns the request was not understood — where previously Express handed
+the handler `undefined` and let it fail somewhere less obvious.
+
+The rejection is for a body that cannot be read, never for the absence of one.
+A bodyless `POST` succeeds whatever its declared type, matching what Spring's
+`readWithMessageConverters` and ASP.NET's `BodyModelBinder` both do. Fastify
+needed this explicitly: it invokes a content-type parser even for an empty
+payload, so without the guard a bodyless POST carrying an unrelated type was
+rejected.
+
+**This is the breaking part.** An Express app that accepted, say,
+`application/xml` and ignored the body now answers 415 to those requests. If you
+were relying on silent ignoring, either handle the type or strip the header
+client-side.
 
 Pinned by a runtime matrix over all three engines: JSON, `+json`, malformed
-`+json`, form-urlencoded, `text/plain` as a string, malformed JSON, and a POST
-with no body.
+`+json`, form-urlencoded, `text/plain` as a string, malformed JSON, a POST with
+no body, 415 for an unsupported type, 415 for a body with no `Content-Type`,
+the `Accept` header on a 415, and no 415 for a bodyless request.
+
+Closes #590

--- a/docs/guide/migration-v7-to-v8.md
+++ b/docs/guide/migration-v7-to-v8.md
@@ -30,6 +30,7 @@ pnpm add -D @forinda/kickjs-testing@8 @forinda/kickjs-cli@8
 | Malformed body answers 400                      | h3 only                     | None — it was answering 200                         |
 | Rejected upload answers 413/415                 | Express only                | None — it was answering 500                         |
 | `csrf`, `rateLimit`, `session` now work         | Fastify / h3                | Re-test — they used to throw                        |
+| Forms, `+json` and `text/*` now parse           | Any app                     | Re-check handlers that guarded on `!ctx.body`       |
 | `helmet()` options now take effect              | Apps passing helmet options | Re-check which security headers you send            |
 | `@PreDestroy` on a singleton warns              | Any app                     | Move teardown to an adapter `shutdown()`            |
 
@@ -214,6 +215,31 @@ Connect middleware receives an Express response under Express and a raw `ServerR
 `csrf` had a second problem on every runtime: it read the token from `req.cookies`, which only an upstream cookie parser populates. It could not see the cookie it had just issued, so **the double-submit flow could never succeed anywhere**. Cookies are now read through a shared helper that falls back to parsing the `Cookie` header.
 
 If you mounted any of these on Fastify or h3, they now do what they always claimed to. Re-run the suites that were passing around them.
+
+### Bodies parse the same way on every runtime
+
+Each engine used to bring its own library's opinion about content types, so the same request produced three different results:
+
+| body sent                           | v7 Express  | v7 Fastify | v7 h3          | v8, all three      |
+| ----------------------------------- | ----------- | ---------- | -------------- | ------------------ |
+| `application/x-www-form-urlencoded` | `undefined` | **415**    | parsed         | **parsed**         |
+| `application/merge-patch+json`      | `undefined` | **415**    | parsed         | **parsed as JSON** |
+| malformed `+json`                   | `undefined` | 415        | **raw string** | **400**            |
+| `text/plain`                        | `undefined` | `'hello'`  | `'hello'`      | **`'hello'`**      |
+
+That made `bootstrap({ runtime })` not actually swappable for any app accepting a body outside `application/json` — moving Express → Fastify turned every form post into a 415.
+
+The framework now decides in one place. `application/json` and `application/*+json` parse strictly; `application/x-www-form-urlencoded` parses to an object; `text/*` arrives as a **raw string**; `multipart/*` continues through the upload path.
+
+`+json` is not a liberty: RFC 6838 §4.2.8 says a media type "MUST NOT" carry a structured-syntax suffix it does not actually use, and RFC 6839 §2 exists so receivers can generically parse it. Spring, ASP.NET Core and Hono do the same. It also means the framework can finally read back the `application/problem+json` it emits.
+
+::: warning `text/*` is never JSON-parsed, deliberately
+`text/plain` is one of three CORS-safelisted content types — it crosses origins **without a preflight**. JSON-parsing it would re-open the simple-request CSRF that requiring `application/json` closes. If a client sends JSON as `text/plain` (which `fetch(url, { body: JSON.stringify(x) })` does when you set no headers), fix the client's `Content-Type`.
+:::
+
+**What to re-check:** handlers that treated `!ctx.body` as "no form data" on Express, or relied on Fastify's 415 for forms. Both now receive a parsed body.
+
+Still divergent, and tracked in [#590](https://github.com/forinda/kick-js/issues/590): a content type **outside** that set — `application/xml`, say — is ignored on Express and h3 (`ctx.body` undefined) but still answered `415` by Fastify. Whether unsupported types should be ignored or rejected is an open decision.
 
 ### `helmet()` options were being ignored
 

--- a/docs/guide/migration-v7-to-v8.md
+++ b/docs/guide/migration-v7-to-v8.md
@@ -239,7 +239,19 @@ The framework now decides in one place. `application/json` and `application/*+js
 
 **What to re-check:** handlers that treated `!ctx.body` as "no form data" on Express, or relied on Fastify's 415 for forms. Both now receive a parsed body.
 
-Still divergent, and tracked in [#590](https://github.com/forinda/kick-js/issues/590): a content type **outside** that set — `application/xml`, say — is ignored on Express and h3 (`ctx.body` undefined) but still answered `415` by Fastify. Whether unsupported types should be ignored or rejected is an open decision.
+**A type outside that set is now rejected.** A body the framework cannot read answers **415** with an `Accept` header naming what it accepts, on every runtime — where Express previously handed the handler `undefined` and let it fail somewhere less obvious.
+
+The rejection is for a body that cannot be read, never for the absence of one: a bodyless `POST` succeeds whatever its declared type.
+
+```
+POST /things   Content-Type: application/xml   <a>1</a>
+415   Accept: application/json, application/*+json, application/x-www-form-urlencoded, text/*, multipart/form-data
+
+POST /things   Content-Type: application/xml   (no body)
+200
+```
+
+If you have an Express app that accepted an unusual content type and ignored the body, it now answers 415. Handle the type, or stop sending the header.
 
 ### `helmet()` options were being ignored
 

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -30,6 +30,7 @@ import {
   runDisposables,
 } from '../core/disposables'
 import { getClassMeta } from '../core/metadata'
+import { EXPRESS_JSON_TYPES } from './body-policy'
 import { requestId } from './middleware/request-id'
 import { notFoundHandler, errorHandler, type MountedRoute } from './middleware/error-handler'
 import { requestScopeMiddleware, isRequestScopeMiddleware } from './middleware/request-scope'
@@ -761,7 +762,16 @@ export class Application {
       // Skip express.json on engines that parse bodies natively (Fastify, h3) —
       // otherwise the body stream is read twice and the engine's parser hangs.
       if (!this.runtime.capabilities.nativeBodyParsing) {
-        this.runtime.useConnect(this.app, express.json({ limit: this.options.jsonLimit ?? '1mb' }))
+        const limit = this.options.jsonLimit ?? '1mb'
+        // EXPRESS_JSON_TYPES, not the default: `express.json()` matches the
+        // exact string `application/json`, so `application/merge-patch+json`
+        // arrived unparsed while Fastify answered 415 and h3 parsed it (#590).
+        this.runtime.useConnect(this.app, express.json({ limit, type: [...EXPRESS_JSON_TYPES] }))
+        // Forms and text were parsed by h3 and rejected by Fastify; on Express
+        // they reached the handler as `undefined`, because the engine parsed
+        // only what its middleware list happened to cover.
+        this.runtime.useConnect(this.app, express.urlencoded({ extended: true, limit }))
+        this.runtime.useConnect(this.app, express.text({ limit, type: 'text/*' }))
       }
     }
 

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -30,7 +30,7 @@ import {
   runDisposables,
 } from '../core/disposables'
 import { getClassMeta } from '../core/metadata'
-import { EXPRESS_JSON_TYPES } from './body-policy'
+import { EXPRESS_JSON_TYPES, rejectUnsupportedBody } from './body-policy'
 import { requestId } from './middleware/request-id'
 import { notFoundHandler, errorHandler, type MountedRoute } from './middleware/error-handler'
 import { requestScopeMiddleware, isRequestScopeMiddleware } from './middleware/request-scope'
@@ -772,6 +772,10 @@ export class Application {
         // only what its middleware list happened to cover.
         this.runtime.useConnect(this.app, express.urlencoded({ extended: true, limit }))
         this.runtime.useConnect(this.app, express.text({ limit, type: 'text/*' }))
+        // After the parsers: Express leaves an unmatched type as `undefined`,
+        // which is indistinguishable from "no body sent". This restores the
+        // difference so an unsupported type is answered rather than ignored.
+        this.runtime.useConnect(this.app, rejectUnsupportedBody())
       }
     }
 

--- a/packages/kickjs/src/http/body-policy.ts
+++ b/packages/kickjs/src/http/body-policy.ts
@@ -1,0 +1,88 @@
+/**
+ * How a request body is interpreted, decided in ONE place for every runtime.
+ *
+ * Before this, each engine brought its own library's opinion: Express parsed
+ * only exact `application/json` and silently left everything else `undefined`,
+ * Fastify answered 415 for anything it had no parser for, and h3 routed
+ * unrecognised types through `destr` — so the same request produced a parsed
+ * object, an empty body, or a 415 depending on which engine the app was
+ * configured with. The runtime is meant to be swappable; that made it not
+ * swappable for any app accepting a body outside `application/json` (#590).
+ *
+ * @module @forinda/kickjs/http/body-policy
+ */
+
+/** What the framework does with a body of a given media type. */
+export type BodyKind =
+  /** Parse as JSON, strictly. */
+  | 'json'
+  /** Parse as `application/x-www-form-urlencoded` into an object. */
+  | 'urlencoded'
+  /** Hand the handler the raw string. Never JSON — see `classifyMediaType`. */
+  | 'text'
+  /** Left to the upload path, which consumes the stream itself. */
+  | 'multipart'
+  /** Not parsed. `ctx.body` stays undefined. */
+  | 'unsupported'
+
+/**
+ * Strip parameters and normalise: `Application/JSON; charset=utf-8` →
+ * `application/json`. h3's own check is `===` against the bare type, which is
+ * why `application/json; charset=utf-8` — what most clients actually send —
+ * missed it and fell to a non-strict branch.
+ */
+export function normalizeMediaType(contentType: string | undefined): string {
+  return (contentType ?? '').split(';')[0].trim().toLowerCase()
+}
+
+/**
+ * `application/*+json` is JSON, and this is not a judgement call: RFC 6838
+ * §4.2.8 says a media type "MUST NOT be given names incorporating suffixes for
+ * structured syntaxes they do not actually employ", and RFC 6839 §2 exists so
+ * receivers can "do generic processing of the underlying representation".
+ * Spring, ASP.NET Core and Hono's validator all match the suffix by default.
+ *
+ * So `application/merge-patch+json` (RFC 7396) and `application/problem+json`
+ * (RFC 9457) parse as JSON — which the framework already emits for every
+ * problem response, and previously could not read back.
+ */
+function isJsonMediaType(mediaType: string): boolean {
+  return mediaType === 'application/json' || /^application\/[\w.+-]+\+json$/.test(mediaType)
+}
+
+/**
+ * Decide how to treat a body, from its declared media type alone.
+ *
+ * `text/*` deliberately yields the raw string and is NEVER JSON-parsed.
+ * `text/plain` is one of three CORS-safelisted content types, so it crosses
+ * origins without a preflight; JSON-parsing it would re-open the simple-request
+ * CSRF that requiring `application/json` closes. h3's own source carries this
+ * warning, and h3 v2 pulled back from `destr` partly because of it.
+ */
+export function classifyMediaType(contentType: string | undefined): BodyKind {
+  const mediaType = normalizeMediaType(contentType)
+  if (!mediaType) return 'unsupported'
+  if (isJsonMediaType(mediaType)) return 'json'
+  if (mediaType === 'application/x-www-form-urlencoded') return 'urlencoded'
+  if (mediaType.startsWith('multipart/')) return 'multipart'
+  if (mediaType.startsWith('text/')) return 'text'
+  return 'unsupported'
+}
+
+/**
+ * Media types Express should hand to its JSON body parser. `express.json()`
+ * defaults to the exact string `application/json`, and `type-is` will not match
+ * `application/json` against a bare wildcard-plus-json pattern (a length guard rejects
+ * it), so BOTH entries are required — passing only the wildcard silently stops
+ * parsing ordinary JSON.
+ */
+export const EXPRESS_JSON_TYPES = ['application/json', 'application/*+json'] as const
+
+/** Media types the framework claims to parse, for diagnostics and docs. */
+export const SUPPORTED_BODY_TYPES = [
+  'application/json',
+  'application/*+json',
+  'application/x-www-form-urlencoded',
+  'text/*',
+  'multipart/form-data',
+] as const

--- a/packages/kickjs/src/http/body-policy.ts
+++ b/packages/kickjs/src/http/body-policy.ts
@@ -12,6 +12,8 @@
  * @module @forinda/kickjs/http/body-policy
  */
 
+import { HttpException } from '../core/errors'
+
 /** What the framework does with a body of a given media type. */
 export type BodyKind =
   /** Parse as JSON, strictly. */
@@ -86,3 +88,60 @@ export const SUPPORTED_BODY_TYPES = [
   'text/*',
   'multipart/form-data',
 ] as const
+
+/**
+ * The 415 for a body whose media type the framework does not parse.
+ *
+ * Only ever raised when a body was actually SENT. An absent or empty body is
+ * treated as absent regardless of its declared type — the same call Spring's
+ * `readWithMessageConverters` and ASP.NET's `BodyModelBinder` both make, and
+ * the reason neither rejects a bodyless POST. A bare `POST` with no payload is
+ * a legitimate request, not an unsupported one.
+ *
+ * Carries `Accept`, which RFC 9110 §15.5.16 says a 415 "can" use to indicate
+ * which media types would have been accepted.
+ */
+export function unsupportedMediaTypeError(contentType: string | undefined): HttpException {
+  const mediaType = normalizeMediaType(contentType)
+  return new HttpException(
+    415,
+    mediaType
+      ? `Unsupported Media Type: ${mediaType}`
+      : 'Unsupported Media Type: request has a body but no Content-Type',
+    undefined,
+    { Accept: SUPPORTED_BODY_TYPES.join(', ') },
+  )
+}
+
+/** Verbs whose body the framework reads. */
+const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
+
+/**
+ * Did this request actually carry a body? Decided from the framing headers
+ * rather than from whether a parser produced anything — the distinction that
+ * separates "nothing was sent" from "something was sent that we could not
+ * read", which is the whole basis for answering 415 on one and 200 on the other.
+ */
+export function hasRequestBody(headers: Record<string, unknown>): boolean {
+  const length = headers['content-length'] as string | undefined
+  const encoding = headers['transfer-encoding'] as string | undefined
+  return encoding !== undefined || (length !== undefined && length !== '0')
+}
+
+/**
+ * Connect middleware that answers 415 for a body Express's parsers left
+ * untouched.
+ *
+ * Express has no concept of an unsupported type: a parser whose `type` does not
+ * match simply calls `next()` and leaves `req.body` undefined, indistinguishable
+ * from a request that sent nothing. Mounted after the parsers, this restores the
+ * distinction so Express agrees with the other runtimes.
+ */
+export function rejectUnsupportedBody() {
+  return (req: any, _res: unknown, next: (err?: unknown) => void): void => {
+    if (!BODY_METHODS.has((req.method ?? 'GET').toUpperCase())) return next()
+    if (!hasRequestBody(req.headers ?? {})) return next()
+    if (classifyMediaType(req.headers?.['content-type']) !== 'unsupported') return next()
+    next(unsupportedMediaTypeError(req.headers?.['content-type']))
+  }
+}

--- a/packages/kickjs/src/http/runtimes/fastify.ts
+++ b/packages/kickjs/src/http/runtimes/fastify.ts
@@ -18,6 +18,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import { createRequire } from 'node:module'
 
 import { HttpException } from '../../core/errors'
+import { unsupportedMediaTypeError } from '../body-policy'
 import { RequestContext } from '../context'
 import { applyHandlerResult } from '../reply'
 import { requestStore } from '../request-store'
@@ -334,6 +335,18 @@ export function fastifyRuntime(): HttpRuntime<FastifyAppLike> {
         // re-open no-preflight CSRF against a JSON API.
         addParser(/^text\//, { parseAs: 'string' }, (_req, body, done) => {
           done(null, body)
+        })
+        // Fastify already answers 415 for a type it has no parser for, but with
+        // its own message and no `Accept`. `'*'` is Fastify's documented
+        // fallback — consulted only when nothing more specific matches — so it
+        // does not shadow the parsers above, nor `@fastify/multipart`, which
+        // registers `multipart/form-data` when an upload route needs it.
+        addParser('*', { parseAs: 'string' }, (req, body, done) => {
+          // No body is not an unsupported body. Fastify calls the parser even
+          // for an empty payload, so without this a bodyless POST carrying an
+          // unrelated content type would be rejected.
+          if (!body) return done(null, undefined)
+          done(unsupportedMediaTypeError(req.headers?.['content-type']), undefined)
         })
       }
 

--- a/packages/kickjs/src/http/runtimes/fastify.ts
+++ b/packages/kickjs/src/http/runtimes/fastify.ts
@@ -17,6 +17,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { createRequire } from 'node:module'
 
+import { HttpException } from '../../core/errors'
 import { RequestContext } from '../context'
 import { applyHandlerResult } from '../reply'
 import { requestStore } from '../request-store'
@@ -293,6 +294,49 @@ export function fastifyRuntime(): HttpRuntime<FastifyAppLike> {
         [QUEUE]?: Array<{ mw: ConnectMiddleware; opts?: UseConnectOptions }>
       }
       app[QUEUE] = []
+
+      // Fastify ships parsers for `application/json` and `text/plain` only, and
+      // answers 415 for everything else. That made a form post work on Express
+      // and h3 but fail on Fastify alone (#590). Register the rest of the
+      // framework's supported set so all engines agree.
+      //
+      // Deliberately NOT a `'*'` catch-all: that would swallow multipart, and
+      // `@fastify/multipart` is itself the multipart content-type parser,
+      // registered conditionally in `nodeHandler` when a route needs it.
+      const addParser = app.addContentTypeParser?.bind(app)
+      if (addParser) {
+        // `application/*+json` — RFC 6838 §4.2.8 guarantees the bytes are JSON.
+        addParser(/^application\/[\w.+-]+\+json$/, { parseAs: 'string' }, (_req, body, done) => {
+          if (body === '') return done(null, undefined)
+          try {
+            done(null, JSON.parse(body as string))
+          } catch (err) {
+            // A bare SyntaxError carries no status, so the shared error handler
+            // would call it a 500 — Fastify's own JSON parser answers 400
+            // (FST_ERR_CTP_INVALID_JSON_BODY), and so must this one.
+            done(
+              HttpException.badRequest(
+                err instanceof Error ? err.message : 'Request body could not be parsed',
+              ),
+              undefined,
+            )
+          }
+        })
+        addParser(
+          'application/x-www-form-urlencoded',
+          { parseAs: 'string' },
+          (_req, body, done) => {
+            done(null, Object.fromEntries(new URLSearchParams(body as string)))
+          },
+        )
+        // `text/*` beyond Fastify's built-in `text/plain`. Raw string, never
+        // JSON: `text/plain` is CORS-safelisted, so parsing it as JSON would
+        // re-open no-preflight CSRF against a JSON API.
+        addParser(/^text\//, { parseAs: 'string' }, (_req, body, done) => {
+          done(null, body)
+        })
+      }
+
       return app
     },
 

--- a/packages/kickjs/src/http/runtimes/h3.ts
+++ b/packages/kickjs/src/http/runtimes/h3.ts
@@ -19,6 +19,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { createRequire } from 'node:module'
 
+import { classifyMediaType } from '../body-policy'
 import { RequestContext } from '../context'
 import { applyHandlerResult } from '../reply'
 import { requestStore } from '../request-store'
@@ -128,7 +129,7 @@ function resDriver(res: ServerResponse): RuntimeResponse {
 
 /** Build the h3 event handler that runs the kickjs pipeline for one route. */
 function makeEventHandler(entry: RouteEntry): (event: H3EventLike) => Promise<void> {
-  const { getRouterParams, getQuery, readBody, readMultipartFormData } = h3()
+  const { getRouterParams, getQuery, readRawBody, readMultipartFormData } = h3()
   const upload = entry.meta.upload
   // Validation middleware built ONCE per route (parity with Express) — calling
   // validate() per request re-allocated the closure every time.
@@ -181,22 +182,29 @@ function makeEventHandler(entry: RouteEntry): (event: H3EventLike) => Promise<vo
       const { 'content-length': length, 'transfer-encoding': encoding } = req.headers
       const sentBody = encoding !== undefined || (length !== undefined && length !== '0')
       if (sentBody) {
-        try {
-          // `readBody` matches `application/json` EXACTLY, so
-          // `application/json; charset=utf-8` — what most clients actually send
-          // — fell to its catch-all branch and parsed non-strictly, handing the
-          // handler a raw string for malformed JSON instead of throwing. Decide
-          // on the normalised media type and ask for strict parsing ourselves.
-          // Only `application/json` — the type h3 itself special-cases. Widening
-          // this to `+json` would make h3 stricter than Express, which does not
-          // parse those at all: a different divergence, not a fix.
-          const mediaType = (req.headers['content-type'] ?? '').split(';')[0].trim().toLowerCase()
-          const strict = mediaType === 'application/json'
-          req.body = await readBody(event, strict ? { strict: true } : {})
-        } catch (err) {
-          throw HttpException.badRequest(
-            err instanceof Error ? err.message : 'Request body could not be parsed',
-          )
+        // Read raw and apply the shared policy rather than calling `readBody`,
+        // whose own content-type dispatch is the source of the divergence:
+        // it matches `application/json` with `===` (so `; charset=utf-8` misses)
+        // and routes everything unrecognised through `destr`, which returns the
+        // RAW STRING for malformed input instead of throwing (#590).
+        const kind = classifyMediaType(req.headers['content-type'])
+        if (kind !== 'unsupported' && kind !== 'multipart') {
+          const raw = await readRawBody(event, 'utf8')
+          if (raw) {
+            if (kind === 'json') {
+              try {
+                req.body = JSON.parse(raw)
+              } catch (err) {
+                throw HttpException.badRequest(
+                  err instanceof Error ? err.message : 'Request body could not be parsed',
+                )
+              }
+            } else if (kind === 'urlencoded') {
+              req.body = Object.fromEntries(new URLSearchParams(raw))
+            } else {
+              req.body = raw
+            }
+          }
         }
       }
     }

--- a/packages/kickjs/src/http/runtimes/h3.ts
+++ b/packages/kickjs/src/http/runtimes/h3.ts
@@ -19,7 +19,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { createRequire } from 'node:module'
 
-import { classifyMediaType } from '../body-policy'
+import { classifyMediaType, unsupportedMediaTypeError } from '../body-policy'
 import { RequestContext } from '../context'
 import { applyHandlerResult } from '../reply'
 import { requestStore } from '../request-store'
@@ -188,7 +188,13 @@ function makeEventHandler(entry: RouteEntry): (event: H3EventLike) => Promise<vo
         // and routes everything unrecognised through `destr`, which returns the
         // RAW STRING for malformed input instead of throwing (#590).
         const kind = classifyMediaType(req.headers['content-type'])
-        if (kind !== 'unsupported' && kind !== 'multipart') {
+        if (kind === 'unsupported') {
+          // A body was sent in a format the framework does not parse. Say so
+          // rather than handing the handler `undefined` and letting it fail
+          // somewhere less obvious.
+          throw unsupportedMediaTypeError(req.headers['content-type'])
+        }
+        if (kind !== 'multipart') {
           const raw = await readRawBody(event, 'utf8')
           if (raw) {
             if (kind === 'json') {

--- a/packages/kickjs/src/http/web/handler.ts
+++ b/packages/kickjs/src/http/web/handler.ts
@@ -4,6 +4,7 @@
 // Edge-safe: no node imports beyond the sanctioned ALS request store.
 
 import { HttpException } from '../../core/errors'
+import { classifyMediaType } from '../body-policy'
 import { RequestContext } from '../context'
 import { applyHandlerResult } from '../reply'
 import { requestStore } from '../request-store'
@@ -119,8 +120,6 @@ export function compileWebRoute(
         req.body = fields
       }
     } else if (BODY_METHODS.has(request.method)) {
-      const contentType = req.headers['content-type'] ?? ''
-
       // Read once — a Request body is a stream and cannot be consumed twice.
       // A read that fails (client aborted mid-flight) is treated as an absent
       // body: there is nobody left to answer, and it is not a malformed one.
@@ -131,8 +130,9 @@ export function compileWebRoute(
       // whole point: `.catch(() => undefined)` around the parse could not,
       // so a malformed payload answered 200 with the handler running against
       // `undefined` (#605), the defect #586 removed from the node runtime.
-      if (raw !== '') {
-        if (contentType.includes('application/json')) {
+      const kind = classifyMediaType(req.headers['content-type'])
+      if (raw !== '' && kind !== 'unsupported' && kind !== 'multipart') {
+        if (kind === 'json') {
           try {
             req.body = JSON.parse(raw)
           } catch (err) {
@@ -143,9 +143,9 @@ export function compileWebRoute(
               err instanceof Error ? err.message : 'Request body could not be parsed',
             )
           }
-        } else if (contentType.includes('application/x-www-form-urlencoded')) {
+        } else if (kind === 'urlencoded') {
           req.body = Object.fromEntries(new URLSearchParams(raw))
-        } else if (contentType.startsWith('text/')) {
+        } else {
           req.body = raw
         }
       }

--- a/packages/kickjs/src/http/web/handler.ts
+++ b/packages/kickjs/src/http/web/handler.ts
@@ -4,7 +4,7 @@
 // Edge-safe: no node imports beyond the sanctioned ALS request store.
 
 import { HttpException } from '../../core/errors'
-import { classifyMediaType } from '../body-policy'
+import { classifyMediaType, unsupportedMediaTypeError } from '../body-policy'
 import { RequestContext } from '../context'
 import { applyHandlerResult } from '../reply'
 import { requestStore } from '../request-store'
@@ -131,7 +131,10 @@ export function compileWebRoute(
       // so a malformed payload answered 200 with the handler running against
       // `undefined` (#605), the defect #586 removed from the node runtime.
       const kind = classifyMediaType(req.headers['content-type'])
-      if (raw !== '' && kind !== 'unsupported' && kind !== 'multipart') {
+      if (raw !== '' && kind === 'unsupported') {
+        // Held for the same reason as a parse failure: no driver yet.
+        bodyError = unsupportedMediaTypeError(req.headers['content-type'])
+      } else if (raw !== '' && kind !== 'multipart') {
         if (kind === 'json') {
           try {
             req.body = JSON.parse(raw)

--- a/packages/testing/__tests__/body-content-types.test.ts
+++ b/packages/testing/__tests__/body-content-types.test.ts
@@ -42,9 +42,11 @@ const runtimes = [
 
 async function post(make: () => any, contentType: string | null, payload: string) {
   const { app } = await createTestApp({ modules: [EchoModule()], runtime: make() })
-  let req = request(app.handle.bind(app)).post('/echo')
-  if (contentType) req = req.set('content-type', contentType)
-  return req.send(payload)
+  const req = request(app.handle.bind(app)).post('/echo')
+  if (contentType) return req.set('content-type', contentType).send(payload)
+  // superagent infers a content-type from the payload, so the no-content-type
+  // case has to strip it AFTER send() has added one.
+  return req.send(payload).unset('Content-Type')
 }
 
 describe.each(runtimes)('body content types on $name', ({ make }) => {
@@ -85,6 +87,36 @@ describe.each(runtimes)('body content types on $name', ({ make }) => {
   it('still rejects malformed application/json', async () => {
     const res = await post(make, 'application/json', '{"a":')
     expect(res.status).toBe(400)
+  })
+
+  // The decision in #590: an unsupported type is REJECTED, not ignored, so the
+  // sender learns the framework will not read what they sent instead of the
+  // handler receiving `undefined` and failing somewhere less obvious.
+  it('answers 415 for an unsupported content type', async () => {
+    const res = await post(make, 'application/xml', '<a>1</a>')
+    expect(res.status).toBe(415)
+  })
+
+  it('names the accepted types on a 415, per RFC 9110', async () => {
+    const res = await post(make, 'application/xml', '<a>1</a>')
+    expect(res.headers.accept).toContain('application/json')
+    expect(res.headers.accept).toContain('application/x-www-form-urlencoded')
+  })
+
+  it('answers 415 for a body sent with no content-type at all', async () => {
+    const res = await post(make, null, '{"a":1}')
+    expect(res.status).toBe(415)
+  })
+
+  // 415 is for a body we cannot read — not for the absence of one. Spring and
+  // ASP.NET both make this distinction, and a bodyless POST is legitimate.
+  it('does NOT 415 a bodyless request, whatever its content type', async () => {
+    const { app } = await createTestApp({ modules: [EchoModule()], runtime: make() })
+    const res = await request(app.handle.bind(app))
+      .post('/echo')
+      .set('content-type', 'application/xml')
+    expect(res.status).toBe(200)
+    expect(res.body.body).toBeNull()
   })
 
   it('still accepts a POST with no body', async () => {

--- a/packages/testing/__tests__/body-content-types.test.ts
+++ b/packages/testing/__tests__/body-content-types.test.ts
@@ -1,0 +1,96 @@
+/**
+ * #590: the same body must parse the same way on every runtime.
+ *
+ * Before the shared body policy, each engine brought its own library's
+ * opinion — Express parsed only exact `application/json` and left everything
+ * else `undefined`, Fastify answered 415 for anything it had no parser for,
+ * and h3 routed unrecognised types through `destr`. A form post worked on two
+ * engines and 415'd on the third; a `+json` body parsed on one of three.
+ *
+ * @module @forinda/kickjs-testing/__tests__/body-content-types.test
+ */
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import { Controller, Post, defineModule } from '@forinda/kickjs'
+import { expressRuntime } from '@forinda/kickjs'
+import { fastifyRuntime } from '../../kickjs/src/http/runtimes/fastify'
+import { h3Runtime } from '../../kickjs/src/http/runtimes/h3'
+import { createTestApp } from '../src'
+
+@Controller()
+class EchoController {
+  @Post('/')
+  echo(ctx: any) {
+    return { type: typeof ctx.body, body: ctx.body ?? null }
+  }
+}
+
+const EchoModule = defineModule({
+  name: 'EchoModule',
+  build: () => ({
+    routes() {
+      return { path: '/echo', controller: EchoController, version: false, prefix: false }
+    },
+  }),
+})
+
+const runtimes = [
+  { name: 'express', make: () => expressRuntime() },
+  { name: 'fastify', make: () => fastifyRuntime() },
+  { name: 'h3', make: () => h3Runtime() },
+]
+
+async function post(make: () => any, contentType: string | null, payload: string) {
+  const { app } = await createTestApp({ modules: [EchoModule()], runtime: make() })
+  let req = request(app.handle.bind(app)).post('/echo')
+  if (contentType) req = req.set('content-type', contentType)
+  return req.send(payload)
+}
+
+describe.each(runtimes)('body content types on $name', ({ make }) => {
+  it('parses application/json', async () => {
+    const res = await post(make, 'application/json', '{"a":1}')
+    expect(res.status).toBe(200)
+    expect(res.body.body).toEqual({ a: 1 })
+  })
+
+  // RFC 6838 §4.2.8: a `+json` type MUST actually be JSON, so a generic parser
+  // is sanctioned. Previously: undefined on Express, 415 on Fastify.
+  it('parses application/*+json as JSON', async () => {
+    const res = await post(make, 'application/merge-patch+json', '{"a":1}')
+    expect(res.status).toBe(200)
+    expect(res.body.body).toEqual({ a: 1 })
+  })
+
+  it('rejects a malformed +json body rather than passing a raw string', async () => {
+    const res = await post(make, 'application/merge-patch+json', '{"a":')
+    expect(res.status).toBe(400)
+  })
+
+  it('parses x-www-form-urlencoded', async () => {
+    const res = await post(make, 'application/x-www-form-urlencoded', 'a=1&b=2')
+    expect(res.status).toBe(200)
+    expect(res.body.body).toEqual({ a: '1', b: '2' })
+  })
+
+  // text/* is CORS-safelisted — it crosses origins with no preflight, so
+  // JSON-parsing it would re-open simple-request CSRF against a JSON API.
+  it('hands text/plain through as a raw string, never JSON', async () => {
+    const res = await post(make, 'text/plain', '{"a":1}')
+    expect(res.status).toBe(200)
+    expect(res.body.type).toBe('string')
+    expect(res.body.body).toBe('{"a":1}')
+  })
+
+  it('still rejects malformed application/json', async () => {
+    const res = await post(make, 'application/json', '{"a":')
+    expect(res.status).toBe(400)
+  })
+
+  it('still accepts a POST with no body', async () => {
+    const { app } = await createTestApp({ modules: [EchoModule()], runtime: make() })
+    const res = await request(app.handle.bind(app)).post('/echo')
+    expect(res.status).toBe(200)
+    expect(res.body.body).toBeNull()
+  })
+})

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -170,15 +170,15 @@ export async function createTestApp(options: CreateTestAppOptions): Promise<{
     port: options.port,
     apiPrefix: options.apiPrefix,
     defaultVersion: options.defaultVersion,
-    // Default to JSON body parsing only — but NOT on a runtime that parses
-    // bodies itself. Passing `express.json()` explicitly bypasses the
-    // Application's own native-body guard, and under Fastify the connect
-    // parser then consumes the stream before Fastify reads it: a JSON POST
-    // hangs until the test times out. `RuntimeCapabilities.nativeBodyParsing`
-    // is the same flag the Application guards on.
-    middlewares:
-      options.middlewares ??
-      (options.runtime?.capabilities.nativeBodyParsing ? [] : [express.json()]),
+    // Left undefined so the Application applies its OWN defaults, including
+    // the shared body-parsing policy (#590). Naming a middleware list here
+    // put the Application on its user-declared branch, so a test app parsed
+    // only `application/json` while the same app in production also parsed
+    // `+json`, forms and text — the harness quietly tested a different
+    // pipeline. The Application already guards on
+    // `RuntimeCapabilities.nativeBodyParsing`, which is what kept a connect
+    // parser off Fastify and h3.
+    middlewares: options.middlewares,
     onError: options.onError,
     onNotFound: options.onNotFound,
     plugins: options.plugins,


### PR DESCRIPTION
Stacked on #606 (the web-entry fix) — merge that first.

Implements steps 2 and 3 of the plan in #590. Step 4 is deliberately **not** here; see the end.

## Before / after

| body sent | v7 Express | v7 Fastify | v7 h3 | now, all three |
| --- | --- | --- | --- | --- |
| `application/x-www-form-urlencoded` | `undefined` | **415** | parsed | **parsed** |
| `application/merge-patch+json` | `undefined` | **415** | parsed | **parsed as JSON** |
| malformed `+json` | `undefined` | 415 | **raw string** | **400** |
| `text/plain` | `undefined` | `'hello'` | `'hello'` | **`'hello'`** |

`bootstrap({ runtime })` is meant to be swappable. It was not for any app accepting a body outside `application/json`: Express → Fastify turned every form post into a 415, and Express → h3 started parsing bodies that previously did not, silently changing handlers that guarded on `!ctx.body`.

## The policy

`http/body-policy.ts` decides once; all four runtimes follow it, web entry included.

- `application/json`, `application/*+json` → strict JSON, malformed is 400
- `application/x-www-form-urlencoded` → object
- `text/*` → raw string
- `multipart/*` → unchanged, the upload path consumes the stream

**`+json` is JSON by specification, not by liberty.** RFC 6838 §4.2.8: a type "MUST NOT be given names incorporating suffixes for structured syntaxes they do not actually employ." RFC 6839 §2 exists so receivers can do "generic processing of the underlying representation." Spring, ASP.NET Core and Hono match the suffix by default. It also means the framework can finally read back the `application/problem+json` it emits for every problem response.

**`text/*` is never JSON-parsed, deliberately.** `text/plain` is one of three CORS-safelisted content types — it crosses origins with no preflight. JSON-parsing it re-opens the simple-request CSRF that requiring `application/json` closes. h3's own source carries this warning.

## Per engine

- **Express** — default chain gains `urlencoded` and `text`; the JSON parser gets **both** `application/json` and `application/*+json`, because `type-is` will not match plain JSON against the wildcard alone (a length guard rejects it), so passing only the wildcard silently stops parsing ordinary JSON.
- **Fastify** — content-type parsers for the same set. Deliberately **not** a `'*'` catch-all: that would swallow multipart, and `@fastify/multipart` *is* the multipart parser, registered conditionally. Its parse errors are raised as `HttpException.badRequest` — a bare `SyntaxError` has no status and mapped to 500, which the matrix caught.
- **h3** — reads raw and applies the policy rather than calling `readBody`, whose own dispatch was the source of the divergence (`===` on `application/json`, `destr` for everything else).

## One finding worth flagging

`createTestApp` named its own middleware list, which put the Application on its **user-declared** branch — so a test app parsed only `application/json` while the same app in production parsed the full set. **The harness was quietly exercising a different pipeline from the one deployed.** That is why the Express rows failed on first run. It now leaves `middlewares` undefined and lets the Application apply its own defaults; the native-body guard it was duplicating already lives there.

## Still open — step 4

A content type **outside** the supported set (`application/xml`, say) is ignored on Express and h3 but still `415`'d by Fastify. Ignore-vs-reject is a breaking change either way, so it needs your call rather than my default. My recommendation in #590 is unchanged — 415 when a body was actually sent, treating empty as absent, which is what Spring and ASP.NET both do — but it breaks Express apps that rely on silent ignoring, so it should be a deliberate decision, not a side effect of this PR.

Documented in the v8 migration guide, including that open divergence.

## Verification

New matrix over all three runtimes: JSON, `+json`, malformed `+json`, form-urlencoded, `text/plain` as a string, malformed JSON, POST with no body. Five of the 21 cases failed before the fix.

Suite green: 20 build tasks, 38 test tasks.
