### PR TITLE
docs: say which adapter and plugin middleware actually port across engines

### DIFF
--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -127,11 +127,64 @@ The `middleware()` method returns entries that are inserted at a specific phase 
 
 ```ts
 interface AdapterMiddleware {
-  handler: any
+  /** `(req, res, next)` — or `(err, req, res, next)`, dispatched by arity. */
+  handler: RequestHandler | ErrorRequestHandler
   phase?: 'beforeGlobal' | 'afterGlobal' | 'beforeRoutes' | 'afterRoutes'
-  path?: string
+  /** Prefix, pattern, or a list mixing both. Omit to apply unconditionally. */
+  path?: string | RegExp | ReadonlyArray<string | RegExp>
 }
 ```
+
+`path` mirrors what `app.use(path, handler)` accepts: `'/api'` matches `/api` and
+everything under it, `/^\/api\/v\d+/` matches `/api/v1` and `/api/v42`, and
+`['/api', /^\/internal\//]` matches either.
+
+### Write the handler connect-style, not Express-style
+
+Entries are mounted through `runtime.useConnect()`, which every engine
+implements — so an adapter's middleware runs under Express, Fastify and h3
+alike. What does **not** survive the bridge is Express's response sugar. The
+handler receives the raw Node `req` / `res` on the other engines, so:
+
+```ts
+middleware(): AdapterMiddleware[] {
+  return [
+    {
+      phase: 'afterGlobal',
+      handler: (req, res, next) => {
+        // ✅ works on every engine — node API only
+        res.setHeader('x-adapter', 'mine')
+
+        if (blocked(req)) {
+          // ❌ Express only: `res.status is not a function` on Fastify / h3,
+          //    surfacing as a 500 on that request
+          // return res.status(403).json({ error: 'blocked' })
+
+          // ✅ portable equivalent
+          res.statusCode = 403
+          res.setHeader('content-type', 'application/json')
+          return res.end(JSON.stringify({ error: 'blocked' }))
+        }
+        next()
+      },
+    },
+  ]
+}
+```
+
+The `RequestHandler` type comes from Express because that is the shape of the
+contract, not a statement about which engine you get. The rule of thumb: if you
+only touch `req.url`, `req.method`, `req.headers`, `res.setHeader`,
+`res.statusCode`, `res.write` and `res.end`, the adapter is portable.
+
+::: tip Two places where the sugar _is_ safe
+`bootstrap({ onNotFound, onError })` receive a `RuntimeResponse` driver rather
+than the raw response, so `res.status().json()` works there on every engine —
+see [Middleware → Custom error handlers](./middleware.md#custom-error-handlers).
+And anything with a `RequestContext` in scope (guards, `@Middleware()`,
+contributors) should use `ctx.json()` / `ctx.problem.*`, which are portable by
+construction.
+:::
 
 | Phase          | When it runs                                            |
 | -------------- | ------------------------------------------------------- |

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -133,7 +133,7 @@ interface KickPluginInstance {
 | `modules()`      | Before user modules (static)     | Add feature modules — array form, statically introspectable                               |
 | `setup()`        | After `modules()`, before user   | Conditionally `.mount(module)` based on captured config / env / runtime                   |
 | `adapters()`     | Before user adapters             | Add lifecycle adapters                                                                    |
-| `middleware()`   | Before user middleware           | Add global middleware                                                                     |
+| `middleware()`   | Before user middleware           | Add global middleware — see [Plugin middleware](#plugin-middleware)                       |
 | `contributors()` | Per-route, at mount              | Ship typed [Context Contributors](./context-decorators.md) the plugin owns                |
 | `onReady()`      | After server starts              | Post-startup tasks                                                                        |
 | `shutdown()`     | On shutdown AND every HMR reload | Release what the plugin owns                                                              |
@@ -340,6 +340,47 @@ export const AdminAuthPlugin = definePlugin({
 ```
 
 `.definition` is **metadata only** — it does not produce a mountable plugin. To mount, call the factory: `AuthPlugin()`, `AuthPlugin.scoped(...)`, or `AuthPlugin.async(...)`.
+
+## Plugin Middleware
+
+`middleware()` returns connect-style handlers that are mounted globally, in
+plugin order, before any user-declared middleware:
+
+```ts
+build: (config) => ({
+  middleware() {
+    return [cors({ origin: config.origin })]
+  },
+})
+```
+
+Two limits distinguish it from [adapter middleware](./adapters.md#middleware-phases):
+
+- **No phases.** Every entry lands at the same point — after plugin
+  `register()`, before the global pipeline. An adapter can choose between
+  `beforeGlobal`, `afterGlobal`, `beforeRoutes` and `afterRoutes`.
+- **No path scoping.** Entries apply to every request. Adapter entries take a
+  `path` (string, RegExp, or a list). Scope it inside the handler, or ship an
+  adapter via `adapters()` instead.
+
+Reach for `adapters()` when either of those matters — a plugin can return
+adapters, so this is not a fork in the road.
+
+### Write handlers connect-style
+
+Plugin middleware is mounted through `runtime.useConnect()`, the same bridge
+adapter middleware uses, so it runs under Express, Fastify and h3. Express's
+response sugar does **not** cross that bridge: on the other engines the handler
+receives the raw Node `res`, and `res.status(...).json(...)` throws
+`TypeError: res.status is not a function`, surfacing as a 500 on that request.
+
+Stick to node API — `res.setHeader`, `res.statusCode`, `res.end` — or wrap what
+you need in an adapter and use the `RequestContext` helpers. The framework's own
+middleware (`cors`, `helmet`, `csrf`, `rateLimit`, `requestId`, `session`) is
+written this way, which is why returning it from a plugin works on every engine.
+
+If a plugin genuinely targets one engine, say so in its README and check
+`bootstrap({ runtime })` at boot rather than failing per-request.
 
 ## Plugin Ordering: `dependsOn`
 


### PR DESCRIPTION
## What prompted this

"Are adapter and plugin middleware Express-only?" The answer turned out to be *neither yes nor
no*, and neither guide said which.

Both surfaces are mounted through `runtime.useConnect()` (`application.ts:723`, `:1496`), which
every engine implements — so they are not structurally Express-bound. But `AdapterMiddleware.handler`
is typed `RequestHandler | ErrorRequestHandler` from Express's own types, and adapters.md calls
them "Express middleware entries", which reads as a promise of Express semantics.

Tested an adapter across all three engines:

| handler style | Express | Fastify | h3 |
| --- | :-: | :-: | :-: |
| connect-style (node `req`/`res`, `next`) | ✅ | ✅ | ✅ |
| Express sugar (`res.status(418).json(...)`) | ✅ | ❌ 500 | ❌ 500 |

`TypeError: res.status is not a function` — per request, no boot error, no type error at the
call site. Same failure as a mounted `express.Router()`.

## adapters.md

- The portability rule, with the portable equivalent written out (`res.statusCode` +
  `res.setHeader` + `res.end`) and a heuristic: touch only `req.url`, `req.method`,
  `req.headers` and the node response API and the adapter runs anywhere.
- Corrected the interface. It showed `handler: any` and `path?: string`; the real type is
  `RequestHandler | ErrorRequestHandler` and `string | RegExp | ReadonlyArray<string | RegExp>`,
  so scoping by pattern or by a mixed list was undocumented.
- Called out the two places the sugar *is* safe, because that inconsistency is what would
  otherwise burn someone: `bootstrap({ onNotFound, onError })` receive a `RuntimeResponse`
  driver (already documented in middleware.md), and anything holding a `RequestContext` has
  `ctx.json()` / `ctx.problem.*`.

## plugins.md

`middleware()` had one table row and no section. Added one covering:

- the same connect-style rule, with the note that the framework's own middleware (`cors`,
  `helmet`, `csrf`, `rateLimit`, `requestId`, `session`) is written that way — verified, zero
  `res.status(` / `res.json(` / `res.send(` between them — which is why returning it from a
  plugin works on every engine
- the two ways plugin middleware is weaker than the adapter surface: **no phases** (every entry
  lands after plugin `register()` and before the global pipeline) and **no path scoping** (an
  adapter entry takes `path`). `adapters()` is the way out, since a plugin can return adapters.

## Guards were already fine

Checked as part of this: `kick g guard` emits `(ctx, next)` using `ctx.problem.*`, and the
generated file carries its own comment explaining that `ctx.res.status(401).json(...)` is
Express-only because `FastifyReply` has no `.json()` and h3's event has no `.status()`. No
change needed.

## Verification

- Runtime matrix confirmed with a throwaway test across express / fastify / h3 (removed before
  commit)
- `pnpm format:check` clean (899 files)
- Docs only, no changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVCyhU9ghEntXjQwzXvjhE
