### PR TITLE
docs: fix the two Express migration snippets that don't run

### DIFF
--- a/docs/guide/migration-from-express.md
+++ b/docs/guide/migration-from-express.md
@@ -414,9 +414,16 @@ return { path: '/legacy', router: legacyRouter, version: false, prefix: false } 
 ::: warning What a router opts out of
 `router` and `controller` take different paths through the framework. When you pass `router`,
 KickJS mounts it as an opaque handler and cannot see inside it: those routes don't appear in
-the boot-time duplicate-route check (KICK006), in `kick typegen` / the typed client, or in the
-generated OpenAPI spec. That's fine for code on its way out — just don't expect the framework
-features that read the route table to know about them.
+the boot-time duplicate-route check (KICK006), in `kick typegen` / the typed client, in the
+generated OpenAPI spec, or in the boot route summary and the DevTools route list. That's fine
+for code on its way out — just don't expect the framework features that read the route table to
+know about them.
+
+**Nothing warns about this.** `controller` is optional, and a route entry only fails
+(`KICK005`) when _neither_ `router` nor `controller` is given — so a router-only module boots
+silently and the first sign that it's invisible is usually a missing Swagger entry. Adapter
+notification (`onRouteMount`) and the route summary both run on the `controller` branch, not the
+`router` one.
 
 The duplicate check is the one worth watching during a migration: if a router and a controller
 both claim `GET /api/v1/things/:id`, boot succeeds and whichever module mounted first answers

--- a/docs/guide/migration-from-express.md
+++ b/docs/guide/migration-from-express.md
@@ -32,6 +32,99 @@ Or let the CLI resolve the package and its peers for you:
 
 <PmCommand exec="kick add swagger" />
 
+### The build setup KickJS expects
+
+Decorators need a compiler that emits metadata, and `kick dev` runs your app
+_inside_ Vite. An existing Express project built with `tsc` and `nodemon` needs
+four files before `bootstrap()` will run. `kick new` writes them for a fresh
+project; migrating means adding them by hand.
+
+**`tsconfig.json`** — decorator metadata is what makes `@Inject()` and
+`@Autowired()` resolve types at runtime, and the `include` is what puts the
+generated types in scope:
+
+```jsonc
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node", "vite/client"],
+    "experimentalDecorators": true, // required
+    "emitDecoratorMetadata": true, // required
+    "strict": true,
+    "paths": { "@/*": ["./src/*"] },
+  },
+  // .kickjs/types is written by `kick typegen`, outside src/
+  "include": ["src", ".kickjs/types/**/*.d.ts", ".kickjs/types/**/*.ts"],
+}
+```
+
+**`vite.config.ts`** — SWC does the decorator transform (esbuild, Vite's
+default, does not emit decorator metadata), and `kickjsVitePlugin` reads your
+`app` export to drive HMR:
+
+```ts
+import { defineConfig } from 'vite'
+import { fileURLToPath } from 'node:url'
+import swc from 'unplugin-swc'
+import { kickjsVitePlugin, envWatchPlugin } from '@forinda/kickjs-vite'
+
+export default defineConfig({
+  oxc: false, // let SWC own the transform
+  plugins: [
+    swc.vite(),
+    kickjsVitePlugin({ entry: 'src/index.ts' }),
+    envWatchPlugin(), // full reload when .env changes
+  ],
+  resolve: { alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) } },
+  build: {
+    target: 'node20',
+    ssr: true,
+    outDir: 'dist',
+    rollupOptions: {
+      input: fileURLToPath(new URL('./src/index.ts', import.meta.url)),
+      output: { format: 'esm' },
+    },
+  },
+})
+```
+
+<PmCommand add="@forinda/kickjs-vite unplugin-swc" dev />
+
+**`kick.config.ts`** — what the generators read (module directory, repository
+default, typegen settings). Let the CLI write it:
+
+<PmCommand exec="kick g config" />
+
+**`package.json`** — `"type": "module"`, and the scripts move to the CLI. Use
+`kick dev`, not bare `vite`: `kick dev` boots Vite _and_ owns the
+typegen-on-save watcher, so new routes keep their types.
+
+```jsonc
+{
+  "type": "module",
+  "scripts": {
+    "dev": "kick dev",
+    "build": "kick build",
+    "start": "kick start",
+    "test": "vitest run",
+  },
+}
+```
+
+Then run `kick typegen` once so `KickRoutes` and `KickEnv` exist before you
+reference them (`kick dev` re-runs it on every save):
+
+<PmCommand exec="kick typegen" />
+
+::: tip Check the setup before converting routes
+`kick doctor` runs pre-flight checks on an existing project and reports each one
+with a fix — including the two decorator flags above, which are the failure
+that's hardest to read: without them the app boots and then throws
+`No provider for …` on the first injected dependency.
+:::
+
 ## Step 2: Replace app.listen with bootstrap
 
 ### Before (Express)
@@ -174,11 +267,11 @@ export class UserService {
 ```ts
 // modules/users/user.service.ts
 import { Service, Inject } from '@forinda/kickjs'
-import { DB_CLIENT } from '@forinda/kickjs-db'
+import { DB_CLIENT, type KickDbClient } from '@forinda/kickjs-db'
 
 @Service()
 export class UserService {
-  constructor(@Inject(DB_CLIENT) private db: Database) {}
+  constructor(@Inject(DB_CLIENT) private db: KickDbClient) {}
 
   async findAll() {
     return this.db.query('SELECT * FROM users')

--- a/docs/guide/migration-from-express.md
+++ b/docs/guide/migration-from-express.md
@@ -1,21 +1,24 @@
 # Migrating from Express to KickJS
 
-KickJS is built on Express 5, so your existing Express knowledge applies directly. This guide shows how to translate common Express patterns into KickJS equivalents.
+KickJS runs on Express 5 by default, so your existing Express knowledge applies directly. This guide shows how to translate common Express patterns into KickJS equivalents.
+
+One thing to know up front, because it explains most of the differences below: the HTTP engine is **pluggable**. The same app runs on Express, Fastify, or h3 depending on `bootstrap({ runtime })`, so anything the framework hands your code is engine-neutral — a `RequestContext`, not Express's `req`/`res`. Global middleware is the deliberate exception: it stays engine-native, so your existing `(req, res, next)` functions keep working.
 
 ## Quick Comparison
 
-| Express                      | KickJS                                      |
-| ---------------------------- | ------------------------------------------- |
-| `app.get('/users', handler)` | `@Get('/') list(ctx)` on a `@Controller`    |
-| `app.use(middleware)`        | `bootstrap({ middlewares: [...] })`         |
-| `req.body`                   | `ctx.body`                                  |
-| `req.params`                 | `ctx.params`                                |
-| `req.query`                  | `ctx.query` or `ctx.qs()`                   |
-| `res.json(data)`             | `ctx.json(data)`                            |
-| `res.status(201).json(data)` | `ctx.created(data)`                         |
-| Manual DI / singletons       | `@Service()` + `@Inject()` / `@Autowired()` |
-| `express.Router()`           | `@Controller()` + `buildRoutes()`           |
-| Swagger via swagger-jsdoc    | `@ApiTags()` + `SwaggerAdapter` (automatic) |
+| Express                      | KickJS                                                                  |
+| ---------------------------- | ----------------------------------------------------------------------- |
+| `app.get('/users', handler)` | `@Get('/') list(ctx)` on a `@Controller`                                |
+| `app.use(middleware)`        | `bootstrap({ middlewares: [...] })` — same `(req, res, next)` signature |
+| `router.get('/x', mw, h)`    | `@Middleware((ctx, next) => …)` — ctx, not `req`/`res`                  |
+| `req.body`                   | `ctx.body`                                                              |
+| `req.params`                 | `ctx.params`                                                            |
+| `req.query`                  | `ctx.query` or `ctx.qs()`                                               |
+| `res.json(data)`             | `ctx.json(data)`                                                        |
+| `res.status(201).json(data)` | `ctx.created(data)`                                                     |
+| Manual DI / singletons       | `@Service()` + `@Inject()` / `@Autowired()`                             |
+| `express.Router()`           | `@Controller()` + `buildRoutes()`                                       |
+| Swagger via swagger-jsdoc    | `@ApiTags()` + `SwaggerAdapter` (automatic)                             |
 
 ## Step 1: Install KickJS
 
@@ -175,7 +178,7 @@ import { DB_CLIENT } from '@forinda/kickjs-db'
 
 @Service()
 export class UserService {
-  constructor(@Inject(DB_CLIENT) private db: AppDatabase) {}
+  constructor(@Inject(DB_CLIENT) private db: Database) {}
 
   async findAll() {
     return this.db.query('SELECT * FROM users')
@@ -204,14 +207,54 @@ router.get('/profile', authMiddleware, (req, res) => { ... })
 
 ### After (KickJS)
 
-```ts
-// You can still use Express middleware directly:
-import { Controller, Get, Middleware, HttpException, type Ctx } from '@forinda/kickjs'
+There are two places middleware can go, and they take **different signatures**. Getting this
+backwards is the most common migration bug, so it's worth reading the distinction once.
 
-const requireAuth = (req, res, next) => {
-  const token = req.headers.authorization?.split(' ')[1]
+#### Global middleware — keep your Express functions as-is
+
+`bootstrap({ middlewares })` is engine-native. Under the default Express runtime your existing
+`(req, res, next)` middleware runs unchanged, third-party packages included:
+
+```ts
+import cors from 'cors'
+import helmet from 'helmet'
+import express from 'express'
+import { authMiddleware } from './middleware/auth'
+
+export const app = await bootstrap({
+  modules,
+  middlewares: [cors(), helmet(), express.json(), authMiddleware],
+})
+```
+
+Anything `authMiddleware` hangs off `req` is still reachable: `ctx.user` falls back to
+`req.user`, and `ctx.req` is the raw request.
+
+::: warning Engine-native means engine-specific
+These run before route matching and are handed to the engine directly, so a middleware written
+against Express won't port if you later switch `runtime` to Fastify or h3. That's the trade for
+being able to reuse what you already have.
+:::
+
+#### Per-route middleware — `@Middleware()` takes `(ctx, next)`
+
+`@Middleware()` is engine-neutral, so the framework hands the handler a `RequestContext`, not
+`req`/`res`:
+
+```ts
+import { Controller, Get, Middleware, HttpException, type RequestContext } from '@forinda/kickjs'
+
+// Declare the key once so `ctx.set('user', …)` and `ctx.user` are typed.
+declare module '@forinda/kickjs' {
+  interface ContextMeta {
+    user: { id: string; email: string }
+  }
+}
+
+const requireAuth = (ctx: RequestContext, next: () => void) => {
+  const token = ctx.headers.authorization?.split(' ')[1]
   if (!token) throw new HttpException(401, 'Unauthorized')
-  ;(req as any).user = verifyToken(token)
+  ctx.set('user', verifyToken(token))
   next()
 }
 
@@ -219,21 +262,43 @@ const requireAuth = (req, res, next) => {
 export class ProfileController {
   @Get('/profile')
   @Middleware(requireAuth)
-  async getProfile(ctx: Ctx<KickRoutes.ProfileController['getProfile']>) {
-    const user = (ctx.req as any).user
-    ctx.json(user)
+  async getProfile(ctx: RequestContext) {
+    ctx.json(ctx.user)
   }
 }
 ```
 
-Or keep your Express middleware as-is and apply it globally:
+`ctx.set('key', value)` is how a middleware passes a value down to the handler; `ctx.get('key')`
+reads it back, and `ctx.user` is a built-in shortcut for the `'user'` key.
+
+::: danger Don't pass an Express middleware to `@Middleware()`
+Handing `(req, res, next)` to `@Middleware()` fails in a confusing way rather than a loud one.
+The first argument is a `RequestContext`, so `req.headers.authorization` appears to work — and
+then `req.user = …` throws `Cannot set property user of #<RequestContext> which has only a
+getter`, surfacing as a 500 on that route only. Convert the function to `(ctx, next)`, or move
+it to the global `middlewares` array where the Express signature is what's expected.
+:::
+
+#### Or skip middleware entirely
+
+If the middleware's only job is to compute a value the handler reads off the request, a
+[context decorator](./context-decorators.md) does it with typed DI and declared ordering:
 
 ```ts
-export const app = await bootstrap({
-  modules,
-  middlewares: [authMiddleware, express.json()],
+const LoadUser = defineHttpContextDecorator({
+  key: 'user',
+  resolve: (ctx) => verifyToken(ctx.headers.authorization?.split(' ')[1]),
 })
+
+@LoadUser
+@Get('/profile')
+getProfile(ctx: RequestContext) {
+  ctx.json(ctx.get('user'))
+}
 ```
+
+Keep `@Middleware()` for the jobs contributors deliberately don't do: short-circuiting a
+response, touching the response stream, or running before route matching.
 
 ## Step 6: Create a Module
 
@@ -251,25 +316,27 @@ app.use('/api/v1/products', productsRouter)
 
 ```ts
 // src/modules/users/user.module.ts
-import { type AppModule, type ModuleRoutes, buildRoutes } from '@forinda/kickjs'
+import { defineModule } from '@forinda/kickjs'
 import { UserController } from './user.controller'
 
-export class UserModule implements AppModule {
-  routes(): ModuleRoutes {
-    return {
-      path: '/users',
-      router: buildRoutes(UserController),
-      controller: UserController,
-    }
-  }
-}
+export const UserModule = defineModule({
+  name: 'UserModule',
+  build: () => ({
+    routes() {
+      // `router` is optional — omit it and the framework calls
+      // `buildRoutes(controller)` for you.
+      return { path: '/users', controller: UserController }
+    },
+  }),
+})
 
 // src/modules/index.ts
-import type { AppModuleEntry } from '@forinda/kickjs'
+import { defineModules } from '@forinda/kickjs'
 import { UserModule } from './users/user.module'
 import { ProductModule } from './products/product.module'
 
-export const modules: AppModuleEntry[] = [UserModule(), ProductModule()]
+// `defineModule` factories are invoked at the registration site.
+export const modules = defineModules().mount(UserModule()).mount(ProductModule())
 
 // src/index.ts — apiPrefix + versioning are automatic
 export const app = await bootstrap({
@@ -279,6 +346,13 @@ export const app = await bootstrap({
 })
 // Routes: /api/v1/users, /api/v1/products
 ```
+
+::: tip Class modules are still supported — but don't call them
+A `class UserModule implements AppModule` works too; pass the **class itself**, not a call:
+`[UserModule, ProductModule]`. Calling a class without `new` throws
+`TypeError: Class constructor cannot be invoked without 'new'`. Only `defineModule()` factories
+are invoked at the registration site, which is why the generator emits those.
+:::
 
 ## What You Get for Free
 
@@ -291,33 +365,57 @@ By migrating to KickJS, you automatically get:
 - **Query parsing** — `ctx.qs()` with filters, sort, pagination, search
 - **Paginated responses** — `ctx.paginate()` with standardized meta
 - **File uploads** — `@FileUpload` decorator with MIME validation
-- **CLI generators** — `kick g module user` scaffolds 18 DDD files
+- **CLI generators** — `kick g module user` scaffolds a complete flat REST module (controller, service, repository, DTOs, tests)
 
 ## Incremental Migration
 
-You don't have to convert everything at once. KickJS runs on Express 5, so you can:
+You don't have to convert everything at once:
 
 1. Start with `bootstrap()` and your existing middleware
 2. Convert one route file at a time to a `@Controller`
 3. Add `@Service()` to existing classes gradually
-4. Keep raw Express routes alongside KickJS modules
+4. Keep raw Express routers mounted alongside KickJS modules
+
+### Mounting an existing Express Router
+
+A module can hand the framework a finished router instead of a controller. `ModuleRoutes.router`
+takes any connect-style handler — an `express.Router()`, a third-party router, a hand-composed
+stack — and mounts it at the module's path:
 
 ```ts
-export const app = await bootstrap({
-  modules, // converted modules from src/modules/index.ts
-  middlewares: [
-    cors(),
-    express.json(),
-    // Mount legacy Express router directly:
-    (req, res, next) => {
-      if (req.path.startsWith('/legacy')) {
-        return legacyRouter(req, res, next)
-      }
-      next()
+// src/modules/legacy/legacy.module.ts
+import { defineModule } from '@forinda/kickjs'
+import { legacyRouter } from '../../routes/legacy' // your existing express.Router()
+
+export const LegacyModule = defineModule({
+  name: 'LegacyModule',
+  build: () => ({
+    routes() {
+      return { path: '/legacy', router: legacyRouter }
     },
-  ],
+  }),
 })
 ```
+
+It mounts under the same prefix rules as everything else — `/api/v1/legacy/*` above — so
+converted and unconverted routes sit side by side and you migrate one router at a time. Use
+`version: false` to drop the `/v1` segment, or `prefix: false` to mount outside `apiPrefix`
+entirely, when a legacy URL has to stay exactly where it is.
+
+::: warning What a router opts out of
+`router` and `controller` take different paths through the framework. When you pass `router`,
+KickJS mounts it as an opaque handler and cannot see inside it: those routes don't appear in
+the boot-time duplicate-route check, in `kick typegen` / the typed client, or in the generated
+OpenAPI spec. That's fine for code on its way out — just don't expect the framework features
+that read the route table to know about them.
+
+You can pass **both**: `router` mounts the traffic, and `controller` is what adapters like
+`SwaggerAdapter` introspect. Useful while a controller is being extracted from a router.
+:::
+
+The engine bridge is `useConnect()`, which every runtime implements — so a connect-style router
+still mounts if you later switch to Fastify or h3. An `express.Router()` specifically keeps its
+own dependency on `express`, so budget for replacing it if you plan to drop the Express engine.
 
 ## Related
 

--- a/docs/guide/migration-from-express.md
+++ b/docs/guide/migration-from-express.md
@@ -398,24 +398,52 @@ export const LegacyModule = defineModule({
 ```
 
 It mounts under the same prefix rules as everything else — `/api/v1/legacy/*` above — so
-converted and unconverted routes sit side by side and you migrate one router at a time. Use
-`version: false` to drop the `/v1` segment, or `prefix: false` to mount outside `apiPrefix`
-entirely, when a legacy URL has to stay exactly where it is.
+converted and unconverted routes sit side by side and you migrate one router at a time.
+Everything in front of it still runs: global `middlewares` (so `express.json()` parses bodies
+for the router too), the framework's error handler (a `throw` inside the router becomes a
+normal JSON 500), and the 404 handler for unmatched paths underneath it.
+
+When a legacy URL has to stay exactly where it is, `version: false` drops the `/v{n}` segment
+and `prefix: false` drops `apiPrefix`. They're independent — set **both** to mount at `path`
+exactly, which is what the built-in health module does:
+
+```ts
+return { path: '/legacy', router: legacyRouter, version: false, prefix: false } // → /legacy/*
+```
 
 ::: warning What a router opts out of
 `router` and `controller` take different paths through the framework. When you pass `router`,
 KickJS mounts it as an opaque handler and cannot see inside it: those routes don't appear in
-the boot-time duplicate-route check, in `kick typegen` / the typed client, or in the generated
-OpenAPI spec. That's fine for code on its way out — just don't expect the framework features
-that read the route table to know about them.
+the boot-time duplicate-route check (KICK006), in `kick typegen` / the typed client, or in the
+generated OpenAPI spec. That's fine for code on its way out — just don't expect the framework
+features that read the route table to know about them.
+
+The duplicate check is the one worth watching during a migration: if a router and a controller
+both claim `GET /api/v1/things/:id`, boot succeeds and whichever module mounted first answers
+every request. The half you just rewrote can sit there serving nothing, silently — so remove the
+old route from the router in the same commit that adds the controller.
 
 You can pass **both**: `router` mounts the traffic, and `controller` is what adapters like
 `SwaggerAdapter` introspect. Useful while a controller is being extracted from a router.
 :::
 
-The engine bridge is `useConnect()`, which every runtime implements — so a connect-style router
-still mounts if you later switch to Fastify or h3. An `express.Router()` specifically keeps its
-own dependency on `express`, so budget for replacing it if you plan to drop the Express engine.
+::: warning An `express.Router()` only works on the Express engine
+The bridge is `useConnect()`, which every runtime implements, so a **plain connect handler**
+(one that writes with `res.setHeader` / `res.end`) mounts and runs on Express, Fastify and h3
+alike.
+
+An `express.Router()` is not that. Its handlers call Express's response sugar — `res.json()`,
+`res.send()`, `res.status()` — which only exists because Express decorated the response object.
+Bridged into Fastify or h3, the handler gets the raw Node `ServerResponse` and dies on the first
+call:
+
+```
+TypeError: res.json is not a function
+```
+
+It fails per-request, at 500, not at boot. So a mounted Express router is fine while Express is
+your engine — just convert those routes before switching `runtime`.
+:::
 
 ## Related
 


### PR DESCRIPTION
## How this was checked

I transcribed the guide's "After (KickJS)" snippets into a throwaway vitest file against
`packages/kickjs/src` and drove them with supertest, rather than reading for plausibility. Most
of the guide ports cleanly — `bootstrap({ middlewares, apiPrefix, defaultVersion })`,
`@Controller` + route decorators, `@Autowired`, `ctx.json/created/notFound`, `/api/v1/...`
mounting, and keeping `express.json()` and your own Express middleware globally all work exactly
as written. Two snippets don't.

## Step 5 returned 500

The guide attaches an Express-style `(req, res, next)` function via `@Middleware()`. But
`MiddlewareHandler` is `(ctx, next)` — the decorator is engine-neutral, because the runtime is
pluggable. The handler receives a `RequestContext`, so `req.headers.authorization` appears to
work, and then `req.user = ...` throws:

```
TypeError: Cannot set property user of #<RequestContext> which has only a getter
```

It surfaces as a 500 on that one route — no boot error, no type error at the call site.

Rewritten around the real signature (`ctx.set('user', …)` plus the `ContextMeta` augmentation
that types it), and split the section in two so the distinction is explicit:

- **global** `bootstrap({ middlewares })` is engine-native — your `(req, res, next)` functions
  and third-party packages run unchanged, and `ctx.user` falls back to `req.user`
- **per-route** `@Middleware()` is `(ctx, next)`

The guide's own framing — "You can still use Express middleware directly" — is true of the first
and not the second, which is what made it a trap. Added a danger block naming the exact error,
and a pointer to context decorators for the compute-a-value-per-request case.

## Step 6 threw

```ts
export class UserModule implements AppModule { ... }
export const modules: AppModuleEntry[] = [UserModule(), ProductModule()]
```

Calling a class without `new` is a `TypeError`. Switched to `defineModule()` +
`defineModules().mount(...)` (what the CLI generates), with a tip covering the class form:
`AppModuleEntry` accepts the class itself, so pass `[UserModule, ProductModule]` — don't call it.

## New: mounting an existing Express Router

The guide's incremental-migration section suggested path-sniffing inside a global middleware to
keep legacy routes alive. `ModuleRoutes.router` does this properly and the guide never mentioned
it — a module can hand over a finished `express.Router()` and it mounts under the same prefix
rules as everything else.

I ran this across all three engines rather than trusting that `useConnect()` is implemented
everywhere (it is — the question is what survives the bridge):

| Case | Express | Fastify | h3 |
| --- | --- | --- | --- |
| plain connect handler (`res.setHeader` / `res.end`) | ✅ | ✅ | ✅ |
| `express.Router()` using `res.json()` | ✅ | ❌ 500 | ❌ 500 |

Under Fastify or h3 an Express router's handler gets the raw Node `ServerResponse` and dies on
`TypeError: res.json is not a function` — per request, not at boot. Documented as a warning,
because "connect-style routers are portable" is true in a way that doesn't help anyone holding
an `express.Router()`.

Also confirmed working, and now documented: global `middlewares` run before a mounted router (so
`express.json()` parses its bodies), a `throw` inside it becomes a normal framework 500, and
unmatched paths underneath it 404 through the framework.

Two traps documented alongside:

- **`prefix: false` keeps the version segment.** `{ path: '/root', prefix: false }` mounts at
  `/v1/root`, not `/root`. You need `version: false` too — which is what the built-in health
  module does.
- **A router route colliding with a controller route is not caught at boot.** `router` and
  `controller` take different branches in `Application.setup()`, so KICK006 never sees inside the
  router. Both mount, the first one answers, silently. During a migration that means the
  controller you just extracted can serve nothing while the old router keeps winning — so drop
  the old route in the same commit.

Routes behind a `router` are likewise invisible to `kick typegen` and the OpenAPI spec. Passing
both `router` and `controller` is a real pattern: `router` mounts the traffic, `controller` is
what `SwaggerAdapter` introspects.

## Stale claims

- "KickJS is built on Express 5" → Express is the *default* of three engines. This isn't
  pedantry: it's the reason `@Middleware` is ctx-based, so the intro now says it up front.
- "`kick g module user` scaffolds 18 DDD files" → a flat REST module (controller, service,
  repository, DTOs, tests).
- `@Inject(DB_CLIENT) private db: AppDatabase` referenced an undeclared type.

## Verification

- `pnpm format:check` clean (899 files)
- The scratch test file was removed; nothing test-side is added by this PR
- Docs only — no changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVCyhU9ghEntXjQwzXvjhE
