### PR TITLE
feat(kickjs): route flags — one vocabulary for per-route policy

### DIFF
--- a/.changeset/route-flags-phase-1.md
+++ b/.changeset/route-flags-phase-1.md
@@ -1,0 +1,43 @@
+---
+'@forinda/kickjs': minor
+---
+
+Route flags — one vocabulary for per-route policy (phase 1 of `route-flags-design.md`).
+
+`defineRouteFlag()` declares a named, inheritable fact about a route. Declare it on a controller and it applies to every route below; a method overrides its class:
+
+```ts
+export const Public = defineRouteFlag('auth.public')
+
+@Public
+@Controller()
+class WebhooksController {
+  @Get('/health') health(ctx: RequestContext) {} // inherits auth.public
+
+  @Public(false) // method wins
+  @Post('/admin')
+  admin(ctx: RequestContext) {} // flag is ABSENT here
+}
+```
+
+A flag resolves to **absent**, or **present with a value defaulting to `true`** — never present-and-false. That is what makes `flags.has(name)` safe to write in a guard: `@Public(false)` removes the flag the class set rather than storing `false`, so a presence check can't read a re-protected route as public.
+
+**`ctx.route`** exposes the matched route — `method`, `path`, `controller`, `handlerName`, and the resolved `flags` — to anything holding a `RequestContext`: handlers, `@Middleware()`, guards, contributors. Works identically on Express, Fastify, h3, and the `@forinda/kickjs/web` fetch entry.
+
+```ts
+const requireAuth = (ctx: RequestContext, next: () => void) => {
+  if (ctx.route?.flags.has('auth.public')) return next()
+  // …
+}
+```
+
+**Contributors gain `skipWhen` / `onlyWhen`**, which is what makes exemption composable. Previously a contributor could only be opted out of by registering a permissive twin under the same key — something only its author can do. A flag lives on the route, so an adopter can exempt a plugin's contributor without owning its key:
+
+```ts
+defineHttpContextDecorator({ key: 'user', skipWhen: 'auth.public', resolve })
+defineHttpContextDecorator({ key: 'usage', onlyWhen: 'billing.metered', resolve })
+```
+
+Both accept a flag name, a list of names (matched **any-of**), or a predicate `({ flags, route }) => boolean` for anything else — all-of, a flag's value, a path check.
+
+Additive: no existing API changes behaviour, and a route with no flags resolves an empty map.

--- a/packages/kickjs/__tests__/route-flags.test.ts
+++ b/packages/kickjs/__tests__/route-flags.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Route flags (spec: `route-flags-design.md`).
+ *
+ * The load-bearing case is the last group: a class-level `@Public` with a
+ * method-level `@Public(false)` must resolve with the flag ABSENT on that
+ * method, not present-and-false. Both directions are asserted, because a
+ * resolver that dropped the key everywhere would pass a one-sided test.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import {
+  Application,
+  Container,
+  Controller,
+  Get,
+  HttpException,
+  Middleware,
+  defineHttpContextDecorator,
+  defineRouteFlag,
+  buildRoutes,
+  type AppModule,
+  type ModuleRoutes,
+  type RequestContext,
+} from '../src/index'
+import { buildRouteTable } from '../src/http/router-builder'
+import { fastifyRuntime } from '../src/http/runtimes/fastify'
+import { h3Runtime } from '../src/http/runtimes/h3'
+
+declare module '../src/index' {
+  interface ContextMeta {
+    user: { id: string } | null
+  }
+}
+
+const Public = defineRouteFlag('auth.public')
+const RateLimit = defineRouteFlag<{ rpm: number }>('rate.limit')
+
+const mod = (path: string, controller: unknown): AppModule =>
+  ({ routes: (): ModuleRoutes => ({ path, controller }) }) as AppModule
+
+const boot = async (controllers: [string, unknown][], runtime?: () => unknown) => {
+  const app = new Application({
+    modules: controllers.map(([p, c]) => mod(p, c)),
+    apiPrefix: '/api',
+    defaultVersion: 1,
+    ...(runtime ? { runtime: runtime() } : {}),
+  } as never)
+  await app.setup()
+  return app
+}
+
+const bootWith = async (options: Record<string, unknown>) => {
+  const app = new Application({ apiPrefix: '/api', defaultVersion: 1, ...options } as never)
+  await app.setup()
+  return app
+}
+
+describe('route flags — resolution', () => {
+  beforeEach(() => Container.reset())
+
+  it('a class-level flag lands on every route of the controller', () => {
+    @Public
+    @Controller()
+    class C {
+      @Get('/a') a(_ctx: RequestContext) {}
+      @Get('/b') b(_ctx: RequestContext) {}
+    }
+
+    const table = buildRouteTable(C)
+    expect(table.map((e) => e.meta.flags?.get('auth.public'))).toEqual([true, true])
+  })
+
+  it('a method-level flag applies to that route only', () => {
+    @Controller()
+    class C {
+      @Public
+      @Get('/open')
+      open(_ctx: RequestContext) {}
+      @Get('/closed') closed(_ctx: RequestContext) {}
+    }
+
+    const table = buildRouteTable(C)
+    const byPath = Object.fromEntries(table.map((e) => [e.path, e.meta.flags?.has('auth.public')]))
+    expect(byPath).toEqual({ '/open': true, '/closed': false })
+  })
+
+  it('carries a value, not just presence', () => {
+    @Controller()
+    class C {
+      @RateLimit({ rpm: 10 })
+      @Get('/limited')
+      limited(_ctx: RequestContext) {}
+    }
+
+    expect(buildRouteTable(C)[0].meta.flags?.get('rate.limit')).toEqual({ rpm: 10 })
+  })
+
+  it('a false flag resolves ABSENT, not present-and-false', () => {
+    @Public
+    @Controller()
+    class C {
+      @Get('/inherits') inherits(_ctx: RequestContext) {}
+
+      @Public(false)
+      @Get('/overrides')
+      overrides(_ctx: RequestContext) {}
+    }
+
+    const table = buildRouteTable(C)
+    const flags = Object.fromEntries(table.map((e) => [e.path, e.meta.flags!]))
+
+    // Both directions: the sibling still carries it, the override does not.
+    expect(flags['/inherits'].has('auth.public')).toBe(true)
+    expect(flags['/overrides'].has('auth.public')).toBe(false)
+    // …and specifically not stored as `false`, which `has()` would report true.
+    expect(flags['/overrides'].get('auth.public')).toBeUndefined()
+  })
+})
+
+describe('route flags — ctx.route', () => {
+  beforeEach(() => Container.reset())
+
+  it('exposes the matched route to the handler', async () => {
+    @Public
+    @Controller()
+    class C {
+      @Get('/:id')
+      show(ctx: RequestContext) {
+        ctx.json({
+          method: ctx.route?.method,
+          path: ctx.route?.path,
+          handler: ctx.route?.handlerName,
+          isPublic: ctx.route?.flags.has('auth.public'),
+        })
+      }
+    }
+
+    const app = await boot([['/things', C]])
+    const res = await request(app.handle.bind(app)).get('/api/v1/things/7')
+    expect(res.body).toEqual({
+      method: 'GET',
+      path: '/:id',
+      handler: 'show',
+      isPublic: true,
+    })
+  })
+
+  it('route middleware sees flags before the handler runs', async () => {
+    const seen: (boolean | undefined)[] = []
+    const spy = (ctx: RequestContext, next: () => void) => {
+      seen.push(ctx.route?.flags.has('auth.public'))
+      next()
+    }
+
+    @Public
+    @Controller()
+    class C {
+      @Middleware(spy)
+      @Get('/x')
+      x(ctx: RequestContext) {
+        ctx.json({ ok: true })
+      }
+    }
+
+    const app = await boot([['/m', C]])
+    await request(app.handle.bind(app)).get('/api/v1/m/x')
+    expect(seen).toEqual([true])
+  })
+
+  for (const [name, runtime] of [
+    ['fastify', fastifyRuntime],
+    ['h3', h3Runtime],
+  ] as const) {
+    it(`works under ${name} without runtime-specific wiring`, async () => {
+      @Public
+      @Controller()
+      class C {
+        @Get('/x')
+        x(ctx: RequestContext) {
+          ctx.json({ isPublic: ctx.route?.flags.has('auth.public') })
+        }
+      }
+
+      const app = await boot([['/r', C]], runtime as () => unknown)
+      const res = await request(app.handle.bind(app)).get('/api/v1/r/x')
+      expect({ rt: name, body: res.body }).toEqual({ rt: name, body: { isPublic: true } })
+    })
+  }
+})
+
+describe('route flags — contributor skipWhen', () => {
+  beforeEach(() => Container.reset())
+
+  const LoadAuthUser = defineHttpContextDecorator({
+    key: 'user',
+    skipWhen: 'auth.public',
+    resolve: (ctx: RequestContext) => {
+      const token = ctx.headers.authorization
+      if (!token) throw new HttpException(401, 'Unauthorized')
+      return { id: 'u1' }
+    },
+  })
+
+  @Controller()
+  class PrivateController {
+    @Get('/secret')
+    secret(ctx: RequestContext) {
+      ctx.json({ user: ctx.get('user') ?? null })
+    }
+  }
+
+  @Public
+  @Controller()
+  class OpenController {
+    @Get('/a')
+    a(ctx: RequestContext) {
+      ctx.json({ user: ctx.get('user') ?? null })
+    }
+
+    @Public(false)
+    @Get('/admin')
+    admin(ctx: RequestContext) {
+      ctx.json({ user: ctx.get('user') ?? null })
+    }
+  }
+
+  const bootWithGlobalAuth = async () =>
+    bootWith({
+      modules: [mod('/p', PrivateController), mod('/o', OpenController)],
+      contributors: [LoadAuthUser.registration],
+    })
+
+  it('runs the contributor on an unflagged route', async () => {
+    const app = await bootWithGlobalAuth()
+    const res = await request(app.handle.bind(app)).get('/api/v1/p/secret')
+    expect(res.status).toBe(401)
+  })
+
+  it('skips it on a route flagged by its controller', async () => {
+    const app = await bootWithGlobalAuth()
+    const res = await request(app.handle.bind(app)).get('/api/v1/o/a')
+    expect({ status: res.status, user: res.body?.user }).toEqual({ status: 200, user: null })
+  })
+
+  it('runs again where the method turned the flag off', async () => {
+    const app = await bootWithGlobalAuth()
+    const res = await request(app.handle.bind(app)).get('/api/v1/o/admin')
+    expect(res.status).toBe(401)
+  })
+
+  it('still resolves the user when authenticated', async () => {
+    const app = await bootWithGlobalAuth()
+    const res = await request(app.handle.bind(app))
+      .get('/api/v1/p/secret')
+      .set('authorization', 'Bearer t')
+    expect({ status: res.status, user: res.body?.user }).toEqual({
+      status: 200,
+      user: { id: 'u1' },
+    })
+  })
+
+  it('onlyWhen is the inverse — runs solely on flagged routes', async () => {
+    const calls: string[] = []
+    const Metered = defineRouteFlag('billing.metered')
+    const CountUsage = defineHttpContextDecorator({
+      key: 'user',
+      onlyWhen: 'billing.metered',
+      resolve: (ctx: RequestContext) => {
+        calls.push(ctx.route?.path ?? '?')
+        return null
+      },
+    })
+
+    @Controller()
+    class C {
+      @Metered
+      @Get('/metered')
+      metered(ctx: RequestContext) {
+        ctx.json({ ok: true })
+      }
+      @Get('/free')
+      free(ctx: RequestContext) {
+        ctx.json({ ok: true })
+      }
+    }
+
+    const app = await bootWith({
+      modules: [mod('/b', C)],
+      contributors: [CountUsage.registration],
+    })
+    const h = app.handle.bind(app)
+    await request(h).get('/api/v1/b/metered')
+    await request(h).get('/api/v1/b/free')
+    expect(calls).toEqual(['/metered'])
+  })
+})
+
+describe('route flags — multiple flag checks', () => {
+  beforeEach(() => Container.reset())
+
+  const Probe = defineRouteFlag('health.probe')
+
+  const runsFor = async (skipWhen: unknown) => {
+    const ran: string[] = []
+    const Track = defineHttpContextDecorator({
+      key: 'user',
+      skipWhen: skipWhen as never,
+      resolve: (ctx: RequestContext) => {
+        ran.push(ctx.route?.path ?? '?')
+        return null
+      },
+    })
+
+    @Controller()
+    class C {
+      @Public
+      @Get('/public')
+      pub(ctx: RequestContext) {
+        ctx.json({})
+      }
+
+      @Probe
+      @Get('/probe')
+      probe(ctx: RequestContext) {
+        ctx.json({})
+      }
+
+      @Public
+      @Probe
+      @Get('/both')
+      both(ctx: RequestContext) {
+        ctx.json({})
+      }
+
+      @Get('/plain')
+      plain(ctx: RequestContext) {
+        ctx.json({})
+      }
+    }
+
+    const app = await bootWith({ modules: [mod('/f', C)], contributors: [Track.registration] })
+    const h = app.handle.bind(app)
+    for (const p of ['/public', '/probe', '/both', '/plain']) await request(h).get(`/api/v1/f${p}`)
+    return ran
+  }
+
+  it('a list of flags matches any of them', async () => {
+    expect(await runsFor(['auth.public', 'health.probe'])).toEqual(['/plain'])
+  })
+
+  it('a single flag leaves the others alone', async () => {
+    expect(await runsFor('auth.public')).toEqual(['/probe', '/plain'])
+  })
+
+  it('a predicate expresses all-of, which a list deliberately cannot', async () => {
+    const ran = await runsFor(
+      ({ flags }: { flags: ReadonlyMap<string, unknown> }) =>
+        flags.has('auth.public') && flags.has('health.probe'),
+    )
+    expect(ran).toEqual(['/public', '/probe', '/plain'])
+  })
+
+  it('a predicate can read a flag value, not just its presence', async () => {
+    const ran = await runsFor(
+      ({ flags }: { flags: ReadonlyMap<string, unknown> }) =>
+        (flags.get('rate.limit') as { rpm: number } | undefined)?.rpm === 0,
+    )
+    // No route declares rate.limit: 0, so nothing is skipped.
+    expect(ran).toEqual(['/public', '/probe', '/both', '/plain'])
+  })
+
+  it('a predicate can route on the matched path', async () => {
+    const ran = await runsFor(({ route }: { route?: { path: string } }) => route?.path === '/plain')
+    expect(ran).toEqual(['/public', '/probe', '/both'])
+  })
+})
+
+describe('route flags — buildRoutes parity', () => {
+  beforeEach(() => Container.reset())
+
+  it('a hand-built router still gets flags via buildRoutes', () => {
+    @Public
+    @Controller()
+    class C {
+      @Get('/x') x(_ctx: RequestContext) {}
+    }
+    // buildRoutes wraps buildRouteTable; the flag must survive that path too.
+    expect(() => buildRoutes(C)).not.toThrow()
+    expect(buildRouteTable(C)[0].meta.flags?.has('auth.public')).toBe(true)
+  })
+})

--- a/packages/kickjs/src/core/context-decorator.ts
+++ b/packages/kickjs/src/core/context-decorator.ts
@@ -1,3 +1,4 @@
+import type { RouteFlagTest } from './route-flag'
 import 'reflect-metadata'
 import { METADATA, type Constructor, type MaybePromise } from './interfaces'
 import { pushClassMeta, pushMethodMeta } from './metadata'
@@ -111,6 +112,16 @@ export interface ContextDecoratorSpec<
 > {
   /** ContextMeta key the resolved value is written to. */
   key: K
+  /**
+   * Skip this contributor on routes carrying the named route flag
+   * (`defineRouteFlag`). See {@link ContributorRegistration.skipWhen}.
+   */
+  skipWhen?: RouteFlagTest
+  /**
+   * Run this contributor only on routes carrying the named route flag, or
+   * matching the predicate.
+   */
+  onlyWhen?: RouteFlagTest
   /**
    * DI dependencies resolved by the runner before `resolve()` runs.
    * Map entry keys become property names on the resolved-deps argument
@@ -247,6 +258,25 @@ export interface ContributorRegistration<
    * the first non-framework frame for display.
    */
   readonly definedAt?: string
+  /**
+   * Skip this contributor on routes carrying the named route flag.
+   *
+   * The composable way to say "not here". Exempting a contributor otherwise
+   * means registering a permissive twin under the same key, which only its
+   * author can do — a flag is declared on the route, so an adopter can exempt
+   * a plugin's contributor without owning its key or forking it.
+   *
+   * ```ts
+   * defineHttpContextDecorator({ key: 'user', skipWhen: 'auth.public', resolve })
+   * ```
+   */
+  readonly skipWhen?: RouteFlagTest
+  /**
+   * Run this contributor **only** on routes carrying the named flag. The
+   * inverse of {@link skipWhen}, and the case with no expression today short
+   * of an `if` inside every resolver.
+   */
+  readonly onlyWhen?: RouteFlagTest
 }
 
 /**
@@ -681,6 +711,8 @@ function defineContextDecoratorImpl<
       deps: sharedDeps,
       dependsOn: sharedDependsOn,
       optional: sharedOptional,
+      skipWhen: spec.skipWhen,
+      onlyWhen: spec.onlyWhen,
       onError,
       resolve,
       definedAt,

--- a/packages/kickjs/src/core/contributor-runner.ts
+++ b/packages/kickjs/src/core/contributor-runner.ts
@@ -2,6 +2,8 @@ import type { Container } from './container'
 import type { ContributorRegistration } from './context-decorator'
 import type { ExecutionContext } from './execution-context'
 import type { ContributorPipeline } from './contributor-pipeline'
+import type { RouteFlagTest } from './route-flag'
+import type { MatchedRoute } from '../http/runtime'
 
 export interface RunContributorsOptions {
   /** Pre-built, validated, topo-sorted pipeline. */
@@ -10,7 +12,59 @@ export interface RunContributorsOptions {
   ctx: ExecutionContext
   /** DI container used to resolve declared `deps`. */
   container: Container
+  /**
+   * Route flags in force for the matched route, used to honour a
+   * registration's `skipWhen` / `onlyWhen`. Omitted outside a route (the
+   * pipeline then runs every contributor, as before).
+   */
+  flags?: ReadonlyMap<string, unknown>
 }
+
+/**
+ * Should this contributor run on a route carrying `flags`?
+ *
+ * `skipWhen` is what makes exemption composable: today a contributor can only
+ * be opted out of by registering a permissive twin under the same key, which
+ * requires owning that key. A flag is declared on the route, so an adopter can
+ * exempt a contributor shipped by a plugin without forking it.
+ */
+/**
+ * Evaluate a flag test.
+ *
+ * - `'auth.public'` — the flag is present
+ * - `['auth.public', 'internal']` — **any** of them is present. Any-of is the
+ *   right default: the list reads as "these are all reasons to skip", and
+ *   all-of is the rarer case, expressible with a predicate.
+ * - `({ flags, route }) => boolean` — anything else: all-of, a flag's value, a
+ *   path check, an env switch.
+ */
+function matches(
+  test: RouteFlagTest,
+  flags: ReadonlyMap<string, unknown>,
+  ctx: ExecutionContext,
+): boolean {
+  if (typeof test === 'string') return flags.has(test)
+  // `Array.isArray` doesn't narrow a `readonly string[]` union member, so the
+  // check is written against the callable side instead.
+  if (typeof test === 'function') {
+    return test({ flags, route: (ctx as { route?: MatchedRoute }).route })
+  }
+  return test.some((name) => flags.has(name))
+}
+
+function shouldRun(
+  reg: ContributorRegistration,
+  ctx: ExecutionContext,
+  flags?: ReadonlyMap<string, unknown>,
+): boolean {
+  if (reg.skipWhen === undefined && reg.onlyWhen === undefined) return true
+  const resolved = flags ?? EMPTY_FLAGS
+  if (reg.skipWhen !== undefined && matches(reg.skipWhen, resolved, ctx)) return false
+  if (reg.onlyWhen !== undefined && !matches(reg.onlyWhen, resolved, ctx)) return false
+  return true
+}
+
+const EMPTY_FLAGS: ReadonlyMap<string, unknown> = new Map()
 
 /**
  * Execute a built {@link ContributorPipeline} against an {@link ExecutionContext}.
@@ -37,9 +91,10 @@ export interface RunContributorsOptions {
  * wrap the container access inside their own `resolve()`.
  */
 export async function runContributors(options: RunContributorsOptions): Promise<void> {
-  const { pipeline, ctx, container } = options
+  const { pipeline, ctx, container, flags } = options
 
   for (const reg of pipeline.contributors) {
+    if (!shouldRun(reg, ctx, flags)) continue
     await runOne(reg, ctx, container)
   }
 }

--- a/packages/kickjs/src/core/index.ts
+++ b/packages/kickjs/src/core/index.ts
@@ -296,3 +296,12 @@ export {
   type GroupAssetKeysOptions,
   type GroupAssetKeysResult,
 } from './asset-keys'
+
+export { defineRouteFlag, resolveRouteFlags } from './route-flag'
+export type {
+  RouteFlag,
+  RouteFlagContext,
+  RouteFlagDeclaration,
+  RouteFlagPredicate,
+  RouteFlagTest,
+} from './route-flag'

--- a/packages/kickjs/src/core/interfaces.ts
+++ b/packages/kickjs/src/core/interfaces.ts
@@ -76,6 +76,8 @@ export const METADATA = {
   METHOD_MIDDLEWARES: 'kick:method:middlewares',
   CLASS_CONTRIBUTORS: 'kick:class:contributors',
   METHOD_CONTRIBUTORS: 'kick:method:contributors',
+  CLASS_FLAGS: 'kick:class:flags',
+  METHOD_FLAGS: 'kick:method:flags',
   FILE_UPLOAD: 'kick:file:upload',
   VALUE: 'kick:value',
   ASSET: 'kick:asset',

--- a/packages/kickjs/src/core/route-flag.ts
+++ b/packages/kickjs/src/core/route-flag.ts
@@ -1,0 +1,204 @@
+/**
+ * Route flags — a named, inheritable fact about a route (spec:
+ * `route-flags-design.md`).
+ *
+ * A flag carries no behaviour. It records something about the route that any
+ * consumer may read: `auth.public`, `csrf.exempt`, `rate.limit`. Auth reads it
+ * to skip a contributor, a guard reads it to return early, Swagger reads it to
+ * mark a security scheme — none of them needs to know about the others.
+ *
+ * The rule that makes presence checks safe: a flag resolves to **absent**, or
+ * **present with a value defaulting to `true`**. There is no present-but-false
+ * state, so `flags.has(name)` is always the right question for a boolean flag.
+ * `@Public(false)` on a method does not store `false` — it removes the flag the
+ * class put there. Without that, `has('auth.public')` would answer `true` for
+ * the route that just opted back IN, which is an authorization bypass rather
+ * than a papercut.
+ */
+import { METADATA } from './interfaces'
+import { getClassMeta, getMethodMeta, pushClassMeta, pushMethodMeta } from './metadata'
+
+/** One `@Flag` application, before precedence resolution. */
+export interface RouteFlagDeclaration {
+  readonly name: string
+  /** `false` means "remove whatever a lower-precedence site declared". */
+  readonly value: unknown
+}
+
+/**
+ * A flag decorator. Usable bare (`@Public`) or called with a value
+ * (`@Public(false)`, `@RateLimit({ rpm: 10 })`), on a class or a method.
+ */
+export interface RouteFlag<V = true> {
+  (target: object, propertyKey?: string | symbol): void
+  (value: V | false): (target: object, propertyKey?: string | symbol) => void
+  readonly flagName: string
+}
+
+/**
+ * True when the arguments look like a decorator application rather than a
+ * value. The two forms are `@Public` (TS calls it for us) and `@Public(v)`
+ * (we return the decorator).
+ *
+ * Discrimination has to be exact, because a value can be an object:
+ * `@RateLimit({ rpm: 10 })` is a single object argument, and treating it as a
+ * class-decorator target silently drops the flag.
+ *
+ * - method decorator → `(prototype, 'name', descriptor?)`, so arg 1 is a
+ *   string or symbol
+ * - class decorator → `(constructor)`, a single *function* argument
+ * - anything else → a value
+ */
+function isDecoratorApplication(args: unknown[]): boolean {
+  const [target, propertyKey] = args
+  if (typeof propertyKey === 'string' || typeof propertyKey === 'symbol') return true
+  return args.length === 1 && typeof target === 'function'
+}
+
+/**
+ * Define a route flag.
+ *
+ * ```ts
+ * export const Public = defineRouteFlag('auth.public')
+ * export const RateLimit = defineRouteFlag<{ rpm: number }>('rate.limit')
+ * ```
+ */
+export function defineRouteFlag<V = true>(name: string): RouteFlag<V> {
+  function apply(value: unknown, target: object, propertyKey?: string | symbol): void {
+    const declaration: RouteFlagDeclaration = { name, value }
+    if (propertyKey === undefined) {
+      pushClassMeta<RouteFlagDeclaration>(METADATA.CLASS_FLAGS, target, declaration)
+      return
+    }
+    // Method decorators receive the prototype; metadata helpers key off the
+    // constructor so class + method lookups land in the same place.
+    pushMethodMeta<RouteFlagDeclaration>(
+      METADATA.METHOD_FLAGS,
+      (target as { constructor: object }).constructor,
+      String(propertyKey),
+      declaration,
+    )
+  }
+
+  const flag = (...args: unknown[]): unknown => {
+    if (isDecoratorApplication(args)) {
+      // Bare form: @Public
+      apply(true, args[0] as object, args[1] as string | symbol | undefined)
+      return undefined
+    }
+    // Called form: @Public(false) / @RateLimit({ rpm: 10 })
+    const value = args[0]
+    return (target: object, propertyKey?: string | symbol): void => {
+      apply(value, target, propertyKey)
+    }
+  }
+
+  Object.defineProperty(flag, 'flagName', { value: name, enumerable: true })
+  return flag as RouteFlag<V>
+}
+
+/**
+ * Resolve the flags in force for one route.
+ *
+ * Precedence is method > class, matching the contributor pipeline's top two
+ * levels. Within a level the last declaration wins (decorators apply bottom-up,
+ * so the one nearest the handler is applied last).
+ *
+ * A resolved `false` deletes the key rather than storing it — see the module
+ * docblock.
+ */
+export function resolveRouteFlags(
+  classDeclarations: readonly RouteFlagDeclaration[],
+  methodDeclarations: readonly RouteFlagDeclaration[],
+): ReadonlyMap<string, unknown> {
+  const resolved = new Map<string, unknown>()
+
+  // Lowest precedence first, so higher levels overwrite.
+  for (const { name, value } of [...classDeclarations, ...methodDeclarations]) {
+    if (value === false) {
+      resolved.delete(name)
+      continue
+    }
+    resolved.set(name, value)
+  }
+
+  return resolved
+}
+
+/**
+ * Argument handed to a flag predicate.
+ *
+ * `route` is undefined only where flags are consulted outside a matched route,
+ * which today means a non-HTTP transport running the same contributor pipeline.
+ */
+export interface RouteFlagContext {
+  readonly flags: ReadonlyMap<string, unknown>
+  readonly route?: {
+    readonly method: string
+    readonly path: string
+    readonly controller?: unknown
+    readonly handlerName?: string
+  }
+}
+
+/**
+ * A predicate form of a flag test, for conditions a single name cannot express:
+ * two flags together, a flag's *value*, a path or controller check, an env
+ * switch.
+ *
+ * ```ts
+ * skipWhen: ({ flags }) => flags.has('auth.public') || flags.has('internal'),
+ * skipWhen: ({ flags }) => (flags.get('rate.limit') as { rpm: number })?.rpm === 0,
+ * skipWhen: ({ route }) => route?.path.startsWith('/webhooks') ?? false,
+ * ```
+ *
+ * Keep predicates pure and cheap — they run per request, per contributor.
+ */
+export type RouteFlagPredicate = (ctx: RouteFlagContext) => boolean
+
+/**
+ * How a consumer names the routes it cares about.
+ *
+ * A bare name for the common case, a list when several flags mean the same
+ * thing (matched **any-of**), a predicate for everything else — all-of, a
+ * flag's value, the route's path.
+ *
+ * ```ts
+ * skipWhen: 'auth.public'
+ * skipWhen: ['auth.public', 'health.probe']            // either one
+ * skipWhen: ({ flags }) => flags.has('a') && flags.has('b')   // both
+ * ```
+ */
+export type RouteFlagTest = string | readonly string[] | RouteFlagPredicate
+
+/**
+ * Where the matched route is stashed for `ctx.route` to read.
+ *
+ * It lives on the **request object**, not on the RequestContext: the Express
+ * runtime constructs a fresh `RequestContext` per middleware, so anything
+ * written to one ctx is invisible to the next and to the handler. Fastify and
+ * h3 build a single ctx per request and would not have shown the difference —
+ * the cross-runtime test is what surfaced it.
+ *
+ * `Symbol.for` rather than a private symbol so a duplicated module instance
+ * (pnpm hoisting, a bundled copy) still reads the same slot.
+ */
+export const ROUTE_SLOT: unique symbol = Symbol.for('kick.route') as never
+
+/** Read the class-level declarations off a controller. */
+export function getClassFlagDeclarations(controllerClass: object): RouteFlagDeclaration[] {
+  return getClassMeta<RouteFlagDeclaration[]>(METADATA.CLASS_FLAGS, controllerClass, [])
+}
+
+/** Read the method-level declarations off a controller method. */
+export function getMethodFlagDeclarations(
+  controllerClass: object,
+  handlerName: string,
+): RouteFlagDeclaration[] {
+  return getMethodMeta<RouteFlagDeclaration[]>(
+    METADATA.METHOD_FLAGS,
+    controllerClass,
+    handlerName,
+    [],
+  )
+}

--- a/packages/kickjs/src/http/context.ts
+++ b/packages/kickjs/src/http/context.ts
@@ -1,6 +1,7 @@
 /// <reference types="multer" />
 import type { Request, NextFunction } from 'express'
-import type { ActiveRuntime, RuntimeResponse } from './runtime'
+import { ROUTE_SLOT } from '../core/route-flag'
+import type { ActiveRuntime, MatchedRoute, RuntimeResponse } from './runtime'
 import {
   type ContextMetaKey,
   type ExecutionContext,
@@ -297,6 +298,22 @@ export class RequestContext<
    * over their native reply as the optional fourth argument.
    */
   private readonly _response: RuntimeResponse
+
+  /**
+   * The route this request matched: its method, path, controller, handler name
+   * and resolved {@link MatchedRoute.flags}.
+   *
+   * Available to anything running inside the matched route — route middleware,
+   * contributors, guards, the handler. Global middleware runs before route
+   * matching, so it sees `undefined` there.
+   *
+   * ```ts
+   * if (ctx.route?.flags.has('auth.public')) return next()
+   * ```
+   */
+  get route(): MatchedRoute | undefined {
+    return (this.req as unknown as Record<symbol, MatchedRoute | undefined>)?.[ROUTE_SLOT]
+  }
 
   constructor(
     public readonly req: ActiveRuntime['request'],

--- a/packages/kickjs/src/http/router-builder.ts
+++ b/packages/kickjs/src/http/router-builder.ts
@@ -8,6 +8,11 @@ import { METADATA } from '../core/interfaces'
 import type { ContributorRegistration } from '../core/context-decorator'
 import type { FileUploadConfig, MiddlewareHandler, RouteDefinition } from '../core/decorators'
 import { getClassMeta, getMethodMeta, getMethodMetaOrUndefined } from '../core/metadata'
+import {
+  getClassFlagDeclarations,
+  getMethodFlagDeclarations,
+  resolveRouteFlags,
+} from '../core/route-flag'
 import { duplicateRouteError } from '../core/kick-errors'
 import type { CtxHandler, RouteEntry, RouteMethod } from './runtime'
 
@@ -114,6 +119,10 @@ export function buildRouteTable(
     [],
   )
 
+  // Route flags declared on the controller — inherited by every method below
+  // unless a method declares the same flag `false` (see core/route-flag.ts).
+  const classFlagDeclarations = getClassFlagDeclarations(controllerClass)
+
   const entries: RouteEntry[] = []
 
   for (const route of routes) {
@@ -144,6 +153,13 @@ export function buildRouteTable(
       [],
     )
 
+    // Flags in force for THIS route: class declarations overridden by method
+    // ones. Resolved at build time so the per-request cost is a map lookup.
+    const flags = resolveRouteFlags(
+      classFlagDeclarations,
+      getMethodFlagDeclarations(controllerClass, route.handlerName),
+    )
+
     let contributorRunner: CtxHandler | null = null
     if (
       classContributors.length > 0 ||
@@ -170,7 +186,7 @@ export function buildRouteTable(
       const pipeline = buildPipeline(sources, {
         route: `${method} ${fullPath}`,
       })
-      contributorRunner = (ctx) => runContributors({ pipeline, ctx, container })
+      contributorRunner = (ctx) => runContributors({ pipeline, ctx, container, flags })
     }
 
     // Terminal handler — resolve controller per-request to respect DI scoping.
@@ -187,6 +203,7 @@ export function buildRouteTable(
         handlerName: route.handlerName,
         validation: route.validation,
         upload: fileUploadConfig,
+        flags,
       },
     })
   }

--- a/packages/kickjs/src/http/runtime.ts
+++ b/packages/kickjs/src/http/runtime.ts
@@ -11,6 +11,7 @@
 // that lets `RequestContext` run engine-agnostically lands with them (M3), since
 // under Express the drivers ARE the Express request/response objects already.
 
+import { ROUTE_SLOT } from '../core/route-flag'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type {
   RequestHandler,
@@ -92,6 +93,50 @@ export interface RouteMeta {
   validation?: RouteDefinition['validation']
   /** `@FileUpload` config, if present — the runtime supplies the backend. */
   upload?: FileUploadConfig
+  /**
+   * Route flags in force here, resolved at build time (method over class).
+   * Enabled flags only: a flag declared `false` at a higher-precedence site is
+   * absent rather than present-and-false, so `has()` is always the right
+   * question. See `core/route-flag.ts`.
+   */
+  flags?: ReadonlyMap<string, unknown>
+}
+
+/**
+ * The route a request matched, published on `ctx.route`.
+ *
+ * Everything that holds a {@link RequestContext} — handlers, `@Middleware()`,
+ * guards, contributors — can read it, which is what lets one declaration on a
+ * route serve every consumer.
+ */
+/**
+ * Publish the matched route on the request, for `ctx.route` to read.
+ *
+ * Called by each runtime once per dispatch, before it builds a RequestContext.
+ * It lives on `req` rather than on the ctx because the Express runtime
+ * constructs a fresh RequestContext per middleware step — anything written to
+ * one ctx would be invisible to the next and to the handler.
+ */
+export function publishMatchedRoute(req: unknown, entry: RouteEntry): void {
+  ;(req as Record<symbol, MatchedRoute>)[ROUTE_SLOT] = {
+    method: entry.method,
+    path: entry.path,
+    controller: entry.meta.controller,
+    handlerName: entry.meta.handlerName,
+    flags: entry.meta.flags ?? EMPTY_FLAGS,
+  }
+}
+
+const EMPTY_FLAGS: ReadonlyMap<string, unknown> = new Map()
+
+export interface MatchedRoute {
+  method: RouteMethod
+  /** Path as declared on the handler, e.g. `/:id`. */
+  path: string
+  controller?: Constructor
+  handlerName?: string
+  /** Enabled flags only — see {@link RouteMeta.flags}. */
+  flags: ReadonlyMap<string, unknown>
 }
 
 /** A controller's routes grouped under the module mount prefix. */

--- a/packages/kickjs/src/http/runtimes/express.ts
+++ b/packages/kickjs/src/http/runtimes/express.ts
@@ -19,6 +19,7 @@ import { buildRouteTable, type BuildRoutesOptions } from '../router-builder'
 import { RequestContext } from '../context'
 import { applyHandlerResult } from '../reply'
 import { validate } from '../middleware/validate'
+import { publishMatchedRoute } from '../runtime'
 import { buildUploadMiddleware } from '../middleware/upload'
 import type {
   ConnectMiddleware,
@@ -43,6 +44,13 @@ export function materializeRouter(entries: RouteEntry[]): Router {
   for (const entry of entries) {
     const method = entry.method.toLowerCase() as 'get' | 'post' | 'put' | 'delete' | 'patch'
     const handlers: RequestHandler[] = []
+
+    // Publish the matched route first, so every later step — validation,
+    // upload, middleware, contributors, handler — reads the same `ctx.route`.
+    handlers.push((req: Request, _res: Response, next: NextFunction) => {
+      publishMatchedRoute(req, entry)
+      next()
+    })
 
     // Validation middleware (shared with the standalone validate() export).
     if (entry.meta.validation) {

--- a/packages/kickjs/src/http/runtimes/fastify.ts
+++ b/packages/kickjs/src/http/runtimes/fastify.ts
@@ -20,6 +20,7 @@ import { createRequire } from 'node:module'
 import { HttpException } from '../../core/errors'
 import { unsupportedMediaTypeError } from '../body-policy'
 import { RequestContext } from '../context'
+import { publishMatchedRoute } from '../runtime'
 import { applyHandlerResult } from '../reply'
 import { requestStore } from '../request-store'
 import { createRequestStore, disposeRequestStore } from '../middleware/request-scope'
@@ -251,6 +252,7 @@ function routeHandler(entry: RouteEntry): FastifyHandler {
     reply.raw.once('close', () => disposeRequestStore(store))
 
     await requestStore.run(store, async () => {
+      publishMatchedRoute(raw, entry)
       const ctx = new RequestContext(raw as never, reply as never, NOOP_NEXT, replyDriver(reply))
 
       // Validation (from @Get(path, schema) / route.validation). `validator` is a

--- a/packages/kickjs/src/http/runtimes/h3.ts
+++ b/packages/kickjs/src/http/runtimes/h3.ts
@@ -21,6 +21,7 @@ import { createRequire } from 'node:module'
 
 import { classifyMediaType, unsupportedMediaTypeError } from '../body-policy'
 import { RequestContext } from '../context'
+import { publishMatchedRoute } from '../runtime'
 import { applyHandlerResult } from '../reply'
 import { requestStore } from '../request-store'
 import { createRequestStore, disposeRequestStore } from '../middleware/request-scope'
@@ -248,6 +249,7 @@ function makeEventHandler(
     res.once('close', () => disposeRequestStore(store))
 
     await requestStore.run(store, async () => {
+      publishMatchedRoute(req, entry)
       const ctx = new RequestContext(req as never, res as never, NOOP_NEXT, resDriver(res))
 
       if (validator) {

--- a/packages/kickjs/src/http/web/handler.ts
+++ b/packages/kickjs/src/http/web/handler.ts
@@ -6,6 +6,7 @@
 import { HttpException } from '../../core/errors'
 import { classifyMediaType, unsupportedMediaTypeError } from '../body-policy'
 import { RequestContext } from '../context'
+import { publishMatchedRoute } from '../runtime'
 import { applyHandlerResult } from '../reply'
 import { requestStore } from '../request-store'
 import { createRequestStore, disposeRequestStore } from '../middleware/request-scope'
@@ -159,6 +160,8 @@ export function compileWebRoute(
 
     const driver = new WebResponseDriver(request.signal)
     driver.setHeader('x-request-id', store.requestId)
+
+    publishMatchedRoute(req, entry)
 
     const pipeline = requestStore.run(store, async () => {
       if (bodyError) throw bodyError

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -31,6 +31,14 @@ export {
   type SseHandler,
 } from './http/context'
 export { defineHttpContextDecorator } from './http/define-http-context-decorator'
+export { defineRouteFlag } from './core/route-flag'
+export type {
+  RouteFlag,
+  RouteFlagContext,
+  RouteFlagPredicate,
+  RouteFlagTest,
+} from './core/route-flag'
+export type { MatchedRoute } from './http/runtime'
 
 // Return-value handlers + response inference (response-inference-design.md)
 export {

--- a/route-flags-design.md
+++ b/route-flags-design.md
@@ -1,6 +1,8 @@
 # Route Flags — a shared vocabulary for "this endpoint is open"
 
-> Status: **proposal**. Working spec, not shipped.
+> Status: **phase 1 implemented** (`defineRouteFlag`, `ctx.route`, contributor
+> `skipWhen` / `onlyWhen`) — see `packages/kickjs/__tests__/route-flags.test.ts`.
+> Phases 2–4 (CSRF, rate limiting, OpenAPI + DevTools readers) are still proposals.
 > Decisions taken: core primitive in `@forinda/kickjs`; auth first, other consumers follow;
 > declaration must sit on the controller and propagate to its routes.
 


### PR DESCRIPTION
Phase 1 of [`route-flags-design.md`](https://github.com/forinda/kick-js/blob/main/route-flags-design.md),
built to test the hypothesis before porting anything else onto it. It holds.

## What ships

**`defineRouteFlag()`** — a named, inheritable fact about a route. Declared on a controller it
applies to every route below; a method overrides its class.

```ts
export const Public = defineRouteFlag('auth.public')

@Public
@Controller()
class WebhooksController {
  @Get('/health') health(ctx: RequestContext) {}   // inherits auth.public

  @Public(false)                                    // method wins
  @Post('/admin') admin(ctx: RequestContext) {}     // flag is ABSENT here
}
```

**`ctx.route`** — the matched route (`method`, `path`, `controller`, `handlerName`, `flags`),
available to anything holding a `RequestContext`: handlers, `@Middleware()`, guards, contributors.
One addition covers every post-match consumer, with no per-consumer API.

**Contributor `skipWhen` / `onlyWhen`** — the piece that makes exemption composable. Today a
contributor can only be opted out of by registering a permissive twin under the same key, which
only its author can do. A flag lives on the route, so an adopter can exempt a plugin's
contributor without owning its key.

Per the review discussion, both accept **a name, a list, or a predicate**:

```ts
skipWhen: 'auth.public'
skipWhen: ['auth.public', 'health.probe']                    // any-of
skipWhen: ({ flags }) => flags.has('a') && flags.has('b')     // all-of
skipWhen: ({ flags }) => (flags.get('rate.limit') as Limit)?.rpm === 0
skipWhen: ({ route }) => route?.path.startsWith('/webhooks') ?? false
```

Any-of is the list default because a list reads as "these are all reasons to skip"; all-of is
rarer and goes through the predicate.

## The safety rule, enforced in the resolver

A flag resolves to **absent**, or **present with a value defaulting to `true`** — never
present-and-false. `@Public(false)` removes the flag its class set rather than storing `false`.
Without that, `flags.has('auth.public')` answers `true` for the route that just opted back **in**
— an authorization bypass. Putting the rule in the resolver rather than in each consumer keeps
the security-relevant step away from whoever writes the next guard.

## Two things the tests caught that reading wouldn't have

- **Express builds a fresh `RequestContext` per middleware step** (`express.ts:60/69/81`). The
  first version stashed the route on `ctx` — it worked on Fastify and h3, which build one ctx per
  request, and silently did nothing on Express. The route now lives on `req` under a `Symbol.for`
  slot, read through the `ctx.route` getter. The cross-runtime test is the only reason this
  surfaced.
- **Publishing the route via a prepended middleware changed `RouteEntry.middlewares`** for every
  route, breaking `http-runtime-seam.test.ts`. Replaced with `publishMatchedRoute(req, entry)`,
  called by each runtime where it already holds the entry — including the web/edge entry, so
  `ctx.route` works on Workers/Bun/Deno too.

## Verification

19 new tests: resolution (class propagation, method override, values, absent-not-false asserted
in **both** directions), `ctx.route` on Express + Fastify + h3, contributor skipping both ways,
and each of the name / list / predicate forms.

`packages/kickjs`: **879 tests, 81 files, all passing.** No new failures.

> Note for anyone running these locally: run `pnpm test` (or vitest from inside the package).
> A bare `npx vitest` at the repo root reports ~120 phantom failures — the assets and env-file
> suites resolve paths against `process.cwd()`, and `turbo.json` builds before testing, which a
> root invocation skips.

## Scope

Additive. Nothing existing changes behaviour; a route with no flags resolves an empty map. CSRF,
rate limiting, and the OpenAPI/DevTools readers are phases 2–4 and deliberately not in this PR —
the point was to prove the substrate first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
