### PR TITLE
docs: stop calling AdapterContext.app the Express app

### DIFF
--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -50,7 +50,7 @@ export const MyAdapter = defineAdapter<MyAdapterConfig>({
     },
 
     /** Runs before global middleware — mount routes that bypass the stack. */
-    beforeMount({ app }: AdapterContext): void | Promise<void> {},
+    beforeMount({ http }: AdapterContext): void | Promise<void> {},
 
     /** Fires once per controller class as the router mounts. Useful for
      *  building OpenAPI specs, dependency graphs, route inventories. */
@@ -81,7 +81,8 @@ export const MyAdapter = defineAdapter<MyAdapterConfig>({
 
 ```ts
 interface AdapterContext {
-  app: Express // Express application instance
+  http: AdapterHttp // engine-agnostic HTTP surface — use this
+  app: ActiveRuntime['app'] // engine-native instance — escape hatch
   container: Container // DI container
   server?: http.Server // populated only inside afterStart
   env: string // NODE_ENV (default 'development')
@@ -89,7 +90,32 @@ interface AdapterContext {
 }
 ```
 
-No need to import Express or http types — destructure only what you use.
+No need to import any engine types — destructure only what you use.
+
+### `http` vs `app`
+
+`http` is the supported surface. It is the same four operations on every engine,
+so an adapter written against it works under Express, Fastify and h3 unchanged:
+
+```ts
+interface AdapterHttp {
+  /** Register one ctx-handler route (docs endpoint, transport, probe). */
+  route(method: RouteMethod, path: string, handler: CtxHandler): void
+  /** Mount a pre-built route table under a prefix. */
+  mount(prefix: string, routes: RouteEntry[]): void
+  /** Serve a static directory under a prefix. */
+  serveStatic(prefix: string, dir: string): void
+  /** Register a connect-style middleware, optionally path-scoped. */
+  use(mw: ConnectMiddleware, opts?: UseConnectOptions): void
+}
+```
+
+`app` is the **engine-native** instance — an `express.Express` under the default
+runtime, a `FastifyInstance` under Fastify, an h3 app under h3. It is typed from
+the active runtime (`ActiveRuntime['app']`), not as Express. Reach for it only
+when you need something genuinely engine-specific, and know that an adapter
+which calls `app.get(...)` or `app.use(...)` is an Express adapter, not a KickJS
+one — those methods don't exist, or don't mean the same thing, elsewhere.
 
 ## Every hook, and what runs it
 
@@ -288,9 +314,10 @@ import { defineAdapter, type AdapterContext, type AdapterMiddleware } from '@for
 export const HealthAdapter = defineAdapter({
   name: 'HealthAdapter',
   build: () => ({
-    beforeMount({ app }: AdapterContext): void {
-      app.get('/health', (_req, res) => {
-        res.json({
+    beforeMount({ http }: AdapterContext): void {
+      // `http.route` takes a ctx handler, so this works on every engine.
+      http.route('GET', '/health', (ctx) => {
+        ctx.json({
           status: 'ok',
           timestamp: new Date().toISOString(),
           uptime: process.uptime(),

--- a/docs/guide/hmr.md
+++ b/docs/guide/hmr.md
@@ -17,7 +17,7 @@ import { modules } from './modules'
 bootstrap({ modules })
 ```
 
-On the first call, `bootstrap()` creates the application and registers error/shutdown handlers. In dev, Vite owns the `http.Server` and exposes it as `globalThis.__kickjs_httpServer`; `bootstrap()` attaches to that server rather than creating or listening on its own. (Outside dev, with no such global, it does create and listen.) On subsequent calls (triggered by HMR), it **tears the previous app down**, rebuilds the Express app, and swaps the request handler on the existing server — no restart needed.
+On the first call, `bootstrap()` creates the application and registers error/shutdown handlers. In dev, Vite owns the `http.Server` and exposes it as `globalThis.__kickjs_httpServer`; `bootstrap()` attaches to that server rather than creating or listening on its own. (Outside dev, with no such global, it does create and listen.) On subsequent calls (triggered by HMR), it **tears the previous app down**, rebuilds the application on whichever runtime is configured, and swaps the request handler on the existing server — no restart needed.
 
 ### What Is Preserved
 

--- a/packages/kickjs/src/core/adapter.ts
+++ b/packages/kickjs/src/core/adapter.ts
@@ -66,14 +66,19 @@ export interface AdapterMiddleware {
 
 /**
  * Context passed to adapter lifecycle hooks.
- * Populated by the Application — provides access to the Express app,
- * DI container, http.Server, and environment info without requiring
- * external type imports. Cast `app` or `server` if you need specific types.
+ * Populated by the Application — provides the engine-agnostic HTTP surface,
+ * the engine-native app instance, the DI container, the http.Server, and
+ * environment info without requiring external type imports.
+ *
+ * Prefer `http` over `app`: `http` is the same on every runtime, while `app`
+ * is whatever the active engine's instance happens to be (Express, Fastify,
+ * h3), so an adapter that reaches for it only runs on that engine.
  *
  * @example
  * ```ts
- * beforeMount({ app, container }: AdapterContext) {
- *   app.use(myMiddleware())
+ * beforeMount({ http, container }: AdapterContext) {
+ *   http.use(myConnectMiddleware())
+ *   http.route('GET', '/status', (ctx) => ctx.json({ ok: true }))
  * }
  * ```
  */
@@ -115,8 +120,11 @@ export interface AdapterContext {
  * class SentryAdapter implements AppAdapter {
  *   name = 'SentryAdapter'
  *
- *   beforeMount({ app, container }: AdapterContext) {
- *     app.use(Sentry.expressRequestHandler())
+ *   beforeMount({ http, container }: AdapterContext) {
+ *     // `http.use` takes any connect-style middleware and mounts it on
+ *     // whichever engine is active. Reach for `app` only when the thing you
+ *     // are wiring is engine-specific — and accept the engine lock-in.
+ *     http.use(Sentry.expressRequestHandler())
  *   }
  *
  *   afterStart({ server }: AdapterContext) {


### PR DESCRIPTION
Follow-up to #625 — this commit was pushed to that branch just after it merged, so it never
landed. Same content, rebased onto `main`.

## The problem

`AdapterContext` has two surfaces: `http`, the engine-agnostic one, and `app`, the engine-native
instance typed `ActiveRuntime['app']`. `adapters.md` documented neither accurately — it listed
`app: Express` and omitted `http` entirely.

The consequence wasn't cosmetic: the documented way to add a route from an adapter was

```ts
beforeMount({ app }: AdapterContext) {
  app.get('/health', (_req, res) => res.json({ status: 'ok' }))
}
```

`app.get` exists on Express and nowhere else, so every adapter written from this guide is an
Express adapter — on a framework whose selling point is that the engine is swappable.

## What changed

**`docs/guide/adapters.md`**

- The `AdapterContext` listing now leads with `http: AdapterHttp` and shows `app` as
  `ActiveRuntime['app']` — Express under the default runtime, `FastifyInstance` under Fastify,
  an h3 app under h3.
- New "`http` vs `app`" section with the four operations spelled out (`route`, `mount`,
  `serveStatic`, `use`), and the rule stated plainly: an adapter that reaches for `app.get` /
  `app.use` is an Express adapter, not a KickJS one.
- The HealthAdapter example moves to `http.route('GET', '/health', (ctx) => ctx.json(…))`.
  Verified working under Express, Fastify and h3 before writing it.

**`packages/kickjs/src/core/adapter.ts`** — the same claim was in the JSDoc ("provides access to
the Express app") along with an `app.use(...)` example. That text ships in the `.d.ts`, so it is
what appears on editor hover; corrected there and in the `AppAdapter` example.

**`docs/guide/hmr.md`** — "rebuilds the Express app" → rebuilds on whichever runtime is
configured.

## Left alone

`migration-v2.md` still shows `AdapterContext.app: Express` in its before/after table. That
records what v2 changed at the time; rewriting history in a migration doc makes it harder to
follow, not easier.

## Verification

- `http.route('GET', …)` confirmed on all three engines with a throwaway test (removed before
  commit) — note `RouteMethod` is uppercase
- `pnpm format:check` clean (899 files)
- Docs + JSDoc only, no behaviour change, no changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVCyhU9ghEntXjQwzXvjhE
