### PR TITLE
chore: ship the problem-details change as a minor

### DIFF
--- a/.changeset/proud-lions-repeat.md
+++ b/.changeset/proud-lions-repeat.md
@@ -1,5 +1,5 @@
 ---
-'@forinda/kickjs': major
+'@forinda/kickjs': minor
 ---
 
 Every error the framework serialises is RFC 9457 problem details.
@@ -28,6 +28,12 @@ bodies move with it.
 
 **Migrating:** assert on `body.detail` rather than `body.message`. Nothing is
 lost, it is renamed to the RFC's field.
+
+Released as a **minor** rather than a major, deliberately. The response shape
+does change, so semver would argue for a major — but 8.0.0 shipped a day
+earlier, and moving to 9.0.0 for this would say something much louder about the
+release cadence than about the change. The window where an adopter has pinned
+`{ message }` against 8.0.0 specifically is roughly that one day.
 
 The error handler's own contract previously said `HttpException` "keeps the
 existing `{ message, errors? }` shape for backward compatibility". That clause

--- a/docs/guide/migration-v7-to-v8.md
+++ b/docs/guide/migration-v7-to-v8.md
@@ -80,7 +80,7 @@ Renamed for the same reason, in the same release:
 
 **`AppAdapter.middleware()` and `Plugin.middleware()` are unchanged.** Those are a different API — a hook that returns entries, not an option that takes them — and nothing about them was ambiguous. If you write adapters, nothing there moves.
 
-## Breaking: every error is problem details
+## In 8.1: every error is problem details
 
 A plain `HttpException` used to answer a bare `{ "message": … }` with `application/json`. It now emits RFC 9457, the same as `ProblemException` and `ctx.problem.*`:
 
@@ -96,6 +96,8 @@ throw HttpException.forbidden('Not your project')
 `HttpException` was the last shape a client parsing `application/problem+json` had to special-case — and the most common one, since it is how most apps reject a request. Route validation raises `HttpException` too, so 422 bodies move with it: `details` becomes an `errors` extension member, still withheld in production.
 
 **If you assert on `body.message`, read `body.detail`.** The message is not lost; it is the `detail` field.
+
+This landed in **8.1**, just after the v8 release, rather than in 8.0 itself.
 
 ## Breaking: the catch-all
 


### PR DESCRIPTION
The changeset for #612 is marked `major`. Since 8.0.0 had already been released, that bumps from the published version rather than stacking on the v8 changesets — so the open release PR #613 currently says **9.0.0**, one day after 8.

This sets it to `minor`, giving **8.1.0**. #613 will regenerate once this merges.

## My mistake

I pushed this correction to #612 after it had already been merged, so it never reached `main`. I should have checked the PR state before pushing to it. Same commit, re-applied on top of current `main`.

## The call, recorded rather than silent

The response shape does change, so semver argues for a major. The case for minor is that 8.0.0 shipped a day earlier and 9.0.0 would say far more about release cadence than about the change — the window in which an adopter has pinned `{ message }` against 8.0.0 specifically is about one day wide. That reasoning is now in the changeset itself, so it reads as a decision rather than a mislabel.

Also retitles the migration guide section from "Breaking: every error is problem details" to "In 8.1", and tags the at-a-glance row, so someone upgrading from v7 does not look for it in the 8.0 notes.

Resulting versions: `@forinda/kickjs` **8.1.0**, `@forinda/kickjs-cli` **8.0.1** (the widened eager glob from #609).