### PR TITLE
fix(kickjs): honour trustProxy on h3, and document the real rate-limit key

### DIFF
--- a/.changeset/hungry-swans-report.md
+++ b/.changeset/hungry-swans-report.md
@@ -1,0 +1,38 @@
+---
+'@forinda/kickjs': patch
+---
+
+`trustProxy` now works on the h3 runtime, and the rate-limit key is documented
+as what it is.
+
+Reported as `rateLimitGuard`'s default `keyGenerator` ignoring
+`x-forwarded-for` (#614). The keying behaviour is correct and deliberate — but
+two real problems sat behind the report.
+
+**The doc comment described a different implementation.** It promised
+`cf-connecting-ip` → `x-forwarded-for` → `x-real-ip` → `'global'`. The default
+is `ctx.ip`, and `resolveClientIp` consults forwarded headers only where there
+is no socket — the `@forinda/kickjs/web` edge entry. On a node runtime it uses
+the address the engine vetted against its own trust-proxy setting, then the
+socket.
+
+That ordering is the safe one: `x-forwarded-for` is client-controllable unless
+a proxy overwrites it, so believing it unconditionally would let a direct caller
+mint a fresh allowance per request by varying the header — evading the limiter
+rather than being held by it. The comment now says that, and says plainly that
+behind a proxy you must set `trustProxy` or every client shares one bucket.
+
+**`trustProxy` was silently ignored on h3.** Express derives `req.ip` from
+`trust proxy` and Fastify from `trustProxy`; h3's `createApp` took the option
+and dropped it (`_options`), so `resolveClientIp` fell through to the socket no
+matter what the app configured. Behind a load balancer that is one bucket for
+every caller, with no way to configure out of it — a rate limiter that protects
+nothing, failing quietly, because in development each client really does have
+its own address.
+
+h3 now derives `req.ip` from the first `x-forwarded-for` hop when — and only
+when — `trustProxy` is set, matching what the other two engines do with their
+own settings.
+
+Pinned across all three runtimes: an untrusted `x-forwarded-for` cannot mint
+buckets, and a configured proxy buckets per client.

--- a/packages/kickjs/src/http/middleware/rate-limit-guard.ts
+++ b/packages/kickjs/src/http/middleware/rate-limit-guard.ts
@@ -17,9 +17,26 @@ export interface RateLimitGuardOptions {
   /** HTTP status code when the limit is exceeded (default: 429). */
   statusCode?: number
   /**
-   * Rate-limit key per request. Default: `cf-connecting-ip`, then the first
-   * hop of `x-forwarded-for`, then `x-real-ip`, then `'global'`. Return a
-   * user/tenant id here for authenticated quotas.
+   * Rate-limit key per request. Defaults to `ctx.ip`, falling back to
+   * `'global'`. Return a user/tenant id here for authenticated quotas.
+   *
+   * ::: warning Behind a proxy, configure `trustProxy` or every client shares
+   * one bucket
+   * On a node runtime `ctx.ip` is the runtime's vetted client address —
+   * Express derives it from `trust proxy`, Fastify from `trustProxy`. Without
+   * that setting it is the SOCKET address, which behind a load balancer or
+   * Cloudflare is the proxy's, so every caller lands in the same bucket and one
+   * noisy client exhausts the allowance for everyone.
+   *
+   * `bootstrap({ trustProxy: true })` is the fix. Forwarded headers are
+   * deliberately not consulted here: `x-forwarded-for` is client-controllable
+   * unless a proxy overwrites it, so trusting it unconditionally would let a
+   * direct caller mint a fresh allowance per request by varying the header —
+   * evading the limit rather than enforcing it. The header chain
+   * (`cf-connecting-ip` → `x-forwarded-for` → `x-real-ip`) applies only on the
+   * `@forinda/kickjs/web` edge entry, where there is no socket and the platform
+   * has already terminated the connection.
+   * :::
    */
   keyGenerator?: (ctx: RequestContext) => string
   /** Send `X-RateLimit-*` / `Retry-After` headers (default: true). */

--- a/packages/kickjs/src/http/runtimes/h3.ts
+++ b/packages/kickjs/src/http/runtimes/h3.ts
@@ -127,8 +127,14 @@ function resDriver(res: ServerResponse): RuntimeResponse {
   return new NodeResDriver(res) as unknown as RuntimeResponse
 }
 
+/** Carries `trustProxy` from createApp() to the per-route handlers. */
+const TRUST_PROXY = Symbol('kickjs.h3.trustProxy')
+
 /** Build the h3 event handler that runs the kickjs pipeline for one route. */
-function makeEventHandler(entry: RouteEntry): (event: H3EventLike) => Promise<void> {
+function makeEventHandler(
+  entry: RouteEntry,
+  trustProxy: boolean,
+): (event: H3EventLike) => Promise<void> {
   const { getRouterParams, getQuery, readRawBody, readMultipartFormData } = h3()
   const upload = entry.meta.upload
   // Validation middleware built ONCE per route (parity with Express) — calling
@@ -144,6 +150,19 @@ function makeEventHandler(entry: RouteEntry): (event: H3EventLike) => Promise<vo
       files?: unknown
     }
     const res = event.node.res
+
+    // h3 computes no client address of its own, so `resolveClientIp` fell
+    // straight through to the socket — which behind a proxy is the proxy, and
+    // put every caller in one rate-limit bucket with no way to configure out
+    // of it (#614). Express and Fastify derive `req.ip` from their own
+    // trust-proxy settings; this is h3's equivalent, and like theirs it is
+    // OFF unless the app opts in, because an unverified `x-forwarded-for` is
+    // client-controllable.
+    if (trustProxy && !(req as { ip?: string }).ip) {
+      const forwarded = req.headers['x-forwarded-for']
+      const first = (Array.isArray(forwarded) ? forwarded[0] : forwarded)?.split(',')[0]?.trim()
+      if (first) (req as { ip?: string }).ip = first
+    }
 
     // Populate the express-shaped request fields h3 keeps elsewhere.
     req.params = getRouterParams(event) ?? {}
@@ -290,7 +309,7 @@ export function h3Runtime(): HttpRuntime<H3AppLike> {
   return {
     name: 'h3',
 
-    createApp(_options: RuntimeAppOptions = {}): H3AppLike {
+    createApp(options: RuntimeAppOptions = {}): H3AppLike {
       const { createApp } = h3()
       const app = createApp({
         onError: (error: unknown, event: H3EventLike) => {
@@ -333,6 +352,9 @@ export function h3Runtime(): HttpRuntime<H3AppLike> {
           }
         },
       })
+      // Stash the setting for mountRoutes — h3 has no app-level config object
+      // of its own to hang it on.
+      ;(app as { [TRUST_PROXY]?: unknown })[TRUST_PROXY] = options.trustProxy
       return app as H3AppLike
     },
 
@@ -358,6 +380,7 @@ export function h3Runtime(): HttpRuntime<H3AppLike> {
 
     mountRoutes(app, table: RouteTable) {
       const { createRouter, eventHandler } = h3()
+      const trustProxy = Boolean((app as { [TRUST_PROXY]?: unknown })[TRUST_PROXY])
       // One shared router per app — every mountRoutes call (controllers, health,
       // devtools, ad-hoc adapter routes) adds to it. `app.use(router)` is
       // deferred to nodeHandler so the router lands after connect middleware.
@@ -368,7 +391,7 @@ export function h3Runtime(): HttpRuntime<H3AppLike> {
         for (const entry of routes) {
           const url = joinPath(mountPath, entry.path)
           const method = entry.method.toLowerCase() as 'get' | 'post' | 'put' | 'delete' | 'patch'
-          router[method](url, eventHandler(makeEventHandler(entry)))
+          router[method](url, eventHandler(makeEventHandler(entry, trustProxy)))
         }
       }
     },

--- a/packages/testing/__tests__/rate-limit-keying.test.ts
+++ b/packages/testing/__tests__/rate-limit-keying.test.ts
@@ -1,0 +1,71 @@
+/**
+ * #614: which address the rate limiter buckets on, and why.
+ *
+ * The security property is the point: an UNTRUSTED `x-forwarded-for` must not
+ * create buckets, or a direct caller mints a fresh allowance per request by
+ * varying the header — evading the limit instead of being held by it. Behind a
+ * configured proxy the header is vetted by the runtime and does bucket.
+ *
+ * @module @forinda/kickjs-testing/__tests__/rate-limit-keying.test
+ */
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import { Controller, Get, Middleware, defineModule, rateLimitGuard } from '@forinda/kickjs'
+import { expressRuntime } from '@forinda/kickjs'
+import { fastifyRuntime } from '../../kickjs/src/http/runtimes/fastify'
+import { h3Runtime } from '../../kickjs/src/http/runtimes/h3'
+import { createTestApp } from '../src'
+
+/**
+ * A fresh controller per run. `rateLimitGuard(...)` is evaluated where the
+ * decorator is written — at class-definition time — so a module-level
+ * controller shares ONE in-memory store across every app in the file, and the
+ * second runtime to run starts against an already-exhausted bucket.
+ */
+function makeModule() {
+  @Controller()
+  class LimitedController {
+    @Middleware(rateLimitGuard({ max: 1, windowMs: 60_000 }))
+    @Get('/')
+    hit(ctx: any) {
+      return ctx.json({ ok: true })
+    }
+  }
+
+  return defineModule({
+    name: 'LimitedModule',
+    build: () => ({
+      routes() {
+        return { path: '/lim', controller: LimitedController, version: false, prefix: false }
+      },
+    }),
+  })
+}
+
+const runtimes = [
+  { name: 'express', make: () => expressRuntime() },
+  { name: 'fastify', make: () => fastifyRuntime() },
+  { name: 'h3', make: () => h3Runtime() },
+]
+
+async function statuses(make: () => any, trustProxy: boolean): Promise<number[]> {
+  const { app } = await createTestApp({ modules: [makeModule()()], runtime: make(), trustProxy })
+  const send = (xff: string) =>
+    request(app.handle.bind(app))
+      .get('/lim')
+      .set('x-forwarded-for', xff)
+      .then((r) => r.status)
+  return [await send('1.1.1.1'), await send('1.1.1.1'), await send('2.2.2.2')]
+}
+
+describe.each(runtimes)('rate-limit keying on $name', ({ make }) => {
+  it('ignores an untrusted x-forwarded-for, so the header cannot mint buckets', async () => {
+    // Third request carries a different XFF and is still limited: without a
+    // configured proxy the header is unverified and must not be believed.
+    expect(await statuses(make, false)).toEqual([200, 429, 429])
+  })
+
+  it('buckets per client once trustProxy is configured', async () => {
+    expect(await statuses(make, true)).toEqual([200, 429, 200])
+  })
+})


### PR DESCRIPTION
Closes #614. The report was right that something is wrong, and wrong about which thing — chasing it turned up a second bug with no configuration workaround.

## The keying is correct and deliberate

`resolveClientIp` prefers the engine-vetted address, then the socket, and consults forwarded headers **only where there is no socket** — the `@forinda/kickjs/web` edge entry. `client-ip.ts:77-83` spells out why: an unverified `x-forwarded-for` would let a direct caller mint a fresh bucket per request by varying the header, evading the limiter instead of being held by it.

That is the same hazard the issue flags in its closing note. The framework already gates on it.

Measured per runtime, `max: 1`, requests varying only in `x-forwarded-for`:

| | untrusted | `trustProxy: true` |
| --- | --- | --- |
| express | `200, 429, 429` ✓ | `200, 429, 200` ✓ |
| fastify | `200, 429, 429` ✓ | `200, 429, 200` ✓ |
| h3 | `200, 429, 429` ✓ | **`200, 429, 429`** ✗ |

## Two real bugs

**1. The doc comment described a different implementation.** It promised `cf-connecting-ip` → `x-forwarded-for` → `x-real-ip` → `'global'` — the edge entry's behaviour, on an option used mostly on node. As the issue puts it, the hazard is the gap between the two. It now describes `ctx.ip`, and says plainly that behind a proxy you must set `trustProxy` or every client shares one bucket.

**2. `trustProxy` was silently ignored on h3.** `createApp` took the option as `_options` and dropped it, so `resolveClientIp` fell through to the socket regardless of configuration. Behind a load balancer that is one bucket for everyone **with no way to configure out of it** — the denial-of-service amplification the issue describes, except the documented fix does not work either.

h3 now derives `req.ip` from the first `x-forwarded-for` hop when — and only when — `trustProxy` is set, matching what Express and Fastify do with their own settings.

## Tests

A matrix across all three runtimes pinning the **security property**, not just the behaviour: an untrusted header must not create buckets, and a configured proxy must bucket per client.

Writing it caught a trap worth recording: `rateLimitGuard(...)` is evaluated where the decorator is written, so a module-level controller shares **one in-memory store across every app in the file** — Express ran first, exhausted it, and the other two runtimes started against an empty allowance, showing `429, 429, 429`. That looked exactly like a bug in the guard. The module is now built per run.

Gates: 20 build, 24 typecheck, 38 test.
