### PR TITLE
docs: drive the test app through app.handle, not the deprecated expressApp

### DIFF
--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -1457,8 +1457,8 @@ class HomeModule {
 
 describe('locale contributor — integration', () => {
   it('handler sees the parsed locale from the request', async () => {
-    const { expressApp } = createTestApp({ modules: [HomeModule] })
-    const res = await supertest(expressApp)
+    const { app } = await createTestApp({ modules: [HomeModule] })
+    const res = await supertest(app.handle.bind(app))
       .get('/api/v1/')
       .set('Accept-Language', 'fr-CA')
       .expect(200)
@@ -1487,11 +1487,11 @@ class StaticController {
 }
 
 it('method-level override beats the global contributor', async () => {
-  const { expressApp } = createTestApp({
+  const { app } = await createTestApp({
     modules: [StaticModule],
     contributors: [ResolveLocale.registration], // global
   })
-  const res = await supertest(expressApp)
+  const res = await supertest(app.handle.bind(app))
     .get('/api/v1/static')
     .set('Accept-Language', 'fr-CA') // would be `fr` under the global
     .expect(200)
@@ -1535,8 +1535,8 @@ class GreetingService {
 }
 
 it('service reads the locale via getRequestValue during a request', async () => {
-  const { expressApp } = createTestApp({ modules: [HomeModule] })
-  const res = await supertest(expressApp)
+  const { app } = await createTestApp({ modules: [HomeModule] })
+  const res = await supertest(app.handle.bind(app))
     .get('/api/v1/greet')
     .set('Accept-Language', 'fr-CA')
     .expect(200)

--- a/docs/guide/project-structure.md
+++ b/docs/guide/project-structure.md
@@ -228,8 +228,8 @@ describe('UserController', () => {
   beforeEach(() => Container.reset())
 
   it('lists users', async () => {
-    const { expressApp } = await createTestApp({ modules: [UserModule] })
-    const res = await request(expressApp).get('/api/v1/users')
+    const { app } = await createTestApp({ modules: [UserModule] })
+    const res = await request(app.handle.bind(app)).get('/api/v1/users')
     expect(res.status).toBe(200)
   })
 })


### PR DESCRIPTION
## Why

`createTestApp` returns `expressApp` marked `@deprecated`: it throws under Fastify and h3
rather than handing back that engine's instance mistyped as `express.Express` — which is how a
suite ends up silently exercising the wrong runtime. The replacement is `app.handle`, the
Application's own Node request listener, which follows whichever runtime is configured.

`guide/testing.md` and `api/testing.md` already say this. Four snippets elsewhere hadn't caught
up.

## What changed

- `guide/project-structure.md` — the Testing section destructured `expressApp`
- `guide/context-decorators.md` — three integration examples did the same

```diff
-const { expressApp } = await createTestApp({ modules: [UserModule] })
-const res = await request(expressApp).get('/api/v1/users')
+const { app } = await createTestApp({ modules: [UserModule] })
+const res = await request(app.handle.bind(app)).get('/api/v1/users')
```

## Second bug in the same snippets

The three context-decorator examples also called `createTestApp` **without awaiting it**. It's
async, so the destructure read fields off a Promise and every one came back `undefined` —
copy-paste those and the test fails on the first line. Fixed alongside.

## Verification

- `pnpm format:check` clean (901 files)
- Docs only, no published package touched — no changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVCyhU9ghEntXjQwzXvjhE
