### PR TITLE
docs: correct what `prefix: false` actually drops

### DIFF
--- a/.changeset/prefix-false-jsdoc.md
+++ b/.changeset/prefix-false-jsdoc.md
@@ -1,5 +1,0 @@
----
-'@forinda/kickjs': patch
----
-
-Correct the `ModuleRoutes.prefix` JSDoc. It said `prefix: false` mounts "at `path` exactly", but the flag only drops `apiPrefix` — the `/v{n}` segment stays, so `{ path: '/x', prefix: false }` mounts at `/v1/x` under `defaultVersion: 1`. Mounting at `path` exactly takes `version: false` as well, which is what the built-in health module sets. Comment only; the behaviour is unchanged.

--- a/.changeset/prefix-false-jsdoc.md
+++ b/.changeset/prefix-false-jsdoc.md
@@ -1,0 +1,5 @@
+---
+'@forinda/kickjs': patch
+---
+
+Correct the `ModuleRoutes.prefix` JSDoc. It said `prefix: false` mounts "at `path` exactly", but the flag only drops `apiPrefix` — the `/v{n}` segment stays, so `{ path: '/x', prefix: false }` mounts at `/v1/x` under `defaultVersion: 1`. Mounting at `path` exactly takes `version: false` as well, which is what the built-in health module sets. Comment only; the behaviour is unchanged.

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -220,7 +220,7 @@ interface ModuleRoutes {
   controller?: any
   /** `false` mounts without the `/v{n}` segment, even when the app has a default version. */
   version?: number | false
-  /** `false` mounts at `path` exactly, outside `apiPrefix` — for probes, fixed webhook URLs, `/.well-known`. */
+  /** `false` drops `apiPrefix` — for probes, fixed webhook URLs, `/.well-known`. Pair with `version: false` to mount at `path` exactly. */
   prefix?: false
 }
 ```
@@ -692,7 +692,7 @@ Before v8 these were mounted straight onto the engine, ahead of every middleware
 That is the intended default — your app controls its own auth, and a framework route quietly bypassing it is the surprise — but it will fail a liveness check the first time it runs. Exempt the path as you would any other, or pass `health: false` and mount your own.
 :::
 
-`prefix: false` on their `ModuleRoutes` is what keeps them at the root: a probe URL an orchestrator is configured against must not move when `apiPrefix` or the API version changes.
+`version: false` **and** `prefix: false` on their `ModuleRoutes` is what keeps them at the root: a probe URL an orchestrator is configured against must not move when `apiPrefix` or the API version changes. The two flags are independent — `prefix: false` alone drops `/api` but keeps `/v1`, mounting at `/v1/health`.
 
 ### GET /health/live
 

--- a/docs/guide/migration-v7-to-v8.md
+++ b/docs/guide/migration-v7-to-v8.md
@@ -185,7 +185,18 @@ That completes the URL-shape matrix. Both segments are now droppable at either s
 | whole app | `bootstrap({ defaultVersion: false })` | `bootstrap({ apiPrefix: '' })`              |
 | one mount | `version: false` on `ModuleRoutes`     | `prefix: false` on `ModuleRoutes` **(new)** |
 
-`defaultVersion: false` is not new — it shipped in **7.4.0** — but it is worth knowing next to the per-mount flag, because the two are read together and the per-mount value always wins over the app default, in either direction. `version: false` drops only the version segment and still lands the module under `/api`; `prefix: false` mounts at `path` exactly.
+`defaultVersion: false` is not new — it shipped in **7.4.0** — but it is worth knowing next to the per-mount flag, because the two are read together and the per-mount value always wins over the app default, in either direction.
+
+The two per-mount flags are independent, and each drops exactly one segment. With `apiPrefix: '/api'` and `defaultVersion: 1`, a module at `path: '/x'` mounts at:
+
+| `ModuleRoutes`                                  | Mounted at  |
+| ----------------------------------------------- | ----------- |
+| `{ path: '/x' }`                                | `/api/v1/x` |
+| `{ path: '/x', version: false }`                | `/api/x`    |
+| `{ path: '/x', prefix: false }`                 | `/v1/x`     |
+| `{ path: '/x', version: false, prefix: false }` | `/x`        |
+
+So mounting at `path` exactly takes **both** flags — which is what the built-in health module sets.
 
 ## Fixes that change what you observe
 

--- a/packages/kickjs/src/core/app-module.ts
+++ b/packages/kickjs/src/core/app-module.ts
@@ -36,7 +36,10 @@ export interface ModuleRoutes {
    * `/.well-known` document. Those move with the prefix and break on a change
    * that has nothing to do with them.
    *
-   * Set `false` to mount at `path` exactly. The built-in health module uses it.
+   * Set `false` to drop `apiPrefix`. It does **not** drop the version segment:
+   * with `defaultVersion: 1`, `{ path: '/x', prefix: false }` mounts at
+   * `/v1/x`. Pair it with `version: false` to mount at `path` exactly — the
+   * built-in health module sets both.
    */
   prefix?: false
 


### PR DESCRIPTION
## What I checked

Swept the other guides for the router / mount-path claims from #622. The `router:` usages
elsewhere are all fine — `guide/testing.md:228`, `api/testing.md:88`,
`guide/tutorial-typed-client.md:185` and `guide/context-decorators.md:1454` pass
`router: buildRoutes(X)` alongside `controller`, which is the supported shape.

One claim did repeat, and it's wrong.

## `prefix: false` does not mount at `path` exactly

Tested against a running app, `apiPrefix: '/api'`, `defaultVersion: 1`, module at `path: '/x'`:

| `ModuleRoutes`                                  | Mounted at  |
| ----------------------------------------------- | ----------- |
| `{ path: '/x' }`                                | `/api/v1/x` |
| `{ path: '/x', version: false }`                | `/api/x`    |
| `{ path: '/x', prefix: false }`                 | `/v1/x`     |
| `{ path: '/x', version: false, prefix: false }` | `/x`        |

`prefix: false` drops `apiPrefix` and nothing else. `buildMountPath()` still applies the version
segment (`application.ts:952`).

Four places said otherwise:

- `packages/kickjs/src/core/app-module.ts` — "Set `false` to mount at `path` exactly"
- `docs/api/core.md:223` — the same line, copied into the interface listing
- `docs/api/core.md:695` — "`prefix: false` on their `ModuleRoutes` is what keeps them at the
  root". The health routes do stay at the root, but because the module sets **both** flags
  (`health-module.ts:106`), not because of this one.
- `docs/guide/migration-v7-to-v8.md:188` — "`prefix: false` mounts at `path` exactly", in the
  section whose whole job is explaining the URL-shape matrix

All four corrected, and the matrix above added to the v7→v8 guide.

## A decision for you

The JSDoc plausibly described the *intent*, and "mount at `path` exactly" is the more useful
meaning for the flag — the health module needing both reads like a workaround for the flag not
doing what its own comment says. Making `prefix: false` imply `version: false` would change
mounted URLs for anyone relying on today's `/v1/x`, so this PR documents the behaviour instead
of changing it. Say the word if you'd rather fix the code and note it as a break.

## Verification

- Flag matrix confirmed with a throwaway test (removed before commit)
- `pnpm format:check` clean (899 files)
- Changeset included (`@forinda/kickjs`: patch) — JSDoc ships in the `.d.ts`, so it's a
  user-visible text change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVCyhU9ghEntXjQwzXvjhE
