### PR TITLE
docs: add the config + env step to the Express migration guide

### DIFF
--- a/docs/guide/migration-from-express.md
+++ b/docs/guide/migration-from-express.md
@@ -24,7 +24,11 @@ One thing to know up front, because it explains most of the differences below: t
 
 In your existing Express project:
 
-<PmCommand add="@forinda/kickjs @forinda/kickjs-swagger reflect-metadata zod" />
+<PmCommand add="@forinda/kickjs @forinda/kickjs-schema @forinda/kickjs-swagger reflect-metadata zod dotenv" />
+
+`@forinda/kickjs-schema` is what lets one Zod schema serve env validation,
+request validation and the OpenAPI spec; `dotenv` is an optional peer that makes
+`.env` files work. Both are covered in [Step 3](#step-3-config-and-environment).
 
 <PmCommand add="@forinda/kickjs-cli" dev />
 
@@ -175,7 +179,122 @@ The Vite dev plugin reads the `app` export to wire HMR. Skipping the
 update on file changes.
 :::
 
-## Step 3: Convert Routes to Controllers
+## Step 3: Config and Environment
+
+Express projects usually call `dotenv.config()` somewhere near the top and then
+read `process.env.WHATEVER` — a string, unvalidated, everywhere. KickJS wants one
+schema file instead, and gives you typed access to it from anywhere in the DI
+graph.
+
+### Before (Express)
+
+```ts
+import dotenv from 'dotenv'
+dotenv.config()
+
+const port = Number(process.env.PORT ?? 3000) // coerce by hand, every time
+const dbUrl = process.env.DATABASE_URL! // trust me, it's there
+```
+
+### After (KickJS)
+
+Declare the shape once in `src/config/index.ts`:
+
+```ts
+// src/config/index.ts
+import { loadEnvFromSchema } from '@forinda/kickjs/config'
+import { fromZod } from '@forinda/kickjs-schema/zod'
+import { z } from 'zod'
+
+const envSchema = fromZod(
+  z.object({
+    PORT: z.coerce.number().default(3000),
+    NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+    LOG_LEVEL: z.string().default('info'),
+    DATABASE_URL: z.string().url(),
+    JWT_SECRET: z.string().min(32),
+  }),
+)
+
+// Side effect: registers the schema with the env cache at module-load time.
+export const env = loadEnvFromSchema(envSchema)
+
+// Default export: the contract `kick typegen` reads to populate `KickEnv`.
+export default envSchema
+```
+
+`fromZod` wraps the schema as a `KickSchema`, which is the same shape the
+validate middleware and the OpenAPI generator consume — so one schema library
+choice covers env, request validation and docs. Valibot and Yup work too
+(`fromValibot`, `fromYup` from `@forinda/kickjs-schema/*`); the file is otherwise
+identical.
+
+Missing or malformed values fail at startup with a message naming the key,
+rather than surfacing as `undefined` three layers into a request.
+
+### Mount it before `bootstrap()`
+
+The schema registers as a **module-load side effect**, so the import has to come
+first — this is the line in `src/index.ts` from Step 2:
+
+```ts
+import 'reflect-metadata'
+import './config' // ← must be above bootstrap()
+import { bootstrap } from '@forinda/kickjs'
+```
+
+::: danger This is the failure that looks like it works
+Skip that import and `ConfigService.get('DATABASE_URL')` returns `undefined` —
+it reads the env cache, and nothing registered a schema. Meanwhile
+`@Value('DATABASE_URL')` keeps returning a value, because it falls back to raw
+`process.env` when no resolver is registered
+(`container.ts:902`).
+
+So half your config works, the other half is silently `undefined`, and the half
+that "works" hands you the **unparsed string** — `PORT` is `'3000'`, not `3000`,
+and every `z.coerce` / `.default()` in your schema is skipped. Import
+`./config` and both paths agree.
+:::
+
+### Reading config
+
+Two ways, both typed against the schema once `kick typegen` has run:
+
+```ts
+import { Service, Autowired, Value, ConfigService } from '@forinda/kickjs'
+
+@Service()
+export class DatabaseService {
+  // Property injection — good for one or two values
+  @Value('DATABASE_URL') private readonly url!: string
+  @Value('PORT') private readonly port!: number // already a number
+
+  // Or inject the service — good when you need several
+  @Autowired() private readonly config!: ConfigService
+
+  connect() {
+    const level = this.config.get('LOG_LEVEL') // typed string
+    // this.config.get('NOPE')                 // tsc error after typegen
+  }
+}
+```
+
+Before `kick typegen` runs, both accept any string key (so existing code keeps
+compiling). After it runs, `KickEnv` is populated from your default export and
+unknown keys become type errors — that's the whole reason the file
+`export default`s the schema.
+
+### `.env` files
+
+`dotenv` is loaded for you (it ships as a dependency of a scaffolded app). Keep
+your existing `.env`; add `.env.test` when you have a suite, because under a test
+run KickJS reads `.env.test` **instead of** `.env` — no layering, no fallback —
+so a test can't reach a live service through a var it forgot to override.
+
+See [Configuration](./configuration.md) for the full precedence rules and the
+`ConfigService` API.
+
+## Step 4: Convert Routes to Controllers
 
 ### Before (Express)
 
@@ -243,7 +362,7 @@ Key differences:
 - No `new UserService()` — DI injects it via `@Autowired()`
 - `req`/`res` → `ctx` — unified context with helper methods
 
-## Step 4: Convert Services
+## Step 5: Convert Services
 
 ### Before (Express)
 
@@ -281,7 +400,7 @@ export class UserService {
 
 The `@Service()` decorator registers the class as a singleton in the DI container. Dependencies are injected automatically.
 
-## Step 5: Convert Middleware
+## Step 6: Convert Middleware
 
 ### Before (Express)
 
@@ -393,7 +512,7 @@ getProfile(ctx: RequestContext) {
 Keep `@Middleware()` for the jobs contributors deliberately don't do: short-circuiting a
 response, touching the response stream, or running before route matching.
 
-## Step 6: Create a Module
+## Step 7: Create a Module
 
 Modules replace the Express Router mounting pattern:
 


### PR DESCRIPTION
## Why

Step 2 told the reader to write `import './config'` above `bootstrap()`, and the guide never
said what was in that file. You got the wiring line without the thing being wired — and since
the whole point of that import is a module-load side effect, it's the one line where "just copy
it" doesn't teach you anything.

New **Step 3: Config and Environment**, between bootstrap and controllers.

## What it covers

- `src/config/index.ts` as the CLI generates it — `fromZod(...)` + `loadEnvFromSchema(envSchema)`
  as the registering side effect, and `export default envSchema` because that's the contract
  `kick typegen` reads to populate `KickEnv`
- why the schema goes through `@forinda/kickjs-schema`: the same `KickSchema` feeds env
  validation, request validation and the OpenAPI spec, so the schema-library choice is made once
- both read paths — `@Value('KEY')` for one or two values, injected `ConfigService` for several —
  and the fact that both accept any string key until typegen runs, then narrow to the schema
- `.env.test` replaces `.env` outright under a test run rather than layering, which is what keeps
  a suite from reaching live services through a var it forgot to override

## The failure mode, written down

This design has one sharp edge and it presents as a partial success, so it gets a danger block
rather than a footnote. Miss the `import './config'`:

- `ConfigService.get('DATABASE_URL')` → `undefined`. It reads the env cache; nothing registered a
  schema.
- `@Value('DATABASE_URL')` → still returns a value. It falls back to raw `process.env` when no
  resolver is registered (`container.ts:902`).

So half the config silently disappears, and the half that appears to work hands back the
**unparsed string** — `PORT` is `'3000'`, not `3000`, and every `z.coerce` and `.default()` in
the schema is skipped. Nothing throws; you find it when a number comparison behaves oddly.

## Also

Step 1 installed `zod` but not `@forinda/kickjs-schema` — the package the config file imports
`fromZod` from. Added it and `dotenv`, with a line on what each is for.

Steps 3–6 renumbered to 4–7.

## Verification

- Every claim traced to source: `templates/project-app.ts` (the generated file this documents),
  `container.ts:891-906` (the `@Value` fallback), `config-service.ts:75` (cache read),
  `config/index.ts` (exports), `doctor.ts` (the `.env.test` replacement rule)
- `pnpm format:check` clean (899 files)
- Docs only, no changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVCyhU9ghEntXjQwzXvjhE
