### PR TITLE
fix(cli): sync the kick g flag lists with what the commands accept

### DIFF
--- a/.changeset/agents-flag-lists.md
+++ b/.changeset/agents-flag-lists.md
@@ -1,0 +1,15 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+Fix two stale flag lists in `kick g` help text.
+
+- `kick g agents --only` accepts `gemini` and `copilot`, but the option help only
+  listed `agents | claude | skills | both | all`.
+- `kick g agents --template` accepts `fullstack` alongside `rest` and `minimal`;
+  the help omitted it, and the JSDoc still named the removed `ddd` template as
+  the fallback.
+
+Text only — no behaviour change. The matching reference tables in the guide and
+API docs are corrected too, along with a `--repo` flag the scaffold docs
+advertised that `kick g scaffold` never accepted.

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -82,10 +82,10 @@ cd packages/cli && pnpm link --global
 
 **kick g agents** (aliases: `kick g agent-docs`, `kick g ai-docs`)
 
-- `--only <which>` -- Scope: `agents` | `claude` | `skills` | `both` | `all` (default: `all`)
+- `--only <which>` -- Scope: `agents` | `claude` | `skills` | `gemini` | `copilot` | `both` | `all` (default: `all`)
 - `--name <name>` -- Project name override (default: from `package.json`)
 - `--pm <pm>` -- Package manager override (default: from corepack `packageManager` field)
-- `--template <template>` -- Template: `rest` | `minimal` (default: from `kick.config.ts` `pattern`)
+- `--template <template>` -- Template: `rest` | `minimal` | `fullstack` (default: from `kick.config.ts` `pattern`)
 - `-f, --force` -- Overwrite without prompting
 
 ## defineConfig

--- a/docs/guide/cli-commands.md
+++ b/docs/guide/cli-commands.md
@@ -534,12 +534,12 @@ kick g scaffold User name:string email:email:optional role:enum:admin,user,guest
 
 #### Scaffold Flags
 
-| Flag                  | Description               | Default       |
-| --------------------- | ------------------------- | ------------- |
-| `--no-tests`          | Skip test file generation | `false`       |
-| `--no-pluralize`      | Use singular names        | from config   |
-| `--repo <name>`       | Repository name           | from config   |
-| `--modules-dir <dir>` | Modules directory         | `src/modules` |
+| Flag                  | Description                           | Default       |
+| --------------------- | ------------------------------------- | ------------- |
+| `--no-entity`         | Skip entity + value object generation | `false`       |
+| `--no-tests`          | Skip test file generation             | `false`       |
+| `--no-pluralize`      | Use singular names                    | from config   |
+| `--modules-dir <dir>` | Modules directory                     | `src/modules` |
 
 ::: tip Shell-safe optional syntax
 Use `name:type:optional` instead of `"name:type?"` — the `?` character is a shell glob in bash/zsh and needs quoting.
@@ -583,13 +583,13 @@ kick g agents -f --only both       # .agents/AGENTS.md + CLAUDE.md (skip skills)
 
 Aliases: `kick g agent-docs`, `kick g ai-docs`. Auto-detects project name (from `package.json`), package manager (corepack `packageManager` field), and template (from `kick.config.ts` `pattern`).
 
-| Flag                    | Description                                         | Default               |
-| ----------------------- | --------------------------------------------------- | --------------------- |
-| `--only <which>`        | `agents` \| `claude` \| `skills` \| `both` \| `all` | `all`                 |
-| `--name <name>`         | Project name override                               | from `package.json`   |
-| `--pm <pm>`             | Package manager override                            | from `package.json`   |
-| `--template <template>` | `rest` \| `minimal` \| `fullstack`                  | from `kick.config.ts` |
-| `-f, --force`           | Overwrite without prompting                         | `false`               |
+| Flag                    | Description                                                                  | Default               |
+| ----------------------- | ---------------------------------------------------------------------------- | --------------------- |
+| `--only <which>`        | `agents` \| `claude` \| `skills` \| `gemini` \| `copilot` \| `both` \| `all` | `all`                 |
+| `--name <name>`         | Project name override                                                        | from `package.json`   |
+| `--pm <pm>`             | Package manager override                                                     | from `package.json`   |
+| `--template <template>` | `rest` \| `minimal` \| `fullstack`                                           | from `kick.config.ts` |
+| `-f, --force`           | Overwrite without prompting                                                  | `false`               |
 
 See [Generators — kick g agents](./generators.md#kick-g-agents) for what each file contains and how to keep local customisations from being overwritten.
 

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -298,16 +298,16 @@ Scaffold emits the same flat REST module layout as `kick g module`, but with fie
 | `dtos/post-response.dto.ts` | Response interface                                      |
 | `__tests__/`                | Controller + repository tests                           |
 
-With a custom repo name (e.g. `--repo postgres`), the same `post.repository.ts` is emitted — still a working Map-backed factory, with the prose and TODO markers naming the store you asked for. Replace the factory body; the contract is `ReturnType<typeof createPostRepository>`, so nothing else changes.
+`post.repository.ts` is always the Map-backed factory — `kick g scaffold` takes no `--repo` flag, so it can't name a store in the generated prose the way `kick g module --repo postgres` does. Replace the factory body with your own queries; the contract is `ReturnType<typeof createPostRepository>`, so nothing else changes.
 
 ### Scaffold Flags
 
-| Flag                  | Description               | Default                      |
-| --------------------- | ------------------------- | ---------------------------- |
-| `--no-tests`          | Skip test file generation | `false`                      |
-| `--no-pluralize`      | Use singular names        | from config or `false`       |
-| `--repo <name>`       | Repository name           | from config or `inmemory`    |
-| `--modules-dir <dir>` | Modules directory         | from config or `src/modules` |
+| Flag                  | Description                           | Default                      |
+| --------------------- | ------------------------------------- | ---------------------------- |
+| `--no-entity`         | Skip entity + value object generation | `false`                      |
+| `--no-tests`          | Skip test file generation             | `false`                      |
+| `--no-pluralize`      | Use singular names                    | from config or `false`       |
+| `--modules-dir <dir>` | Modules directory                     | from config or `src/modules` |
 
 ### Example
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -744,12 +744,12 @@ export function registerGenerateCommand(program: Command, ctx?: KickCliPluginCon
     .description('Regenerate .agents/* + root CLAUDE.md (sync after framework upgrades)')
     .option(
       '--only <which>',
-      'Limit scope: agents | claude | skills | both (agents+claude) | all (default: all)',
+      'Limit scope: agents | claude | skills | gemini | copilot | both (agents+claude) | all (default: all)',
       'all',
     )
     .option('--name <name>', 'Project name (defaults to package.json name)')
     .option('--pm <pm>', 'Package manager (defaults to package.json packageManager)')
-    .option('--template <template>', 'Template: rest | minimal')
+    .option('--template <template>', 'Template: rest | minimal | fullstack')
     .option('-f, --force', 'Overwrite existing files without prompting')
     .action(async (opts: AgentDocsOpts, cmd: Command) => {
       const dryRun = isDryRun(cmd)

--- a/packages/cli/src/generators/agent-docs.ts
+++ b/packages/cli/src/generators/agent-docs.ts
@@ -34,7 +34,7 @@ export interface GenerateAgentDocsOptions {
   name?: string
   /** Override package manager (defaults to package.json `packageManager` field, then 'pnpm'). */
   pm?: string
-  /** Override template (defaults to kick.config.ts `pattern`, then 'ddd'). */
+  /** Override template (defaults to kick.config.ts `pattern`, then 'rest'). */
   template?: ProjectTemplate
   /**
    * Which file(s) to (re)generate. All `.agents/`-bound files land in


### PR DESCRIPTION
## Why

Follow-up to #618. CodeRabbit flagged two flag lists that had drifted from the code; both
verified against `packages/cli/src/commands/generate.ts` and confirmed real.

## `kick g agents`

`--only` accepts `gemini` and `copilot` (`AGENT_DOCS_ONLY_VALUES`, and `generateAgentDocs`
branches on both), but the option help and both reference tables stopped at
`agents | claude | skills | both | all`. A user reading either would think per-agent
regeneration wasn't available.

`--template` has the same shape of problem: `VALID_TEMPLATES` is
`rest | minimal | fullstack`, while the help and `docs/api/cli.md` listed only the first two.
The `GenerateAgentDocsOptions.template` JSDoc also still named `ddd` as the fallback default —
a template that no longer exists.

## `kick g scaffold`

The docs advertised a `--repo <name>` flag in two flag tables and in prose. The command
registers no such option and never passes a repo to `generateScaffold`, which defaults to the
Map-backed factory. Passing it would just be an unknown-option error.

Removed the claim, and added the `--no-entity` flag both tables were missing. Naming a store
is still `kick g module --repo postgres`.

## Not done

Wiring `--repo` through `kick g scaffold` for parity with `kick g module` — that's a feature,
not a docs fix, and worth its own PR if you want it. Since the repository is now a single
factory file, `--repo` only changes the generated prose and TODO markers, so the gap is
cosmetic.

## Verification

- `pnpm format:check` clean (901 files)
- Changeset included (`@forinda/kickjs-cli`: patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVCyhU9ghEntXjQwzXvjhE
