### PR TITLE
fix(cli): sync the generated-project docs with what the CLI emits

### DIFF
--- a/.changeset/agents-help-text.md
+++ b/.changeset/agents-help-text.md
@@ -1,0 +1,13 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+Fix `kick g agents` help text, which still advertised files the generator no longer writes.
+
+`--help` (and the generator list) described the output as "AGENTS.md + CLAUDE.md +
+kickjs-skills.md". Since the move to the `.agents/` layout there is no `kickjs-skills.md`:
+the command writes `.agents/AGENTS.md`, `.agents/GEMINI.md`, `.agents/COPILOT.md`, one
+`.agents/skills/<slug>/SKILL.md` per skill, and `CLAUDE.md` at the project root. The
+`--only skills` JSDoc pointed at the same missing file.
+
+Text only — no behaviour change.

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -23,27 +23,27 @@ cd packages/cli && pnpm link --global
 
 ## CLI Commands
 
-| Command                                     | Alias                                          | Description                                                                       |
-| ------------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------- |
-| `kick new <name>`                           | `kick init`                                    | Create a new KickJS project                                                       |
-| `kick dev`                                  |                                                | Start dev server with Vite HMR                                                    |
-| `kick list`                                 | `kick ls`                                      | List all available KickJS packages                                                |
-| `kick add <packages...>`                    |                                                | Install KickJS packages with peer deps                                            |
-| `kick generate --list`                      | `kick g --list`                                | List all available generators                                                     |
-| `kick generate module <name>`               | `kick g module`                                | Generate a full DDD module with all layers                                        |
-| `kick generate scaffold <name> <fields...>` | `kick g scaffold`                              | CRUD module from field definitions (`name:type:optional`)                         |
-| `kick generate adapter <name>`              | `kick g adapter`                               | Generate an AppAdapter scaffold                                                   |
-| `kick generate middleware <name>`           | `kick g middleware`                            | Generate an Express middleware function                                           |
-| `kick generate guard <name>`                | `kick g guard`                                 | Generate a route guard                                                            |
-| `kick generate service <name>`              | `kick g service`                               | Generate a `@Service()` class                                                     |
-| `kick generate controller <name>`           | `kick g controller`                            | Generate a `@Controller()` class with routes                                      |
-| `kick generate dto <name>`                  | `kick g dto`                                   | Generate a Zod DTO schema                                                         |
-| `kick generate test <name>`                 | `kick g test`                                  | Generate a Vitest test scaffold                                                   |
-| `kick generate config`                      | `kick g config`                                | Generate `kick.config.ts`                                                         |
-| `kick generate agents`                      | `kick g agents` (also `agent-docs`, `ai-docs`) | Regenerate `AGENTS.md` / `CLAUDE.md` / `kickjs-skills.md` from upstream templates |
-| `kick info`                                 |                                                | Print system and framework info                                                   |
-| `kick inspect`                              |                                                | Inspect a running KickJS application                                              |
-| `kick tinker`                               |                                                | Interactive REPL                                                                  |
+| Command                                     | Alias                                          | Description                                                       |
+| ------------------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------- |
+| `kick new <name>`                           | `kick init`                                    | Create a new KickJS project                                       |
+| `kick dev`                                  |                                                | Start dev server with Vite HMR                                    |
+| `kick list`                                 | `kick ls`                                      | List all available KickJS packages                                |
+| `kick add <packages...>`                    |                                                | Install KickJS packages with peer deps                            |
+| `kick generate --list`                      | `kick g --list`                                | List all available generators                                     |
+| `kick generate module <name>`               | `kick g module`                                | Generate a full DDD module with all layers                        |
+| `kick generate scaffold <name> <fields...>` | `kick g scaffold`                              | CRUD module from field definitions (`name:type:optional`)         |
+| `kick generate adapter <name>`              | `kick g adapter`                               | Generate an AppAdapter scaffold                                   |
+| `kick generate middleware <name>`           | `kick g middleware`                            | Generate an Express middleware function                           |
+| `kick generate guard <name>`                | `kick g guard`                                 | Generate a route guard                                            |
+| `kick generate service <name>`              | `kick g service`                               | Generate a `@Service()` class                                     |
+| `kick generate controller <name>`           | `kick g controller`                            | Generate a `@Controller()` class with routes                      |
+| `kick generate dto <name>`                  | `kick g dto`                                   | Generate a Zod DTO schema                                         |
+| `kick generate test <name>`                 | `kick g test`                                  | Generate a Vitest test scaffold                                   |
+| `kick generate config`                      | `kick g config`                                | Generate `kick.config.ts`                                         |
+| `kick generate agents`                      | `kick g agents` (also `agent-docs`, `ai-docs`) | Regenerate `.agents/*` + root `CLAUDE.md` from upstream templates |
+| `kick info`                                 |                                                | Print system and framework info                                   |
+| `kick inspect`                              |                                                | Inspect a running KickJS application                              |
+| `kick tinker`                               |                                                | Interactive REPL                                                  |
 
 ### Command Options
 

--- a/docs/guide/cli-commands.md
+++ b/docs/guide/cli-commands.md
@@ -503,7 +503,7 @@ kick g guard admin
 kick g adapter websocket
 kick g dto create-user
 kick g config
-kick g agents -f                 # Refresh AGENTS.md / CLAUDE.md / kickjs-skills.md
+kick g agents -f                 # Refresh .agents/* + CLAUDE.md
 ```
 
 ### kick g scaffold
@@ -568,15 +568,17 @@ If `kick.config.ts` already exists, the CLI prompts for confirmation before over
 
 ### kick g agents
 
-Regenerate the AI-agent documentation trio (`AGENTS.md`, `CLAUDE.md`, `kickjs-skills.md`) from the latest CLI templates. Use after a KickJS upgrade to pull in new conventions and gotchas without copy-pasting between projects.
+Regenerate the AI-agent documentation from the latest CLI templates: `.agents/AGENTS.md`, `.agents/GEMINI.md`, `.agents/COPILOT.md`, one `.agents/skills/<slug>/SKILL.md` per skill, and `CLAUDE.md` at the project root. Use after a KickJS upgrade to pull in new conventions and gotchas without copy-pasting between projects.
 
 ```bash
-kick g agents                      # All three (prompts before overwrite)
-kick g agents -f                   # All three, no prompt
-kick g agents -f --only skills     # Just kickjs-skills.md
+kick g agents                      # Everything (prompts before overwrite)
+kick g agents -f                   # Everything, no prompt
+kick g agents -f --only skills     # Just .agents/skills/<slug>/SKILL.md
 kick g agents -f --only claude     # Just CLAUDE.md
-kick g agents -f --only agents     # Just AGENTS.md
-kick g agents -f --only both       # AGENTS.md + CLAUDE.md (skip skills)
+kick g agents -f --only agents     # Just .agents/AGENTS.md
+kick g agents -f --only gemini     # Just .agents/GEMINI.md
+kick g agents -f --only copilot    # Just .agents/COPILOT.md
+kick g agents -f --only both       # .agents/AGENTS.md + CLAUDE.md (skip skills)
 ```
 
 Aliases: `kick g agent-docs`, `kick g ai-docs`. Auto-detects project name (from `package.json`), package manager (corepack `packageManager` field), and template (from `kick.config.ts` `pattern`).

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -286,20 +286,19 @@ kick g scaffold Post title:string "body?:text" "published?:boolean"
 
 Scaffold emits the same flat REST module layout as `kick g module`, but with field-aware DTOs and a working repository instead of empty stubs. Inside `posts/`:
 
-| File                           | Description                                             |
-| ------------------------------ | ------------------------------------------------------- |
-| `post.module.ts`               | Module declaration (register + routes)                  |
-| `post.constants.ts`            | Query config (filterable, sortable, searchable) + token |
-| `post.controller.ts`           | Full CRUD with typed `Ctx`                              |
-| `post.service.ts`              | `@Service` wrapping the repository                      |
-| `post.repository.ts`           | Interface + Symbol token                                |
-| `in-memory-post.repository.ts` | Working Map-based store (default repo)                  |
-| `dtos/create-post.dto.ts`      | Zod schema built from the fields                        |
-| `dtos/update-post.dto.ts`      | All fields optional                                     |
-| `dtos/post-response.dto.ts`    | Response interface                                      |
-| `__tests__/`                   | Controller + repository tests                           |
+| File                        | Description                                             |
+| --------------------------- | ------------------------------------------------------- |
+| `post.module.ts`            | Module declaration (register + routes)                  |
+| `post.constants.ts`         | Query config (filterable, sortable, searchable) + token |
+| `post.controller.ts`        | Full CRUD with typed `Ctx`                              |
+| `post.service.ts`           | `@Service` wrapping the repository                      |
+| `post.repository.ts`        | Factory + derived contract + DI token, one file         |
+| `dtos/create-post.dto.ts`   | Zod schema built from the fields                        |
+| `dtos/update-post.dto.ts`   | All fields optional                                     |
+| `dtos/post-response.dto.ts` | Response interface                                      |
+| `__tests__/`                | Controller + repository tests                           |
 
-With a custom repo name (e.g. `--repo postgres`), the implementation file is `post-postgres.repository.ts` — a generic stub with TODO markers.
+With a custom repo name (e.g. `--repo postgres`), the same `post.repository.ts` is emitted — still a working Map-backed factory, with the prose and TODO markers naming the store you asked for. Replace the factory body; the contract is `ReturnType<typeof createPostRepository>`, so nothing else changes.
 
 ### Scaffold Flags
 
@@ -344,15 +343,17 @@ The command also supports `kick remove module` as the full form.
 
 ## kick g agents
 
-Regenerate the AI-agent documentation trio (`AGENTS.md`, `CLAUDE.md`, `kickjs-skills.md`) from the latest CLI templates. Use this after a KickJS upgrade to pull in new conventions, decorator changes, and gotchas without manually copy-pasting between projects.
+Regenerate the AI-agent documentation from the latest CLI templates. Everything lands under `.agents/` except `CLAUDE.md`, which stays at the project root because Claude Code auto-loads it from there. Use this after a KickJS upgrade to pull in new conventions, decorator changes, and gotchas without manually copy-pasting between projects.
 
 ```bash
-kick g agents                          # Refresh all three (prompts before overwrite)
-kick g agents -f                       # Refresh all three, no prompt
-kick g agents -f --only skills         # Just kickjs-skills.md
+kick g agents                          # Refresh everything (prompts before overwrite)
+kick g agents -f                       # Refresh everything, no prompt
+kick g agents -f --only skills         # Just .agents/skills/<slug>/SKILL.md
 kick g agents -f --only claude         # Just CLAUDE.md
-kick g agents -f --only agents         # Just AGENTS.md
-kick g agents -f --only both           # AGENTS.md + CLAUDE.md (skip skills)
+kick g agents -f --only agents         # Just .agents/AGENTS.md
+kick g agents -f --only gemini         # Just .agents/GEMINI.md
+kick g agents -f --only copilot        # Just .agents/COPILOT.md
+kick g agents -f --only both           # .agents/AGENTS.md + CLAUDE.md (skip skills)
 ```
 
 Aliases: `kick g agent-docs`, `kick g ai-docs`.
@@ -365,28 +366,29 @@ The generator auto-detects:
 
 Override any of those with `--name`, `--pm`, `--template`.
 
-| Flag                    | Description                                         | Default               |
-| ----------------------- | --------------------------------------------------- | --------------------- |
-| `--only <which>`        | `agents` \| `claude` \| `skills` \| `both` \| `all` | `all`                 |
-| `--name <name>`         | Project name (overrides `package.json`)             | auto                  |
-| `--pm <pm>`             | Package manager (overrides `package.json`)          | auto                  |
-| `--template <template>` | `rest` \| `minimal`                                 | from `kick.config.ts` |
-| `-f, --force`           | Overwrite without prompting                         | `false`               |
+| Flag                    | Description                                                                  | Default               |
+| ----------------------- | ---------------------------------------------------------------------------- | --------------------- |
+| `--only <which>`        | `agents` \| `claude` \| `skills` \| `gemini` \| `copilot` \| `both` \| `all` | `all`                 |
+| `--name <name>`         | Project name (overrides `package.json`)                                      | auto                  |
+| `--pm <pm>`             | Package manager (overrides `package.json`)                                   | auto                  |
+| `--template <template>` | `rest` \| `minimal`                                                          | from `kick.config.ts` |
+| `-f, --force`           | Overwrite without prompting                                                  | `false`               |
 
 ::: tip Local customisations
-The three files are overwritten on regeneration. Keep project-specific notes in `AGENTS.local.md` (or any other filename) so they survive `kick g agents -f`.
+Generated files are overwritten on regeneration. Keep project-specific notes in `.agents/AGENTS.local.md`, `.agents/GEMINI.local.md`, or a per-skill `.agents/skills/<slug>/SKILL.local.md` — `.local.md` siblings are never overwritten.
 :::
 
 ### What's in each file
 
-- **`AGENTS.md`** — narrative reference: project structure, v4 conventions, decorator patterns, env wiring, common pitfalls. Read first by every AI agent.
-- **`CLAUDE.md`** — thin redirect to `AGENTS.md` plus Claude-specific affordances (slash commands, persistent memory, `/loop`, `/schedule`).
-- **`kickjs-skills.md`** — short rigid recipes keyed to triggers (`add-module`, `add-adapter`, `write-controller-test`, `bootstrap-export`, `thin-entry-file`, `context-contributor`, `env-wiring-check`, `refresh-agent-docs`, `deny-list`). Designed for agents that read skills from a top-level index (Claude superpowers, Copilot, …).
+- **`.agents/AGENTS.md`** — narrative reference: project structure, conventions, decorator patterns, env wiring, common pitfalls. Read first by every AI agent.
+- **`CLAUDE.md`** (project root) — thin redirect to `.agents/AGENTS.md` plus Claude-specific affordances (slash commands, persistent memory, `/loop`, `/schedule`).
+- **`.agents/GEMINI.md`**, **`.agents/COPILOT.md`** — the same context shaped for Gemini and Copilot.
+- **`.agents/skills/<slug>/SKILL.md`** — one folder per skill, each a short rigid recipe keyed to a trigger (`add-module`, `add-adapter`, `write-controller-test`, `bootstrap-export`, `thin-entry-file`, `context-contributor`, `env-wiring-check`, `refresh-agent-docs`, `deny-list`). Agents that auto-discover skills pick each up from its frontmatter — no top-level index file.
 
 ## Module-Scoped vs Global Generation
 
 ::: tip When to use `kick g module` vs standalone generators
-**`kick g module <name>`** creates a full flat REST module in one shot — controller, service, DTOs, repository interface + token, repository implementation, and tests. Use this when starting a new feature.
+**`kick g module <name>`** creates a full flat REST module in one shot — controller, service, DTOs, repository (factory + contract + token in one file), and tests. Use this when starting a new feature.
 
 **Standalone generators** (`kick g controller`, `kick g service`, `kick g dto`, `kick g guard`, `kick g middleware`) create a single file. Use these to **add files to an existing module** or to create **app-level** artifacts that don't belong to any module.
 :::

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -26,13 +26,13 @@ This scaffolds a project with the **default layout** — every path below is a c
 - `src/modules/` — feature modules directory (configurable via `modules.dir`)
 - `vite.config.ts` — Vite config for HMR dev server
 - `kick.config.ts` — CLI configuration (optional)
-- `AGENTS.md` — canonical multi-agent reference (Claude, Copilot, Codex, Gemini, …) — conventions, patterns, gotchas
-- `CLAUDE.md` — thin Claude-specific layer that points at `AGENTS.md`
-- `kickjs-skills.md` — task-oriented skill index for AI agents (`add-module`, `bootstrap-export`, `deny-list`, …)
-
+- `.agents/AGENTS.md` — canonical multi-agent reference (Copilot, Codex, Gemini, …) — conventions, patterns, gotchas
+- `.agents/GEMINI.md`, `.agents/COPILOT.md` — per-agent context files
+- `.agents/skills/<slug>/SKILL.md` — one folder per task-oriented skill (`add-module`, `bootstrap-export`, `deny-list`, …), auto-discovered by agents that read skill frontmatter
+- `CLAUDE.md` — stays at the project root (Claude Code auto-loads it there); a thin pointer at `.agents/AGENTS.md`
 - `README.md` — project documentation
 
-After a framework upgrade, refresh the three agent files with `kick g agents -f` (see [Generators → kick g agents](./generators.md#kick-g-agents)).
+After a framework upgrade, refresh the agent files with `kick g agents -f` (see [Generators → kick g agents](./generators.md#kick-g-agents)).
 
 ## Start Development
 

--- a/docs/guide/project-structure.md
+++ b/docs/guide/project-structure.md
@@ -16,11 +16,17 @@ my-api/                           # Default layout — adopters can rearrange
 │       │   ├── hello.module.ts
 │       │   └── hello.service.ts
 │       └── index.ts              # Exports the modules array
-├── .env / .env.example
-├── .prettierrc
-├── AGENTS.md                     # Canonical multi-agent reference (Claude, Copilot, Codex, …)
-├── CLAUDE.md                     # Thin Claude-specific layer pointing at AGENTS.md
-├── kickjs-skills.md              # Task-oriented skill recipes for AI agents
+├── .agents/                      # AI-agent docs (kick g agents regenerates)
+│   ├── AGENTS.md                 # Canonical multi-agent reference (Copilot, Codex, …)
+│   ├── COPILOT.md
+│   ├── GEMINI.md
+│   └── skills/<slug>/SKILL.md    # One folder per skill, auto-discovered by agents
+├── .kickjs/types/                # kick typegen output (KickRoutes, KickEnv, …)
+├── .env / .env.example / .env.test
+├── .editorconfig
+├── .gitattributes / .gitignore
+├── .oxfmtrc.json                 # Formatter config
+├── CLAUDE.md                     # Root by convention — thin pointer to .agents/AGENTS.md
 ├── README.md
 ├── kick.config.ts                # CLI configuration (pattern, repo, modules dir)
 ├── package.json
@@ -33,28 +39,28 @@ my-api/                           # Default layout — adopters can rearrange
 
 ```ts
 // src/index.ts
+import 'reflect-metadata'
+// Side-effect import — registers the env schema BEFORE any @Value() resolves.
+import './config'
 import express from 'express'
-import { bootstrap, helmet, cors, requestId, requestLogger } from '@forinda/kickjs'
+import { bootstrap, expressRuntime, helmet, cors, requestId, requestLogger } from '@forinda/kickjs'
 import { modules } from './modules'
 
-export const app = bootstrap({
+// Exported for the Vite plugin in dev mode.
+export const app = await bootstrap({
   modules,
-  apiPrefix: '/api',
-  defaultVersion: 1,
+  runtime: expressRuntime(),
   middlewares: [
     helmet(),
     cors({ origin: ['https://app.example.com'] }),
     requestId(),
     requestLogger(),
-    express.json(),
+    express.json(), // Express only — Fastify and h3 parse bodies natively
   ],
 })
-
-// Production: start the server directly
-if (process.env.NODE_ENV === 'production') {
-  app.start()
-}
 ```
+
+`bootstrap()` is async — `await` it. On Fastify or h3 the generator swaps `expressRuntime()` for `fastifyRuntime()` (from `@forinda/kickjs/fastify`) or `h3Runtime()` (from `@forinda/kickjs/h3`), and drops the `express.json()` line — those engines parse bodies natively.
 
 ## Dev Mode
 
@@ -109,8 +115,7 @@ src/modules/users/
   users.constants.ts
   users.controller.ts
   users.service.ts
-  users.repository.ts                # Interface + DI token
-  in-memory-users.repository.ts      # Default implementation (in-memory)
+  users.repository.ts                # Factory + contract + DI token, one file
   dtos/
     create-users.dto.ts
     update-users.dto.ts
@@ -120,7 +125,14 @@ src/modules/users/
     users.repository.test.ts
 ```
 
-With a custom repo name (e.g. `--repo postgres`) the implementation file becomes `users-postgres.repository.ts`, a generic stub with TODO markers you wire to your own client.
+The repository is **one file**: `createUsersRepository()` is the factory, its
+return type _is_ the contract, and the DI token sits alongside it. It ships
+backed by a `Map`, so a fresh module runs as generated. With a custom repo name
+(e.g. `--repo postgres`) the same file is emitted as a stub with TODO markers —
+you replace the factory body and nothing else changes, because the contract is
+whatever the factory returns.
+
+Pass `--no-tests` to skip the `__tests__/` pair.
 
 ### Choosing a Pattern
 
@@ -136,18 +148,20 @@ Each generated module uses `import.meta.glob` to eagerly load decorated classes.
 ```ts
 // REST pattern — src/modules/users/users.module.ts
 import { defineModule } from '@forinda/kickjs'
-import { USERS_REPOSITORY } from './users.constants'
-import { InMemoryUsersRepository } from './in-memory-users.repository'
+import { USERS_REPOSITORY, createUsersRepository } from './users.repository'
 import { UsersController } from './users.controller'
 
-// Eagerly load decorated classes so @Service()/@Repository() decorators register in the DI container
-import.meta.glob(['./**/*.service.ts', './**/*.repository.ts', '!./**/*.test.ts'], { eager: true })
+// Eagerly load every module file so decorators (@Controller / @Service /
+// @Repository, and anything you add) register in the DI container. The glob is
+// deliberately broad — a suffix list missed hand-written *.usecase.ts / *.policy.ts
+// files, which then failed at resolve time as `No provider for X` (#609).
+import.meta.glob(['./**/*.ts', '!./**/*.test.ts', '!./**/*.d.ts'], { eager: true })
 
 export const UsersModule = defineModule({
   name: 'UsersModule',
   build: () => ({
     register(container) {
-      container.registerFactory(USERS_REPOSITORY, () => container.resolve(InMemoryUsersRepository))
+      container.registerFactory(USERS_REPOSITORY, () => createUsersRepository())
     },
     routes() {
       return {
@@ -167,14 +181,19 @@ Modules are self-contained and composed via the `modules` array:
 
 ```ts
 // src/modules/index.ts
-import type { AppModuleEntry } from '@forinda/kickjs'
-import { TodoModule } from './todos'
-import { OrderModule } from './orders'
+import { defineModules } from '@forinda/kickjs'
+import { TodoModule } from './todos/todo.module'
+import { OrderModule } from './orders/order.module'
 
-// `defineModule` factories are called at the registration site —
-// the invocation produces the AppModule instance bootstrap registers.
-export const modules: AppModuleEntry[] = [TodoModule(), OrderModule()]
+// `defineModules()` returns a chainable list — `kick g module` appends a
+// `.mount(NewModule())` call on every generation. The `defineModule` factories
+// are invoked at the registration site, producing the AppModule instances
+// bootstrap registers.
+export const modules = defineModules().mount(TodoModule()).mount(OrderModule())
 ```
+
+A plain `AppModuleEntry[]` array still works if you prefer it — the generator
+just can't append to it automatically.
 
 Routes are mounted at `/{apiPrefix}/v{version}{path}`, so a module with `path: '/todos'` becomes `/api/v1/todos`.
 
@@ -184,17 +203,16 @@ The REST pattern supports swapping the repository implementation by name. `inmem
 
 ```bash
 kick g module users --repo inmemory    # Default — working in-memory store
-kick g module users --repo postgres    # Generic custom-repository stub
-kick g module users --repo mongo       # Generic custom-repository stub
+kick g module users --repo postgres    # Same file, emitted as a stub with TODOs
+kick g module users --repo mongo       # Same file, emitted as a stub with TODOs
 ```
 
-The module's `register()` method binds the interface token to the implementation. Swap implementations by changing the factory target — no other code changes needed:
+The module's `register()` binds the token to the factory, so swapping the store
+means editing the factory body in `users.repository.ts` — the binding never
+changes:
 
 ```ts
-container.registerFactory(
-  USER_REPOSITORY,
-  () => container.resolve(InMemoryUserRepository), // ← change this line
-)
+container.registerFactory(USERS_REPOSITORY, () => createUsersRepository())
 ```
 
 ## Testing

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -589,18 +589,31 @@ When you scaffold a module with `kick g module`, the CLI generates test stubs au
 kick g module user
 # Creates:
 #   __tests__/user.controller.test.ts  — HTTP integration test scaffold
-#   __tests__/user.repository.test.ts  — InMemoryRepository unit tests
+#   __tests__/user.repository.test.ts  — repository unit tests
 ```
 
-When you generate a module with a custom repo name (e.g. `--repo postgres`), the generator creates **both** the custom repository stub and an in-memory repository for testing. The in-memory repo implements the same interface, so tests run without a database.
+Pass `--no-tests` to skip both.
 
+A custom repo name (e.g. `--repo postgres`) does **not** add a second file. There
+is one `user.repository.ts`, and as generated its factory is backed by a `Map`,
+so the repository test runs without a database from the start:
+
+```ts
+// __tests__/user.repository.test.ts
+import { createUserRepository, type UserRepository } from '../user.repository'
+
+describe('User repository', () => {
+  let repo: UserRepository
+
+  beforeEach(() => {
+    repo = createUserRepository() // fresh Map per test — no shared state
+  })
+})
 ```
-src/modules/users/
-  postgres-user.repository.ts     # Production — wire to your DB client
-  in-memory-user.repository.ts    # Testing — in-memory stub
-  __tests__/
-    user.repository.test.ts       # Imports InMemoryUserRepository
-```
+
+Once you replace the factory body with real queries, keep the tests honest by
+either pointing them at a test database or exporting a second in-memory factory
+for tests to call.
 
 The generated tests are scaffolds with real assertions. Customize them for your domain logic.
 

--- a/docs/guide/tutorial-ddd-architecture.md
+++ b/docs/guide/tutorial-ddd-architecture.md
@@ -7,11 +7,11 @@ _Part of "Building a Jira Clone with KickJS"_
 A real app has many feature modules — tasks, projects, comments, users — and they all
 benefit from following the same shape. KickJS's generators scaffold that shape for you:
 a **flat REST module** where a controller delegates to a service, the service depends on a
-repository _interface_, and a concrete repository implementation is wired in via a DI token.
+repository _contract_, and the concrete repository is wired in via a DI token.
 
 This article walks through that layout end to end. We'll scaffold a `task` module, read
 every file the generator emits, trace the dependency flow, then swap the default in-memory
-repository for a real database implementation — without touching the controller or service.
+store for a real database — without touching the controller or service.
 
 ## The Module Structure
 
@@ -25,8 +25,7 @@ src/modules/tasks/
 ├── task.controller.ts          # HTTP endpoints (CRUD)
 ├── task.service.ts             # Business logic
 ├── task.constants.ts           # Query config (filter/sort/search fields)
-├── task.repository.ts          # Repository INTERFACE + DI token
-├── in-memory-task.repository.ts # Default repository implementation (a Map)
+├── task.repository.ts          # Repository: factory, derived contract, DI token
 ├── dtos/
 │   ├── create-task.dto.ts      # Zod schema + Create DTO type
 │   ├── update-task.dto.ts      # Zod schema + Update DTO type
@@ -46,11 +45,15 @@ it maps cleanly onto three responsibilities, top to bottom:
 The golden rule that keeps these honest: **each layer depends only on the layer directly
 below it, and the repository is consumed through an interface — never a concrete class.**
 
-::: tip Why "program to an interface"?
-The service depends on `ITaskRepository`, not on `InMemoryTaskRepository`. That single
-indirection is what lets you start with a zero-dependency in-memory store and later drop in
-a real database (e.g. `@forinda/kickjs-db`) without editing a line of the controller or
-service. We'll do exactly that at the end of this guide.
+::: tip Why "program to a contract"?
+The service depends on the `TaskRepository` type and the `TASK_REPOSITORY` token — never on a
+particular store. That single indirection is what lets you start with a zero-dependency
+in-memory store and later drop in a real database (e.g. `@forinda/kickjs-db`) without editing
+a line of the controller or service. We'll do exactly that at the end of this guide.
+
+Note the contract is _derived_, not declared: `type TaskRepository = ReturnType<typeof
+createTaskRepository>`. There is no hand-written interface to keep in step with the
+implementation, so the two cannot drift apart.
 :::
 
 ## Scaffolding a Module
@@ -92,18 +95,19 @@ implementation in `register()` and declares the route prefix in `routes()`:
 ```ts
 // src/modules/tasks/task.module.ts
 import { defineModule } from '@forinda/kickjs'
-import { TASK_REPOSITORY } from './task.repository'
-import { InMemoryTaskRepository } from './in-memory-task.repository'
+import { TASK_REPOSITORY, createTaskRepository } from './task.repository'
 import { TaskController } from './task.controller'
 
-// Eagerly load decorated classes so @Service()/@Repository() decorators register in the DI container
-import.meta.glob(['./**/*.service.ts', './**/*.repository.ts', '!./**/*.test.ts'], { eager: true })
+// Eagerly load every module file so decorators (@Controller / @Service, and anything you
+// add) register in the DI container. The glob is deliberately broad — a suffix list missed
+// hand-written *.usecase.ts / *.policy.ts files, which then failed as `No provider for X`.
+import.meta.glob(['./**/*.ts', '!./**/*.test.ts', '!./**/*.d.ts'], { eager: true })
 
 export const TaskModule = defineModule({
   name: 'TaskModule',
   build: () => ({
     register(container) {
-      container.registerFactory(TASK_REPOSITORY, () => container.resolve(InMemoryTaskRepository))
+      container.registerFactory(TASK_REPOSITORY, () => createTaskRepository())
     },
 
     routes() {
@@ -117,8 +121,8 @@ export const TaskModule = defineModule({
 ```
 
 The `registerFactory(TASK_REPOSITORY, …)` line is the single place that says "when something
-asks for the task repository interface, hand it the in-memory implementation." This is the
-**only** line you change to swap databases.
+asks for the task repository, call this factory." This is the **only** line you change to
+point at a different store.
 
 ### The controller — HTTP in, service calls out
 
@@ -198,20 +202,20 @@ A few things worth noting:
 ### The service — business logic, depends on the interface
 
 `task.service.ts` is where logic lives. Crucially, it injects the repository through the
-**token + interface**, never the concrete class:
+**token + derived contract**, never a concrete store:
 
 ```ts
 // src/modules/tasks/task.service.ts
 import { Service, Inject } from '@forinda/kickjs'
 import type { ParsedQuery } from '@forinda/kickjs'
-import { TASK_REPOSITORY, type ITaskRepository } from './task.repository'
+import { TASK_REPOSITORY, type TaskRepository } from './task.repository'
 import type { TaskResponseDTO } from './dtos/task-response.dto'
 import type { CreateTaskDTO } from './dtos/create-task.dto'
 import type { UpdateTaskDTO } from './dtos/update-task.dto'
 
 @Service()
 export class TaskService {
-  constructor(@Inject(TASK_REPOSITORY) private readonly repo: ITaskRepository) {}
+  constructor(@Inject(TASK_REPOSITORY) private readonly repo: TaskRepository) {}
 
   async findById(id: string): Promise<TaskResponseDTO | null> {
     return this.repo.findById(id)
@@ -244,113 +248,96 @@ where you add real logic: derived fields, authorization checks, cross-entity coo
 transactions. The point is that all of it lives _here_, behind a stable interface, not in the
 controller and not in the database layer.
 
-### The repository interface + DI token
+### The repository — factory, contract, and DI token in one file
 
-`task.repository.ts` defines **what** data operations exist, with no hint of **how**. It also
-exports the DI token that binds the interface to its implementation:
+`task.repository.ts` is a single file holding three things: a **factory** that builds the
+store, the **contract** derived from that factory's return type, and the **DI token** typed
+by the contract. There is no separate interface file and no second implementation file:
 
 ```ts
 // src/modules/tasks/task.repository.ts
-import { createToken } from '@forinda/kickjs'
+import { randomUUID } from 'node:crypto'
+import { createToken, HttpException } from '@forinda/kickjs'
 import type { ParsedQuery } from '@forinda/kickjs'
 import type { TaskResponseDTO } from './dtos/task-response.dto'
 import type { CreateTaskDTO } from './dtos/create-task.dto'
 import type { UpdateTaskDTO } from './dtos/update-task.dto'
 
-export interface ITaskRepository {
-  findById(id: string): Promise<TaskResponseDTO | null>
-  findAll(): Promise<TaskResponseDTO[]>
-  findPaginated(parsed: ParsedQuery): Promise<{ data: TaskResponseDTO[]; total: number }>
-  create(dto: CreateTaskDTO): Promise<TaskResponseDTO>
-  update(id: string, dto: UpdateTaskDTO): Promise<TaskResponseDTO>
-  delete(id: string): Promise<void>
+export function createTaskRepository() {
+  const store = new Map<string, TaskResponseDTO>()
+
+  return {
+    async findById(id: string): Promise<TaskResponseDTO | null> {
+      return store.get(id) ?? null
+    },
+
+    async findAll(): Promise<TaskResponseDTO[]> {
+      return [...store.values()]
+    },
+
+    async findPaginated(parsed: ParsedQuery): Promise<{ data: TaskResponseDTO[]; total: number }> {
+      const all = [...store.values()]
+      const { offset, limit } = parsed.pagination
+      return { data: all.slice(offset, offset + limit), total: all.length }
+    },
+
+    async create(dto: CreateTaskDTO): Promise<TaskResponseDTO> {
+      const now = new Date().toISOString()
+      const entity = { id: randomUUID(), ...dto, createdAt: now, updatedAt: now } as TaskResponseDTO
+      store.set(entity.id, entity)
+      return entity
+    },
+
+    async update(id: string, dto: UpdateTaskDTO): Promise<TaskResponseDTO> {
+      const existing = store.get(id)
+      if (!existing) throw HttpException.notFound('Task not found')
+      const updated = { ...existing, ...dto, updatedAt: new Date().toISOString() }
+      store.set(id, updated)
+      return updated
+    },
+
+    async delete(id: string): Promise<void> {
+      if (!store.has(id)) throw HttpException.notFound('Task not found')
+      store.delete(id)
+    },
+  }
 }
 
-// Collision-safe DI token bound to `ITaskRepository`.
-// `container.resolve(TASK_REPOSITORY)` and `@Inject(TASK_REPOSITORY)`
-// both return the typed interface — no manual generic, no `any` cast.
-export const TASK_REPOSITORY = createToken<ITaskRepository>('app/Task/repository')
+/** The contract, derived from the factory rather than declared beside it. */
+export type TaskRepository = ReturnType<typeof createTaskRepository>
+
+/** Collision-safe DI token bound to `TaskRepository`. */
+export const TASK_REPOSITORY = createToken<TaskRepository>('app/Task/repository')
 ```
 
-`createToken<T>` returns a frozen, reference-identified token that carries its type
-parameter. That's what makes `@Inject(TASK_REPOSITORY) repo: ITaskRepository` type-safe with
-no cast, and what prevents the classic "two `Symbol('TaskRepository')` calls produce two
-different symbols" bug. See [Dependency Injection](./dependency-injection.md) for the full
-token hierarchy (class identity → `createToken<T>` → symbol → raw string).
+Three things are worth pausing on.
 
-::: tip One token per interface
-The generator declares exactly one token per repository interface and exports it from the
-same file. Import that token everywhere you need the repository — never declare a parallel
+**The contract is derived.** `TaskRepository` is `ReturnType<typeof createTaskRepository>`, so
+the implementation and its type cannot drift — there is no hand-written interface to forget to
+update. Consumers still program against a name (`TaskRepository`), they just never maintain it.
+
+**It is a closure, not a class.** `store` is private because it is a local variable, not
+because a keyword says so, and each `createTaskRepository()` call gets a fresh one. That is
+what makes the repository trivial to instantiate in a test.
+
+**It always works as generated.** Even with `--repo postgres`, the body ships backed by a
+`Map`. An earlier generation named that file `PostgresTaskRepository` while it was really a
+`Map` — a name asserting a technology it did not implement, which an app could boot and smoke-test
+on. With the store out of the name, an in-memory body is honest: this is the repository,
+currently in memory, and the file's TODO says what to swap in.
+
+`createToken<T>` returns a frozen, reference-identified token that carries its type parameter.
+That's what makes `@Inject(TASK_REPOSITORY) repo: TaskRepository` type-safe with no cast, and
+what prevents the classic "two `Symbol('TaskRepository')` calls produce two different symbols"
+bug. See [Dependency Injection](./dependency-injection.md) for the full token hierarchy (class
+identity → `createToken<T>` → symbol → raw string).
+
+::: tip One token per repository
+The generator declares exactly one token per repository and exports it from the same file as
+the factory. Import that token everywhere you need the repository — never declare a parallel
 `Symbol()` or a centralized `TOKENS` map. A single source of truth is what keeps the binding
 unambiguous across HMR reloads and cross-module injection.
 :::
-
-### The in-memory implementation — the default
-
-`in-memory-task.repository.ts` fulfills the contract with a plain `Map`. It carries zero
-dependencies, so a freshly scaffolded module runs and passes its tests immediately:
-
-```ts
-// src/modules/tasks/in-memory-task.repository.ts
-import { randomUUID } from 'node:crypto'
-import { Repository, HttpException } from '@forinda/kickjs'
-import type { ParsedQuery } from '@forinda/kickjs'
-import type { ITaskRepository } from './task.repository'
-import type { TaskResponseDTO } from './dtos/task-response.dto'
-import type { CreateTaskDTO } from './dtos/create-task.dto'
-import type { UpdateTaskDTO } from './dtos/update-task.dto'
-
-@Repository()
-export class InMemoryTaskRepository implements ITaskRepository {
-  private store = new Map<string, TaskResponseDTO>()
-
-  async findById(id: string): Promise<TaskResponseDTO | null> {
-    return this.store.get(id) ?? null
-  }
-
-  async findAll(): Promise<TaskResponseDTO[]> {
-    return Array.from(this.store.values())
-  }
-
-  async findPaginated(parsed: ParsedQuery): Promise<{ data: TaskResponseDTO[]; total: number }> {
-    const all = Array.from(this.store.values())
-    const data = all.slice(
-      parsed.pagination.offset,
-      parsed.pagination.offset + parsed.pagination.limit,
-    )
-    return { data, total: all.length }
-  }
-
-  async create(dto: CreateTaskDTO): Promise<TaskResponseDTO> {
-    const now = new Date().toISOString()
-    const entity: TaskResponseDTO = {
-      id: randomUUID(),
-      ...dto,
-      createdAt: now,
-      updatedAt: now,
-    }
-    this.store.set(entity.id, entity)
-    return entity
-  }
-
-  async update(id: string, dto: UpdateTaskDTO): Promise<TaskResponseDTO> {
-    const existing = this.store.get(id)
-    if (!existing) throw HttpException.notFound('Task not found')
-    const updated = { ...existing, ...dto, updatedAt: new Date().toISOString() }
-    this.store.set(id, updated)
-    return updated
-  }
-
-  async delete(id: string): Promise<void> {
-    if (!this.store.has(id)) throw HttpException.notFound('Task not found')
-    this.store.delete(id)
-  }
-}
-```
-
-`@Repository()` registers the class in the DI container as a singleton (it's semantically the
-same as `@Service()`, just clearer about intent). The module's `register()` then routes the
-`TASK_REPOSITORY` token to this class.
 
 ### The DTOs — request and response shapes
 
@@ -423,92 +410,105 @@ Put the pieces together and the direction of dependency is strictly one-way:
 HTTP request
    │
    ▼
-TaskController        depends on →  TaskService           (concrete class, @Autowired)
+TaskController        depends on →  TaskService          (concrete class, @Autowired)
    │
    ▼
-TaskService           depends on →  ITaskRepository        (interface, via TASK_REPOSITORY token)
+TaskService           depends on →  TaskRepository       (derived contract, via TASK_REPOSITORY token)
    │
    ▼
-TASK_REPOSITORY  ──bound in module's register()──►  InMemoryTaskRepository  (implements ITaskRepository)
+TASK_REPOSITORY  ──bound in module's register()──►  createTaskRepository()  (currently a Map)
 ```
 
 The controller knows nothing about the database. The service knows nothing about _which_
-database — only the `ITaskRepository` contract. The single arrow that crosses into "how data
-is actually stored" is the `registerFactory` call in `task.module.ts`. That's the seam you
-exploit to swap implementations.
+database — only the `TaskRepository` contract. The single arrow that crosses into "how data is
+actually stored" is the `registerFactory` call in `task.module.ts`. That's the seam you exploit
+to swap implementations.
 
-## Swapping the In-Memory Repo for a Real Database
+## Swapping the In-Memory Store for a Real Database
 
 The in-memory store is perfect for prototyping and tests, but eventually you need persistence.
-Because everything above the repository depends on the _interface_, switching is a localized
-change. There are two steps.
+Because everything above the repository depends on the derived contract, switching is a
+localized change. There are two ways to do it.
 
-### 1. Write a new implementation of the same interface
+### Option 1 — replace the factory body
 
-Generate a custom stub by passing any database name as the repo. Anything other than
-`inmemory` scaffolds a generic custom repository file with TODOs:
-
-<PmCommand exec="kick g module task --repo postgres" />
-
-That writes `postgres-task.repository.ts` — a stub that already `implements ITaskRepository`
-and is decorated with `@Repository()`. Fill in the TODOs with your real client calls:
+The simplest path, and the one the generator's TODOs point at: keep one factory, swap what it
+returns.
 
 ```ts
-// src/modules/tasks/postgres-task.repository.ts
-import { Repository, HttpException } from '@forinda/kickjs'
+// src/modules/tasks/task.repository.ts
+import { createToken, HttpException } from '@forinda/kickjs'
 import type { ParsedQuery } from '@forinda/kickjs'
-import type { ITaskRepository } from './task.repository'
 import type { TaskResponseDTO } from './dtos/task-response.dto'
 import type { CreateTaskDTO } from './dtos/create-task.dto'
 import type { UpdateTaskDTO } from './dtos/update-task.dto'
 import { db } from '../../db' // your own client
 
-@Repository()
-export class PostgresTaskRepository implements ITaskRepository {
-  async findById(id: string): Promise<TaskResponseDTO | null> {
-    const row = await db.query('SELECT * FROM tasks WHERE id = $1', [id])
-    return row ?? null
-  }
+export function createTaskRepository() {
+  return {
+    async findById(id: string): Promise<TaskResponseDTO | null> {
+      const row = await db.query('SELECT * FROM tasks WHERE id = $1', [id])
+      return row ?? null
+    },
 
-  async findPaginated(parsed: ParsedQuery): Promise<{ data: TaskResponseDTO[]; total: number }> {
-    // Use parsed.pagination, parsed.filters, parsed.sort, parsed.search here
-    // ...
-    return { data, total }
-  }
+    async findPaginated(parsed: ParsedQuery): Promise<{ data: TaskResponseDTO[]; total: number }> {
+      // Use parsed.pagination, parsed.filters, parsed.sort, parsed.search here
+      // ...
+      return { data, total }
+    },
 
-  // ...create / update / delete, implementing the same contract
+    // ...findAll / create / update / delete
+  }
+}
+
+export type TaskRepository = ReturnType<typeof createTaskRepository>
+export const TASK_REPOSITORY = createToken<TaskRepository>('app/Task/repository')
+```
+
+Nothing else in the module changes: `task.module.ts` still calls `createTaskRepository()`, and
+the service still injects `TASK_REPOSITORY`.
+
+::: warning Keep the return-type annotations
+The contract is inferred from what the factory returns, so a method that loses its explicit
+`Promise<TaskResponseDTO>` annotation silently widens the contract instead of failing. Annotate
+every method's return type and the compiler catches drift at the call sites, exactly like a
+hand-written interface would.
+:::
+
+### Option 2 — a second factory, bound per environment
+
+When you want the fast in-memory store in tests and Postgres in production, write a second
+factory returning a compatible shape and pick between them in the module:
+
+```ts
+// src/modules/tasks/postgres-task.repository.ts
+import type { TaskRepository } from './task.repository'
+
+export function createPostgresTaskRepository(): TaskRepository {
+  return {
+    /* ...same shape, real queries... */
+  }
 }
 ```
 
-Because TypeScript checks `implements ITaskRepository`, you can't accidentally drift from the
-contract — a missing or mistyped method is a compile error.
-
-::: warning Implement the whole interface
-The new class must satisfy every method on `ITaskRepository`. The interface is your safety
-net: if a method's signature doesn't match, the build fails before runtime.
-:::
-
-### 2. Re-point the token in the module
-
-Change the one binding in `task.module.ts` to resolve the new class:
-
 ```ts
-// src/modules/tasks/task.module.ts
-import { PostgresTaskRepository } from './postgres-task.repository'
-
-// ...inside build().register(container):
-container.registerFactory(TASK_REPOSITORY, () => container.resolve(PostgresTaskRepository))
+// src/modules/tasks/task.module.ts — inside build().register(container):
+container.registerFactory(TASK_REPOSITORY, () =>
+  process.env.NODE_ENV === 'test' ? createTaskRepository() : createPostgresTaskRepository(),
+)
 ```
 
-That's it. The controller, service, DTOs, and query config are untouched. Every consumer that
-injects `TASK_REPOSITORY` now receives the Postgres-backed implementation. You can even keep
-both classes in the tree and switch per environment — in-memory for tests, Postgres for
-production.
+The explicit `: TaskRepository` return annotation is what makes this safe — a missing or
+mistyped method is a compile error in the new factory, not a surprise at runtime.
+
+Either way the controller, service, DTOs, and query config are untouched. Every consumer that
+injects `TASK_REPOSITORY` receives the new store.
 
 ::: tip Pick persistence by name
-`--repo inmemory` (the default) gives you the zero-dependency working impl; any other name
-(e.g. `--repo postgres`) gives you the generic stub above to wire to whatever client you
-prefer. For a first-party database layer, reach for `@forinda/kickjs-db`.
+`--repo inmemory` (the default) and any other name (e.g. `--repo postgres`) emit the **same
+single file** with the same working `Map` body — the store name only changes the prose and the
+TODO markers telling you what to wire in. For a first-party database layer, reach for
+`@forinda/kickjs-db`.
 :::
 
 ## Running and Testing
@@ -532,19 +532,19 @@ curl http://localhost:3000/api/v1/tasks
 curl http://localhost:3000/api/v1/tasks/<id>
 ```
 
-The scaffolded tests (generated by `kick g module`) exercise the repository directly against
-the in-memory implementation — no HTTP, no database, fast to run:
+The scaffolded tests (generated by `kick g module`, unless you passed `--no-tests`) exercise
+the repository directly through its factory — no HTTP, no database, fast to run:
 
 ```ts
 // src/modules/tasks/__tests__/task.repository.test.ts (excerpt)
 import { describe, it, expect, beforeEach } from 'vitest'
-import { InMemoryTaskRepository } from '../in-memory-task.repository'
+import { createTaskRepository, type TaskRepository } from '../task.repository'
 
-describe('InMemoryTaskRepository', () => {
-  let repo: InMemoryTaskRepository
+describe('Task repository', () => {
+  let repo: TaskRepository
 
   beforeEach(() => {
-    repo = new InMemoryTaskRepository()
+    repo = createTaskRepository() // fresh Map per test — no shared state
   })
 
   it('should create and retrieve a task', async () => {
@@ -561,8 +561,8 @@ Run the suite:
 pnpm test
 ```
 
-Because the repository is just a class implementing an interface, you can unit-test it in
-isolation, and you can hand a fresh `InMemoryTaskRepository` to a service in a test without
+Because the repository is just a function returning an object, you can unit-test it in
+isolation, and you can hand a fresh `createTaskRepository()` to a service in a test without
 spinning up a database — the same indirection that lets you swap Postgres in production lets
 you swap the fast in-memory store in tests.
 

--- a/docs/guide/tutorial-ddd-architecture.md
+++ b/docs/guide/tutorial-ddd-architecture.md
@@ -486,7 +486,10 @@ import type { TaskRepository } from './task.repository'
 
 export function createPostgresTaskRepository(): TaskRepository {
   return {
-    /* ...same shape, real queries... */
+    async findById(id) {
+      return db.query('SELECT * FROM tasks WHERE id = $1', [id])
+    },
+    // ...the rest of the contract, backed by real queries
   }
 }
 ```

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -155,7 +155,7 @@ const GENERATORS = [
   { name: 'config', description: 'Generate kick.config.ts' },
   {
     name: 'agents',
-    description: 'Regenerate AGENTS.md + CLAUDE.md + kickjs-skills.md from upstream templates',
+    description: 'Regenerate .agents/* + root CLAUDE.md from upstream templates',
   },
 ]
 
@@ -741,9 +741,7 @@ export function registerGenerateCommand(program: Command, ctx?: KickCliPluginCon
     .command('agents')
     .alias('agent-docs')
     .alias('ai-docs')
-    .description(
-      'Regenerate AGENTS.md + CLAUDE.md + kickjs-skills.md (sync after framework upgrades)',
-    )
+    .description('Regenerate .agents/* + root CLAUDE.md (sync after framework upgrades)')
     .option(
       '--only <which>',
       'Limit scope: agents | claude | skills | both (agents+claude) | all (default: all)',

--- a/packages/cli/src/generators/agent-docs.ts
+++ b/packages/cli/src/generators/agent-docs.ts
@@ -43,7 +43,7 @@ export interface GenerateAgentDocsOptions {
    *
    * - `agents`  → `.agents/AGENTS.md`
    * - `claude`  → `CLAUDE.md` (root; thin pointer to .agents/)
-   * - `skills`  → `.agents/kickjs-skills.md`
+   * - `skills`  → `.agents/skills/<slug>/SKILL.md` (one per skill)
    * - `gemini`  → `.agents/GEMINI.md`
    * - `copilot` → `.agents/COPILOT.md`
    * - `both`    → `.agents/AGENTS.md` + `CLAUDE.md` (legacy alias)


### PR DESCRIPTION
## Why

The docs describing what `kick new` and `kick g module` produce had drifted from what the
generators actually write. Someone following `guide/project-structure.md` or the module
tutorial today would look for files that no longer exist, and copy a module registration that
imports a class the generator stopped emitting.

Every claim below was checked against the CLI source (`generators/project.ts`,
`generators/patterns/rest.ts`, `generators/scaffold.ts`, `generators/agent-docs.ts`,
`generators/templates/{project-app,module-index,repository,tests}.ts`), not from memory.

## What was wrong

**Generated project root**

| Docs said | Actually written |
| --- | --- |
| `.prettierrc` | `.oxfmtrc.json` |
| — | `.editorconfig`, `.gitignore`, `.gitattributes`, `.env.test`, `.kickjs/types/` all missing from the tree |
| root `AGENTS.md` + `kickjs-skills.md` | `.agents/{AGENTS,GEMINI,COPILOT}.md` + `.agents/skills/<slug>/SKILL.md`; only `CLAUDE.md` stays at the root |
| `bootstrap({ ... })`, no `runtime` | `await bootstrap({ runtime: expressRuntime(), ... })`, after `import 'reflect-metadata'` and `import './config'` |
| `modules: AppModuleEntry[] = [A(), B()]` | `defineModules().mount(A()).mount(B())` |

`kickjs-skills.md` is not written by any code path — `--only skills` emits one
`.agents/skills/<slug>/SKILL.md` per skill.

**Generated modules**

| Docs said | Actually written |
| --- | --- |
| `users.repository.ts` (interface + token) **and** `in-memory-users.repository.ts` | one `users.repository.ts` — factory, derived contract, token |
| `--repo postgres` → `users-postgres.repository.ts` | the same single file, Map-backed, with TODOs naming the store |
| `registerFactory(TOKEN, () => container.resolve(InMemoryUsersRepository))` | `registerFactory(TOKEN, () => createUsersRepository())` |
| glob `['./**/*.service.ts', './**/*.repository.ts', ...]` | `['./**/*.ts', '!./**/*.test.ts', '!./**/*.d.ts']` (broadened in #609) |
| a custom repo also scaffolds an in-memory repo "for testing" | never did after the merge to one file |

## What changed

- `guide/project-structure.md` — root tree, entry point, module composition, REST module tree, repository options
- `guide/getting-started.md`, `guide/cli-commands.md`, `guide/generators.md`, `api/cli.md` — `kick g agents` output paths, plus the missing `--only gemini|copilot` values and the `.local.md` customisation note
- `guide/generators.md` — scaffold's generated-structure table
- `guide/testing.md` — dropped the "generates both repositories" claim, replaced with the factory-based test
- `guide/tutorial-ddd-architecture.md` — rewritten around the factory-and-derived-contract shape: repository section (the interface and in-memory sections merged into one), dependency-flow diagram, database-swap walkthrough (replace the factory body, or bind a second factory per environment), and the test excerpt

## CLI fix

`kick g agents --help` and the generator list advertised `kickjs-skills.md`, and the `--only`
JSDoc pointed at the same missing file. Corrected — text only, no behaviour change. Changeset
included (`@forinda/kickjs-cli`: patch).

## Not touched

`guide/dependency-injection.md`, `guide/modules.md`, `guide/samples.md`, `api/testing.md` and
`guide/ai.md` still show hand-written `class InMemoryX` examples. Those are valid DI patterns a
user can write by hand — they aren't claims about generator output — so they're left as-is.
Worth a follow-up if we want the docs to speak one style throughout.

## Verification

- `oxfmt --check` clean on all 9 changed files
- Claims traced to source; no generated project was scaffolded to diff against, because the
  local `packages/cli/dist` predates these commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVCyhU9ghEntXjQwzXvjhE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated CLI help and guides to describe the `.agents/` layout, root `CLAUDE.md`, per-agent files, and individual skill documentation.
  - Added Gemini and Copilot generation targets and clarified `--only` options.
  - Updated project structure, testing, scaffolding, and tutorial guidance for factory-based repositories and current module setup.
  - Clarified upgrade and regeneration workflows.

- **Bug Fixes**
  - Corrected `kick g agents` help text to match the current generated file layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->