### PR TITLE
feat(kickjs): rateLimit({ exemptWhen }) via a boot-built route policy table

### DIFF
--- a/.changeset/route-policy-table.md
+++ b/.changeset/route-policy-table.md
@@ -1,0 +1,30 @@
+---
+'@forinda/kickjs': minor
+---
+
+`rateLimit({ exemptWhen })` — the app-wide limiter reads route flags (phase 3 of `route-flags-design.md`).
+
+`rateLimit()` runs before route matching, so it has no `ctx.route` to read, and its only exemption handle was `skipPaths` — an exact pathname that cannot express `/probe/:name` and drifts when `apiPrefix` or a module's `version` changes.
+
+It now reads a **policy table**: every mounted route registers its method, path and resolved flags at boot, and the limiter looks up the incoming request.
+
+```ts
+const Public = defineRouteFlag('auth.public')
+
+bootstrap({
+  modules,
+  middlewares: [rateLimit({ max: 60, exemptWhen: 'auth.public' })],
+})
+```
+
+```ts
+@Public
+@Get('/probe/:name')   // exempt for every :name — skipPaths could not say this
+probe(ctx: RequestContext) {}
+```
+
+**A request matching no route matches no flags and stays limited.** That is why this middleware keeps running before matching rather than becoming a route-scoped guard: an abuse control has to see traffic that hits nothing.
+
+`exemptWhen` takes the same name / any-of list / predicate as everywhere else. `skipPaths` still applies to paths that are not routes at all — a static mount, a proxied prefix — which no flag can describe.
+
+Pre-match middleware of your own can read the table by declaring the slot with the exported `bindRoutePolicy(handler, receive)`. The table is per-application, not a global, so two apps in one process never see each other's routes.

--- a/docs/guide/rate-limiting.md
+++ b/docs/guide/rate-limiting.md
@@ -140,6 +140,30 @@ rateLimitGuard({
 })
 ```
 
-The connect-style `rateLimit()` keeps `skipPaths` / `skip`: it runs before route
-matching, which is what you want for an abuse control that must also see traffic
-matching no route — but it cannot read flags. See [route flags](./route-flags.md).
+### The app-wide limiter reads flags too
+
+`rateLimit()` runs before route matching, so there is no `ctx.route` for it to read. It gets the
+flags a different way: every mounted route registers its method, path and flags in a table at
+boot, and the limiter looks the incoming request up against it.
+
+```ts
+bootstrap({
+  modules,
+  middlewares: [rateLimit({ max: 60, exemptWhen: 'auth.public' })],
+})
+```
+
+That covers what `skipPaths` could not — a flagged route with a param is exempt by declaration:
+
+```ts
+@Public
+@Get('/probe/:name') // exempt for every :name
+probe(ctx: RequestContext) {}
+```
+
+**A request matching no route matches no flags, and stays limited.** That is the reason to keep
+this middleware pre-match rather than replacing it with a guard: an abuse control has to see
+traffic that hits nothing, and a route-scoped guard never does.
+
+Keep `skipPaths` for paths that are not routes at all — a static mount, a proxied prefix. A flag
+cannot describe those, because there is no handler to put it on.

--- a/docs/guide/route-flags.md
+++ b/docs/guide/route-flags.md
@@ -102,7 +102,39 @@ This is what makes exemption composable. Without it, the only way to opt out of 
 export class ApiController {}
 ```
 
-Both are ctx-style, so they run inside the matched route. The connect-style `csrf()` and `rateLimit()` run _before_ route matching — they cover requests that match no route, but they cannot read flags. That is a real choice, not a migration.
+Both are ctx-style, so they run inside the matched route.
+
+### Middleware that runs before routing
+
+`rateLimit()` is mounted app-wide and runs before a route is matched, so it has no `ctx.route`. It reads flags from a **policy table** instead: every mounted route registers its method, path and flags at boot, and the limiter looks up the incoming request.
+
+```ts
+bootstrap({ middlewares: [rateLimit({ max: 60, exemptWhen: 'auth.public' })] })
+```
+
+A request matching no route matches no flags and stays limited — which is exactly why this one keeps running pre-match instead of becoming a guard.
+
+Your own pre-match middleware can read the same table:
+
+```ts
+import { bindRoutePolicy, type RoutePolicyTable } from '@forinda/kickjs'
+
+export function auditUnflagged() {
+  let policy: RoutePolicyTable | undefined
+  const handler = (req, _res, next) => {
+    const flags = policy?.lookup(req.method, req.url ?? '/')
+    if (!flags?.has('audit.skip')) log(req.url)
+    next()
+  }
+  return bindRoutePolicy(handler, (table) => {
+    policy = table
+  })
+}
+```
+
+The Application hands the table to any middleware declaring that slot, once routes are mounted. It is per-application rather than a global, so two apps in one process never see each other's routes.
+
+The connect-style `csrf()` has no table equivalent — a token check on an unmatched route is meaningless, so use `csrfGuard()` where you want flags.
 
 ## Matching: name, list, or predicate
 

--- a/docs/guide/route-flags.md
+++ b/docs/guide/route-flags.md
@@ -136,6 +136,37 @@ The Application hands the table to any middleware declaring that slot, once rout
 
 The connect-style `csrf()` has no table equivalent — a token check on an unmatched route is meaningless, so use `csrfGuard()` where you want flags.
 
+### Readers: OpenAPI and DevTools
+
+Two consumers read flags without running per request.
+
+**OpenAPI.** Name the flag your project uses for public endpoints and the spec reads the same
+declaration the runtime does, instead of a second annotation that can drift from it:
+
+```ts
+SwaggerAdapter({ bearerAuth: true, publicFlag: 'auth.public' })
+SwaggerAdapter({ bearerAuth: true, publicFlag: ['auth.public', 'health.probe'] })
+```
+
+The name is configuration because the framework names no flags — see [Naming](#naming). For
+anything richer than a name (a flag's value, two flags combined), `securityResolver` plus
+`getRouteFlags` covers it:
+
+```ts
+SwaggerAdapter({
+  securityResolver: ({ controllerClass, handlerName }) =>
+    getRouteFlags(controllerClass, handlerName).has('auth.public') ? null : undefined,
+})
+```
+
+**DevTools.** `GET /_debug/routes` reports each route's resolved flags, and the dashboard's Routes
+tab shows them in a Flags column — so "why does this endpoint not require auth" is answerable from
+the route list rather than by reading the controller.
+
+`getRouteFlags(controllerClass, handlerName)` is the out-of-request resolver behind both: the same
+method-over-class result `ctx.route.flags` carries, for consumers that see a controller and a
+method name rather than a live request.
+
 ## Matching: name, list, or predicate
 
 Every `skipWhen` / `onlyWhen` / `exemptWhen` accepts the same three forms:

--- a/packages/kickjs/__tests__/route-policy-table.test.ts
+++ b/packages/kickjs/__tests__/route-policy-table.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Phase 3 of `route-flags-design.md`: the connect-style `rateLimit()` runs
+ * before route matching, so it reads flags from a table built at boot instead
+ * of from `ctx.route`.
+ *
+ * The case that justifies keeping it pre-match at all is the last one here —
+ * a request matching no route is still limited.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import {
+  Application,
+  Container,
+  Controller,
+  Get,
+  defineRouteFlag,
+  rateLimit,
+  type AppModule,
+  type ModuleRoutes,
+  type RequestContext,
+} from '../src/index'
+import { RoutePolicyTable } from '../src/core/route-policy'
+
+const Public = defineRouteFlag('auth.public')
+
+const mod = (controller: unknown): AppModule =>
+  ({ routes: (): ModuleRoutes => ({ path: '/t', controller }) }) as AppModule
+
+describe('RoutePolicyTable', () => {
+  it('matches a literal path', () => {
+    const t = new RoutePolicyTable()
+    t.add('GET', '/api/v1/health', new Map([['auth.public', true]]))
+    expect(t.lookup('GET', '/api/v1/health').has('auth.public')).toBe(true)
+    expect(t.lookup('GET', '/api/v1/other').size).toBe(0)
+  })
+
+  it('matches a param segment — what an exact path list cannot do', () => {
+    const t = new RoutePolicyTable()
+    t.add('POST', '/api/v1/webhooks/:provider', new Map([['csrf.exempt', true]]))
+    expect(t.lookup('POST', '/api/v1/webhooks/stripe').has('csrf.exempt')).toBe(true)
+    expect(t.lookup('POST', '/api/v1/webhooks/stripe/extra').size).toBe(0)
+  })
+
+  it('is method-scoped', () => {
+    const t = new RoutePolicyTable()
+    t.add('GET', '/api/v1/thing', new Map([['auth.public', true]]))
+    expect(t.lookup('POST', '/api/v1/thing').size).toBe(0)
+  })
+
+  it('ignores routes with no flags, so lookups stay cheap', () => {
+    const t = new RoutePolicyTable()
+    t.add('GET', '/a', new Map())
+    t.add('GET', '/b', undefined)
+    t.add('GET', '/c', new Map([['x', true]]))
+    expect(t.size).toBe(1)
+  })
+
+  it('tolerates a trailing slash', () => {
+    const t = new RoutePolicyTable()
+    t.add('GET', '/api/v1/health', new Map([['auth.public', true]]))
+    expect(t.lookup('GET', '/api/v1/health/').has('auth.public')).toBe(true)
+  })
+})
+
+describe('rateLimit({ exemptWhen }) — pre-match, flag-aware', () => {
+  beforeEach(() => Container.reset())
+
+  const makeController = () => {
+    @Controller()
+    class C {
+      @Get('/limited')
+      limited(ctx: RequestContext) {
+        ctx.json({ ok: true })
+      }
+
+      @Public
+      @Get('/health')
+      health(ctx: RequestContext) {
+        ctx.json({ ok: true })
+      }
+
+      @Public
+      @Get('/probe/:name')
+      probe(ctx: RequestContext) {
+        ctx.json({ name: ctx.params.name })
+      }
+    }
+    return C
+  }
+
+  const boot = async (options: Record<string, unknown>) => {
+    const app = new Application({
+      modules: [mod(makeController())],
+      apiPrefix: '/api',
+      defaultVersion: 1,
+      ...options,
+    } as never)
+    await app.setup()
+    return app
+  }
+
+  it('limits an unflagged route', async () => {
+    const app = await boot({ middlewares: [rateLimit({ max: 1, exemptWhen: 'auth.public' })] })
+    const h = app.handle.bind(app)
+    const first = await request(h).get('/api/v1/t/limited')
+    const second = await request(h).get('/api/v1/t/limited')
+    expect({ first: first.status, second: second.status }).toEqual({ first: 200, second: 429 })
+  })
+
+  it('exempts a flagged route, before the route is matched', async () => {
+    const app = await boot({ middlewares: [rateLimit({ max: 1, exemptWhen: 'auth.public' })] })
+    const h = app.handle.bind(app)
+    const statuses: number[] = []
+    for (let i = 0; i < 4; i++) statuses.push((await request(h).get('/api/v1/t/health')).status)
+    expect(statuses).toEqual([200, 200, 200, 200])
+  })
+
+  it('exempts a flagged route with a param — `skipPaths` cannot express this', async () => {
+    const app = await boot({ middlewares: [rateLimit({ max: 1, exemptWhen: 'auth.public' })] })
+    const h = app.handle.bind(app)
+    const first = await request(h).get('/api/v1/t/probe/alpha')
+    const second = await request(h).get('/api/v1/t/probe/beta')
+    expect({ first: first.status, second: second.status }).toEqual({ first: 200, second: 200 })
+  })
+
+  it('still limits a request that matches no route at all', async () => {
+    // The reason this middleware stays pre-match: a route-scoped guard never
+    // sees this traffic, and an abuse control must.
+    const app = await boot({ middlewares: [rateLimit({ max: 1, exemptWhen: 'auth.public' })] })
+    const h = app.handle.bind(app)
+    const first = await request(h).get('/api/v1/t/nope')
+    const second = await request(h).get('/api/v1/t/nope')
+    expect({ first: first.status, second: second.status }).toEqual({ first: 404, second: 429 })
+  })
+
+  it('a list and a predicate work the same as everywhere else', async () => {
+    const app = await boot({
+      middlewares: [rateLimit({ max: 1, exemptWhen: ['nope.one', 'auth.public'] })],
+    })
+    const h = app.handle.bind(app)
+    const statuses = [
+      (await request(h).get('/api/v1/t/health')).status,
+      (await request(h).get('/api/v1/t/health')).status,
+    ]
+    expect(statuses).toEqual([200, 200])
+  })
+
+  it('without exemptWhen nothing changes', async () => {
+    const app = await boot({ middlewares: [rateLimit({ max: 1 })] })
+    const h = app.handle.bind(app)
+    const first = await request(h).get('/api/v1/t/health')
+    const second = await request(h).get('/api/v1/t/health')
+    expect({ first: first.status, second: second.status }).toEqual({ first: 200, second: 429 })
+  })
+})

--- a/packages/kickjs/src/core/index.ts
+++ b/packages/kickjs/src/core/index.ts
@@ -298,6 +298,7 @@ export {
 } from './asset-keys'
 
 export { defineRouteFlag, resolveRouteFlags } from './route-flag'
+export { RoutePolicyTable, bindRoutePolicy, offerRoutePolicy } from './route-policy'
 export type {
   RouteFlag,
   RouteFlagContext,

--- a/packages/kickjs/src/core/route-policy.ts
+++ b/packages/kickjs/src/core/route-policy.ts
@@ -1,0 +1,111 @@
+/**
+ * The route policy table — phase 3 of `route-flags-design.md`.
+ *
+ * Middleware mounted app-wide (the connect-style `rateLimit()`, `csrf()`) runs
+ * *before* a route is matched, so it cannot read `ctx.route.flags`: there is no
+ * route yet. That is also the reason to keep it there — an abuse control has to
+ * see traffic that matches nothing, which a route-scoped guard never does.
+ *
+ * So the flags come to it instead. Every mounted route registers its method,
+ * full path and resolved flags here at boot; a global middleware asks the table
+ * what flags *would* apply to an incoming method + pathname.
+ *
+ * The table is per-Application, handed to middleware that opts in via
+ * {@link bindRoutePolicy}. Nothing global: two apps in one process (a test file,
+ * an embedded admin app) each get their own.
+ */
+
+/** Flags for one mounted route, keyed for lookup by an incoming request. */
+interface PolicyEntry {
+  /** Compiled from the mounted path — `/users/:id` → `^/users/([^/]+)$`. */
+  readonly pattern: RegExp
+  readonly flags: ReadonlyMap<string, unknown>
+}
+
+const EMPTY: ReadonlyMap<string, unknown> = new Map()
+
+/**
+ * Turn a mounted path into a matcher.
+ *
+ * Deliberately small: `:param` matches one segment, `*` matches the rest, and
+ * everything else is literal. This is a *lookup* over paths the engine already
+ * chose to mount, not a second router — if it ever disagrees with the engine,
+ * the answer is fewer features here, not more.
+ */
+function compile(path: string): RegExp {
+  const source = path
+    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\/:[^/]+/g, '/([^/]+)')
+    .replace(/\*/g, '.*')
+  return new RegExp(`^${source}/?$`)
+}
+
+export class RoutePolicyTable {
+  /** Bucketed by method: an incoming request only scans its own verb. */
+  private readonly byMethod = new Map<string, PolicyEntry[]>()
+
+  add(method: string, path: string, flags: ReadonlyMap<string, unknown> | undefined): void {
+    if (!flags || flags.size === 0) return // nothing to say about this route
+    const verb = method.toUpperCase()
+    const bucket = this.byMethod.get(verb) ?? []
+    bucket.push({ pattern: compile(path), flags })
+    this.byMethod.set(verb, bucket)
+  }
+
+  /**
+   * Flags that apply to `method pathname`, or an empty map when the path
+   * matches no flagged route — including when it matches no route at all,
+   * which is exactly the traffic this exists to keep visible.
+   */
+  lookup(method: string, pathname: string): ReadonlyMap<string, unknown> {
+    const bucket = this.byMethod.get(method.toUpperCase())
+    if (!bucket) return EMPTY
+    for (const entry of bucket) {
+      if (entry.pattern.test(pathname)) return entry.flags
+    }
+    return EMPTY
+  }
+
+  /** Drop everything — the Application rebuilds on every HMR reload. */
+  clear(): void {
+    this.byMethod.clear()
+  }
+
+  get size(): number {
+    let total = 0
+    for (const bucket of this.byMethod.values()) total += bucket.length
+    return total
+  }
+}
+
+/**
+ * Slot a middleware exposes to say "hand me the policy table once routes are
+ * mounted". The Application calls it during setup; middleware that never
+ * declares it is untouched.
+ */
+export const ROUTE_POLICY_SLOT: unique symbol = Symbol.for('kick.routePolicy') as never
+
+/** A middleware that accepts the policy table. */
+export interface RoutePolicyAware {
+  [ROUTE_POLICY_SLOT]?: (table: RoutePolicyTable) => void
+}
+
+/**
+ * Declare that `handler` wants the policy table.
+ *
+ * Explicit hand-off rather than a module-level singleton, so the table a
+ * middleware reads is always the one belonging to the app that mounted it.
+ */
+export function bindRoutePolicy<T extends object>(
+  handler: T,
+  receive: (table: RoutePolicyTable) => void,
+): T {
+  Object.defineProperty(handler, ROUTE_POLICY_SLOT, { value: receive, enumerable: false })
+  return handler
+}
+
+/** Hand the table to a middleware if it declared the slot. */
+export function offerRoutePolicy(handler: unknown, table: RoutePolicyTable): void {
+  const receive = (handler as RoutePolicyAware | null)?.[ROUTE_POLICY_SLOT]
+  if (typeof receive === 'function') receive(table)
+}

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -23,6 +23,7 @@ import {
   MutableModuleRegistry,
 } from '../core'
 import { moduleRouteMissingControllerError } from '../core/kick-errors'
+import { RoutePolicyTable, offerRoutePolicy } from '../core/route-policy'
 import {
   disposeAll,
   drainDisposables,
@@ -492,6 +493,12 @@ export class Application {
   private container: Container
   private httpServer: http.Server | null = null
   private readonly adapters: AppAdapter[]
+  /**
+   * Flags of every mounted route, for middleware that runs before routing and
+   * therefore cannot read `ctx.route` (the connect-style rate limiter). Handed
+   * to middleware that declares the slot — see `core/route-policy.ts`.
+   */
+  private readonly routePolicy = new RoutePolicyTable()
 
   private readonly plugins: KickPlugin[]
 
@@ -971,6 +978,7 @@ export class Application {
               const fullPath = joinPaths(mountPath, entry.path)
               assertRouteUnique(seenRoutes, entry.method, fullPath, owner)
               mountedPaths.push({ method: entry.method, path: fullPath })
+              this.routePolicy.add(entry.method, fullPath, entry.meta.flags)
             }
             this.runtime.mountRoutes(this.app, [{ mountPath, routes: routeTable }])
           } else {
@@ -1051,6 +1059,16 @@ export class Application {
     // a chance to match before the catch-all 404 fires.
     // `onNotFound` / `onError` still win — the route table only sharpens the
     // DEFAULT, so an app that supplies its own catch-all is unaffected.
+    // Routes are mounted: middleware that asked for the policy table can have
+    // it now. Global middleware was mounted earlier — its closure reads the
+    // table per request, so binding after the fact is in time.
+    for (const entry of this.options.middlewares ?? []) {
+      offerRoutePolicy(typeof entry === 'function' ? entry : entry.handler, this.routePolicy)
+    }
+    for (const adapter of this.adapters) {
+      for (const mw of adapter.middleware?.() ?? []) offerRoutePolicy(mw.handler, this.routePolicy)
+    }
+
     this.runtime.setNotFound(this.app, this.options.onNotFound ?? notFoundHandler(mountedPaths))
     this.runtime.setErrorHandler(this.app, this.options.onError ?? errorHandler())
   }

--- a/packages/kickjs/src/http/middleware/rate-limit.ts
+++ b/packages/kickjs/src/http/middleware/rate-limit.ts
@@ -1,3 +1,5 @@
+import { matchesFlagTest, type RouteFlagTest } from '../../core/route-flag'
+import { bindRoutePolicy, type RoutePolicyTable } from '../../core/route-policy'
 import { sendJson } from './respond'
 import type { Request, Response, NextFunction } from 'express'
 import { resolveClientIp, resolvePathname, type ClientRequestLike } from '../client-ip'
@@ -29,6 +31,25 @@ export interface RateLimitOptions {
   skip?: (req: Request) => boolean
   /** Paths to exclude from rate limiting */
   skipPaths?: string[]
+  /**
+   * Skip limiting on routes carrying a route flag — a name, a list of names
+   * (any-of), or a predicate.
+   *
+   * This middleware runs before route matching, so it has no `ctx.route` to
+   * read. Instead the Application hands it a table of every mounted route's
+   * flags at boot, and the incoming method + pathname is looked up against it.
+   * Requests matching no route match no flags — which is the point of limiting
+   * here rather than in a route-scoped guard.
+   *
+   * ```ts
+   * const Public = defineRouteFlag('auth.public')
+   * bootstrap({ middlewares: [rateLimit({ max: 60, exemptWhen: 'auth.public' })] })
+   * ```
+   *
+   * Prefer `skipPaths` only for paths that are not routes at all (a static
+   * mount, a proxied prefix); a flag cannot describe those.
+   */
+  exemptWhen?: RouteFlagTest
 }
 
 interface MemoryStoreEntry {
@@ -129,13 +150,30 @@ export function rateLimit(options: RateLimitOptions = {}) {
   const store = options.store ?? new MemoryStore(windowMs)
   const skip = options.skip
   const skipPaths = new Set(options.skipPaths ?? [])
+  const exemptWhen = options.exemptWhen
 
-  return async (req: Request, res: Response, next: NextFunction) => {
+  // Filled in by the Application once routes are mounted, via the slot
+  // declared below. Absent when this middleware runs outside an Application
+  // (a bare connect stack, a unit test) — `exemptWhen` then matches nothing,
+  // which fails closed: everything stays limited.
+  let policy: RoutePolicyTable | undefined
+
+  const handler = async (req: Request, res: Response, next: NextFunction) => {
     // Skip if path is in the skip list
     // `req.path` is Express-only; `has(undefined)` never matched, so
     // configured skips were silently dead on the other runtimes.
-    if (skipPaths.has(resolvePathname(req as ClientRequestLike))) {
+    const pathname = resolvePathname(req as ClientRequestLike)
+    if (skipPaths.has(pathname)) {
       return next()
+    }
+
+    // Flag exemption: ask the table what flags the matched route WOULD carry.
+    // A request matching no route matches no flags and stays limited.
+    if (exemptWhen !== undefined && policy) {
+      const flags = policy.lookup(String(req.method ?? 'GET'), pathname)
+      if (matchesFlagTest(exemptWhen, flags)) {
+        return next()
+      }
     }
 
     // Skip if the skip function returns true
@@ -159,4 +197,8 @@ export function rateLimit(options: RateLimitOptions = {}) {
 
     next()
   }
+
+  return bindRoutePolicy(handler, (table) => {
+    policy = table
+  })
 }

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -32,6 +32,7 @@ export {
 } from './http/context'
 export { defineHttpContextDecorator } from './http/define-http-context-decorator'
 export { defineRouteFlag } from './core/route-flag'
+export { bindRoutePolicy, type RoutePolicyTable } from './core/route-policy'
 export type {
   RouteFlag,
   RouteFlagContext,

--- a/route-flags-design.md
+++ b/route-flags-design.md
@@ -1,11 +1,12 @@
 # Route Flags — a shared vocabulary for "this endpoint is open"
 
-> Status: **phases 1–2 implemented.** Phase 1: `defineRouteFlag`, `ctx.route`,
+> Status: **phases 1–3 implemented.** Phase 1: `defineRouteFlag`, `ctx.route`,
 > contributor `skipWhen` / `onlyWhen`. Phase 2: `exemptWhen` on the ctx-style
 > guards — `csrfGuard()` (new) and `rateLimitGuard()`. See
 > `packages/kickjs/__tests__/route-flags.test.ts` and `route-flag-guards.test.ts`.
-> Phase 3 (the connect-style `rateLimit()` policy table) and phase 4 (OpenAPI +
-> DevTools readers) are still proposals.
+> Phase 3: the policy table, so the pre-match `rateLimit()` reads flags without
+> giving up the traffic a guard cannot see. Phase 4 (OpenAPI + DevTools readers)
+> ships alongside in its own PR.
 > Decisions taken: core primitive in `@forinda/kickjs`; auth first, other consumers follow;
 > declaration must sit on the controller and propagate to its routes.
 


### PR DESCRIPTION
> **Stacked on #634** (phase 2) — it needs `matchesFlagTest` from there. Merge #634 first, or this
> shows its commits too.

Phase 3 of [`route-flags-design.md`](https://github.com/forinda/kick-js/blob/main/route-flags-design.md),
and the last case the ctx-style guards could not cover.

## The problem

`rateLimit()` is mounted app-wide and runs *before* route matching, so there is no `ctx.route` to
read. Its only exemption handle was `skipPaths` — an exact pathname, which cannot express
`/probe/:name` and keeps parsing after an `apiPrefix` or `version` change that silently voids it.

Moving it into a route-scoped guard would fix the flags and break the middleware: an abuse control
has to see traffic that matches **no** route, and a guard never does.

## The fix — the flags come to it

Every mounted route registers method + full path + resolved flags in a `RoutePolicyTable` during
`setup()`. The limiter looks up the incoming request:

```ts
const Public = defineRouteFlag('auth.public')

bootstrap({ modules, middlewares: [rateLimit({ max: 60, exemptWhen: 'auth.public' })] })
```

```ts
@Public
@Get('/probe/:name')   // exempt for every :name — skipPaths could not say this
probe(ctx: RequestContext) {}
```

**A request matching no route matches no flags and stays limited.** There's a test asserting
exactly that (404, then 429 on the retry) — it's the property that justifies keeping this
middleware where it is.

## Design notes

- **The table is handed over, not global.** Middleware declares a slot via the exported
  `bindRoutePolicy(handler, receive)`; the Application offers the table once routes are mounted.
  Two apps in one process (a test file, an embedded admin app) each read their own routes. A
  limiter used outside an Application never receives a table, so `exemptWhen` matches nothing —
  it fails closed, everything stays limited.
- **The matcher is deliberately small.** `:param` is one segment, `*` is the rest, everything else
  literal. It is a lookup over paths the engine already chose to mount, not a second router — if
  it ever disagrees with the engine, the answer is fewer features here, not more.
- **Flagless routes aren't stored**, so the per-request scan stays short on apps that use few
  flags.
- **`csrf()` gets no table.** A token check on an unmatched route is meaningless; `csrfGuard()`
  from #634 is the flag-aware path there. Stated in the docs so the asymmetry reads as a decision.

## Verification

11 new tests — the table itself (literal, param, method scoping, trailing slash, flagless routes
skipped) and the limiter end to end, including the no-route case.

Repo suite: **313 files, 3263 tests, all passing.**

With this, phases 1–4 are all implemented: the primitive and `ctx.route` (#631), the ctx-style
guards (#634), the readers (#635), and the pre-match table here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
