### PR TITLE
feat(kickjs)!: every error is RFC 9457 problem details

### DIFF
--- a/.changeset/proud-lions-repeat.md
+++ b/.changeset/proud-lions-repeat.md
@@ -1,0 +1,42 @@
+---
+'@forinda/kickjs': major
+---
+
+Every error the framework serialises is RFC 9457 problem details.
+
+A plain `HttpException` answered a bare `{ "message": … }` with
+`application/json`, while `ProblemException` and `ctx.problem.*` answered
+`application/problem+json`. So `HttpException` was the one shape a client
+parsing problem details had to special-case — and the most common one, since it
+is how most apps reject a request. The same situation the v8 catch-all change
+removed, in the path it did not reach (#611).
+
+```ts
+throw HttpException.forbidden('Not your project')
+```
+
+```json
+403  content-type: application/problem+json
+{ "type": "about:blank", "title": "Forbidden", "status": 403, "detail": "Not your project" }
+```
+
+The message becomes `detail`; `title` and `type` default from the status.
+`details` becomes an `errors` extension member, permitted by §3.2 and still
+withheld in production for the same reason as before — it can carry the shape
+of the request that failed. Route validation raises `HttpException`, so 422
+bodies move with it.
+
+**Migrating:** assert on `body.detail` rather than `body.message`. Nothing is
+lost, it is renamed to the RFC's field.
+
+The error handler's own contract previously said `HttpException` "keeps the
+existing `{ message, errors? }` shape for backward compatibility". That clause
+is gone — it was cheapest to drop inside the v8 window, and keeping it meant the
+framework shipped two error shapes and no rule for which one an app would get.
+
+Reported against contributors, which is where it is most visible: a contributor
+is the natural place to authorise, and answering off-spec there pushed
+authorisation checks back into `@Middleware()` for the wrong reason. Contributors
+could always reach `ctx.problem.*` — `resolve()` gets a full `RequestContext` —
+but should not have had to in order to get a conformant body. Both guides now
+say which to reach for and why.

--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -326,6 +326,35 @@ Integration tests that exercise each route are still worth having; narrowing cov
 
 ## Error handling
 
+A contributor is the natural place to authorise — `dependsOn` gives you "resolve the actor, then check them" without a second lookup — so it needs the same error vocabulary as a handler. It has it.
+
+`resolve()` receives a full `RequestContext` under `defineHttpContextDecorator`, so both forms are available and both emit RFC 9457:
+
+```ts
+const RequireAdmin = defineHttpContextDecorator({
+  key: 'allowed',
+  dependsOn: ['user'],
+  resolve: (ctx) => {
+    const user = ctx.require('user')
+
+    // A status and a sentence — the common case.
+    if (!user.roles.includes('admin')) throw HttpException.forbidden('Admin only')
+
+    // Or the full problem shape, when a client should branch on `type`.
+    if (user.suspended) {
+      ctx.problem.forbidden({
+        type: 'https://example.com/probs/suspended',
+        detail: 'This account is suspended',
+      })
+    }
+
+    return true
+  },
+})
+```
+
+Both answer `application/problem+json`; see [Error Handling](./error-handling.md#rfc-9457-problem-details) for which to pick. There is no shape penalty for rejecting from a contributor rather than a guard — which there was before v8, and which pushed authorisation checks back into `@Middleware()` for the wrong reason.
+
 When a `resolve()` throws, the runner consults two flags before deciding what to do:
 
 | `resolve()` outcome                    | `optional` | `onError` defined | Behaviour                                                               |

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -232,7 +232,29 @@ The `context` field carries structured data (the token name, the env key, the mo
 
 KickJS ships first-class support for [RFC 9457 — Problem Details for HTTP APIs](https://datatracker.ietf.org/doc/html/rfc9457) (the successor to RFC 7807). It's the canonical answer to "what shape should our error JSON have?" — five standard fields, a known content type (`application/problem+json`), and arbitrary extensions per §3.2.
 
-Two entry points: `ctx.problem.*` for the response-side flow, and `ProblemException` for throwing from services where `ctx` isn't in scope.
+**Every error the framework serialises is problem details.** A plain `HttpException` produces the same content type and shape as `ProblemException` — its message becomes `detail`, and `title` / `type` default from the status:
+
+```ts
+throw HttpException.forbidden('Not your project')
+```
+
+```json
+403  content-type: application/problem+json
+{ "type": "about:blank", "title": "Forbidden", "status": 403, "detail": "Not your project" }
+```
+
+So a client parses one shape, whichever way the app rejected the request. Before v8, `HttpException` answered a bare `{ "message": … }`, which left it as the single path a problem-details client had to special-case.
+
+### Which one to throw
+
+|                                      | use                                                                                                             | you control                          |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `HttpException.forbidden('…')`       | the common case — a status and a sentence                                                                       | `status`, `detail`                   |
+| `ProblemException` / `ctx.problem.*` | when the response needs a stable machine-readable `type`, a custom `title`, an `instance`, or extension members | all five RFC fields, plus extensions |
+
+Reach for `HttpException` by default. Reach for `ProblemException` when a client is expected to branch on `type` — that is the field the RFC intends for programmatic dispatch, and a defaulted `about:blank` carries no information.
+
+Two entry points for the richer form: `ctx.problem.*` for the response-side flow, and `ProblemException` for throwing from services where `ctx` isn't in scope.
 
 ### `ctx.problem` — response helpers
 

--- a/docs/guide/migration-v7-to-v8.md
+++ b/docs/guide/migration-v7-to-v8.md
@@ -27,6 +27,7 @@ pnpm add -D @forinda/kickjs-testing@8 @forinda/kickjs-cli@8
 | `kick add auth\|drizzle\|prisma` now fails      | Anyone scripting `kick add` | Drop those from setup scripts and CI                |
 | `middleware` option renamed to `middlewares`    | Any app setting it          | Rename the key — the compiler finds every one       |
 | 404 body is now problem details                 | Any app                     | Read `title`/`status`, or restore with `onNotFound` |
+| Every `HttpException` is problem details        | Any app                     | Read `detail`/`status`, not `message`               |
 | Wrong verb answers 405, not 404                 | Any app                     | Move the case to the 405 branch                     |
 | Health probes moved inside the middleware chain | Apps with global auth       | Exempt the path, or `health: false`                 |
 | `/health/ready` answers instead of 500          | Fastify / h3                | None — the probe was permanently failing            |
@@ -78,6 +79,23 @@ Renamed for the same reason, in the same release:
 `createTestApp` passes the option straight through to `bootstrap()`, so a harness whose option name disagreed with the thing it configures was exactly the inconsistency being removed — that is why `@forinda/kickjs-testing` takes a major too.
 
 **`AppAdapter.middleware()` and `Plugin.middleware()` are unchanged.** Those are a different API — a hook that returns entries, not an option that takes them — and nothing about them was ambiguous. If you write adapters, nothing there moves.
+
+## Breaking: every error is problem details
+
+A plain `HttpException` used to answer a bare `{ "message": … }` with `application/json`. It now emits RFC 9457, the same as `ProblemException` and `ctx.problem.*`:
+
+```ts
+throw HttpException.forbidden('Not your project')
+```
+
+```json
+403  content-type: application/problem+json
+{ "type": "about:blank", "title": "Forbidden", "status": 403, "detail": "Not your project" }
+```
+
+`HttpException` was the last shape a client parsing `application/problem+json` had to special-case — and the most common one, since it is how most apps reject a request. Route validation raises `HttpException` too, so 422 bodies move with it: `details` becomes an `errors` extension member, still withheld in production.
+
+**If you assert on `body.message`, read `body.detail`.** The message is not lost; it is the `detail` field.
 
 ## Breaking: the catch-all
 

--- a/packages/kickjs/__tests__/http-exception.test.ts
+++ b/packages/kickjs/__tests__/http-exception.test.ts
@@ -22,7 +22,12 @@ describe('HttpException', () => {
       const res = await request(appThrowing(err)).get('/boom')
       expect(res.status).toBe(429)
       expect(res.headers['retry-after']).toBe('60')
-      expect(res.body).toEqual({ message: 'slow down' })
+      expect(res.body).toEqual({
+        status: 429,
+        type: 'about:blank',
+        title: 'Too Many Requests',
+        detail: 'slow down',
+      })
     })
 
     it('propagates a WWW-Authenticate header on 401', async () => {
@@ -47,7 +52,12 @@ describe('HttpException', () => {
       const err = new HttpException(404, 'Not Found')
       const res = await request(appThrowing(err)).get('/boom')
       expect(res.status).toBe(404)
-      expect(res.body).toEqual({ message: 'Not Found' })
+      expect(res.body).toEqual({
+        status: 404,
+        type: 'about:blank',
+        title: 'Not Found',
+        detail: 'Not Found',
+      })
     })
   })
 
@@ -138,7 +148,12 @@ describe('HttpException', () => {
       const err = new HttpException(500, 'something broke', { dbError: 'syntax error at line 12' })
       const res = await request(appThrowing(err)).get('/boom')
       expect(res.status).toBe(500)
-      expect(res.body).toEqual({ message: 'something broke' })
+      expect(res.body).toEqual({
+        status: 500,
+        type: 'about:blank',
+        title: 'Internal Server Error',
+        detail: 'something broke',
+      })
       expect(res.body).not.toHaveProperty('errors')
     })
 
@@ -149,7 +164,7 @@ describe('HttpException', () => {
       ])
       const res = await request(appThrowing(err)).get('/boom')
       expect(res.status).toBe(422)
-      expect(res.body.message).toBe('bad')
+      expect(res.body.detail).toBe('bad')
       expect(res.body).not.toHaveProperty('errors')
     })
 

--- a/packages/kickjs/__tests__/problem-details.test.ts
+++ b/packages/kickjs/__tests__/problem-details.test.ts
@@ -250,12 +250,21 @@ describe('errorHandler — ProblemException', () => {
     expect(res.headers['retry-after']).toBe('60')
   })
 
-  it('keeps existing JSON shape for plain HttpException (backward compat)', async () => {
+  // #611: a plain HttpException is RFC 9457 too. It used to answer a bare
+  // `{ message }`, which left it as the one shape a client parsing
+  // problem+json had to special-case — the situation #587 removed from the
+  // catch-all. The message becomes `detail`; title and type default.
+  it('emits problem details for a plain HttpException', async () => {
     const ex = new HttpException(404, 'Old shape')
     const res = await request(appThrowing(ex)).get('/boom')
     expect(res.status).toBe(404)
-    expect(res.headers['content-type']).toMatch(/^application\/json/)
-    expect(res.body).toEqual({ message: 'Old shape' })
+    expect(res.headers['content-type']).toMatch(/^application\/problem\+json/)
+    expect(res.body).toEqual({
+      status: 404,
+      type: 'about:blank',
+      title: 'Not Found',
+      detail: 'Old shape',
+    })
   })
 })
 

--- a/packages/kickjs/src/http/middleware/error-handler.ts
+++ b/packages/kickjs/src/http/middleware/error-handler.ts
@@ -107,10 +107,11 @@ export function notFoundHandler(routes: readonly MountedRoute[] = []) {
  * handle back to the log line) and, outside production, the error summary
  * plus stack. Production bodies stay opaque.
  *
- * {@link ProblemException} is dispatched first and emits an
- * `application/problem+json` response per RFC 9457. Plain
- * {@link HttpException} keeps the existing `{ message, errors? }` shape
- * for backward compatibility.
+ * {@link ProblemException} and plain {@link HttpException} both emit
+ * `application/problem+json` per RFC 9457. `ProblemException` carries a
+ * caller-supplied `type` / `title` / extensions; an `HttpException`'s message
+ * becomes `detail`, with `title` and `type` defaulted from the status. One
+ * shape, so a client never has to branch on which one the app threw.
  */
 export function errorHandler() {
   const isProduction = process.env.NODE_ENV === 'production'
@@ -147,7 +148,11 @@ export function errorHandler() {
       })
     }
 
-    // HttpException (expected application errors)
+    // HttpException (expected application errors) — RFC 9457, same as
+    // ProblemException. It used to answer a bare `{ message }`, which made it
+    // THE path a client parsing `application/problem+json` had to special-case
+    // (#611) — the exact situation #587 removed from the catch-all. The
+    // message becomes `detail`; `title` and `type` default from the status.
     if (err instanceof HttpException) {
       if (err.status >= 500) {
         log.error(err, err.message)
@@ -158,10 +163,17 @@ export function errorHandler() {
         }
       }
       const exposeDetails = !isProduction && err.details !== undefined
-      return res.status(err.status).json({
-        message: err.message,
-        ...(exposeDetails ? { errors: err.details } : {}),
-      })
+      res.setHeader('Content-Type', 'application/problem+json')
+      return res.status(err.status).json(
+        normalizeProblem({
+          status: err.status,
+          detail: err.message,
+          // Extension member, permitted by RFC 9457 §3.2. Held back in
+          // production for the same reason as before: `details` can carry the
+          // shape of the request that failed.
+          ...(exposeDetails ? { errors: err.details } : {}),
+        }),
+      )
     }
 
     // Unexpected errors — always log

--- a/packages/testing/__tests__/error-parity.test.ts
+++ b/packages/testing/__tests__/error-parity.test.ts
@@ -108,7 +108,18 @@ describe.each(runtimes)('error handling on $name', ({ make }) => {
     // one because its wrapper defeated the `instanceof` check.
     const res = await (await agent()).get('/api/v1/things/teapot')
     expect(res.status).toBe(418)
-    expect(res.body).toEqual({ message: 'I am a teapot' })
+    // #611: an HttpException is RFC 9457 like everything else — the message
+    // becomes `detail`, title and type default from the status.
+    expect(res.headers['content-type']).toContain('application/problem+json')
+    expect(res.body).toEqual({
+      status: 418,
+      type: 'about:blank',
+      // 418 is RFC 2324's joke status and is "(Unused)" in the IANA registry,
+      // so it has no reason phrase to default from — `defaultProblemTitle`
+      // falls back to "Error". The status and detail are what carry here.
+      title: 'Error',
+      detail: 'I am a teapot',
+    })
   })
 
   it('maps an unexpected throw to a 500 that names the error once', async () => {

--- a/packages/testing/__tests__/upload-validate-matrix.test.ts
+++ b/packages/testing/__tests__/upload-validate-matrix.test.ts
@@ -153,7 +153,7 @@ describe.each(runtimes)('uploads and validation on $name', ({ make }) => {
       // Express names the FIELD here and the others the filename — multer's
       // LIMIT_FILE_SIZE error carries no filename to report. The status and the
       // limit are what a client acts on, so those are what this pins.
-      expect(res.body.message).toContain('exceeds the 16-byte limit')
+      expect(res.body.detail).toContain('exceeds the 16-byte limit')
     })
 
     it('accepts a file under maxSize', async () => {
@@ -177,7 +177,7 @@ describe.each(runtimes)('uploads and validation on $name', ({ make }) => {
         })
 
       expect(res.status).toBe(415)
-      expect(res.body.message).toBe('File type text/plain is not allowed')
+      expect(res.body.detail).toBe('File type text/plain is not allowed')
     })
   })
 


### PR DESCRIPTION
Closes #611. Option 1 from the issue thread — one error shape everywhere.

## What changed

A plain `HttpException` now emits RFC 9457, the same as `ProblemException` and `ctx.problem.*`:

```ts
throw HttpException.forbidden('Not your project')
```

```json
403  content-type: application/problem+json
{ "type": "about:blank", "title": "Forbidden", "status": 403, "detail": "Not your project" }
```

The message becomes `detail`; `title` and `type` default from the status. `details` becomes an `errors` extension member (§3.2), still withheld in production — it can carry the shape of the request that failed. **Route validation raises `HttpException`, so 422 bodies move with it**, which is the largest practical effect.

The handler's own contract used to say `HttpException` *"keeps the existing `{ message, errors? }` shape for backward compatibility"*. That clause is gone. Keeping it meant shipping two error shapes and no rule for which one an app would get, and dropping it is cheapest inside the v8 window.

## The report's diagnosis was off by one axis

Worth recording, because it changed the fix. #611 read as contributor-specific. It isn't — a **handler**-thrown `HttpException` produced the identical bare body:

| where | before | after |
| --- | --- | --- |
| contributor, `throw HttpException` | `{"message":"nope"}` | problem details |
| handler, `throw HttpException` | `{"message":"nope"}` | problem details |
| either, `ctx.problem.*` | problem details | unchanged |

The split was `HttpException` vs `ProblemException`, not where the throw happened. Routing only contributor errors through `normalizeProblem`, as the issue suggested, would have made contributors inconsistent with handlers rather than removing the inconsistency.

## Docs

Both guides now say which to reach for, rather than leaving it implicit:

- **error-handling.md** — a table: `HttpException` for the common case (a status and a sentence), `ProblemException` / `ctx.problem.*` when a client should branch on `type`. That is the field the RFC intends for programmatic dispatch, and a defaulted `about:blank` carries no information.
- **context-decorators.md** — the same from the contributor side, with a worked authorisation example. A contributor is the natural place to authorise, since `dependsOn` gives you "resolve the actor, then check them" — and there is no longer a shape penalty for doing it there, which is what had been pushing these checks back into `@Middleware()`.

Contributors could always reach `ctx.problem.*` (`resolve()` gets a full `RequestContext`) — they just shouldn't have had to in order to get a conformant body.

## Verification

Nine assertions updated from `message` to `detail`, including one in `problem-details.test.ts` that pinned the old shape as "backward compat" — that test *was* the contract being changed, so updating it is the point rather than a workaround.

One expectation is deliberately unglamorous: a 418 gets `title: "Error"`, because 418 is RFC 2324's joke status and is "(Unused)" in the IANA registry, so there is no reason phrase to default from.

Gates: 20 build, 24 typecheck, 38 test, docs clean.
