### PR TITLE
feat: route flags reach the OpenAPI spec and the DevTools dashboard

### DIFF
--- a/.changeset/route-flag-readers.md
+++ b/.changeset/route-flag-readers.md
@@ -1,0 +1,21 @@
+---
+'@forinda/kickjs': minor
+'@forinda/kickjs-swagger': minor
+'@forinda/kickjs-devtools': minor
+---
+
+Route flags reach the OpenAPI spec and the DevTools dashboard (phase 4 of `route-flags-design.md`).
+
+**`getRouteFlags(controllerClass, handlerName)`** resolves a route's flags from the controller — the same method-over-class result `ctx.route.flags` carries at request time, for consumers that see a controller and a method name rather than a live request: an adapter's `onRouteMount`, spec generation, tooling.
+
+**Swagger gains `publicFlag`.** Name the flag your project uses for public endpoints and the spec reads the same declaration the runtime does, instead of asking for a second annotation that can drift from it:
+
+```ts
+export const Public = defineRouteFlag('auth.public')
+
+SwaggerAdapter({ bearerAuth: true, publicFlag: 'auth.public' })
+```
+
+The name is configuration rather than a constant, because the framework deliberately names no flags — one project's `auth.public` is another's `public` or `security.none`. A list accepts several. It sits after `@ApiPublic` and `securityResolver` in the resolution order and before the `@ApiSecurity` / `@ApiBearerAuth` decorators, so an explicit resolver still wins while a flag still overrides class-level security.
+
+**DevTools reports flags per route.** `GET /_debug/routes` includes a `flags` object on each entry, and the dashboard's Routes tab shows them in a Flags column — so "why does this endpoint not require auth" is answerable from the route list rather than by reading the controller. Only flags in force appear: one turned off at the method is absent, not `false`.

--- a/__tests__/devtools.test.ts
+++ b/__tests__/devtools.test.ts
@@ -6,7 +6,15 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import 'reflect-metadata'
 import request from 'supertest'
-import { Container, Scope, Controller, Get, Post, type AppAdapter } from '@forinda/kickjs-core'
+import {
+  Container,
+  Scope,
+  Controller,
+  Get,
+  Post,
+  defineRouteFlag,
+  type AppAdapter,
+} from '@forinda/kickjs-core'
 import { buildRoutes, RequestContext } from '@forinda/kickjs-http'
 import { DevToolsAdapter } from '@forinda/kickjs-devtools'
 import { createTestApp, createTestModule } from '@forinda/kickjs-testing'
@@ -79,6 +87,49 @@ describe('DevTools: debug endpoints', () => {
     expect(res.status).toBe(200)
     expect(res.body).toHaveProperty('routes')
     expect(Array.isArray(res.body.routes)).toBe(true)
+  })
+
+  it("/_debug/routes reports each route's resolved flags", async () => {
+    const Public = defineRouteFlag('auth.public')
+    const Limit = defineRouteFlag<{ rpm: number }>('rate.limit')
+
+    @Public
+    @Controller()
+    class FlaggedCtrl {
+      @Get('/open')
+      open(ctx: RequestContext) {
+        ctx.json({})
+      }
+
+      @Limit({ rpm: 10 })
+      @Public(false)
+      @Get('/metered')
+      metered(ctx: RequestContext) {
+        ctx.json({})
+      }
+    }
+
+    const module = createTestModule({
+      register: (c) => reg(FlaggedCtrl, c),
+      routes: () => ({
+        path: '/flagged',
+        router: buildRoutes(FlaggedCtrl),
+        controller: FlaggedCtrl,
+      }),
+    })
+    const { expressApp } = await createTestApp({
+      modules: [module],
+      adapters: [DevToolsAdapter({ secret: false })],
+    })
+
+    const res = await request(expressApp).get('/_debug/routes')
+    const byPath = Object.fromEntries(
+      res.body.routes.map((r: { path: string; flags: unknown }) => [r.path, r.flags]),
+    )
+
+    expect(byPath['/api/v1/flagged/open']).toEqual({ 'auth.public': true })
+    // Class flag turned off at the method, so it is absent — not `false`.
+    expect(byPath['/api/v1/flagged/metered']).toEqual({ 'rate.limit': { rpm: 10 } })
   })
 })
 

--- a/docs/guide/devtools.md
+++ b/docs/guide/devtools.md
@@ -66,7 +66,8 @@ Resolution order: explicit `enabled` option → `KICKJS_DEVTOOLS=0|1|true|false`
 
 ### `GET /_debug/routes`
 
-Lists all registered routes with their HTTP method, path, controller, handler, and middleware.
+Lists all registered routes with their HTTP method, path, controller, handler, middleware, and
+resolved [route flags](./route-flags.md).
 
 ```json
 {
@@ -76,18 +77,33 @@ Lists all registered routes with their HTTP method, path, controller, handler, a
       "path": "/api/v1/users",
       "controller": "UserController",
       "handler": "getAll",
-      "middleware": ["authGuard"]
+      "middleware": ["authGuard"],
+      "flags": {}
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/health",
+      "controller": "HealthController",
+      "handler": "live",
+      "middleware": [],
+      "flags": { "auth.public": true }
     },
     {
       "method": "POST",
-      "path": "/api/v1/users",
-      "controller": "UserController",
-      "handler": "create",
-      "middleware": ["authGuard", "validate"]
+      "path": "/api/v1/login",
+      "controller": "AuthController",
+      "handler": "login",
+      "middleware": ["validate"],
+      "flags": { "rate.limit": { "rpm": 10 } }
     }
   ]
 }
 ```
+
+`flags` holds only the flags in force: one turned off at the method (`@Public(false)`) is absent
+rather than `false`, matching what every other consumer sees. The dashboard's Routes tab shows the
+same values in a Flags column, so "why does this endpoint not require auth" is answerable from the
+route list instead of by reading the controller.
 
 ### `GET /_debug/container`
 

--- a/docs/guide/swagger.md
+++ b/docs/guide/swagger.md
@@ -224,6 +224,42 @@ SwaggerAdapter({
 })
 ```
 
+## Public routes from a route flag — `publicFlag`
+
+If your auth already marks public endpoints with a [route flag](./route-flags.md), name the flag
+and the spec reads the same declaration the runtime does — no second annotation to keep in step:
+
+```typescript
+// src/flags.ts
+export const Public = defineRouteFlag('auth.public')
+
+SwaggerAdapter({ bearerAuth: true, publicFlag: 'auth.public' })
+```
+
+```typescript
+@Public // whole controller documented public
+@Controller()
+export class WebhooksController {
+  @Get('/health') health(ctx: RequestContext) {}
+
+  @Public(false) // this one is documented as secured again
+  @Post('/admin')
+  admin(ctx: RequestContext) {}
+}
+```
+
+The **name is configuration, not a constant**: the framework deliberately names no flags, so one
+project's `auth.public` is another's `public` or `security.none`. Pass a list to accept several:
+
+```typescript
+SwaggerAdapter({ bearerAuth: true, publicFlag: ['auth.public', 'health.probe'] })
+```
+
+Flags inherit from the controller and a method can turn one off, so the spec follows the same
+method-over-class rule as the runtime. For anything more involved than a name — reading a flag's
+value, combining two — use `securityResolver` with `getRouteFlags(controllerClass, handlerName)`,
+which resolves the same map outside a request.
+
 The resolver runs **after** `@ApiPublic()` (which short-circuits to public) but **before** the decorator-driven `@ApiSecurity` / `@ApiBearerAuth` lookups. Returning a value drives the requirement; returning `null` is "explicitly public" (overrides class-level security); returning `undefined` falls through.
 
 ## Resolution order
@@ -232,10 +268,11 @@ When the spec builder picks security for a route, the first match wins:
 
 1. `@ApiPublic()` on the method → no security emitted.
 2. `securityResolver({ controllerClass, handlerName })` returns a value (or `null` for public).
-3. `@ApiSecurity` on the method.
-4. `@ApiBearerAuth` on the method.
-5. `@ApiSecurity` on the class.
-6. `@ApiBearerAuth` on the class.
+3. `publicFlag` — the route carries one of the named flags → no security emitted.
+4. `@ApiSecurity` on the method.
+5. `@ApiBearerAuth` on the method.
+6. `@ApiSecurity` on the class.
+7. `@ApiBearerAuth` on the class.
 
 ## Schema-Driven Documentation
 

--- a/packages/devtools/spa/src/lib/store.ts
+++ b/packages/devtools/spa/src/lib/store.ts
@@ -35,6 +35,8 @@ export interface RouteEntry {
   controller: string
   handler: string
   middleware: string[]
+  /** Route flags in force, resolved method-over-class. */
+  flags?: Record<string, unknown>
 }
 
 export interface ContainerRegistration {

--- a/packages/devtools/spa/src/tabs/RoutesTab.tsx
+++ b/packages/devtools/spa/src/tabs/RoutesTab.tsx
@@ -1,5 +1,5 @@
 /**
- * Route registry tab — method/path/controller/handler/middleware
+ * Route registry tab — method/path/controller/handler/middleware/flags
  * listing with search + method-filter + pagination.
  *
  * Sources its data from the shared store (`store.routes()`), which
@@ -17,6 +17,16 @@ import { Pagination, usePagination } from '../lib/pagination'
 
 const METHODS = ['ALL', 'GET', 'POST', 'PUT', 'DELETE', 'PATCH'] as const
 type MethodFilter = (typeof METHODS)[number]
+
+/**
+ * Render resolved route flags. A flag whose value is `true` carries no more
+ * information than its name, so only valued flags show one.
+ */
+function formatFlags(flags?: Record<string, unknown>): string {
+  const entries = Object.entries(flags ?? {})
+  if (!entries.length) return '—'
+  return entries.map(([k, v]) => (v === true ? k : `${k}=${JSON.stringify(v)}`)).join(', ')
+}
 
 export const RoutesTab: Component = () => {
   const [search, setSearch] = createSignal('')
@@ -108,6 +118,7 @@ export const RoutesTab: Component = () => {
                 <th>Controller</th>
                 <th>Handler</th>
                 <th>Middleware</th>
+                <th>Flags</th>
               </tr>
             </thead>
             <tbody>
@@ -123,6 +134,7 @@ export const RoutesTab: Component = () => {
                     <td class="text-text-muted text-xs">
                       {r.middleware.length ? r.middleware.join(', ') : '—'}
                     </td>
+                    <td class="text-text-muted text-xs">{formatFlags(r.flags)}</td>
                   </tr>
                 )}
               </For>

--- a/packages/devtools/src/adapter.ts
+++ b/packages/devtools/src/adapter.ts
@@ -20,6 +20,7 @@ import {
   type ComputedRef,
   getClassMeta,
   getMethodMeta,
+  getRouteFlags,
 } from '@forinda/kickjs'
 import {
   MemoryAnalyzer,
@@ -41,6 +42,12 @@ interface RouteInfo {
   controller: string
   handler: string
   middleware: string[]
+  /**
+   * Route flags in force, resolved method-over-class. Present so the dashboard
+   * can answer "why is this endpoint not requiring auth" from the route list
+   * itself, rather than by reading the controller.
+   */
+  flags: Record<string, unknown>
 }
 
 /** Per-route latency stats with percentile tracking */
@@ -1062,6 +1069,7 @@ export const DevToolsAdapter = defineAdapter<DevToolsOptions, DevToolsAdapterExt
               ...classMiddleware.map((m: any) => m.name || 'anonymous'),
               ...methodMiddleware.map((m: any) => m.name || 'anonymous'),
             ],
+            flags: Object.fromEntries(getRouteFlags(controllerClass, route.handlerName)),
           })
         }
       },

--- a/packages/kickjs/src/core/index.ts
+++ b/packages/kickjs/src/core/index.ts
@@ -297,7 +297,7 @@ export {
   type GroupAssetKeysResult,
 } from './asset-keys'
 
-export { defineRouteFlag, resolveRouteFlags } from './route-flag'
+export { defineRouteFlag, getRouteFlags, resolveRouteFlags } from './route-flag'
 export type {
   RouteFlag,
   RouteFlagContext,

--- a/packages/kickjs/src/core/route-flag.ts
+++ b/packages/kickjs/src/core/route-flag.ts
@@ -185,6 +185,34 @@ export type RouteFlagTest = string | readonly string[] | RouteFlagPredicate
  */
 export const ROUTE_SLOT: unique symbol = Symbol.for('kick.route') as never
 
+/**
+ * Resolve the flags in force for one handler, straight from the controller
+ * class — the same method-over-class result `buildRouteTable` computes.
+ *
+ * For consumers that see a controller and a method name rather than a live
+ * request: an adapter's `onRouteMount`, an OpenAPI generator, a DevTools route
+ * listing. Inside a request, read `ctx.route.flags` instead — it is already
+ * resolved.
+ *
+ * ```ts
+ * // Mark flagged routes public in the OpenAPI spec:
+ * SwaggerAdapter({
+ *   bearerAuth: true,
+ *   securityResolver: ({ controllerClass, handlerName }) =>
+ *     getRouteFlags(controllerClass, handlerName).has('auth.public') ? null : undefined,
+ * })
+ * ```
+ */
+export function getRouteFlags(
+  controllerClass: object,
+  handlerName: string,
+): ReadonlyMap<string, unknown> {
+  return resolveRouteFlags(
+    getClassFlagDeclarations(controllerClass),
+    getMethodFlagDeclarations(controllerClass, handlerName),
+  )
+}
+
 /** Read the class-level declarations off a controller. */
 export function getClassFlagDeclarations(controllerClass: object): RouteFlagDeclaration[] {
   return getClassMeta<RouteFlagDeclaration[]>(METADATA.CLASS_FLAGS, controllerClass, [])

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -31,7 +31,7 @@ export {
   type SseHandler,
 } from './http/context'
 export { defineHttpContextDecorator } from './http/define-http-context-decorator'
-export { defineRouteFlag } from './core/route-flag'
+export { defineRouteFlag, getRouteFlags } from './core/route-flag'
 export type {
   RouteFlag,
   RouteFlagContext,

--- a/packages/swagger/__tests__/swagger.test.ts
+++ b/packages/swagger/__tests__/swagger.test.ts
@@ -17,7 +17,15 @@ import {
   redocHtml,
   type SchemaParser,
 } from '@forinda/kickjs-swagger'
-import { Controller, Get, Post, Delete, Container } from '@forinda/kickjs'
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Container,
+  defineRouteFlag,
+  getRouteFlags,
+} from '@forinda/kickjs'
 
 // ── Decorator Metadata Tests ──────────────────────────────────────────
 
@@ -715,6 +723,128 @@ describe('buildOpenAPISpec — security (Swagger-owned, not coupled to any auth 
     })
     expect(spec.paths['/api/secret']?.get?.security).toEqual([{ BearerAuth: [] }])
     expect(spec.paths['/api/health']?.get?.security).toBeUndefined()
+  })
+
+  it('options.publicFlag reads the flag name the project chose', () => {
+    // The flag name is configuration, not a constant: one project's
+    // 'auth.public' is another's 'public'. Swagger looks up whichever name it
+    // was given, so the spec agrees with the runtime without a second
+    // annotation on every route.
+    const Open = defineRouteFlag('my.open')
+
+    @Controller()
+    @ApiSecurity('BearerAuth')
+    class NamedFlagController {
+      @Open
+      @Get('/open')
+      open() {}
+
+      @Get('/secret')
+      secret() {}
+    }
+
+    registerControllerForDocs(NamedFlagController, '/api')
+    const spec = buildOpenAPISpec({ publicFlag: 'my.open' })
+
+    expect(spec.paths['/api/open']?.get?.security).toBeUndefined()
+    expect(spec.paths['/api/secret']?.get?.security).toEqual([{ BearerAuth: [] }])
+  })
+
+  it('options.publicFlag accepts several names', () => {
+    const A = defineRouteFlag('team.public')
+    const B = defineRouteFlag('probe')
+
+    @Controller()
+    @ApiSecurity('BearerAuth')
+    class MultiFlagController {
+      @A
+      @Get('/a')
+      a() {}
+
+      @B
+      @Get('/b')
+      b() {}
+
+      @Get('/c')
+      c() {}
+    }
+
+    registerControllerForDocs(MultiFlagController, '/api')
+    const spec = buildOpenAPISpec({ publicFlag: ['team.public', 'probe'] })
+
+    expect(spec.paths['/api/a']?.get?.security).toBeUndefined()
+    expect(spec.paths['/api/b']?.get?.security).toBeUndefined()
+    expect(spec.paths['/api/c']?.get?.security).toEqual([{ BearerAuth: [] }])
+  })
+
+  it('publicFlag inherits from the class and a method can turn it off', () => {
+    const Public = defineRouteFlag('auth.public')
+
+    @Public
+    @Controller()
+    @ApiSecurity('BearerAuth')
+    class InheritedFlagController {
+      @Get('/open')
+      open() {}
+
+      @Public(false)
+      @Get('/admin')
+      admin() {}
+    }
+
+    registerControllerForDocs(InheritedFlagController, '/api')
+    const spec = buildOpenAPISpec({ publicFlag: 'auth.public' })
+
+    expect(spec.paths['/api/open']?.get?.security).toBeUndefined()
+    // The flag is absent here, not false — so the class security applies.
+    expect(spec.paths['/api/admin']?.get?.security).toEqual([{ BearerAuth: [] }])
+  })
+
+  it('an explicit securityResolver still wins over publicFlag', () => {
+    const Public = defineRouteFlag('auth.public')
+
+    @Public
+    @Controller()
+    class OverriddenController {
+      @Get('/open')
+      open() {}
+    }
+
+    registerControllerForDocs(OverriddenController, '/api')
+    const spec = buildOpenAPISpec({
+      publicFlag: 'auth.public',
+      securityResolver: () => 'BearerAuth',
+    })
+
+    expect(spec.paths['/api/open']?.get?.security).toEqual([{ BearerAuth: [] }])
+  })
+
+  it('securityResolver + getRouteFlags marks flagged routes public', () => {
+    // Phase 4 of route-flags-design.md: the OpenAPI spec reads the same flag
+    // the auth contributor and the guards read, so a route declared public in
+    // one place is documented public without a second annotation.
+    const Public = defineRouteFlag('auth.public')
+
+    @Public
+    @Controller()
+    @ApiSecurity('BearerAuth')
+    class FlagController {
+      @Get('/open')
+      open() {}
+
+      @Public(false)
+      @Get('/secret')
+      secret() {}
+    }
+
+    registerControllerForDocs(FlagController, '/api')
+    const spec = buildOpenAPISpec({
+      securityResolver: ({ controllerClass, handlerName }) =>
+        getRouteFlags(controllerClass, handlerName).has('auth.public') ? null : undefined,
+    })
+
+    expect(spec.paths['/api/open']?.get?.security).toBeUndefined()
+    expect(spec.paths['/api/secret']?.get?.security).toEqual([{ BearerAuth: [] }])
   })
 
   it('refuses to silently synthesise a scheme for non-BearerAuth names — adopter must declare', () => {

--- a/packages/swagger/src/openapi-builder.ts
+++ b/packages/swagger/src/openapi-builder.ts
@@ -8,6 +8,7 @@ import {
   getMethodMeta,
   getMethodMetaOrUndefined,
   hasClassMeta,
+  getRouteFlags,
 } from '@forinda/kickjs'
 import {
   SWAGGER_KEYS,
@@ -136,6 +137,27 @@ export interface SwaggerOptions {
    * })
    * ```
    */
+  /**
+   * Name of the route flag that marks an endpoint public — the spec then reads
+   * the same declaration the runtime does, instead of asking for a second
+   * annotation that can drift from it.
+   *
+   * The name is configuration rather than a constant because the framework
+   * deliberately names no flags: one project's `auth.public` is another's
+   * `public` or `security.none`. Pass a list to accept several.
+   *
+   * ```ts
+   * // src/flags.ts
+   * export const Public = defineRouteFlag('auth.public')
+   *
+   * SwaggerAdapter({ bearerAuth: true, publicFlag: 'auth.public' })
+   * ```
+   *
+   * Checked after {@link ApiPublic} and {@link securityResolver}, before the
+   * `@ApiSecurity` / `@ApiBearerAuth` decorators — so an explicit resolver
+   * still wins, and a flag still overrides class-level security.
+   */
+  publicFlag?: string | readonly string[]
   securityResolver?: (
     ctx: SecurityResolverContext,
   ) => string | ApiSecurityRequirement | (string | ApiSecurityRequirement)[] | null | undefined
@@ -707,8 +729,9 @@ function buildOpenAPISpecUncached(options: SwaggerOptions = {}): any {
       //      — adopter-provided bridge for external auth libraries.
       //        Returning `null` is "explicitly public" (same as
       //        @ApiPublic); a value or array drives the requirements.
-      //   3. @ApiSecurity / @ApiBearerAuth on the method.
-      //   4. @ApiSecurity / @ApiBearerAuth on the class.
+      //   3. options.publicFlag — a route flag naming this endpoint public.
+      //   4. @ApiSecurity / @ApiBearerAuth on the method.
+      //   5. @ApiSecurity / @ApiBearerAuth on the class.
       const isPublicMethod = !!getMethodMetaOrUndefined<boolean>(
         SWAGGER_KEYS.PUBLIC,
         controllerClass,
@@ -728,6 +751,22 @@ function buildOpenAPISpecUncached(options: SwaggerOptions = {}): any {
           : normaliseSecurity(resolverOutput)
       const resolverPublic = resolverOutput === null
 
+      // A route flag naming this endpoint public. Resolved from the controller
+      // metadata, so it is the same method-over-class value `ctx.route.flags`
+      // carries at request time.
+      const publicFlagNames =
+        options.publicFlag === undefined
+          ? []
+          : typeof options.publicFlag === 'string'
+            ? [options.publicFlag]
+            : options.publicFlag
+      const flagPublic =
+        publicFlagNames.length > 0 &&
+        (() => {
+          const flags = getRouteFlags(controllerClass, route.handlerName)
+          return publicFlagNames.some((name) => flags.has(name))
+        })()
+
       let requirements: ApiSecurityRequirement[] | undefined
       // Track whether the resolution path came from `@ApiBearerAuth`
       // (any name) so a bearer-shaped scheme gets auto-synthesised
@@ -738,7 +777,7 @@ function buildOpenAPISpecUncached(options: SwaggerOptions = {}): any {
       // generic — adopters must declare custom schemes via
       // `SwaggerOptions.securitySchemes` when using those paths.
       let bearerAuthSourced = false
-      if (isPublicMethod || resolverPublic) {
+      if (isPublicMethod || resolverPublic || (flagPublic && resolverSecurity === undefined)) {
         requirements = undefined
       } else if (resolverSecurity && resolverSecurity.length > 0) {
         requirements = resolverSecurity


### PR DESCRIPTION
Phase 4 of [`route-flags-design.md`](https://github.com/forinda/kick-js/blob/main/route-flags-design.md)
— the readers. Independent of #634 (phase 2); both build on the phase 1 core in #631.

## `getRouteFlags(controllerClass, handlerName)`

Resolves a route's flags **outside a request** — the same method-over-class result
`ctx.route.flags` carries, for consumers that see a controller and a method name rather than a
live ctx: an adapter's `onRouteMount`, spec generation, tooling.

## Swagger: `publicFlag`

```ts
export const Public = defineRouteFlag('auth.public')

SwaggerAdapter({ bearerAuth: true, publicFlag: 'auth.public' })
```

```ts
@Public                      // whole controller documented public
@Controller()
class WebhooksController {
  @Get('/health')  health(ctx) {}

  @Public(false)             // documented as secured again
  @Post('/admin')  admin(ctx) {}
}
```

**The flag name is the option, not a constant** — that's the point. The framework deliberately
names no flags, so one project's `auth.public` is another's `public` or `security.none`. Naming it
lets the spec read the same declaration the runtime reads, instead of asking for a second
annotation that drifts from it. A list accepts several:

```ts
SwaggerAdapter({ bearerAuth: true, publicFlag: ['auth.public', 'health.probe'] })
```

Resolution order: `@ApiPublic` → `securityResolver` → **`publicFlag`** → `@ApiSecurity` /
`@ApiBearerAuth` (method, then class). So an explicit resolver still wins, and a flag still
overrides class-level security.

Swagger needed no new plumbing beyond the option — `securityResolver` already existed for exactly
this kind of bridge, and `publicFlag` is its common case spelled as config. For anything richer
(reading a flag's *value*, combining two), `securityResolver` + `getRouteFlags` still covers it,
and there's a test for that too.

## DevTools: flags in the route list

`GET /_debug/routes` now carries `flags` per entry, and the dashboard's Routes tab shows them in a
Flags column:

```json
{
  "method": "GET",
  "path": "/api/v1/health",
  "controller": "HealthController",
  "handler": "live",
  "middleware": [],
  "flags": { "auth.public": true }
}
```

Only flags **in force** appear — one turned off at the method is absent, not `false` — so the
dashboard agrees with every other consumer. Valued flags render as `rate.limit={"rpm":10}`.

That makes "why does this endpoint not require auth" answerable from the route list instead of by
reading the controller.

## Verification

6 new tests across swagger and devtools: the named lookup, a list of names, class inheritance with
a method-level opt-out, an explicit resolver overriding the flag, the `getRouteFlags` +
`securityResolver` form, and `/_debug/routes` reporting resolved flags.

Repo suite: **311 files, 3248 tests, all passing.**

## Note

`docs/guide/route-flags.md` arrives with #634, so the reader docs here live in the Swagger and
DevTools guides and link to it. If #634 merges first the links resolve immediately; if this merges
first they're dead for one merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
