### PR TITLE
docs: add route flags to the roadmap as B.6, with the working spec

### DIFF
--- a/docs/guide/roadmap.md
+++ b/docs/guide/roadmap.md
@@ -348,6 +348,53 @@ Only the **error-shape helpers** (`ctx.notFound()`, `ctx.badRequest()`) get a `@
 
 ---
 
+### B.6 Route flags — one vocabulary for per-route policy
+
+**Status:** `in design` — working spec at [`route-flags-design.md`](https://github.com/forinda/kick-js/blob/main/route-flags-design.md)
+**Effort:** 1–2 weeks for phase 1; phases 2–4 independently schedulable
+
+**Why it matters.** "Whitelist these endpoints" is a request every API eventually makes, and today the answer depends on which subsystem is asking. Auth uses a contributor (`@Public` = `LoadAuthUser({ on401: 'allow' })`). CSRF uses `ignorePaths`. Rate limiting uses `skipPaths` / `skip`. One fact — _this endpoint is open_ — stated three ways, in two places, under two notions of identity.
+
+The path-string half has real defects: both are an exact `Set.has(pathname)`, so `/users/:id` cannot be expressed; and the list keeps parsing after an `apiPrefix` or `version` change that silently voids it.
+
+The contributor half looks better but doesn't compose. `@Public` wins by being a _second instance of the same contributor_ at higher precedence — which only works if you own the key. You cannot exempt a plugin's contributor, and you cannot exempt anything that isn't a contributor at all.
+
+**What it looks like.** A flag is a named, inheritable fact about a route, resolved through the existing five registration sites (`method > class > module > adapter > global`) and readable by every consumer:
+
+```ts
+export const Public = defineRouteFlag('auth.public')
+
+@Public // class level — propagates to every route below
+@Controller()
+class WebhooksController {
+  @Get('/health') health(ctx: RequestContext) {} // inherits
+
+  @Public(false) // method wins
+  @Post('/admin')
+  admin(ctx: RequestContext) {}
+}
+```
+
+Consumers read them wherever they already hold a `RequestContext`:
+
+```ts
+ctx.route.flags.has('auth.public')          // guards, @Middleware(), handlers
+defineHttpContextDecorator({ skipWhen: 'auth.public', … })   // contributors
+csrf({ exemptWhen: 'csrf.exempt' })                          // phase 2
+```
+
+That split is what keeps the cost down: everything after route matching gets flags from one addition (`ctx.route`), with no per-consumer API. Only the two pre-match middleware need further mechanism.
+
+Phasing: **1)** primitive + `ctx.route` + contributor `skipWhen`/`onlyWhen`; **2)** CSRF; **3)** rate limiting (also unlocks per-route limits, which the current shape cannot express); **4)** OpenAPI security schemes + DevTools display. Phase 1 stands alone.
+
+**Open questions.**
+
+- Do flags carry values, or is presence enough? `@RateLimit({ rpm: 10 })` wants values, and values turn precedence into a merge question rather than pick-one.
+- `skipWhen` as a flag name only, or also a predicate? A predicate that reads anything but flags reintroduces the coupling this removes.
+- Pre-match consumers: per-route mounting (exact, but a 404 then skips the check) or a boot-compiled policy table (preserves ordering, but is a second implementation of routing)? Current thinking: per-route for CSRF, table for rate limiting — a token check is meaningless on an unmatched route, an abuse control is not.
+
+**Risk.** `kickjs-auth` was deprecated for baking in an auth opinion. Mitigation: core ships `defineRouteFlag` and names no flags. `auth.public` is a string the adopter picks; nothing in core branches on it.
+
 ## Track C — Bold Bets
 
 High-risk, high-reward. Each of these could be the thing KickJS is famous for, if it works.
@@ -535,11 +582,12 @@ Rough order if we were optimizing for **impact-per-effort**:
 2. **B.2 — Error messages with fix hints** (2–3 weeks, changes how the framework feels forever)
 3. **B.4 — `kick doctor` command** (1 week, kills a huge category of support questions)
 4. **A.1 — Typed client** (2–3 months, but it's the moat)
-5. **B.1 — Scaffolder feature-overlay** (3–6 weeks, contributor-friendly)
-6. **A.2 — Observability** (1–2 months, production-readiness story)
-7. **B.3 — Interactive docs** (2–4 weeks, depends on hosting cost analysis)
-8. **A.3 — Runtime-portable core** (long arc — gradual, every peer-dep cleanup advances it)
-9. **C.1, C.2, C.3** — bold bets, sequence after the moat is in place
+5. **B.6 — Route flags** (1–2 weeks for phase 1, retires three exemption mechanisms and unblocks per-route rate limits)
+6. **B.1 — Scaffolder feature-overlay** (3–6 weeks, contributor-friendly)
+7. **A.2 — Observability** (1–2 months, production-readiness story)
+8. **B.3 — Interactive docs** (2–4 weeks, depends on hosting cost analysis)
+9. **A.3 — Runtime-portable core** (long arc — gradual, every peer-dep cleanup advances it)
+10. **C.1, C.2, C.3** — bold bets, sequence after the moat is in place
 
 Open for redirection — these are starting points, not commitments.
 

--- a/docs/guide/roadmap.md
+++ b/docs/guide/roadmap.md
@@ -2,6 +2,10 @@
 
 This document captures ideas for how to evolve KickJS. Each proposal carries enough detail to deliberate on it without re-deriving the motivation every time. **DB-related items are deferred** — we're working through the non-DB tracks first.
 
+> **Last audited 2026-09-03** against the source, not from memory. Statuses below reflect what
+> actually ships; where a proposal was delivered by a different design than the one sketched, the
+> status says so rather than quietly matching the text to the code.
+
 ## How to read this document
 
 Each proposal uses the same template:
@@ -29,7 +33,7 @@ Things that make a developer say "I'm using KickJS specifically because nothing 
 
 ### A.1 End-to-end typed client
 
-**Status:** `proposed`
+**Status:** `shipped` — `@forinda/kickjs-client` (typed `api.get/post`), `kick typegen` emitting `KickRoutes.Api`, and `createRpc(api, kickRpc)` for the tRPC-style namespace. See the [typed client guide](./typed-client.md).
 **Effort:** 2–3 months
 
 **Why it matters.** tRPC's whole pitch is full-stack type safety without a separate schema. KickJS already has the inputs (decorator-introspectable controllers, Zod schemas, the `kick typegen` command), but no consumer-side SDK. A developer using a kickjs backend with a Next/Remix/Vite frontend has to either hand-write API clients or pull in a separate schema layer (OpenAPI generator, gRPC, etc.) — and pay the schema-drift tax.
@@ -63,7 +67,7 @@ const user = await api.users.create({ email: 'a@b.com' })
 
 ### A.2 First-class observability
 
-**Status:** `proposed`
+**Status:** `proposed` — **premise has moved.** `@forinda/kickjs-otel` was deprecated to a [BYO recipe](./byo-recipes.md) rather than promoted, so the sketch below (a `bootstrap({ observability })` block owned by the framework) now runs against the BYO direction. What did ship is the seam: `Logger.setProvider()`, `processHooks` so an observability SDK can own SIGTERM, and adapter `introspect()`. Re-scope before building.
 **Effort:** 1–2 months
 
 **Why it matters.** The `@forinda/kickjs-otel` package exists but isn't the headline experience. Production-readiness is one of the top reasons engineering teams pick a framework — and "just install us, every controller is traced" is a story Nest doesn't have.
@@ -95,7 +99,7 @@ Auto-instrument: every controller method, every adapter call (db, queue, cron, m
 
 ### A.3 Runtime-portable core
 
-**Status:** `proposed`
+**Status:** `shipped` — **via a different shape than sketched below.** There is no `kickjs-core` / `-hono` / `-edge` / `-bun` package split. Instead the engine is a runtime seam inside `@forinda/kickjs` (`bootstrap({ runtime })` → Express / Fastify / h3), and `@forinda/kickjs/web` is a `fetch(Request) → Response` entry running on Cloudflare Workers, Bun and Deno, kept honest by a bundle-purity test that fails on any node-only import. The open questions below were answered as: Web Streams in the runtime seam, Fetch `Request`/`Response` at the web entry, `nodejs_compat` for AsyncLocalStorage on Workers.
 **Effort:** 2–4 months (gradual)
 
 **Why it matters.** Every decorator framework is locked to Node + Express (Nest, KickJS today). Hono runs everywhere — Bun, Deno, Cloudflare Workers, Vercel Edge, Fastly — and that's a real audience. Being the only decorator-driven framework that runs on edge runtimes is a genuine wedge.
@@ -168,7 +172,7 @@ The scaffolder picks the user's chosen dirs and renders them in order. Code/text
 
 ### B.2 Error messages with "here's the fix"
 
-**Status:** `proposed`
+**Status:** `shipped` (first pass, codes still being added) — `KickError` carries `code` / `summary` / `cause` / `fix`, and six `KICK00x` codes use it today (e.g. KICK005 missing controller-or-router, KICK006 duplicate route). Adding a code to a new failure is now the pattern rather than a project.
 **Effort:** 2–3 weeks per pass; ongoing
 
 **Why it matters.** NestJS errors are infamous for being cryptic. KickJS errors today are functional but rarely tell the user _how to fix_ the problem. The framework that has the best error messages — Rust's compiler, Elm, Astro — wins on first-impressions retention.
@@ -216,7 +220,7 @@ A centralized error catalog (`packages/kickjs/src/core/error-catalog.ts`) keyed 
 
 ### B.3 Interactive docs / WebContainers playground
 
-**Status:** `proposed`
+**Status:** `proposed` — nothing in the docs site references WebContainers or an embedded playground yet.
 **Effort:** 2–4 weeks
 
 **Why it matters.** VitePress + markdown is great, but everything is static. Vue's docs let you tweak code in the page and see it run. SvelteKit, Astro, Hono — they all do this now. For a backend framework, the friction-to-evaluation is even higher (you need a terminal, Node, a port…) — letting visitors try `bootstrap({ modules: [HelloModule] })` in the docs without leaving the page would be a real adoption boost.
@@ -235,7 +239,7 @@ A centralized error catalog (`packages/kickjs/src/core/error-catalog.ts`) keyed 
 
 ### B.4 `kick doctor` command
 
-**Status:** `proposed`
+**Status:** `shipped` — `kick doctor` runs pre-flight checks and reports each with a fix (tsconfig decorator flags, env-file layering, and more). See `packages/cli/src/commands/doctor.ts`.
 **Effort:** 1 week
 
 **Why it matters.** "It works on my machine" debugging eats hours. Common misconfigs (env not loaded, peer dep missing, typegen stale, decorators not enabled in tsconfig, prisma not generated) are all detectable.
@@ -272,7 +276,7 @@ $ kick doctor
 
 ### B.5 RFC 9457 Problem Details on `ctx`
 
-**Status:** `proposed`
+**Status:** `shipped` — `ctx.problem(...)` plus the typed convenience methods (`ctx.problem.notFound()`, `.unauthorized()`, …). The generated guard template uses them, and they are the runtime-portable way to answer from a guard or middleware.
 **Effort:** 1–2 weeks
 
 **Why it matters.** Every API has the same error-shape bikeshedding conversation: should the JSON be `{ error: ... }` or `{ message: ... }` or `{ status, message }` or some custom envelope? [RFC 9457 — Problem Details for HTTP APIs](https://datatracker.ietf.org/doc/html/rfc9457) (July 2024, supersedes RFC 7807) is the standard answer: a single canonical shape with five fields and a known content type. Adopting it gives kickjs a "standards-compliant by default" line without forcing anything — most Node frameworks make adopters reach for a library.
@@ -401,7 +405,7 @@ High-risk, high-reward. Each of these could be the thing KickJS is famous for, i
 
 ### C.1 Schema-first via one decorator
 
-**Status:** `proposed`
+**Status:** `proposed` — **partially superseded.** `@forinda/kickjs-db` took the code-first route instead: schema defined in TS, with snapshot / diff / migrate and dialect subpaths. That covers the schema-to-database projection; the `@Schema` / `@Field` class projecting to validator + OpenAPI + types in one declaration is still unbuilt. Decide whether this is now "project kick/db schemas into Zod + OpenAPI" rather than a fresh decorator surface.
 **Effort:** 4–6 months
 
 **Why it matters.** Today an entity is defined four times: Prisma/Drizzle schema, Zod validator, TypeScript type, OpenAPI doc. Each has its own syntax. Drift is constant. A single source of truth — declared once, projected to all four — is the holy grail.
@@ -448,7 +452,7 @@ From this one class:
 
 ### C.2 TS compiler plugin for runtime types
 
-**Status:** `proposed`
+**Status:** `proposed` — **partially superseded.** `kick typegen` gets much of this from a source scan rather than a compiler transformer: `KickRoutes`, `KickEnv`, `KickAssets`, `KickJsPluginRegistry`. What a transformer would still add is inference the scan cannot do. Worth re-reading against typegen's current reach before committing months to it.
 **Effort:** 3–6 months
 
 **Why it matters.** TypeScript's types are erased at runtime. That's why we need decorators in the first place — to recover the type info at runtime. A `ts-patch` / `swc` plugin (like `ts-runtime-checks`, `typia`, or `tspl`) preserves the type info, making decorators in some cases unnecessary.
@@ -489,7 +493,7 @@ class UserService {
 
 ### C.3 Multi-tenant as a config flag
 
-**Status:** `proposed`
+**Status:** `rejected` — superseded by BYO. `@forinda/kickjs-multi-tenant` was deprecated to a [recipe](./multi-tenancy.md) built on `defineContextDecorator`, which is the opposite direction to a framework-owned config flag: tenancy models vary too much per project to bless one. Kept here so the idea is not relitigated.
 **Effort:** 2–3 months
 
 **Why it matters.** The [multi-tenant examples in the archive](https://github.com/forinda/kickjs-examples-archive) exist (`multi-tenant-drizzle-api`, `multi-tenant-prisma-api`, `multi-tenant-mongoose-api`) but they're separate templates with significant boilerplate. SaaS teams pick frameworks partly on how easy multi-tenancy is. Making it `bootstrap({ multiTenant: ... })` instead of a project rewrite is a real differentiator.
@@ -523,15 +527,15 @@ The framework wires per-request tenant resolution, scopes the DI container, swit
 
 Small enough to bundle into other work or do in a half-day. Listed for visibility.
 
-| #   | Idea                                                           | Effort | Status          |
-| --- | -------------------------------------------------------------- | ------ | --------------- |
-| Q.1 | `@Flag('feature-name')` decorator + ConfigService integration  | 2 days | `proposed`      |
-| Q.2 | `kick db:seed` first-class command                             | 3 days | `proposed` (DB) |
-| Q.3 | HTTP/2 + HTTP/3 support in the default adapter                 | 1 week | `proposed`      |
-| Q.4 | `kick new --with auth,swagger,drizzle,docker` preset bundles   | 3 days | `proposed`      |
-| Q.5 | `kick test:e2e` wrapper around supertest + test-app            | 1 week | `proposed`      |
-| Q.6 | First-party `SentryLoggerProvider` example snippet in docs     | 1 day  | `proposed`      |
-| Q.7 | `kick info` — print resolved versions, peer deps, runtime info | 1 day  | `proposed`      |
+| #   | Idea                                                           | Effort | Status                                                                                                         |
+| --- | -------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------- |
+| Q.1 | `@Flag('feature-name')` decorator + ConfigService integration  | 2 days | `proposed` — overlaps [B.6](#b-6-route-flags-one-vocabulary-for-per-route-policy); fold in or drop             |
+| Q.2 | `kick db:seed` first-class command                             | 3 days | `proposed` (DB)                                                                                                |
+| Q.3 | HTTP/2 + HTTP/3 support in the default adapter                 | 1 week | `proposed`                                                                                                     |
+| Q.4 | `kick new --with auth,swagger,drizzle,docker` preset bundles   | 3 days | `shipped` in part — `kick new --packages a,b` and `kick add --list`; no docker or named presets                |
+| Q.5 | `kick test:e2e` wrapper around supertest + test-app            | 1 week | `proposed` — `createTestApp` + supertest covers it without a command; confirm the wrapper still earns its keep |
+| Q.6 | First-party `SentryLoggerProvider` example snippet in docs     | 1 day  | `shipped` — [Sentry integration](./integrations/sentry.md)                                                     |
+| Q.7 | `kick info` — print resolved versions, peer deps, runtime info | 1 day  | `shipped` — `kick info`                                                                                        |
 
 ---
 
@@ -576,18 +580,18 @@ These will get their own track once we have a clearer picture from the non-DB wo
 
 ## Prioritization — current thinking
 
+Already delivered, in roughly the order the list first proposed them: **B.5** Problem Details,
+**B.2** error messages with fix hints, **B.4** `kick doctor`, **A.1** typed client, and **A.3**
+runtime portability (via the runtime seam + web entry rather than the package split sketched
+above). The list below is what remains.
+
 Rough order if we were optimizing for **impact-per-effort**:
 
-1. **B.5 — RFC 9457 Problem Details on `ctx`** (1–2 weeks, clear spec, no breaking change, "standards-compliant" pitch)
-2. **B.2 — Error messages with fix hints** (2–3 weeks, changes how the framework feels forever)
-3. **B.4 — `kick doctor` command** (1 week, kills a huge category of support questions)
-4. **A.1 — Typed client** (2–3 months, but it's the moat)
-5. **B.6 — Route flags** (1–2 weeks for phase 1, retires three exemption mechanisms and unblocks per-route rate limits)
-6. **B.1 — Scaffolder feature-overlay** (3–6 weeks, contributor-friendly)
-7. **A.2 — Observability** (1–2 months, production-readiness story)
-8. **B.3 — Interactive docs** (2–4 weeks, depends on hosting cost analysis)
-9. **A.3 — Runtime-portable core** (long arc — gradual, every peer-dep cleanup advances it)
-10. **C.1, C.2, C.3** — bold bets, sequence after the moat is in place
+1. **B.6 — Route flags** (1–2 weeks for phase 1, retires three exemption mechanisms and unblocks per-route rate limits)
+2. **B.1 — Scaffolder feature-overlay** (3–6 weeks, contributor-friendly)
+3. **A.2 — Observability** (re-scope first — the BYO turn changed the premise)
+4. **B.3 — Interactive docs** (2–4 weeks, depends on hosting cost analysis)
+5. **C.1, C.2** — bold bets, and both want re-reading against what kick/db and typegen already do
 
 Open for redirection — these are starting points, not commitments.
 

--- a/route-flags-design.md
+++ b/route-flags-design.md
@@ -1,0 +1,287 @@
+# Route Flags — a shared vocabulary for "this endpoint is open"
+
+> Status: **proposal**. Working spec, not shipped.
+> Decisions taken: core primitive in `@forinda/kickjs`; auth first, other consumers follow;
+> declaration must sit on the controller and propagate to its routes.
+
+## The recurring problem
+
+Every cross-cutting concern that can be turned off per route invented its own way to say so.
+
+| Concern           | How a route opts out today                           | Where it lives                             |
+| ----------------- | ---------------------------------------------------- | ------------------------------------------ |
+| Auth (BYO recipe) | `@Public` = `LoadAuthUser({ on401: 'allow' })`       | on the route, as a contributor             |
+| CSRF              | `csrf({ ignorePaths: ['/api/v1/webhooks/stripe'] })` | in `bootstrap()`, as a string              |
+| Rate limiting     | `rateLimit({ skipPaths, skip: (req) => … })`         | in `bootstrap()`, as a string or predicate |
+
+One fact — _this endpoint is open_ — expressed three ways, in two places, with two different
+notions of identity (decorator vs pathname string).
+
+The path-string half has concrete defects, not just aesthetic ones:
+
+- **Exact match only.** Both are a `Set.has(pathname)` (`csrf.ts:88`, `rate-limit.ts:137`), so
+  `/api/v1/users/:id` cannot be expressed at all.
+- **Drifts silently.** Change `apiPrefix`, bump a module's `version`, rename a path — the
+  exemption list still parses, still runs, and now protects nothing. Nothing fails at boot.
+- **Declared far from the thing it describes.** A reader of the controller cannot tell that the
+  route is CSRF-exempt.
+
+## What already works, and why it doesn't generalise
+
+The contributor chain already delivers the declaration model we want. Spiked with four tests
+against `packages/kickjs/src`, all passing:
+
+| Case                                                                                    | Result              |
+| --------------------------------------------------------------------------------------- | ------------------- |
+| Global `contributors: [LoadAuthUser().registration]` protects an undecorated controller | 401                 |
+| `@Public` on the **controller class** opens every method under it                       | 200 for all methods |
+| Method-level `LoadAuthUser({ on401: 'throw' })` beats the class-level `@Public`         | 401                 |
+| Authenticated request on a protected route resolves `ctx.get('user')`                   | 200                 |
+
+So the five registration sites (`method > class > module > adapter > global`,
+`contributor-pipeline.ts:20`) plus per-key dedup give controller-level declaration with
+method-level override — for contributors.
+
+**But look at how `@Public` actually wins.** It is not a way of saying "skip auth". It is a
+_second instance of the same contributor_, registered at higher precedence, that happens to be
+permissive:
+
+```ts
+const Public = LoadAuthUser({ on401: 'allow' }) // same key: 'user'
+```
+
+That only works because one author owns both sides — same `key`, same resolver, one behavioural
+switch. It does not compose:
+
+- A **third party's** contributor cannot be exempted. You do not own its key, so you cannot
+  out-rank it with a permissive twin.
+- A **non-contributor** consumer cannot be exempted at all — `csrf()` and `rateLimit()` have no
+  key to override, which is exactly why they fell back to pathname strings.
+- **Two concerns cannot share one decision.** "This endpoint is open" has to be re-stated for
+  auth, for CSRF, and for rate limiting, because the statement is encoded in each concern's own
+  mechanism rather than in the route.
+
+The fact is about **the route**. Encoding it inside one consumer's mechanism is the mistake, and
+it is why the problem keeps recurring.
+
+## What doesn't work
+
+1. **Pre-route middleware cannot participate.** `csrf()` and `rateLimit()` are mounted globally
+   via `useConnect`, so they run before route matching and have no access to decorator metadata.
+2. **No shared vocabulary.** A concern that wants to be exemptable has to invent an option shape.
+   The next one will invent a fourth.
+3. **Exemption is not composable.** See above — it requires owning the thing you are exempting.
+4. **`RequestContext` exposes no matched route.** No `ctx.route` — nothing downstream can ask
+   what handler it is on or what was declared there.
+
+## Proposal
+
+Flags are a **substrate**, not a fourth mechanism. One statement on the route; every consumer
+reads it, including the contributor pipeline itself.
+
+```
+                 @Public  /  @CsrfExempt  /  @RateLimit({ rpm: 10 })
+                                   │
+                            route flags          ← the fact, stated once on the route
+                                   │
+      ┌────────────────┬───────────┴───────────┬──────────────────┐
+ contributors      middleware              guards            readers
+ (skipWhen)      (exemptWhen)          (ctx.route.flags)   (swagger, devtools)
+```
+
+Contributors do not disappear — they become the most ergonomic consumer, and gain sugar they
+cannot express today.
+
+### 1. `defineRouteFlag()` — the primitive
+
+A flag is a named, inheritable fact about a route. It carries no behaviour; consumers interpret it.
+
+```ts
+import { defineRouteFlag } from '@forinda/kickjs'
+
+export const Public = defineRouteFlag('auth.public')
+export const CsrfExempt = defineRouteFlag('csrf.exempt')
+export const RateLimit = defineRouteFlag<{ rpm: number }>('rate.limit') // flags may carry a value
+```
+
+Applied at any of the same five sites as contributors, with the same precedence:
+
+```ts
+@Public // class level — propagates to every route below
+@Controller()
+class WebhooksController {
+  @Get('/health') health(ctx: RequestContext) {} // inherits auth.public
+
+  @Public(false) // method wins
+  @Post('/admin')
+  admin(ctx: RequestContext) {} // opts back in
+}
+```
+
+Resolution reuses `contributor-pipeline.ts`'s ranked-source dedup verbatim — highest precedence
+wins per flag name. No new ordering rules to learn or document.
+
+### 2. `ctx.route` — the matched route, exposed
+
+```ts
+interface MatchedRoute {
+  method: RouteMethod
+  path: string // mounted path, e.g. '/api/v1/users/:id'
+  controller?: Constructor
+  handlerName?: string
+  flags: ReadonlyMap<string, unknown>
+}
+```
+
+`RouteEntry.meta` already carries `controller` / `handlerName` at boot
+(`http/runtime.ts:85-94`); this exposes it per request and adds the resolved flags. Useful well
+beyond this proposal — logging, metrics, and DevTools all currently re-derive it.
+
+### 3. Contributors consume flags — the sugar layer
+
+A contributor registration gains `skipWhen` / `onlyWhen`, resolved against the route's flags
+before the resolver runs:
+
+```ts
+const LoadAuthUser = defineHttpContextDecorator({
+  key: 'user',
+  skipWhen: 'auth.public', // ← the whole feature
+  resolve: (ctx) => verify(ctx.headers.authorization),
+})
+```
+
+This is the piece that makes exemption composable. Compare:
+
+```ts
+// today — only the key's owner can do this, and only by re-registering it
+const Public = LoadAuthUser({ on401: 'allow' })
+
+// with flags — anyone can exempt anything, without owning it
+@Public
+@Get('/health')
+```
+
+A plugin can now ship `LoadTenant` with `skipWhen: 'tenant.optional'`, and an adopter exempts a
+route without forking the plugin or knowing its key. Same for `onlyWhen`, which covers the
+inverse case that has no expression today at all — "run this contributor **only** on routes
+flagged `billing.metered`" — currently a `dependsOn` chain or an `if` inside every resolver.
+
+Contributor precedence is unchanged; `skipWhen` is evaluated per route after flag resolution, so
+a class-level `@Public` skips the contributor for every route under it.
+
+### 4. Middleware and guards read the same flags
+
+```ts
+csrf({ exemptWhen: 'csrf.exempt' })
+rateLimit({ exemptWhen: 'auth.public' })
+```
+
+Guards and `@Middleware()` handlers read them directly, since they hold a `RequestContext`:
+
+```ts
+const requireAuth = (ctx: RequestContext, next: () => void) => {
+  if (ctx.route.flags.has('auth.public')) return next()
+  // …
+}
+```
+
+Four consumers, one declaration. `ignorePaths` / `skipPaths` stay, deprecated, until a major.
+
+## Reach: anything holding a `ctx` gets flags for free
+
+This is what makes flags worth building rather than patching each consumer. The framework already
+hands a `RequestContext` to almost everything that runs per request, and every one of those
+becomes a flag consumer the moment `ctx.route.flags` exists — with no per-consumer API:
+
+| Consumer                               |   Holds a `ctx`?   | How it reads flags                                        |
+| -------------------------------------- | :----------------: | --------------------------------------------------------- |
+| Controller handlers                    |         ✅         | `ctx.route.flags.has('auth.public')`                      |
+| `@Middleware()` (method/class)         |         ✅         | same                                                      |
+| Guards (`kick g guard`)                |         ✅         | same — they are `(ctx, next)` already                     |
+| Context contributors                   |         ✅         | `skipWhen` / `onlyWhen`, or read `ctx.route` in `resolve` |
+| Adapter middleware                     | ❌ raw `req`/`res` | needs the phase-2 mechanism                               |
+| Global `middlewares` (csrf, rateLimit) |    ❌ pre-match    | needs the phase-2 mechanism                               |
+
+So the surface splits cleanly: **everything after route matching is solved by exposing
+`ctx.route`** — one addition, no per-consumer work, and it covers guards, per-route middleware,
+contributors and handlers at once. Only the two pre-match cases need anything further, and they
+are exactly the two that resorted to pathname strings.
+
+That also means Phase 1 is worth shipping even if Phases 2–3 never happen.
+
+## The one hard problem
+
+Everything above holds a `ctx`, so it reads flags directly. The exception is pre-match
+middleware: a flag lives on a route, and `csrf()` / `rateLimit()` run **before** a route is
+matched, with raw `req`/`res` and no context. Two ways out, and this is the decision to make when
+those consumers land — not now:
+
+**(a) Mount exemptable middleware per route.** When a middleware declares `exemptWhen`, the
+router builder attaches it to each route's chain instead of globally, with flags already
+resolved. No matcher needed, exact semantics. Costs: the middleware no longer sees unmatched
+requests (a 404 would skip rate limiting — arguably wrong for an abuse control), and it moves
+after body parsing.
+
+**(b) Compile a policy table at boot.** `method + mounted path → flags`, consulted by the global
+middleware against the incoming request. Preserves today's ordering, but needs a path matcher —
+a second implementation of routing that can disagree with the engine's.
+
+Recommendation: **(a) for CSRF** (a token check is meaningless on an unmatched route) and **(b)
+for rate limiting** (an abuse control must see traffic that matches nothing). They are different
+problems wearing the same word.
+
+## Phasing
+
+**Phase 1 — primitive + `ctx.route` + contributor `skipWhen`.** `defineRouteFlag`, resolution
+through the existing ranked-source pipeline, `ctx.route.flags`, and `skipWhen` / `onlyWhen` on
+contributor registrations. That last part is what makes Phase 1 useful on its own: `@Public`
+stops being "a permissive twin of the auth contributor" and becomes a fact any consumer can read.
+No behaviour change to any existing app — every field is additive.
+
+**Phase 2 — CSRF.** `exemptWhen`, per-route mounting, `ignorePaths` deprecated with a boot
+warning naming the routes it currently covers.
+
+**Phase 3 — rate limiting.** Policy table; `skipPaths` deprecated the same way. Also unlocks
+per-route limits (`@RateLimit({ rpm: 10 })`), which the current shape cannot express at all.
+
+**Phase 4 — readers.** OpenAPI security schemes from `auth.public`; `/_debug` route list shows
+resolved flags per route.
+
+Each phase ships alone and is useful alone.
+
+## Risks
+
+- **Re-baking an auth opinion.** `kickjs-auth` was deprecated for exactly that. Mitigation: the
+  framework ships `defineRouteFlag` and _names no flags_. `auth.public` is a string the adopter
+  (or a recipe) chooses; nothing in core branches on it.
+- **A flag that lies.** A route flagged `auth.public` while no auth contributor is registered
+  reads as "reviewed and intentionally open" when it is just unprotected. Consider a boot-time
+  warning when a flag has no registered consumer.
+- **Typo-silence.** `'auth.pubic'` should not be a valid flag. Mirror `ContextMeta`: a
+  `KickRouteFlags` interface adopters augment, so unknown names are a tsc error once the first
+  augmentation lands, and any string until then.
+
+## Open questions
+
+1. Do flags need values, or is presence enough? `@RateLimit({ rpm: 10 })` argues for values, and
+   values make precedence a merge question rather than a pick-one.
+2. Should `AppModule` gain a `flags()` site, or is module-level scoping better expressed by the
+   existing adapter/global sites?
+3. Is `ctx.route` worth shipping ahead of the rest? It stands on its own and unblocks logging
+   and metrics work that has nothing to do with public routes.
+4. Should `skipWhen` accept a predicate (`(flags, route) => boolean`) as well as a flag name?
+   Cheap to add, and covers "skip unless both flags are present" without inventing an expression
+   language. Risk: a predicate that reads anything other than flags reintroduces the coupling
+   this design removes.
+5. Does `@Public(false)` (re-opting-in at method level) read clearly enough, or should the
+   inverse be its own decorator? Boolean-valued flags make precedence uniform; a second
+   decorator reads better at the call site.
+
+## Why this is not just the contributor pipeline again
+
+Worth stating plainly, because the two look similar: contributors carry **values** into a
+request (`ctx.get('tenant')`) and run per request. Flags carry **facts about the route**, are
+resolved at boot, and run nothing. Contributors are one consumer of flags; middleware, guards,
+the OpenAPI generator and DevTools are others, and none of those can be expressed as a
+contributor. The pipeline's ranked-source resolution is reused because the precedence question is
+identical — that is shared machinery, not a shared concept.

--- a/route-flags-design.md
+++ b/route-flags-design.md
@@ -79,7 +79,7 @@ it is why the problem keeps recurring.
 Flags are a **substrate**, not a fourth mechanism. One statement on the route; every consumer
 reads it, including the contributor pipeline itself.
 
-```
+```text
                  @Public  /  @CsrfExempt  /  @RateLimit({ rpm: 10 })
                                    │
                             route flags          ← the fact, stated once on the route
@@ -121,6 +121,42 @@ class WebhooksController {
 Resolution reuses `contributor-pipeline.ts`'s ranked-source dedup verbatim — highest precedence
 wins per flag name. No new ordering rules to learn or document.
 
+#### A `false` flag is _absent_, not present-and-false
+
+This rule is load-bearing, and getting it wrong is an authorization bypass rather than a
+papercut. `@Public(false)` at method level must make the flag **unset** on that route, not set it
+to `false` — otherwise `flags.has('auth.public')` returns `true` for the route that just opted
+back **in**, and every presence-checking consumer reads a protected route as public.
+
+So resolution produces a map of **enabled flags only**:
+
+| Declaration                                            | Resolved                   |
+| ------------------------------------------------------ | -------------------------- |
+| `@Public` on the class, nothing on the method          | `auth.public → true`       |
+| `@Public` on the class, `@Public(false)` on the method | _key absent_               |
+| `@RateLimit({ rpm: 10 })`                              | `rate.limit → { rpm: 10 }` |
+| `@RateLimit(false)` overriding an inherited one        | _key absent_               |
+
+A flag therefore resolves to one of two states — absent, or present with a value that defaults to
+`true`. `flags.has(name)` is then always the right question for a boolean flag, and
+`flags.get(name)` for a valued one. There is no third "present but falsy" state to reason about,
+and no consumer can be wrong by checking presence.
+
+Two consequences worth stating:
+
+- **`false` is only meaningful as an override.** `@Public(false)` on a route that never inherited
+  `auth.public` is a no-op, and should probably warn at boot — it usually means the author
+  believed something was inherited that is not.
+- **The resolver, not the consumer, carries this.** Every alternative (a `ReadonlyMap<string,
+unknown>` where consumers must remember `get(x) === true`) puts the security-relevant step in
+  the hands of whoever writes the next guard. That is the failure mode this whole proposal
+  exists to remove.
+
+**Phase 1 acceptance test** (the case that fails if the rule regresses): class-level `@Public`
+with a method-level `@Public(false)` — the method must resolve with `auth.public` absent, and a
+request to it must be rejected by the auth contributor while its sibling routes stay open. Both
+directions asserted, since a resolver that drops the key everywhere would pass a one-sided test.
+
 ### 2. `ctx.route` — the matched route, exposed
 
 ```ts
@@ -129,6 +165,7 @@ interface MatchedRoute {
   path: string // mounted path, e.g. '/api/v1/users/:id'
   controller?: Constructor
   handlerName?: string
+  /** Enabled flags only — see "a `false` flag is absent" above. */
   flags: ReadonlyMap<string, unknown>
 }
 ```
@@ -273,9 +310,9 @@ Each phase ships alone and is useful alone.
    Cheap to add, and covers "skip unless both flags are present" without inventing an expression
    language. Risk: a predicate that reads anything other than flags reintroduces the coupling
    this design removes.
-5. Does `@Public(false)` (re-opting-in at method level) read clearly enough, or should the
-   inverse be its own decorator? Boolean-valued flags make precedence uniform; a second
-   decorator reads better at the call site.
+5. `@Public(false)` now has defined semantics (the flag resolves absent), but does it _read_
+   clearly enough at the call site? A named inverse — `@Protected` — may be plainer than a
+   boolean argument, at the cost of two decorators per flag. Semantics are settled either way.
 
 ## Why this is not just the contributor pipeline again
 


### PR DESCRIPTION
## What this adds

- `route-flags-design.md` at the repo root, next to `response-inference-design.md` — the working
  spec
- **B.6 Route flags** in `docs/guide/roadmap.md`, status `in design`, pointing at it
- B.6 slotted at #5 in the impact-per-effort list; the four below shift down one

## The problem

"Whitelist these endpoints" is a request every API eventually makes, and today the answer depends
on which subsystem is asking:

| Concern | How a route opts out | Where |
| --- | --- | --- |
| Auth | `@Public` = `LoadAuthUser({ on401: 'allow' })` | on the route |
| CSRF | `csrf({ ignorePaths: [...] })` | in `bootstrap()`, as a string |
| Rate limiting | `rateLimit({ skipPaths, skip })` | in `bootstrap()`, as a string |

The path-string half is an exact `Set.has(pathname)` (`csrf.ts:88`, `rate-limit.ts:137`), so
`/users/:id` cannot be expressed at all, and the list keeps parsing after an `apiPrefix` or
`version` change that silently voids it.

## What the spike found

I ran the current behaviour before designing anything (4 tests, all passing): a global auth
contributor protects an undecorated controller, a class-level `@Public` opens every method under
it, and a method-level declaration beats the class-level one. So controller-level declaration
with method override **already works** — for contributors.

But look at *how* `@Public` wins: it is a second instance of the same contributor at higher
precedence, that happens to be permissive. That only composes if you own the key. You cannot
exempt a plugin's contributor, and you cannot exempt anything that isn't a contributor — which is
precisely why CSRF and rate limiting resorted to path strings.

Hence the design: the fact belongs to the **route**, and every consumer reads it.

## Why it's cheap

The surface splits on one line: does the consumer hold a `RequestContext`?

- **Yes** — handlers, `@Middleware()`, guards, contributors → all become flag consumers the
  moment `ctx.route.flags` exists. One addition, no per-consumer API.
- **No** — adapter middleware and the global `csrf` / `rateLimit` → need the phase 2/3 mechanism.

Phase 1 (`defineRouteFlag` + `ctx.route` + contributor `skipWhen`/`onlyWhen`) is therefore useful
on its own, and every phase after it ships independently.

## Open, and deliberately so

The spec ends with five open questions — the sharpest being whether flags carry values
(`@RateLimit({ rpm: 10 })` wants them, and values turn precedence into a merge question rather
than pick-one), and how pre-match consumers resolve flags: per-route mounting versus a
boot-compiled policy table. Current thinking is per-route for CSRF and a table for rate limiting,
since a token check is meaningless on an unmatched route and an abuse control is not.

Nothing here is implemented; this is a proposal to argue with.

## Noticed while editing

B.5 (RFC 9457 Problem Details) is still marked `proposed`, but `ctx.problem.*` ships today — the
generated guard template uses it. Left alone since it's outside this change, but the status wants
a bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a roadmap proposal for a unified, inheritable route-flag system covering route policies such as authentication, CSRF protection, rate limiting, and OpenAPI security.
  - Added design documentation describing route-flag declaration, inheritance, resolution across registration points, and conditional middleware or contributor behavior.
  - Updated roadmap prioritization to include the new proposal and adjust the ordering of subsequent initiatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->