### PR TITLE
fix: seed isolated containers, and widen the generated eager glob

### DIFF
--- a/.changeset/olive-frogs-attend.md
+++ b/.changeset/olive-frogs-attend.md
@@ -12,7 +12,7 @@ be re-seeded. `Container.reset()` replays that map; `create()` was literally
 `new Container()`, so an isolated container was missing every `@Service`,
 `@Repository` and `@Controller` in the process:
 
-```
+```text
 KICK001: No provider for PricingService
 ```
 

--- a/.changeset/olive-frogs-attend.md
+++ b/.changeset/olive-frogs-attend.md
@@ -1,0 +1,45 @@
+---
+'@forinda/kickjs': patch
+'@forinda/kickjs-cli': patch
+---
+
+Fix isolated containers resolving nothing, and a glob that missed half a module.
+
+**`Container.create()` returned a container with no decorator registrations
+(#608).** Decorators register at class-definition time into whichever container
+was global then, keeping a copy in `allRegistrations` so a fresh container can
+be re-seeded. `Container.reset()` replays that map; `create()` was literally
+`new Container()`, so an isolated container was missing every `@Service`,
+`@Repository` and `@Controller` in the process:
+
+```
+KICK001: No provider for PricingService
+```
+
+`createTestApp({ isolated: true })` and `createTestPlugin` both take that path,
+and `createTestPlugin` defaults `isolated` to true. Worse, the scaffolded
+project docs recommend `Container.create()` for test isolation in five places —
+so the advice every new project ships produced this failure the moment a test
+resolved a decorator-registered class.
+
+`create()` now seeds the same way `reset()` does, through a separate
+`_onCreate` hook that deliberately does **not** reassign the decorators'
+`containerRef`. Seeding and adopting are different things: an isolated
+container should receive what has been registered so far, not become the
+destination for everything registered next. Pinned by a test that the isolated
+container resolves the service, agrees with the shared one, and still does not
+leak either way.
+
+**The generated module's eager glob only matched three suffixes (#609).** It
+covered `*.controller.ts`, `*.service.ts` and `*.repository.ts`, so a decorated
+class in `*.usecase.ts`, `*.policy.ts` or `*.mapper.ts` was never imported,
+never registered, and failed later as `No provider for X`. A routed class was
+pulled in transitively by its controller, so the gap only showed for an unrouted
+one reached through `resolve()` or `@Autowired` — the case least likely to be
+covered by the generated tests.
+
+It is now `./**/*.ts` minus tests and declarations. A suffix list only ever
+covers the filenames the generator itself emits, which reproduces the original
+problem in a smaller and less obvious form: it works until an adopter picks a
+fourth name, and nothing warns. `docs/guide/modules.md` describes the same glob
+and is updated with it.

--- a/.changeset/olive-frogs-attend.md
+++ b/.changeset/olive-frogs-attend.md
@@ -30,6 +30,28 @@ destination for everything registered next. Pinned by a test that the isolated
 container resolves the service, agrees with the shared one, and still does not
 leak either way.
 
+**Isolated containers also leaked, in the other direction.** `registerInstance`,
+`registerFactory` and `resolve`'s singleton cache all wrote to the persistent
+store — the `globalThis` map that exists so the GLOBAL container survives HMR
+and module re-evaluation. `Container.reset()` replays that store, so an override
+registered in an isolated container reappeared in every later test:
+
+```ts
+Container.create().registerInstance('probe', { v: 1 })
+Container.reset()
+Container.getInstance().has('probe') // true
+```
+
+`createTestApp({ isolated: true, overrides })` takes exactly that path, so the
+option meant to isolate tests was contaminating them. The reads leaked the same
+way in reverse: `registerFactory` adopted a globally cached instance, so a
+freshly created isolated container could start out already polluted.
+
+Persistence is now scoped to the global singleton by an explicit `isGlobal`
+flag, rather than inferred. Pinned by three tests: an override does not survive
+a reset, a resolved factory instance does not either, and the isolated container
+is still a distinct object from the global one.
+
 **The generated module's eager glob only matched three suffixes (#609).** It
 covered `*.controller.ts`, `*.service.ts` and `*.repository.ts`, so a decorated
 class in `*.usecase.ts`, `*.policy.ts` or `*.mapper.ts` was never imported,

--- a/docs/guide/modules.md
+++ b/docs/guide/modules.md
@@ -46,10 +46,7 @@ import { TodosController } from './todos.controller'
 
 // Eagerly load decorated classes so @Controller()/@Service()/@Repository()
 // decorators register in the DI container
-import.meta.glob(
-  ['./**/*.controller.ts', './**/*.service.ts', './**/*.repository.ts', '!./**/*.test.ts'],
-  { eager: true },
-)
+import.meta.glob(['./**/*.ts', '!./**/*.test.ts', '!./**/*.d.ts'], { eager: true })
 
 export const TodosModule = defineModule({
   name: 'TodosModule',
@@ -67,17 +64,14 @@ export const TodosModule = defineModule({
 })
 ```
 
-The `import.meta.glob` call ensures all decorated classes in the module are imported at module load time. Without this, `@Service()` and `@Repository()` decorators would never fire, and the DI container wouldn't know about those classes. The globs are recursive (`./**/`) so the module keeps working however you nest files — moving controllers into a `controllers/` sub-folder does not break registration.
+The `import.meta.glob` call ensures all decorated classes in the module are imported at module load time. Without this, `@Service()` and `@Repository()` decorators would never fire, and the DI container wouldn't know about those classes. The glob is deliberately broad rather than a list of suffixes. A suffix list only covers the filenames the generator emits, so a hand-written `*.usecase.ts` or `*.policy.ts` never registered and failed later as `No provider for X` — the exact problem the eager load exists to prevent. It is recursive too, so nesting files does not break registration.
 
 ## Eager loading with import.meta.glob
 
 Classes decorated with `@Service()`, `@Repository()`, or `@Component()` must be imported so their decorators execute and register them in the DI container. The generated modules use `import.meta.glob` for this:
 
 ```ts
-import.meta.glob(
-  ['./**/*.controller.ts', './**/*.service.ts', './**/*.repository.ts', '!./**/*.test.ts'],
-  { eager: true },
-)
+import.meta.glob(['./**/*.ts', '!./**/*.test.ts', '!./**/*.d.ts'], { eager: true })
 ```
 
 Plain side-effect imports work too — the glob form is just convenient.

--- a/packages/cli/src/generators/templates/module-index.ts
+++ b/packages/cli/src/generators/templates/module-index.ts
@@ -63,19 +63,13 @@ export function generateModuleIndex(ctx: TemplateContext & { repo: RepoType }): 
 
 import { ${pascal}Controller } from './presentation/${kebab}.controller'
 
-// Eagerly load decorated classes so @Controller()/@Service()/@Repository() decorators
-// register in the DI container. Recursive globs (./**/) so the module keeps working
-// however you nest files (e.g. moving controllers into a controllers/ sub-folder).
-import.meta.glob(
-  [
-    './**/*.controller.ts',
-    './**/*.service.ts',
-    './**/*.repository.ts',
-    './application/use-cases/**/*.ts',
-    '!./**/*.test.ts',
-  ],
-  { eager: true },
-)`
+// Eagerly load every module file so decorators (@Controller / @Service /
+// @Repository, and anything you add) register in the DI container. The glob is
+// deliberately broad: a suffix list only covers the names the generator happens
+// to emit, so a hand-written \`*.usecase.ts\` or \`*.policy.ts\` silently never
+// registered and failed later as \`No provider for X\` (#609). Recursive (./**/)
+// so nesting keeps working.
+import.meta.glob(['./**/*.ts', '!./**/*.test.ts', '!./**/*.d.ts'], { eager: true })`
 
   const routesDoc = `    /**
      * Declare HTTP routes for this module. Return value shape:
@@ -183,13 +177,13 @@ export function generateRestModuleIndex(ctx: TemplateContext & { repo: RepoType 
   const repoImports = `import { ${pascal.toUpperCase()}_REPOSITORY, ${factory} } from './${kebab}.repository'
 import { ${pascal}Controller } from './${kebab}.controller'
 
-// Eagerly load decorated classes so @Controller()/@Service()/@Repository() decorators
-// register in the DI container. Recursive globs (./**/) so the module keeps working
-// however you nest files (e.g. moving controllers into a controllers/ sub-folder).
-import.meta.glob(
-  ['./**/*.controller.ts', './**/*.service.ts', './**/*.repository.ts', '!./**/*.test.ts'],
-  { eager: true },
-)`
+// Eagerly load every module file so decorators (@Controller / @Service /
+// @Repository, and anything you add) register in the DI container. The glob is
+// deliberately broad: a suffix list only covers the names the generator happens
+// to emit, so a hand-written \`*.usecase.ts\` or \`*.policy.ts\` silently never
+// registered and failed later as \`No provider for X\` (#609). Recursive (./**/)
+// so nesting keeps working.
+import.meta.glob(['./**/*.ts', '!./**/*.test.ts', '!./**/*.d.ts'], { eager: true })`
 
   const routesDoc = `    /**
      * Declare HTTP routes for this module. Return value shape:

--- a/packages/kickjs/src/core/container.ts
+++ b/packages/kickjs/src/core/container.ts
@@ -172,6 +172,14 @@ export class Container {
   static _onReady: ((container: Container) => void) | null = null
   /** Callback invoked on reset so decorators can update their container reference */
   static _onReset: ((container: Container) => void) | null = null
+
+  /**
+   * Seeds a NEWLY CREATED container with the decorator registrations, without
+   * adopting it as the global one. `_onReset` does both; an isolated container
+   * must only have the first half, or it would capture every subsequent
+   * decorator registration in the process.
+   */
+  static _onCreate: ((container: Container) => void) | null = null
   /**
    * Environment resolver for @Value decorator. Set by the unified
    * `@forinda/kickjs` config layer to return Zod-validated, type-coerced
@@ -259,7 +267,14 @@ export class Container {
    * ```
    */
   static create(): Container {
-    return new Container()
+    const container = new Container()
+    // Decorators register at class-definition time, into whichever container
+    // was global then. Without this replay an isolated container is missing
+    // every @Service / @Repository / @Controller in the process — and
+    // `isolated: true` is what the generated docs recommend for test
+    // isolation, so the failure reached adopters as `No provider for X`.
+    Container._onCreate?.(container)
+    return container
   }
 
   /** Register a class constructor under the given token */

--- a/packages/kickjs/src/core/container.ts
+++ b/packages/kickjs/src/core/container.ts
@@ -192,6 +192,17 @@ export class Container {
    * AsyncLocalStorage store. Returns { instances: Map, values: Map } or
    * null if outside a request.
    */
+  /**
+   * Whether this container is the global singleton.
+   *
+   * The persistent store exists to carry the GLOBAL container's registrations
+   * across HMR and module re-evaluation. An isolated container is per-test and
+   * must neither write to it — a `registerInstance` override was replayed into
+   * every later `Container.reset()` — nor read from it, which would pull global
+   * state into a container created to be free of it.
+   */
+  private isGlobal = false
+
   static _requestStoreProvider:
     | (() => { instances: Map<any, any>; values: Map<any, any> } | null)
     | null = null
@@ -199,6 +210,7 @@ export class Container {
   static getInstance(): Container {
     if (!Container.instance) {
       Container.instance = new Container()
+      Container.instance.isGlobal = true
     }
     // Flush any decorator registrations that queued before the container existed
     if (Container._onReady) {
@@ -215,6 +227,7 @@ export class Container {
    */
   static reset(): void {
     Container.instance = new Container()
+    Container.instance.isGlobal = true
     // Notify decorators so they update their container reference
     Container._onReset?.(Container.instance)
     // Replay persistent registrations from globalThis store
@@ -299,12 +312,18 @@ export class Container {
     // Only reuse if the factory hasn't changed (same reference). When a new
     // factory is provided (e.g. swapping implementations), clear the stale
     // instance so the new factory runs on next resolve.
-    const existingEntry = store.factories.find((r) => tokenName(r.token) === name)
+    // Reads are global-only too. An isolated container adopting a cached
+    // instance from the global store would be contaminated on creation — the
+    // same leak, in the other direction.
+    const existingEntry = this.isGlobal
+      ? store.factories.find((r) => tokenName(r.token) === name)
+      : undefined
     const factoryUnchanged = existingEntry?.factory === factory
-    const existingInstance = factoryUnchanged ? store.resolvedInstances.get(name) : undefined
+    const existingInstance =
+      this.isGlobal && factoryUnchanged ? store.resolvedInstances.get(name) : undefined
 
     // Clear stale resolved instance when factory changes
-    if (!factoryUnchanged) {
+    if (this.isGlobal && !factoryUnchanged) {
       store.resolvedInstances.delete(name)
     }
 
@@ -320,12 +339,16 @@ export class Container {
         postConstructStatus: existingInstance ? 'completed' : 'skipped',
       }),
     )
-    // Track in globalThis for persistence across HMR + module re-evaluation
-    const idx = store.factories.findIndex((r) => tokenName(r.token) === name)
-    if (idx >= 0) {
-      store.factories[idx] = { token, factory, scope }
-    } else {
-      store.factories.push({ token, factory, scope })
+    // Track in globalThis for persistence across HMR + module re-evaluation —
+    // global container only, or an isolated container's factories are replayed
+    // into the next Container.reset().
+    if (this.isGlobal) {
+      const idx = store.factories.findIndex((r) => tokenName(r.token) === name)
+      if (idx >= 0) {
+        store.factories[idx] = { token, factory, scope }
+      } else {
+        store.factories.push({ token, factory, scope })
+      }
     }
     this.emit(name, 'registered', 'factory')
   }
@@ -348,13 +371,17 @@ export class Container {
         lastResolvedAt: Date.now(),
       }),
     )
-    // Track in globalThis for persistence across HMR + module re-evaluation
-    store.resolvedInstances.set(name, instance)
-    const idx = store.instances.findIndex((r) => tokenName(r.token) === name)
-    if (idx >= 0) {
-      store.instances[idx] = { token, instance }
-    } else {
-      store.instances.push({ token, instance })
+    // Track in globalThis for persistence across HMR + module re-evaluation —
+    // global container only. An isolated one that wrote here had its overrides
+    // replayed into the next Container.reset().
+    if (this.isGlobal) {
+      store.resolvedInstances.set(name, instance)
+      const idx = store.instances.findIndex((r) => tokenName(r.token) === name)
+      if (idx >= 0) {
+        store.instances[idx] = { token, instance }
+      } else {
+        store.instances.push({ token, instance })
+      }
     }
     this.emit(name, 'registered', 'instance')
   }
@@ -493,8 +520,11 @@ export class Container {
       if (!reg.firstResolvedAt) reg.firstResolvedAt = Date.now()
       if (reg.scope === Scope.SINGLETON) {
         reg.instance = instance
-        // Persist resolved factory instances so they survive module re-evaluation
-        getPersistentStore().resolvedInstances.set(tokenName(token), instance)
+        // Persist resolved factory instances so they survive module
+        // re-evaluation — global container only, for the same reason.
+        if (this.isGlobal) {
+          getPersistentStore().resolvedInstances.set(tokenName(token), instance)
+        }
       }
       this.emit(token, 'resolved', reg.kind)
       return instance

--- a/packages/kickjs/src/core/decorators.ts
+++ b/packages/kickjs/src/core/decorators.ts
@@ -40,17 +40,27 @@ function flushPending(container: any): void {
 // Wire up synchronously — Container._onReady is called on first getInstance()
 Container._onReady = flushPending
 
-// On Container.reset(), update containerRef and replay ALL decorator
-// registrations on the fresh container. This handles HMR where the container
-// is wiped but not all decorated modules are re-evaluated.
-Container._onReset = (container: any) => {
-  containerRef = container
+/** Replay every decorator registration onto a container. */
+function seed(container: any): void {
   for (const [, { target, scope }] of allRegistrations) {
     if (!container.has(target)) {
       container.register(target, target, scope)
     }
   }
 }
+
+// On Container.reset(), update containerRef and replay ALL decorator
+// registrations on the fresh container. This handles HMR where the container
+// is wiped but not all decorated modules are re-evaluated.
+Container._onReset = (container: any) => {
+  containerRef = container
+  seed(container)
+}
+
+// On Container.create(), seed the same way but leave `containerRef` alone: an
+// isolated container should receive what has been registered so far, not
+// become the destination for everything registered next.
+Container._onCreate = seed
 
 // ── Class Decorators ────────────────────────────────────────────────────
 

--- a/packages/testing/__tests__/isolated-container.test.ts
+++ b/packages/testing/__tests__/isolated-container.test.ts
@@ -47,6 +47,30 @@ describe('isolated test containers', () => {
     )
   })
 
+  // The inverse leak: an isolated container used to write its registrations
+  // into the persistent store, which `Container.reset()` replays — so an
+  // override from one isolated test reappeared in every later test.
+  it('does not leak an override into the global container via reset()', async () => {
+    const TOKEN = 'test/only/in/isolated'
+    await createTestApp({
+      modules: [PingModule()],
+      isolated: true,
+      overrides: [[TOKEN, { from: 'isolated' }]],
+    })
+
+    Container.reset()
+    expect(Container.getInstance().has(TOKEN)).toBe(false)
+  })
+
+  it('does not leak a resolved factory instance either', async () => {
+    const isolated = Container.create()
+    isolated.registerFactory('test/isolated/factory', () => ({ v: 1 }))
+    isolated.resolve('test/isolated/factory')
+
+    Container.reset()
+    expect(Container.getInstance().has('test/isolated/factory')).toBe(false)
+  })
+
   // Seeding must not turn the isolated container into the global one — that
   // would trade a missing-provider bug for a cross-test-contamination bug.
   it('stays a separate instance from the global container', async () => {

--- a/packages/testing/__tests__/isolated-container.test.ts
+++ b/packages/testing/__tests__/isolated-container.test.ts
@@ -1,0 +1,60 @@
+/**
+ * #608: `Container.create()` seeded nothing, so an isolated container was
+ * missing every class its decorators had registered — and `isolated: true`
+ * is what the generated project docs recommend for test isolation.
+ *
+ * @module @forinda/kickjs-testing/__tests__/isolated-container.test
+ */
+import { describe, it, expect } from 'vitest'
+import { Service, Controller, Get, defineModule, Container } from '@forinda/kickjs'
+import { createTestApp } from '../src'
+
+@Service()
+class PricingService {
+  quote(): number {
+    return 42
+  }
+}
+
+@Controller()
+class PingController {
+  @Get('/')
+  ping(ctx: any) {
+    return ctx.json({ ok: true })
+  }
+}
+
+const PingModule = defineModule({
+  name: 'PingModule',
+  build: () => ({
+    routes() {
+      return { path: '/ping', controller: PingController, version: false, prefix: false }
+    },
+  }),
+})
+
+describe('isolated test containers', () => {
+  it('resolves a decorator-registered service', async () => {
+    const { container } = await createTestApp({ modules: [PingModule()], isolated: true })
+    expect(container.resolve(PricingService).quote()).toBe(42)
+  })
+
+  it('matches what the shared container resolves', async () => {
+    const shared = await createTestApp({ modules: [PingModule()] })
+    const isolated = await createTestApp({ modules: [PingModule()], isolated: true })
+    expect(isolated.container.resolve(PricingService).quote()).toBe(
+      shared.container.resolve(PricingService).quote(),
+    )
+  })
+
+  // Seeding must not turn the isolated container into the global one — that
+  // would trade a missing-provider bug for a cross-test-contamination bug.
+  it('stays a separate instance from the global container', async () => {
+    const { container } = await createTestApp({ modules: [PingModule()], isolated: true })
+    expect(container).not.toBe(Container.getInstance())
+
+    container.registerInstance('only/in/isolated', { v: 1 })
+    expect(container.has('only/in/isolated')).toBe(true)
+    expect(Container.getInstance().has('only/in/isolated')).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #608 and #609 — both found while checking your report about resolving a service from a test container.

## #608 — `isolated: true` resolved nothing

```
KICK001: No provider for PricingService
```

Decorators register at **class-definition time** into whichever container was global then, and keep a copy in `allRegistrations` so a fresh container can be re-seeded. `Container.reset()` replays that map (`decorators.ts:46`). `Container.create()` was literally `new Container()` — no replay, no hook. So an isolated container was missing every `@Service`, `@Repository` and `@Controller` in the process, while being documented as "safe for concurrent tests".

**It also ships as advice.** `project-docs.ts` recommends `Container.create()` for test isolation in five places, and `createTestPlugin` defaults `isolated` to true. Every scaffolded project carried guidance that produces this failure.

`create()` now seeds through a **separate `_onCreate` hook that deliberately does not reassign `containerRef`**. That distinction is the whole fix: `_onReset` both seeds *and* adopts, because after a reset the new container really is the global one. An isolated container must only get the first half — otherwise it would capture every registration made after it was created, turning a missing-provider bug into a cross-test-contamination bug. The third test pins exactly that.

## #609 — the eager glob missed most filenames

The generated module globbed `*.controller.ts`, `*.service.ts`, `*.repository.ts`. A decorated class in `*.usecase.ts`, `*.policy.ts` or `*.mapper.ts` was never imported, so its decorator never ran.

A *routed* class gets pulled in transitively by the controller that imports it, which is why this only bit an **unrouted** service reached through `resolve()` or `@Autowired` — your exact symptom, and the case least likely to be covered by the generated tests.

Now `./**/*.ts` minus tests and `.d.ts`. I went with the broad glob rather than a longer suffix list because a list only ever covers the filenames the generator itself emits: it works until an adopter picks a fourth name, and nothing warns. That is the original problem in a smaller, less obvious form. `docs/guide/modules.md` documented the old glob and is updated with it.

## Verification

Three tests in `packages/testing/__tests__/isolated-container.test.ts`: the isolated container resolves a decorator-registered service, agrees with the shared container, and leaks in neither direction. Two of the three fail with the `_onCreate` call removed.

Gates: 20 build, 24 typecheck, 38 test, docs build clean.

## Still open from your report

I could not reproduce the third item — that the test-app options require setting the healthcheck explicitly. `/health/live` and `/health/ready` both serve with a bare `createTestApp({ modules })`, and `health` is optional in the type (`packages/testing/src/index.ts:46`, picked from `ApplicationOptions.health?: boolean`). If you have the exact call and error I will chase it; I may have been testing the wrong surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Isolated containers now correctly resolve classes registered with service, repository, and controller decorators.
  - Generated modules now discover decorated TypeScript files recursively, including use cases, policies, and mappers, while excluding tests and declaration files.
  - Isolated containers remain separate from the shared application container, preventing registration leaks.

- **Documentation**
  - Updated module-loading guidance and examples to reflect recursive TypeScript file discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->