### PR TITLE
chore: ship the problem-details change as a minor, not a major

### DIFF
--- a/.changeset/proud-lions-repeat.md
+++ b/.changeset/proud-lions-repeat.md
@@ -1,5 +1,5 @@
 ---
-'@forinda/kickjs': major
+'@forinda/kickjs': minor
 ---
 
 Every error the framework serialises is RFC 9457 problem details.
@@ -28,6 +28,12 @@ bodies move with it.
 
 **Migrating:** assert on `body.detail` rather than `body.message`. Nothing is
 lost, it is renamed to the RFC's field.
+
+Released as a **minor** rather than a major, deliberately. The response shape
+does change, so semver would argue for a major — but 8.0.0 shipped a day
+earlier, and moving to 9.0.0 for this would say something much louder about the
+release cadence than about the change. The window where an adopter has pinned
+`{ message }` against 8.0.0 specifically is roughly that one day.
 
 The error handler's own contract previously said `HttpException` "keeps the
 existing `{ message, errors? }` shape for backward compatibility". That clause

--- a/docs/guide/migration-v7-to-v8.md
+++ b/docs/guide/migration-v7-to-v8.md
@@ -80,7 +80,7 @@ Renamed for the same reason, in the same release:
 
 **`AppAdapter.middleware()` and `Plugin.middleware()` are unchanged.** Those are a different API — a hook that returns entries, not an option that takes them — and nothing about them was ambiguous. If you write adapters, nothing there moves.
 
-## Breaking: every error is problem details
+## In 8.1: every error is problem details
 
 A plain `HttpException` used to answer a bare `{ "message": … }` with `application/json`. It now emits RFC 9457, the same as `ProblemException` and `ctx.problem.*`:
 
@@ -96,6 +96,8 @@ throw HttpException.forbidden('Not your project')
 `HttpException` was the last shape a client parsing `application/problem+json` had to special-case — and the most common one, since it is how most apps reject a request. Route validation raises `HttpException` too, so 422 bodies move with it: `details` becomes an `errors` extension member, still withheld in production.
 
 **If you assert on `body.message`, read `body.detail`.** The message is not lost; it is the `detail` field.
+
+This landed in **8.1**, just after the v8 release, rather than in 8.0 itself.
 
 ## Breaking: the catch-all
 


### PR DESCRIPTION
8.0.0 released a day ago, so the major changeset put this at 9.0.0 — which would say far more about the release cadence than about the change.

The response shape does change, so semver argues for a major, and the changeset now says that outright rather than leaving the choice unexplained. The window in which an adopter has pinned `{ message }` against 8.0.0 specifically is about one day wide.

The migration guide framed it under v8's breaking changes; it is retitled to "In 8.1" and the at-a-glance row is tagged, so a reader upgrading from v7 does not go looking for it in the 8.0 notes.


Claude-Session: https://claude.ai/code/session_011wf3GNMSJUfME42a93d5j6

## Summary

<!-- Brief description of changes -->

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] CI / Tooling

## Changes

<!-- Bullet list of what changed -->

-

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Checklist

- [ ] `pnpm build` passes
- [ ] `pnpm test` passes
- [ ] `pnpm format:check` passes
- [ ] Docs updated (if applicable)
- [ ] New exports added to `index.ts` and `package.json` exports map (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Framework errors now use the standardized `application/problem+json` format, including type, title, status, and detail fields.
  - Validation errors now follow the same standardized response format.

- **Documentation**
  - Updated the v7-to-v8 migration guide to clarify that standardized error responses were introduced in version 8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->