### PR TITLE
feat: KickRouteFlags registry, its typegen, and runtime-aware engine peers

### DIFF
--- a/.changeset/add-engine-peers.md
+++ b/.changeset/add-engine-peers.md
@@ -1,0 +1,19 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+`kick add` installs the engine peers your project actually uses.
+
+The catalog listed `express` as a static peer of `@forinda/kickjs`, so `kick add kickjs` pulled Express into a Fastify or h3 project. The HTTP engine is chosen at `bootstrap({ runtime })` — which engine package a project needs is a runtime question, not a fixed dependency.
+
+It now resolves from the project's runtime (the `runtime` field in `kick.config.ts`, else the engine already in `package.json`), matching what `kick new` scaffolds for the same engine:
+
+| Runtime   | Installed with `@forinda/kickjs`             |
+| --------- | -------------------------------------------- |
+| `express` | `express`                                    |
+| `fastify` | `fastify`, `@fastify/middie`, `serve-static` |
+| `h3`      | `h3`, `serve-static`                         |
+
+`kick add --list` names the resolved engine on the row, and the install prints a notice saying which peers it added and why. `kick add upload` already worked this way; this brings the framework package itself in line.
+
+Also: `kick typegen --list` now prints the file each plugin owns and a copy-pasteable `typegen: { disable: [...] }` snippet, since "which plugin writes this file" is the question you have when deciding to turn one off.

--- a/.changeset/add-engine-peers.md
+++ b/.changeset/add-engine-peers.md
@@ -14,6 +14,10 @@ It now resolves from the project's runtime (the `runtime` field in `kick.config.
 | `fastify` | `fastify`, `@fastify/middie`, `serve-static` |
 | `h3`      | `h3`, `serve-static`                         |
 
-`kick add --list` names the resolved engine on the row, and the install prints a notice saying which peers it added and why. `kick add upload` already worked this way; this brings the framework package itself in line.
+Resolution order: `--runtime <engine>` (new flag) → `runtime` in `kick.config.ts` → an engine in `dependencies` → an engine in `devDependencies`. A production dependency outranks a dev one, so Fastify in devDependencies (a benchmark, a comparison test) no longer decides what an Express app installs.
+
+When two engines sit at the same level and nothing settles it, `kick add` **stops** instead of guessing — installing writes `package.json` and `node_modules`, so a wrong guess is work to undo — and names both remedies: set `runtime` in `kick.config.ts`, or pass `--runtime` for one command.
+
+`kick add --list` names the resolved engine on the row and accepts the same flag. `kick add upload` already resolved its multipart driver this way; this brings the framework package itself in line.
 
 Also: `kick typegen --list` now prints the file each plugin owns and a copy-pasteable `typegen: { disable: [...] }` snippet, since "which plugin writes this file" is the question you have when deciding to turn one off.

--- a/.changeset/route-flag-negation.md
+++ b/.changeset/route-flag-negation.md
@@ -1,0 +1,25 @@
+---
+'@forinda/kickjs': minor
+---
+
+Negated route-flag tests: `'!auth.public'`.
+
+Every `skipWhen` / `onlyWhen` / `exemptWhen` now accepts a name with `!` in front, matching routes that do **not** carry the flag:
+
+```ts
+rateLimitGuard({ max: 60, exemptWhen: '!billing.metered' }) // exempt everything unmetered
+```
+
+Previously the only way to express that was a predicate. It matters most on `exemptWhen`, which has no `onlyWhen` counterpart — `skipWhen: '!x'` is just `onlyWhen: 'x'` written differently.
+
+A list stays single-polarity, and the type enforces it:
+
+```ts
+;['auth.public', 'health.probe'] // carries ANY of these
+;['!auth.public', '!health.probe'] // carries NONE of these
+;['auth.public', '!health.probe'] // compile error
+```
+
+Mixed polarity would mean "public present **or** probe absent" under any-of, which most readers parse as "and" — so instead of picking a reading, the type rejects it and a predicate expresses the compound case. Mixing at runtime (from untyped config) throws where the consumer is constructed rather than on the first request that reaches it.
+
+Negated names narrow with `KickRouteFlags` like positive ones, so `'!auth.pubic'` is a compile error too.

--- a/.changeset/route-flag-off.md
+++ b/.changeset/route-flag-off.md
@@ -1,0 +1,32 @@
+---
+'@forinda/kickjs': minor
+---
+
+Route flags: removal is `@Flag.off`, and `false` becomes an ordinary value.
+
+`false` was doing two jobs — "remove this flag" and "the value false" — and the first won. A flag declared `boolean` could never read back as `false`, because `@Enabled(false)` deleted it:
+
+```ts
+const Enabled = defineRouteFlag<boolean>('feature.enabled')
+
+@Enabled(false)                       // before: removed the flag
+                                      // now:    stores false
+flags.get('feature.enabled')          // before: undefined
+                                      // now:    false
+```
+
+Removal now has its own spelling, applied bare like the flag itself:
+
+```ts
+@Public
+@Controller()
+class WebhooksController {
+  @Public.off // drops what the controller set
+  @Post('/admin')
+  admin(ctx) {}
+}
+```
+
+`@Flag(false)` on a flag whose declared value is `true` is now a compile error pointing you at `.off`, so the old form cannot silently change meaning. Nothing else about resolution changed: a flag is absent or present, and `has()` remains the right question.
+
+Also: `defineRouteFlag` rejects a name starting with `!`, which is reserved for negated tests — `'!x'` as a name would be indistinguishable from the negation of `'x'`.

--- a/.changeset/route-flag-typing.md
+++ b/.changeset/route-flag-typing.md
@@ -1,0 +1,25 @@
+---
+'@forinda/kickjs': minor
+---
+
+`KickRouteFlags` — route flags get the same type safety contributors have.
+
+Flag names were plain strings, so a typo produced a flag that silently never matched. Declare them once and every use narrows:
+
+```ts
+declare module '@forinda/kickjs' {
+  interface KickRouteFlags {
+    'auth.public': true
+    'rate.limit': { rpm: number }
+  }
+}
+```
+
+- `defineRouteFlag('auth.pubic')` is a compile error, with TypeScript's "Did you mean" suggestion
+- `defineRouteFlag('rate.limit')` infers `RouteFlag<{ rpm: number }>` from the registry — the explicit generic is no longer needed (and still works)
+- `ctx.route.flags.get('rate.limit')` is typed `{ rpm: number } | undefined` instead of `unknown`, and `has()` takes only declared names
+- `skipWhen`, `onlyWhen` and `exemptWhen` accept only declared names, in every consumer
+
+Additive and opt-in: `KickRouteFlags` is empty by default, and every one of those falls back to plain `string` / `unknown` while it stays empty — a project that declares nothing keeps compiling unchanged, and flags can be adopted one at a time. Same `[Known] extends [never]` fallback `ContextMetaKey` uses.
+
+The framework declares no flags of its own in the registry.

--- a/.changeset/route-flags-typegen.md
+++ b/.changeset/route-flags-typegen.md
@@ -1,0 +1,29 @@
+---
+'@forinda/kickjs-cli': minor
+---
+
+`kick typegen` generates the `KickRouteFlags` registry.
+
+Every `defineRouteFlag('name')` call in `src/` is collected into `.kickjs/types/kick__route-flags.d.ts`, so declaring the flag is the only step — no hand-written `declare module` block:
+
+```ts
+// src/flags.ts — all you write
+export const Public = defineRouteFlag('auth.public')
+export const Limit = defineRouteFlag<{ rpm: number }>('rate.limit')
+```
+
+```ts
+// .kickjs/types/kick__route-flags.d.ts — generated, refreshed on every `kick dev` save
+declare module '@forinda/kickjs' {
+  interface KickRouteFlags {
+    'auth.public': true
+    'rate.limit': { rpm: number }
+  }
+}
+```
+
+From there a misspelt flag name is a compile error at every consumer (`skipWhen`, `onlyWhen`, `exemptWhen`, `flags.has`), and `flags.get('rate.limit')` is typed rather than `unknown`.
+
+Unlike the `ContextKeys` registry, this one records the **value type** too: a bare flag registers as `true`, an explicit generic registers that type verbatim. Empty project emits an empty registry and every name falls back to `string`.
+
+Disable it like any other plugin: `typegen: { disable: ['kick/route-flags'] }`.

--- a/__tests__/devtools.test.ts
+++ b/__tests__/devtools.test.ts
@@ -102,7 +102,7 @@ describe('DevTools: debug endpoints', () => {
       }
 
       @Limit({ rpm: 10 })
-      @Public(false)
+      @Public.off
       @Get('/metered')
       metered(ctx: RequestContext) {
         ctx.json({})

--- a/docs/guide/cli-commands.md
+++ b/docs/guide/cli-commands.md
@@ -452,13 +452,30 @@ kick add --list --all     # full optional catalog
 ```text
   Core packages (always installed by `kick new`):
 
-    kickjs           Unified framework: DI, decorators, routing, middleware (+ express)
+    kickjs           Unified framework: DI, decorators, routing, middleware (+ express) [express engine]
     vite             Vite plugin: dev server, HMR, module discovery (+ vite)
     cli              CLI tool and code generators
 
   Plus N optional packages (swagger, db, queue, …).
   Run `kick add --list --all` for the full catalog.
 ```
+
+### Engine peers follow your runtime
+
+The HTTP engine is chosen at `bootstrap({ runtime })`, so which engine package a project needs is
+not a fixed dependency. `kick add` resolves it from your project's runtime — `kick.config.ts`'s
+`runtime` field, or the engine already in `package.json` — and the listing names the engine it
+resolved:
+
+| Runtime   | Installed with `@forinda/kickjs`             |
+| --------- | -------------------------------------------- |
+| `express` | `express`                                    |
+| `fastify` | `fastify`, `@fastify/middie`, `serve-static` |
+| `h3`      | `h3`, `serve-static`                         |
+
+These match what `kick new` scaffolds for the same engine, so adding the framework to an existing
+Fastify project no longer pulls in Express. `kick add upload` resolves its multipart driver the
+same way.
 
 The framework runtime (`@forinda/kickjs`), the dev/build/HMR layer (`@forinda/kickjs-vite`), and the CLI (`@forinda/kickjs-cli`) are the only members of the core set. Everything else — auth, swagger, db, ws, queue, devtools, mcp, testing — is opt-in via `kick add`.
 

--- a/docs/guide/cli-commands.md
+++ b/docs/guide/cli-commands.md
@@ -477,6 +477,24 @@ These match what `kick new` scaffolds for the same engine, so adding the framewo
 Fastify project no longer pulls in Express. `kick add upload` resolves its multipart driver the
 same way.
 
+Resolution order: `--runtime <engine>` → `runtime` in `kick.config.ts` → the engine in
+`dependencies` → the engine in `devDependencies`. A production dependency outranks a dev one,
+since that is what you deploy on.
+
+If two engines sit at the same level and nothing settles it — Fastify and h3 both in
+`dependencies`, say — `kick add` **stops** rather than guessing:
+
+```text
+  Cannot tell which HTTP engine this app boots on: found fastify, h3 in package.json.
+
+  Installing engine peers for the wrong one is worse than not installing them, so:
+    • set `runtime: '<engine>'` in kick.config.ts (permanent, also fixes kick doctor), or
+    • pass --runtime <fastify|h3> for this command
+```
+
+Installing writes `package.json` and `node_modules`, so a wrong guess is work to undo — refusing
+costs one flag.
+
 The framework runtime (`@forinda/kickjs`), the dev/build/HMR layer (`@forinda/kickjs-vite`), and the CLI (`@forinda/kickjs-cli`) are the only members of the core set. Everything else — auth, swagger, db, ws, queue, devtools, mcp, testing — is opt-in via `kick add`.
 
 ### Package manager resolution

--- a/docs/guide/route-flags.md
+++ b/docs/guide/route-flags.md
@@ -253,6 +253,15 @@ first declaration, and you can adopt it one flag at a time.
 The framework declares nothing in this registry. `auth.public` above is a name you chose — see
 [Naming](#naming).
 
+Two constraints on what a flag can be:
+
+- **A name cannot start with `!`.** That prefix means "does not carry this flag" in a test, so a
+  flag literally named `!x` would be indistinguishable from the negation of `x`. `defineRouteFlag`
+  rejects it.
+- **A value type should not include `false`.** `false` is the deletion sentinel — `@Flag(false)`
+  removes the flag rather than storing it — so a flag declared `boolean` could never actually read
+  back as `false`. `flags.get()` excludes `false` from its result type to say so.
+
 ## Where flags can be declared
 
 Method and class today, resolved method-over-class. Module, adapter and global registration sites are planned, matching the [context contributor](./context-decorators.md) precedence chain.

--- a/docs/guide/route-flags.md
+++ b/docs/guide/route-flags.md
@@ -172,12 +172,27 @@ method name rather than a live request.
 Every `skipWhen` / `onlyWhen` / `exemptWhen` accepts the same three forms:
 
 ```ts
-'auth.public' // this flag
-;['auth.public', 'health.probe'] // any of these
+'auth.public' // carries this flag
+'!auth.public' // does NOT carry it
+;['auth.public', 'health.probe'] // carries any of these
+;['!auth.public', '!health.probe'] // carries none of these
 ;({ flags, route }) => flags.has('a') && flags.has('b') // anything else
 ```
 
-A list is **any-of** — it reads as "these are all reasons to skip". All-of, value checks and path checks go through a predicate:
+A positive list is **any-of** — it reads as "these are all reasons to skip". A negated list is its
+complement, **none-of**, so flipping every entry inverts the meaning the way a reader expects.
+
+::: warning A list is single-polarity
+`['auth.public', '!metered']` is a compile error. Under any-of it would mean "public present **or**
+metered absent", which almost everyone reads as "and" — so rather than pick a reading, the type
+forbids it and a predicate says it unambiguously. Mixing them at runtime (from untyped config)
+throws where the consumer is constructed, not on the first request that hits it.
+:::
+
+Negation matters most on `exemptWhen`, which has no `onlyWhen` counterpart — `skipWhen: '!x'` is
+just `onlyWhen: 'x'` written differently.
+
+All-of, value checks and path checks go through a predicate:
 
 ```ts
 exemptWhen: ({ flags }) => (flags.get('rate.limit') as { rpm: number } | undefined)?.rpm === 0

--- a/docs/guide/route-flags.md
+++ b/docs/guide/route-flags.md
@@ -186,6 +186,44 @@ exemptWhen: ({ route }) => route?.path.startsWith('/internal') ?? false
 
 Keep predicates cheap — they run per request, per consumer.
 
+## Type safety: declare your flags
+
+Flag names are plain strings by default, which means a typo is a flag that silently never matches.
+Declare them once and every use narrows — the same `ContextMeta` mechanism [context
+decorators](./context-decorators.md) use:
+
+```ts
+declare module '@forinda/kickjs' {
+  interface KickRouteFlags {
+    'auth.public': true
+    'rate.limit': { rpm: number }
+  }
+}
+```
+
+Three things switch on at once:
+
+```ts
+defineRouteFlag('auth.pubic') // tsc: Did you mean '"auth.public"'?
+
+const Limit = defineRouteFlag('rate.limit') // RouteFlag<{ rpm: number }> — no generic needed
+ctx.route?.flags.get('rate.limit')?.rpm // typed, not `unknown`
+
+rateLimitGuard({ exemptWhen: 'auth.pubic' }) // tsc error, in every consumer
+```
+
+`skipWhen`, `onlyWhen` and `exemptWhen` all take the narrowed name, so a misspelling fails at the
+call site rather than at 3am.
+
+::: tip It stays optional
+`KickRouteFlags` is empty until you augment it, and everything falls back to plain `string` while
+it is — a project that never declares a flag keeps compiling. The narrowing switches on with the
+first declaration, and you can adopt it one flag at a time.
+:::
+
+The framework declares nothing in this registry. `auth.public` above is a name you chose — see
+[Naming](#naming).
+
 ## Where flags can be declared
 
 Method and class today, resolved method-over-class. Module, adapter and global registration sites are planned, matching the [context contributor](./context-decorators.md) precedence chain.

--- a/docs/guide/route-flags.md
+++ b/docs/guide/route-flags.md
@@ -15,7 +15,7 @@ export class WebhooksController {
   @Get('/health')
   health(ctx: RequestContext) {} // public
 
-  @Public(false) // the method wins
+  @Public.off // the method wins
   @Post('/admin')
   admin(ctx: RequestContext) {} // not public
 }
@@ -59,19 +59,20 @@ ctx.route?.flags.get('rate.limit') // { rpm: 10 }
 
 ## A `false` flag is absent, not false
 
-::: warning This is the rule that makes `has()` safe
-`@Public(false)` **removes** the flag its class set — it does not store `false`. So a resolved flag is either absent or present with a value defaulting to `true`, and there is no present-but-falsy state.
+::: warning Removal is `.off`, not a falsy value
+`@Public.off` **removes** the flag its class set. A resolved flag is either absent or present — presence is the whole question `has()` answers, so there is no "present but turned off" state to reason about.
 
-Without that rule, `flags.has('auth.public')` would answer `true` for the route that just opted back _in_, and every presence-checking consumer would read a protected route as public.
+Removal is spelled as its own member rather than `@Public(false)` for two reasons. It keeps `false` usable as a real value: a flag declared `boolean` can store it, and `flags.get()` can return it. And it removes the trap where `@Public(false)` looked like "not public" while a presence check still answered `true` — which would read a protected route as public.
 :::
 
-| Declaration                                    | Resolved                   |
-| ---------------------------------------------- | -------------------------- |
-| `@Public` on the class, nothing on the method  | `auth.public → true`       |
-| `@Public` on the class, `@Public(false)` on it | _absent_                   |
-| `@RateLimit({ rpm: 10 })`                      | `rate.limit → { rpm: 10 }` |
+| Declaration                                   | Resolved                   |
+| --------------------------------------------- | -------------------------- |
+| `@Public` on the class, nothing on the method | `auth.public → true`       |
+| `@Public` on the class, `@Public.off` on it   | _absent_                   |
+| `@RateLimit({ rpm: 10 })`                     | `rate.limit → { rpm: 10 }` |
+| `@Enabled(false)` (flag declared `boolean`)   | `feature.enabled → false`  |
 
-`@Public(false)` on a route that never inherited the flag is a no-op — usually a sign the author expected an inheritance that isn't there.
+`@Public.off` on a route that never inherited the flag is a no-op — usually a sign the author expected an inheritance that isn't there.
 
 ## Consumers
 
@@ -258,9 +259,9 @@ Two constraints on what a flag can be:
 - **A name cannot start with `!`.** That prefix means "does not carry this flag" in a test, so a
   flag literally named `!x` would be indistinguishable from the negation of `x`. `defineRouteFlag`
   rejects it.
-- **A value type should not include `false`.** `false` is the deletion sentinel — `@Flag(false)`
-  removes the flag rather than storing it — so a flag declared `boolean` could never actually read
-  back as `false`. `flags.get()` excludes `false` from its result type to say so.
+- **Removal is `@Flag.off`, not `@Flag(false)`.** `false` is an ordinary value, so a flag declared
+  `boolean` stores and reads it back normally — `@Enabled(false)` means the feature is off, and
+  `flags.get('feature.enabled')` returns `false`. Only `.off` removes.
 
 ## Where flags can be declared
 

--- a/docs/guide/route-flags.md
+++ b/docs/guide/route-flags.md
@@ -192,7 +192,17 @@ Flag names are plain strings by default, which means a typo is a flag that silen
 Declare them once and every use narrows — the same `ContextMeta` mechanism [context
 decorators](./context-decorators.md) use:
 
+**`kick typegen` writes this for you.** It scans every `defineRouteFlag('name')` call and emits
+the registry to `.kickjs/types/kick__route-flags.d.ts` — so declaring a flag is the only step:
+
 ```ts
+// src/flags.ts — this is all you write
+export const Public = defineRouteFlag('auth.public')
+export const Limit = defineRouteFlag<{ rpm: number }>('rate.limit')
+```
+
+```ts
+// .kickjs/types/kick__route-flags.d.ts — generated, on every `kick dev` save
 declare module '@forinda/kickjs' {
   interface KickRouteFlags {
     'auth.public': true
@@ -200,6 +210,10 @@ declare module '@forinda/kickjs' {
   }
 }
 ```
+
+A bare flag registers as `true`; one declared with an explicit value type registers that type. You
+can also hand-write the augmentation if you prefer — the generated file is a normal declaration
+merge — but there is rarely a reason to.
 
 Three things switch on at once:
 

--- a/docs/guide/swagger.md
+++ b/docs/guide/swagger.md
@@ -242,7 +242,7 @@ SwaggerAdapter({ bearerAuth: true, publicFlag: 'auth.public' })
 export class WebhooksController {
   @Get('/health') health(ctx: RequestContext) {}
 
-  @Public(false) // this one is documented as secured again
+  @Public.off // this one is documented as secured again
   @Post('/admin')
   admin(ctx: RequestContext) {}
 }

--- a/docs/guide/typegen.md
+++ b/docs/guide/typegen.md
@@ -24,6 +24,7 @@ After running `kick typegen` (or starting `kick dev`), you'll have:
     kick__assets.d.ts           # KickAssets augmentation (when assetMap is set)
     kick__db.d.ts               # DB model types (when a DB adapter is configured)
     kick__context.d.ts          # ContextKeys augmentation (when context decorators exist)
+    kick__route-flags.d.ts      # KickRouteFlags augmentation (from defineRouteFlag calls)
 ```
 
 Each file is emitted by its own typegen plugin. There is no barrel
@@ -470,6 +471,37 @@ defineHttpContextDecorator({
 ```
 
 `ContextMeta` still drives the value type of `ctx.get('tenant')`; `ContextKeys` only records that the key exists. Scaffold a contributor (and its `ContextMeta` stub) with [`kick g contributor`](./context-decorators.md). Empty project → no `kick__context.d.ts` emitted and `dependsOn` falls back to `string[]`.
+
+### Route flags — `kick__route-flags.d.ts`
+
+The same pass collects every `defineRouteFlag('name')` call into a `KickRouteFlags` augmentation:
+
+```ts
+// src/flags.ts
+export const Public = defineRouteFlag('auth.public')
+export const Limit = defineRouteFlag<{ rpm: number }>('rate.limit')
+```
+
+```ts
+// .kickjs/types/kick__route-flags.d.ts (generated)
+declare module '@forinda/kickjs' {
+  interface KickRouteFlags {
+    'auth.public': true
+    'rate.limit': { rpm: number }
+  }
+}
+```
+
+This one carries the **value type** as well as the name, which is why it can do more than
+`ContextKeys` does for contributors: `flags.get('rate.limit')` is typed, not just checked for
+existence. A bare flag registers as `true`; an explicit generic registers that type verbatim.
+
+It is also the cheapest plugin in the set. A flag is a positional string literal with no
+`dependsOn` graph and no per-route ordering to resolve, so discovery is a single AST branch and
+the output is a flat map — where the context-key registry has to reason about the contributor
+pipeline before it can say anything. See [Route Flags](./route-flags.md).
+
+Empty project → an empty registry, and every flag name falls back to `string`.
 
 ## Augmentation catalogue
 

--- a/docs/guide/typegen.md
+++ b/docs/guide/typegen.md
@@ -341,16 +341,23 @@ The plugin still loads (so merge-time conflict detection still runs); only its `
 
 <PmCommand exec="kick typegen --list" />
 
-Prints every typegen plugin id with its watched inputs:
+Prints every typegen plugin id, the file it owns, and the inputs it watches:
 
 ```
   Registered typegen plugins:
 
-    kick/db      inputs: src/db/schema.ts, src/db/schema/**/*.ts
-    kick/assets  inputs: kick.config.ts, kick.config.js, kick.config.mjs
+    kick/db      → .kickjs/types/kick__db.d.ts
+                   watches: src/db/schema.ts, src/db/schema/**/*.ts
+    kick/assets  → .kickjs/types/kick__assets.d.ts
+                   watches: kick.config.ts, kick.config.js, kick.config.mjs
+
+  Disable one in kick.config.ts:
+
+    typegen: { disable: ['kick/db'] }
 ```
 
-Disabled ids show `(disabled)` next to the entry. Unknown ids in `typegen.disable` (typos, removed plugins) surface as a startup warning rather than a hard error so the dev loop stays alive while you fix the config.
+The output file is the part you usually want: it answers "which plugin writes this file, and what
+happens if I turn it off". Disabled ids show `(disabled)` next to the entry. Unknown ids in `typegen.disable` (typos, removed plugins) surface as a startup warning rather than a hard error so the dev loop stays alive while you fix the config.
 
 See [CLI Plugins](./cli-plugins.md) for the full plugin contract — every typegen above ships as a `KickCliPlugin.typegens[]` entry, including the built-ins.
 

--- a/packages/cli/__tests__/add-registry.test.ts
+++ b/packages/cli/__tests__/add-registry.test.ts
@@ -10,6 +10,7 @@ import {
   UPLOAD_DRIVERS,
   ENGINE_PEERS,
   detectRuntimeFromDepsDetailed,
+  parseRuntimeFlag,
   AVAILABLE_ADD_PACKAGES,
 } from '../src/commands/add'
 
@@ -127,6 +128,12 @@ describe('planAddPackages', () => {
     expect([...ENGINE_PEERS.express]).toEqual(['express'])
     expect([...ENGINE_PEERS.fastify]).toEqual(['fastify', '@fastify/middie', 'serve-static'])
     expect([...ENGINE_PEERS.h3]).toEqual(['h3', 'serve-static'])
+  })
+
+  it('--runtime overrides everything, including an ambiguous package.json', () => {
+    expect(parseRuntimeFlag('fastify')).toBe('fastify')
+    expect(parseRuntimeFlag(undefined)).toBeUndefined()
+    expect(() => parseRuntimeFlag('bun')).toThrow(/Expected express, fastify or h3/)
   })
 
   it('prefers a prod engine dep over a dev one', () => {

--- a/packages/cli/__tests__/add-registry.test.ts
+++ b/packages/cli/__tests__/add-registry.test.ts
@@ -145,8 +145,9 @@ describe('planAddPackages', () => {
     // Fastify in devDependencies (a benchmark, a comparison test) must not
     // decide which engine the app deploys on.
     const detected = detectRuntimeFromDepsDetailed(dir)
-    expect(detected.runtime).toBe('express')
-    expect(detected.ambiguous).toBe(true)
+    // Resolved, not ambiguous: the prod/dev rule settles it, so `kick add`
+    // must not refuse here.
+    expect(detected).toMatchObject({ runtime: 'express', ambiguous: false })
     rmSync(dir, { recursive: true, force: true })
   })
 

--- a/packages/cli/__tests__/add-registry.test.ts
+++ b/packages/cli/__tests__/add-registry.test.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
 import { describe, it, expect } from 'vitest'
@@ -8,6 +9,7 @@ import {
   planAddPackages,
   UPLOAD_DRIVERS,
   ENGINE_PEERS,
+  detectRuntimeFromDepsDetailed,
   AVAILABLE_ADD_PACKAGES,
 } from '../src/commands/add'
 
@@ -125,6 +127,40 @@ describe('planAddPackages', () => {
     expect([...ENGINE_PEERS.express]).toEqual(['express'])
     expect([...ENGINE_PEERS.fastify]).toEqual(['fastify', '@fastify/middie', 'serve-static'])
     expect([...ENGINE_PEERS.h3]).toEqual(['h3', 'serve-static'])
+  })
+
+  it('prefers a prod engine dep over a dev one', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kick-engine-'))
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ dependencies: { express: '^5' }, devDependencies: { fastify: '^5' } }),
+    )
+    // Fastify in devDependencies (a benchmark, a comparison test) must not
+    // decide which engine the app deploys on.
+    const detected = detectRuntimeFromDepsDetailed(dir)
+    expect(detected.runtime).toBe('express')
+    expect(detected.ambiguous).toBe(true)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('flags genuine ambiguity instead of picking by precedence', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kick-engine-'))
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ dependencies: { fastify: '^5', h3: '^1' } }),
+    )
+    const detected = detectRuntimeFromDepsDetailed(dir)
+    expect(detected.ambiguous).toBe(true)
+    expect(detected.candidates).toEqual(['fastify', 'h3'])
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('is unambiguous with a single engine', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kick-engine-'))
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: { h3: '^1' } }))
+    const detected = detectRuntimeFromDepsDetailed(dir)
+    expect(detected).toMatchObject({ runtime: 'h3', ambiguous: false })
+    rmSync(dir, { recursive: true, force: true })
   })
 
   it('names the engine in a notice so the install is explainable', () => {

--- a/packages/cli/__tests__/add-registry.test.ts
+++ b/packages/cli/__tests__/add-registry.test.ts
@@ -7,6 +7,7 @@ import {
   PACKAGE_REGISTRY,
   planAddPackages,
   UPLOAD_DRIVERS,
+  ENGINE_PEERS,
   AVAILABLE_ADD_PACKAGES,
 } from '../src/commands/add'
 
@@ -101,6 +102,34 @@ describe('planAddPackages', () => {
     expect(plan.prodDeps).not.toContain('@forinda/kickjs-auth')
     expect(plan.prodDeps).not.toContain('jsonwebtoken')
     expect(plan.unknown).toEqual(['auth'])
+  })
+
+  it('installs the engine peers for the project runtime, not always express', () => {
+    // The engine is chosen at `bootstrap({ runtime })`, so a Fastify project
+    // getting `express` from `kick add kickjs` was simply wrong.
+    expect(planAddPackages(['kickjs'], false, 'express').prodDeps).toContain('express')
+
+    const fastify = planAddPackages(['kickjs'], false, 'fastify').prodDeps
+    expect(fastify).toContain('fastify')
+    expect(fastify).toContain('@fastify/middie')
+    expect(fastify).not.toContain('express')
+
+    const h3 = planAddPackages(['kickjs'], false, 'h3').prodDeps
+    expect(h3).toContain('h3')
+    expect(h3).not.toContain('express')
+  })
+
+  it('matches what `kick new` scaffolds for each engine', () => {
+    // Drift here means `kick add` and `kick new` disagree about what a project
+    // needs — the failure mode is a missing peer at boot.
+    expect([...ENGINE_PEERS.express]).toEqual(['express'])
+    expect([...ENGINE_PEERS.fastify]).toEqual(['fastify', '@fastify/middie', 'serve-static'])
+    expect([...ENGINE_PEERS.h3]).toEqual(['h3', 'serve-static'])
+  })
+
+  it('names the engine in a notice so the install is explainable', () => {
+    const plan = planAddPackages(['kickjs'], false, 'h3')
+    expect(plan.notices.join(' ')).toContain('h3')
   })
 
   it('collects unknown names without dropping known ones', () => {

--- a/packages/cli/__tests__/scanner-route-flags.test.ts
+++ b/packages/cli/__tests__/scanner-route-flags.test.ts
@@ -108,6 +108,45 @@ describe('renderRouteFlags', () => {
     expect(out.indexOf('"alpha"')).toBeLessThan(out.indexOf('"zeta"'))
   })
 
+  it('keeps a multiline named type on one line in the diagnostic', () => {
+    const out = render(`import type { Big } from './types'
+      const L = defineRouteFlag<
+        Big
+      >('big')`)
+    // A raw line break would end the `//` comment and drop the rest into the
+    // file as code.
+    for (const line of out.split('\n')) {
+      if (line.includes('not in scope here')) expect(line.trim().startsWith('//')).toBe(true)
+    }
+    expect(out).toContain('"big": unknown')
+  })
+
+  it('fails when one flag is declared with two different value types', () => {
+    const a = extractFileAst(
+      `const L = defineRouteFlag<{ rpm: number }>('rate.limit')`,
+      '/proj/src/a.ts',
+      '/proj',
+    ).routeFlags
+    const b = extractFileAst(
+      `const L = defineRouteFlag<{ rps: number }>('rate.limit')`,
+      '/proj/src/b.ts',
+      '/proj',
+    ).routeFlags
+    expect(() => renderRouteFlags([...a, ...b])).toThrow(/two different value types/)
+  })
+
+  it('tolerates the same flag declared identically twice', () => {
+    const decl = `const L = defineRouteFlag<{ rpm: number }>('rate.limit')`
+    const a = extractFileAst(decl, '/proj/src/a.ts', '/proj').routeFlags
+    const b = extractFileAst(
+      `const L = defineRouteFlag<{rpm:number}>('rate.limit')`,
+      '/proj/src/b.ts',
+      '/proj',
+    ).routeFlags
+    // Same type, different spacing — one flag, no error.
+    expect(renderRouteFlags([...a, ...b])).toContain('"rate.limit"')
+  })
+
   it('emits a valid empty registry when a project declares none', () => {
     const out = renderRouteFlags([])
     expect(out).toContain('interface KickRouteFlags')

--- a/packages/cli/__tests__/scanner-route-flags.test.ts
+++ b/packages/cli/__tests__/scanner-route-flags.test.ts
@@ -70,8 +70,34 @@ describe('renderRouteFlags', () => {
     `)
     expect(out).toContain("declare module '@forinda/kickjs'")
     expect(out).toContain('interface KickRouteFlags')
-    expect(out).toContain("'auth.public': true")
-    expect(out).toContain("'rate.limit': { rpm: number }")
+    expect(out).toContain('"auth.public": true')
+    expect(out).toContain('"rate.limit": { rpm: number }')
+  })
+
+  it('degrades a named value type — it is not in scope in the generated file', () => {
+    const out = render(`import type { RateLimit } from './types'
+      const L = defineRouteFlag<RateLimit>('rate.limit')`)
+    // Emitting `'rate.limit': RateLimit` would be `Cannot find name 'RateLimit'`
+    // inside the declare-module block and break every consumer's typecheck.
+    expect(out).not.toMatch(/'rate\.limit':\s*RateLimit/)
+    expect(out).toContain('"rate.limit": unknown')
+    expect(out).toContain('not in scope here')
+  })
+
+  it('keeps a self-contained type verbatim', () => {
+    const out = render(`const L = defineRouteFlag<{ rpm: number; burst?: number }>('rate.limit')`)
+    expect(out).toContain('"rate.limit": { rpm: number; burst?: number }')
+  })
+
+  it('keeps a self-contained type built from globals', () => {
+    const out = render(`const W = defineRouteFlag<Record<string, number[]>>('w')`)
+    expect(out).toContain('"w": Record<string, number[]>')
+  })
+
+  it('escapes a name containing a quote', () => {
+    const out = render(`const A = defineRouteFlag("author's")`)
+    // A hand-rolled quoted key would emit `'author's'` — a syntax error.
+    expect(out).toContain('"author\'s": true')
   })
 
   it('sorts entries so the file does not churn between runs', () => {
@@ -79,7 +105,7 @@ describe('renderRouteFlags', () => {
       const B = defineRouteFlag('zeta')
       const A = defineRouteFlag('alpha')
     `)
-    expect(out.indexOf("'alpha'")).toBeLessThan(out.indexOf("'zeta'"))
+    expect(out.indexOf('"alpha"')).toBeLessThan(out.indexOf('"zeta"'))
   })
 
   it('emits a valid empty registry when a project declares none', () => {

--- a/packages/cli/__tests__/scanner-route-flags.test.ts
+++ b/packages/cli/__tests__/scanner-route-flags.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for route-flag discovery — the AST extraction that feeds the
+ * `kick/route-flags` typegen plugin, which auto-populates `KickRouteFlags`
+ * from `defineRouteFlag('name')` call sites.
+ *
+ * Cheaper than the context-key equivalent by construction: the name is a
+ * positional string literal and there is no dependency graph, so the whole
+ * contract is "name in, name plus optional value type out".
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { Container } from '@forinda/kickjs'
+import { extractFileAst } from '../src/typegen/extract-ast'
+import { renderRouteFlags } from '../src/typegen/render/manifest'
+
+beforeEach(() => {
+  Container.reset()
+})
+
+const FILE = '/proj/src/flags.ts'
+const flags = (source: string) =>
+  extractFileAst(source, FILE, '/proj').routeFlags.map((f) => ({
+    name: f.name,
+    valueType: f.valueType,
+  }))
+
+describe('route-flag discovery', () => {
+  it('finds a bare flag', () => {
+    expect(flags(`export const Public = defineRouteFlag('auth.public')`)).toEqual([
+      { name: 'auth.public', valueType: null },
+    ])
+  })
+
+  it('captures an explicit value type verbatim', () => {
+    expect(flags(`const Limit = defineRouteFlag<{ rpm: number }>('rate.limit')`)).toEqual([
+      { name: 'rate.limit', valueType: '{ rpm: number }' },
+    ])
+  })
+
+  it('finds several in one file and ignores duplicates', () => {
+    expect(
+      flags(`
+        export const A = defineRouteFlag('a')
+        export const B = defineRouteFlag('b')
+        const AAgain = defineRouteFlag('a')
+      `),
+    ).toEqual([
+      { name: 'a', valueType: null },
+      { name: 'b', valueType: null },
+    ])
+  })
+
+  it('ignores a non-literal name — nothing to put in the registry', () => {
+    expect(flags(`const F = defineRouteFlag(NAME)`)).toEqual([])
+  })
+
+  it('does not confuse a similarly named call', () => {
+    expect(flags(`const X = defineRouteFlagLike('nope')`)).toEqual([])
+  })
+})
+
+describe('renderRouteFlags', () => {
+  const render = (source: string) =>
+    renderRouteFlags(extractFileAst(source, FILE, '/proj').routeFlags)
+
+  it('emits a declaration merge with the value types', () => {
+    const out = render(`
+      export const Public = defineRouteFlag('auth.public')
+      export const Limit = defineRouteFlag<{ rpm: number }>('rate.limit')
+    `)
+    expect(out).toContain("declare module '@forinda/kickjs'")
+    expect(out).toContain('interface KickRouteFlags')
+    expect(out).toContain("'auth.public': true")
+    expect(out).toContain("'rate.limit': { rpm: number }")
+  })
+
+  it('sorts entries so the file does not churn between runs', () => {
+    const out = render(`
+      const B = defineRouteFlag('zeta')
+      const A = defineRouteFlag('alpha')
+    `)
+    expect(out.indexOf("'alpha'")).toBeLessThan(out.indexOf("'zeta'"))
+  })
+
+  it('emits a valid empty registry when a project declares none', () => {
+    const out = renderRouteFlags([])
+    expect(out).toContain('interface KickRouteFlags')
+    expect(out).toContain('no route flags discovered yet')
+  })
+})

--- a/packages/cli/__tests__/scanner-route-flags.test.ts
+++ b/packages/cli/__tests__/scanner-route-flags.test.ts
@@ -135,6 +135,36 @@ describe('renderRouteFlags', () => {
     expect(() => renderRouteFlags([...a, ...b])).toThrow(/two different value types/)
   })
 
+  it('treats literal types differing only in whitespace as a conflict', () => {
+    // `'a b'` and `'ab'` are different types to TypeScript — collapsing all
+    // whitespace would let one silently win.
+    const a = extractFileAst(
+      `const L = defineRouteFlag<'a b'>('mode')`,
+      '/proj/src/a.ts',
+      '/proj',
+    ).routeFlags
+    const b = extractFileAst(
+      `const L = defineRouteFlag<'ab'>('mode')`,
+      '/proj/src/b.ts',
+      '/proj',
+    ).routeFlags
+    expect(() => renderRouteFlags([...a, ...b])).toThrow(/two different value types/)
+  })
+
+  it('still ignores whitespace outside literals', () => {
+    const a = extractFileAst(
+      `const L = defineRouteFlag<{ mode: 'a b' }>('mode')`,
+      '/proj/src/a.ts',
+      '/proj',
+    ).routeFlags
+    const b = extractFileAst(
+      `const L = defineRouteFlag<{mode:'a b'}>('mode')`,
+      '/proj/src/b.ts',
+      '/proj',
+    ).routeFlags
+    expect(renderRouteFlags([...a, ...b])).toContain('"mode"')
+  })
+
   it('tolerates the same flag declared identically twice', () => {
     const decl = `const L = defineRouteFlag<{ rpm: number }>('rate.limit')`
     const a = extractFileAst(decl, '/proj/src/a.ts', '/proj').routeFlags

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -244,28 +244,84 @@ export type AppRuntime = 'express' | 'fastify' | 'h3'
  * `runtime` field existed.
  */
 export async function resolveAppRuntime(cwd = process.cwd()): Promise<AppRuntime> {
+  return (await resolveAppRuntimeDetailed(cwd)).runtime
+}
+
+/**
+ * As {@link resolveAppRuntime}, but says whether the answer was a guess.
+ *
+ * `kick.config.ts`'s `runtime` is authoritative and never ambiguous. Sniffing
+ * is, so callers that act on the result — installing engine peers — surface the
+ * ambiguity instead of silently picking.
+ */
+export async function resolveAppRuntimeDetailed(
+  cwd = process.cwd(),
+): Promise<RuntimeDetection & { fromConfig: boolean }> {
   const config = await loadKickConfig(cwd)
   const fromConfig = (config as { runtime?: AppRuntime } | null)?.runtime
   if (fromConfig === 'express' || fromConfig === 'fastify' || fromConfig === 'h3') {
-    return fromConfig
+    return { runtime: fromConfig, candidates: [fromConfig], ambiguous: false, fromConfig: true }
   }
-  return detectRuntimeFromDeps(cwd)
+  return { ...detectRuntimeFromDepsDetailed(cwd), fromConfig: false }
 }
 
 /** Sniff the runtime from installed deps when kick.config has no `runtime`. */
-export function detectRuntimeFromDeps(cwd = process.cwd()): AppRuntime {
+/**
+ * Sniff result, with enough detail for a caller to say when it is guessing.
+ *
+ * `ambiguous` means more than one engine is installed and nothing settles which
+ * one the app boots on. That happens legitimately — a project on Express with
+ * Fastify in devDependencies for a benchmark — and the old precedence order
+ * (fastify first, whether prod or dev) answered `fastify` there, which installed
+ * the wrong engine peers.
+ */
+export interface RuntimeDetection {
+  runtime: AppRuntime
+  /** Engines found, in `dependencies` then `devDependencies`. */
+  candidates: AppRuntime[]
+  ambiguous: boolean
+}
+
+const ENGINE_BY_PACKAGE: ReadonlyArray<readonly [string, AppRuntime]> = [
+  ['express', 'express'],
+  ['fastify', 'fastify'],
+  ['h3', 'h3'],
+]
+
+/** Sniff the runtime from installed deps when kick.config has no `runtime`. */
+export function detectRuntimeFromDepsDetailed(cwd = process.cwd()): RuntimeDetection {
   const dir = findUp('package.json', cwd)
-  if (dir) {
-    try {
-      const pkg = JSON.parse(readFileSync(resolve(dir, 'package.json'), 'utf-8'))
-      const deps = { ...pkg.dependencies, ...pkg.devDependencies } as Record<string, unknown>
-      if ('fastify' in deps) return 'fastify'
-      if ('h3' in deps) return 'h3'
-    } catch {
-      // ignore — fall through to the default engine
-    }
+  if (!dir) return { runtime: 'express', candidates: [], ambiguous: false }
+
+  let prod: Record<string, unknown> = {}
+  let dev: Record<string, unknown> = {}
+  try {
+    const pkg = JSON.parse(readFileSync(resolve(dir, 'package.json'), 'utf-8'))
+    prod = (pkg.dependencies ?? {}) as Record<string, unknown>
+    dev = (pkg.devDependencies ?? {}) as Record<string, unknown>
+  } catch {
+    return { runtime: 'express', candidates: [], ambiguous: false }
   }
-  return 'express'
+
+  const inProd = ENGINE_BY_PACKAGE.filter(([p]) => p in prod).map(([, r]) => r)
+  const inDev = ENGINE_BY_PACKAGE.filter(([p]) => p in dev && !(p in prod)).map(([, r]) => r)
+  const candidates = [...inProd, ...inDev]
+
+  // A runtime dependency outranks a dev one: you deploy on what you ship.
+  if (inProd.length === 1) return { runtime: inProd[0], candidates, ambiguous: inDev.length > 0 }
+  if (inProd.length === 0 && inDev.length === 1) {
+    return { runtime: inDev[0], candidates, ambiguous: false }
+  }
+  if (candidates.length === 0) return { runtime: 'express', candidates, ambiguous: false }
+
+  // Two or more engines at the same level — nothing here can tell them apart.
+  // Default to the framework default and let the caller say it is guessing.
+  return { runtime: 'express', candidates, ambiguous: true }
+}
+
+/** Back-compat wrapper — the runtime only. */
+export function detectRuntimeFromDeps(cwd = process.cwd()): AppRuntime {
+  return detectRuntimeFromDepsDetailed(cwd).runtime
 }
 
 /**
@@ -494,8 +550,20 @@ export function registerAddCommand(program: Command): void {
       const { pm, source } = await resolvePackageManagerWithSource(opts.pm)
       console.log(`\n  Using ${pm} (resolved from ${source})`)
       // Resolve the runtime so `kick add upload` installs the right multipart
-      // driver (express → multer, fastify → @fastify/multipart, h3 → none).
-      const runtime = await resolveAppRuntime(process.cwd())
+      // driver (express → multer, fastify → @fastify/multipart, h3 → none) and
+      // the framework gets the engine peers it actually runs on.
+      const detection = await resolveAppRuntimeDetailed(process.cwd())
+      const runtime = detection.runtime
+      if (detection.ambiguous) {
+        // More than one engine installed and nothing says which one boots.
+        // Guessing here installs peers for an engine the app may not use, so
+        // name the guess and point at the field that settles it.
+        console.warn(
+          `\n  WARNING: found ${detection.candidates.join(' and ')} in package.json and cannot tell ` +
+            `which engine this app boots on — assuming ${runtime}.` +
+            `\n           Set \`runtime: '<engine>'\` in kick.config.ts to make this exact.`,
+        )
+      }
       const { prodDeps, devDeps, unknown, warnings, notices } = planAddPackages(
         packages,
         Boolean(opts.dev),

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -243,6 +243,13 @@ export type AppRuntime = 'express' | 'fastify' | 'h3'
  * the engine-correct multipart driver even in projects scaffolded before the
  * `runtime` field existed.
  */
+/** Validate `--runtime`, returning undefined when absent and exiting on a bad value. */
+export function parseRuntimeFlag(value: unknown): AppRuntime | undefined {
+  if (value === undefined) return undefined
+  if (value === 'express' || value === 'fastify' || value === 'h3') return value
+  throw new Error(`Invalid --runtime '${String(value)}'. Expected express, fastify or h3.`)
+}
+
 export async function resolveAppRuntime(cwd = process.cwd()): Promise<AppRuntime> {
   return (await resolveAppRuntimeDetailed(cwd)).runtime
 }
@@ -527,8 +534,12 @@ export function registerListCommand(program: Command): void {
     .alias('ls')
     .description('List KickJS packages (core only; pair with --all for the full catalog)')
     .option('--all', 'Include the full optional catalog')
-    .action(async (opts: { all?: boolean }) => {
-      printPackageList(Boolean(opts.all), await resolveAppRuntime())
+    .option('--runtime <engine>', 'HTTP engine to show peers for: express | fastify | h3')
+    .action(async (opts: { all?: boolean; runtime?: string }) => {
+      printPackageList(
+        Boolean(opts.all),
+        parseRuntimeFlag(opts.runtime) ?? (await resolveAppRuntime()),
+      )
     })
 }
 
@@ -539,11 +550,18 @@ export function registerAddCommand(program: Command): void {
     .option('--pm <manager>', 'Package manager override')
     .option('-D, --dev', 'Install as dev dependency')
     .option('--list', 'List packages (core only by default; pair with --all)')
+    .option(
+      '--runtime <engine>',
+      'HTTP engine for peer resolution: express | fastify | h3 (overrides kick.config.ts)',
+    )
     .option('--all', 'When listing, include the full optional catalog')
     .action(async (packages: string[], opts: any) => {
       // List mode
       if (opts.list || packages.length === 0) {
-        printPackageList(Boolean(opts.all), await resolveAppRuntime())
+        printPackageList(
+          Boolean(opts.all),
+          parseRuntimeFlag(opts.runtime) ?? (await resolveAppRuntime()),
+        )
         return
       }
 
@@ -552,17 +570,24 @@ export function registerAddCommand(program: Command): void {
       // Resolve the runtime so `kick add upload` installs the right multipart
       // driver (express → multer, fastify → @fastify/multipart, h3 → none) and
       // the framework gets the engine peers it actually runs on.
+      const fromFlag = parseRuntimeFlag(opts.runtime)
       const detection = await resolveAppRuntimeDetailed(process.cwd())
-      const runtime = detection.runtime
-      if (detection.ambiguous) {
-        // More than one engine installed and nothing says which one boots.
-        // Guessing here installs peers for an engine the app may not use, so
-        // name the guess and point at the field that settles it.
-        console.warn(
-          `\n  WARNING: found ${detection.candidates.join(' and ')} in package.json and cannot tell ` +
-            `which engine this app boots on — assuming ${runtime}.` +
-            `\n           Set \`runtime: '<engine>'\` in kick.config.ts to make this exact.`,
+      const runtime = fromFlag ?? detection.runtime
+
+      // Two engines at the same dependency level and nothing to break the tie.
+      // Installing writes package.json and node_modules, so guessing here
+      // leaves an adopter to undo it by hand — refuse instead, with both ways
+      // to say what the app actually boots on.
+      if (!fromFlag && detection.ambiguous) {
+        console.error(
+          `\n  Cannot tell which HTTP engine this app boots on: found ` +
+            `${detection.candidates.join(', ')} in package.json.\n` +
+            `\n  Installing engine peers for the wrong one is worse than not installing them, so:\n` +
+            `    • set \`runtime: '<engine>'\` in kick.config.ts (permanent, also fixes kick doctor), or\n` +
+            `    • pass --runtime <${detection.candidates.join('|')}> for this command\n`,
         )
+        process.exitCode = 1
+        return
       }
       const { prodDeps, devDeps, unknown, warnings, notices } = planAddPackages(
         packages,

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -314,8 +314,11 @@ export function detectRuntimeFromDepsDetailed(cwd = process.cwd()): RuntimeDetec
   const inDev = ENGINE_BY_PACKAGE.filter(([p]) => p in dev && !(p in prod)).map(([, r]) => r)
   const candidates = [...inProd, ...inDev]
 
-  // A runtime dependency outranks a dev one: you deploy on what you ship.
-  if (inProd.length === 1) return { runtime: inProd[0], candidates, ambiguous: inDev.length > 0 }
+  // A runtime dependency outranks a dev one: you deploy on what you ship. That
+  // IS a resolution, so it is not ambiguous — reporting otherwise made the
+  // refusal below block the exact case this rule exists to allow (an Express
+  // app keeping fastify in devDependencies for a benchmark).
+  if (inProd.length === 1) return { runtime: inProd[0], candidates, ambiguous: false }
   if (inProd.length === 0 && inDev.length === 1) {
     return { runtime: inDev[0], candidates, ambiguous: false }
   }

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -7,6 +7,13 @@ import { loadKickConfig, PACKAGE_MANAGERS, type PackageManager } from '../config
 interface PackageEntry {
   pkg: string
   peers: string[]
+  /**
+   * Peers depend on the project's HTTP engine, so they are resolved from
+   * {@link resolveAppRuntime} rather than listed statically. Set on the
+   * framework package itself: the engine is chosen at `bootstrap({ runtime })`,
+   * so a Fastify project must not be handed `express`.
+   */
+  enginePeers?: boolean
   description: string
   dev?: boolean
   /**
@@ -28,7 +35,9 @@ export const PACKAGE_REGISTRY: Record<string, PackageEntry> = {
   // Core (always installed by kick new — required for the framework to run)
   kickjs: {
     pkg: '@forinda/kickjs',
-    peers: ['express'],
+    // Resolved per runtime — see `enginePeers` / ENGINE_PEERS.
+    peers: [],
+    enginePeers: true,
     description: 'Unified framework: DI, decorators, routing, middleware',
     core: true,
   },
@@ -192,6 +201,20 @@ export const AVAILABLE_ADD_PACKAGES = Object.entries(PACKAGE_REGISTRY)
  * engine. `planAddPackages` resolves `upload` against the configured runtime
  * (see {@link KickConfig.runtime}); `kick doctor` validates the same mapping.
  */
+/**
+ * Engine peers per runtime — the same set `kick new` scaffolds for the chosen
+ * engine (`generators/templates/project-config.ts`). `@forinda/kickjs` declares
+ * all three as optional peers; which ones a project actually needs is decided
+ * by `bootstrap({ runtime })`, so installing them is a runtime-dependent
+ * question, not a static dependency.
+ */
+export const ENGINE_PEERS: Record<'express' | 'fastify' | 'h3', readonly string[]> = {
+  express: ['express'],
+  // `serve-static` rather than express for static files — no express dependency.
+  fastify: ['fastify', '@fastify/middie', 'serve-static'],
+  h3: ['h3', 'serve-static'],
+}
+
 export const UPLOAD_DRIVERS: Record<
   'express' | 'fastify' | 'h3',
   { prod?: string; dev?: string; note: string }
@@ -345,7 +368,7 @@ export async function resolvePackageManager(flagPm: string | undefined): Promise
  * everything; that's what `kick add --list --all` triggers when an
  * adopter genuinely wants the live catalog.
  */
-export function printPackageList(all = false): void {
+export function printPackageList(all = false, runtime?: 'express' | 'fastify' | 'h3'): void {
   const entries = Object.entries(PACKAGE_REGISTRY)
   const maxName = Math.max(...entries.map(([k]) => k.length))
   const core = entries.filter(([, info]) => info.core)
@@ -353,7 +376,13 @@ export function printPackageList(all = false): void {
 
   const formatRow = ([name, info]: [string, PackageEntry]): string => {
     const padded = name.padEnd(maxName + 2)
-    const peers = info.peers.length ? ` (+ ${info.peers.join(', ')})` : ''
+    // Engine peers depend on the runtime, so name it rather than printing a
+    // list that would be wrong for two projects out of three.
+    const resolved = info.enginePeers
+      ? [...info.peers, ...ENGINE_PEERS[runtime ?? 'express']]
+      : info.peers
+    const engineNote = info.enginePeers ? ` [${runtime ?? 'express'} engine]` : ''
+    const peers = resolved.length ? ` (+ ${resolved.join(', ')})${engineNote}` : ''
     const deprecated = info.deprecated ? ` [DEPRECATED — ${info.deprecated}]` : ''
     return `    ${padded} ${info.description}${peers}${deprecated}`
   }
@@ -426,6 +455,11 @@ export function planAddPackages(
     for (const peer of entry.peers) {
       target.add(peer)
     }
+    if (entry.enginePeers) {
+      const enginePeers = ENGINE_PEERS[runtime]
+      for (const peer of enginePeers) target.add(peer)
+      notices.push(`${name} (${runtime}): engine peers ${enginePeers.join(', ')}`)
+    }
   }
 
   return { prodDeps: [...prodDeps], devDeps: [...devDeps], unknown, warnings, notices }
@@ -437,8 +471,8 @@ export function registerListCommand(program: Command): void {
     .alias('ls')
     .description('List KickJS packages (core only; pair with --all for the full catalog)')
     .option('--all', 'Include the full optional catalog')
-    .action((opts: { all?: boolean }) => {
-      printPackageList(Boolean(opts.all))
+    .action(async (opts: { all?: boolean }) => {
+      printPackageList(Boolean(opts.all), await resolveAppRuntime())
     })
 }
 
@@ -453,7 +487,7 @@ export function registerAddCommand(program: Command): void {
     .action(async (packages: string[], opts: any) => {
       // List mode
       if (opts.list || packages.length === 0) {
-        printPackageList(Boolean(opts.all))
+        printPackageList(Boolean(opts.all), await resolveAppRuntime())
         return
       }
 

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -124,12 +124,17 @@ export function registerTypegenCommand(program: Command): void {
         const idWidth = Math.max(...merged.typegens.map((t) => t.id.length))
         console.log('\n  Registered typegen plugins:\n')
         for (const tg of merged.typegens) {
-          const status = disabled.has(tg.id) ? ' (disabled)' : ''
+          const status = disabled.has(tg.id) ? '  (disabled)' : ''
+          // Same derivation as the runner — the file it owns is what an
+          // adopter actually needs when deciding whether to disable it.
+          const outFile = `${tg.id.replace(/\//g, '__')}${tg.outExtension ?? '.d.ts'}`
+          console.log(`    ${tg.id.padEnd(idWidth + 2)}→ .kickjs/types/${outFile}${status}`)
           console.log(
-            `    ${tg.id.padEnd(idWidth + 2)}inputs: ${tg.inputs.join(', ') || '(none)'}${status}`,
+            `    ${' '.repeat(idWidth + 2)}  watches: ${tg.inputs.join(', ') || '(none)'}`,
           )
         }
-        console.log()
+        console.log('\n  Disable one in kick.config.ts:\n')
+        console.log("    typegen: { disable: ['" + (merged.typegens[0]?.id ?? 'kick/x') + "'] }\n")
         return
       }
       const cliValidator = parseSchemaValidatorFlag(opts.schemaValidator)

--- a/packages/cli/src/plugin/builtins.ts
+++ b/packages/cli/src/plugin/builtins.ts
@@ -32,6 +32,7 @@ import { kickModuleTokensTypegen } from '../typegen/builtin/module-tokens'
 import { kickPluginsRegistryTypegen } from '../typegen/builtin/plugins-registry'
 import { kickAugmentationsTypegen } from '../typegen/builtin/augmentations'
 import { kickContextTypegen } from '../typegen/builtin/context'
+import { kickRouteFlagsTypegen } from '../typegen/builtin/route-flags'
 import { kickRuntimeTypegen } from '../typegen/builtin/runtime'
 
 import { defineCliPlugin, type KickCliPlugin } from './types'
@@ -70,6 +71,7 @@ export const builtinCliPlugins: readonly KickCliPlugin[] = [
   defineCliPlugin({ name: 'kick/plugins', typegens: [kickPluginsRegistryTypegen()] }),
   defineCliPlugin({ name: 'kick/augmentations', typegens: [kickAugmentationsTypegen()] }),
   defineCliPlugin({ name: 'kick/context', typegens: [kickContextTypegen()] }),
+  defineCliPlugin({ name: 'kick/route-flags', typegens: [kickRouteFlagsTypegen()] }),
   defineCliPlugin({ name: 'kick/assets', typegens: [kickAssetsTypegen()] }),
   defineCliPlugin({ name: 'kick/routes', typegens: [kickRoutesTypegen()] }),
   // After kick/routes, and that IS load-bearing here: this plugin resolves

--- a/packages/cli/src/typegen/builtin/route-flags.ts
+++ b/packages/cli/src/typegen/builtin/route-flags.ts
@@ -1,0 +1,23 @@
+// kick/route-flags typegen plugin.
+//
+// Emits the `KickRouteFlags` registry to `.kickjs/types/kick__route-flags.d.ts`
+// from every `defineRouteFlag('name')` call in the project.
+//
+// This is the cheap end of typegen: a flag is a positional string literal with
+// an optional explicit value type, so there is no dependency graph to resolve
+// and no per-route narrowing to compute — unlike context keys, whose registry
+// needs the contributor pipeline's ordering rules to say anything useful. One
+// AST branch in, a flat map out.
+
+import { renderRouteFlags } from '../render/manifest'
+import { sharedScanOptions } from './scan-opts'
+import type { TypegenPlugin } from '../plugin'
+
+export const kickRouteFlagsTypegen = (): TypegenPlugin => ({
+  id: 'kick/route-flags',
+  inputs: ['src/**/*.ts'],
+  async generate(ctx) {
+    const scan = await ctx.getScanResult(sharedScanOptions(ctx))
+    return renderRouteFlags(scan.routeFlags)
+  },
+})

--- a/packages/cli/src/typegen/extract-ast.ts
+++ b/packages/cli/src/typegen/extract-ast.ts
@@ -29,6 +29,7 @@ import {
   type DiscoveredAugmentation,
   type DiscoveredClass,
   type DiscoveredContextKey,
+  type DiscoveredRouteFlag,
   type DiscoveredInject,
   type DiscoveredPluginOrAdapter,
   type DiscoveredRoute,
@@ -451,6 +452,8 @@ export function extractFileAst(source: string, filePath: string, cwd: string): F
   const pluginsAndAdapters: DiscoveredPluginOrAdapter[] = []
   const augmentations: DiscoveredAugmentation[] = []
   const contextKeys: DiscoveredContextKey[] = []
+  const routeFlags: DiscoveredRouteFlag[] = []
+  const seenRouteFlags = new Set<string>()
   const routes: DiscoveredRoute[] = []
   const moduleMounts: ModuleMount[] = []
   const globPatterns: string[] = []
@@ -619,6 +622,28 @@ export function extractFileAst(source: string, filePath: string, cwd: string): F
           name: augName,
           description: stringValue(getProp(meta, 'description')),
           example: stringValue(getProp(meta, 'example')),
+          filePath,
+          relativePath: relPath,
+        })
+      }
+      return
+    }
+
+    // defineRouteFlag('name') — the name is a positional string literal, and
+    // an explicit value type (`defineRouteFlag<{ rpm: number }>('x')`) is
+    // taken verbatim from the source span. Nothing else to resolve: a flag has
+    // no deps and no per-route narrowing, which is why this is one branch
+    // where a context key needs a graph.
+    if (name === 'defineRouteFlag') {
+      const flagName = stringValue((node as { arguments?: Node[] }).arguments?.[0])
+      if (flagName !== null && !seenRouteFlags.has(flagName)) {
+        seenRouteFlags.add(flagName)
+        const typeArgs = (node as { typeArguments?: { start: number; end: number } }).typeArguments
+        const raw = typeArgs ? source.slice(typeArgs.start, typeArgs.end) : null
+        routeFlags.push({
+          name: flagName,
+          // Strip the surrounding angle brackets: `<{ rpm: number }>` → `{ rpm: number }`.
+          valueType: raw ? raw.slice(1, -1).trim() : null,
           filePath,
           relativePath: relPath,
         })
@@ -872,6 +897,7 @@ export function extractFileAst(source: string, filePath: string, cwd: string): F
     pluginsAndAdapters,
     augmentations,
     contextKeys,
+    routeFlags,
     routes,
     moduleMounts,
     globPatterns: /\.module\.[mc]?[tj]sx?$/.test(filePath) ? globPatterns : [],

--- a/packages/cli/src/typegen/render/manifest.ts
+++ b/packages/cli/src/typegen/render/manifest.ts
@@ -282,8 +282,26 @@ export function isSelfContainedType(typeText: string): boolean {
   return identifiers.every((id) => SELF_CONTAINED_NAMES.has(id))
 }
 
-/** Whitespace-insensitive comparison — `{ rpm: number }` and `{rpm:number}` are one type. */
-const normaliseType = (t: string | null): string => (t ?? 'true').replace(/\s+/g, '')
+/**
+ * Compare two type texts ignoring only *syntactic* whitespace.
+ *
+ * `{ rpm: number }` and `{rpm:number}` are one type, so a re-export with
+ * different formatting must not read as a conflict. But whitespace inside a
+ * string or template literal type is significant — `'a b'` and `'ab'` are
+ * different types — so literals are held out of the collapse and compared
+ * verbatim.
+ */
+const normaliseType = (t: string | null): string => {
+  const text = t ?? 'true'
+  const literals: string[] = []
+  // Park each literal behind a marker that contains no whitespace to collapse.
+  const parked = text.replace(/'[^']*'|"[^"]*"|`[^`]*`/g, (lit) => {
+    literals.push(lit)
+    return `\u0000${literals.length - 1}\u0000`
+  })
+  const collapsed = parked.replace(/\s+/g, '')
+  return collapsed.replace(/\u0000(\d+)\u0000/g, (_, i) => literals[Number(i)])
+}
 
 export function renderRouteFlags(items: DiscoveredRouteFlag[]): string {
   // Two calls with the same name are the same flag. Identical declarations are

--- a/packages/cli/src/typegen/render/manifest.ts
+++ b/packages/cli/src/typegen/render/manifest.ts
@@ -18,6 +18,7 @@
 
 import { dirname, relative, sep } from 'node:path'
 import type {
+  DiscoveredRouteFlag,
   ClassCollision,
   DiscoveredAugmentation,
   DiscoveredClass,
@@ -214,6 +215,49 @@ export function buildModuleTokens(classes: DiscoveredClass[]): string[] {
  * `keyof` constraint resolves to `never` (harmless — `dependsOn: []`
  * still works).
  */
+/**
+ * Emit the `KickRouteFlags` registry from discovered `defineRouteFlag` calls.
+ *
+ * Once emitted, a misspelt flag name is a compile error at every consumer
+ * (`skipWhen`, `exemptWhen`, `flags.has`), and `flags.get(name)` is typed —
+ * without anyone hand-writing a `declare module` block.
+ */
+export function renderRouteFlags(items: DiscoveredRouteFlag[]): string {
+  // Two calls with the same name are the same flag; first wins, and a
+  // conflicting value type is the author's problem to notice, not ours to
+  // guess at.
+  const byName = new Map<string, DiscoveredRouteFlag>()
+  for (const item of items) {
+    if (!byName.has(item.name)) byName.set(item.name, item)
+  }
+
+  const sorted = [...byName.values()].toSorted((a, b) => a.name.localeCompare(b.name))
+  const entries = sorted.map((item) => `    '${item.name}': ${item.valueType ?? 'true'}`).join('\n')
+
+  const body = entries
+    ? entries
+    : '    // (no route flags discovered yet — `defineRouteFlag(...)` calls feed this)'
+
+  return `${HEADER}
+declare module '@forinda/kickjs' {
+  /**
+   * Every route flag declared in this project, from its \`defineRouteFlag\`
+   * call site. A bare flag carries \`true\`; one declared with an explicit
+   * value type carries that type.
+   *
+   * The \`keyof\` narrows every flag name in the codebase — \`skipWhen\`,
+   * \`onlyWhen\`, \`exemptWhen\`, \`flags.has()\` — so a typo is a compile
+   * error rather than a flag that silently never matches.
+   */
+  interface KickRouteFlags {
+${body}
+  }
+}
+
+export {}
+`
+}
+
 export function renderPlugins(items: DiscoveredPluginOrAdapter[]): string {
   // Dedupe by name — two declarations with the same name are a runtime
   // boot-time error in `mount-sort.ts`; we surface the conflict via a

--- a/packages/cli/src/typegen/render/manifest.ts
+++ b/packages/cli/src/typegen/render/manifest.ts
@@ -222,6 +222,66 @@ export function buildModuleTokens(classes: DiscoveredClass[]): string[] {
  * (`skipWhen`, `exemptWhen`, `flags.has`), and `flags.get(name)` is typed —
  * without anyone hand-writing a `declare module` block.
  */
+/**
+ * Can this type text stand alone inside a generated `declare module` block?
+ *
+ * The value type is captured as raw source from the call site, where imports
+ * and local declarations are in scope — neither of which exists in the emitted
+ * `.d.ts`. A reference to anything the global scope lacks would emit as
+ * `Cannot find name`, so it is degraded to `unknown` instead.
+ *
+ * The allowlist is deliberately conservative: primitives, type keywords, and
+ * the handful of always-available globals. A false negative costs an adopter
+ * one `unknown`; a false positive breaks their build.
+ */
+const SELF_CONTAINED_NAMES = new Set([
+  'string',
+  'number',
+  'boolean',
+  'bigint',
+  'symbol',
+  'object',
+  'unknown',
+  'any',
+  'never',
+  'void',
+  'null',
+  'undefined',
+  'true',
+  'false',
+  'Array',
+  'ReadonlyArray',
+  'Record',
+  'Partial',
+  'Required',
+  'Readonly',
+  'Pick',
+  'Omit',
+  'Date',
+  'RegExp',
+  'Map',
+  'Set',
+  'ReadonlyMap',
+  'ReadonlySet',
+  'Promise',
+  'Error',
+  'URL',
+  'Uint8Array',
+  'ArrayBuffer',
+])
+
+export function isSelfContainedType(typeText: string): boolean {
+  const scrubbed = typeText
+    // String-literal types: their contents are values, not references.
+    .replace(/'[^']*'|"[^"]*"|`[^`]*`/g, '')
+    // Property names in an object type — `{ rpm: number; burst?: number }`.
+    // These are declarations, not references, so they need no scope.
+    .replace(/[A-Za-z_$][A-Za-z0-9_$]*\s*\??\s*:/g, ':')
+
+  const identifiers = scrubbed.match(/[A-Za-z_$][A-Za-z0-9_$]*/g) ?? []
+  return identifiers.every((id) => SELF_CONTAINED_NAMES.has(id))
+}
+
 export function renderRouteFlags(items: DiscoveredRouteFlag[]): string {
   // Two calls with the same name are the same flag; first wins, and a
   // conflicting value type is the author's problem to notice, not ours to
@@ -232,7 +292,25 @@ export function renderRouteFlags(items: DiscoveredRouteFlag[]): string {
   }
 
   const sorted = [...byName.values()].toSorted((a, b) => a.name.localeCompare(b.name))
-  const entries = sorted.map((item) => `    '${item.name}': ${item.valueType ?? 'true'}`).join('\n')
+  const entries = sorted
+    .map((item) => {
+      // `JSON.stringify`, not a hand-rolled quoted key: a flag name may legally
+      // contain a quote (`defineRouteFlag("author's")`), which would emit a
+      // syntax error into the generated file.
+      const key = JSON.stringify(item.name)
+      if (item.valueType === null) return `    ${key}: true`
+      if (isSelfContainedType(item.valueType)) return `    ${key}: ${item.valueType}`
+      // A named type is resolved in the flag's own module and means nothing
+      // inside this `declare module` block — emitting it produces
+      // `Cannot find name 'X'` and breaks every consumer's typecheck. Degrade
+      // to `unknown` and say why, rather than emitting a file that won't compile.
+      return (
+        `    // '${item.valueType}' is declared in ${item.relativePath}, not in scope here.\n` +
+        `    // Inline the type at the defineRouteFlag call, or declare this flag by hand.\n` +
+        `    ${key}: unknown`
+      )
+    })
+    .join('\n')
 
   const body = entries
     ? entries

--- a/packages/cli/src/typegen/render/manifest.ts
+++ b/packages/cli/src/typegen/render/manifest.ts
@@ -295,12 +295,14 @@ const normaliseType = (t: string | null): string => {
   const text = t ?? 'true'
   const literals: string[] = []
   // Park each literal behind a marker that contains no whitespace to collapse.
+  // Marker is plain ASCII with no whitespace: a control character would trip
+  // `no-control-regex`, and the collapse below must not touch it.
   const parked = text.replace(/'[^']*'|"[^"]*"|`[^`]*`/g, (lit) => {
     literals.push(lit)
-    return `\u0000${literals.length - 1}\u0000`
+    return `@@kicklit${literals.length - 1}@@`
   })
   const collapsed = parked.replace(/\s+/g, '')
-  return collapsed.replace(/\u0000(\d+)\u0000/g, (_, i) => literals[Number(i)])
+  return collapsed.replace(/@@kicklit(\d+)@@/g, (_, i) => literals[Number(i)])
 }
 
 export function renderRouteFlags(items: DiscoveredRouteFlag[]): string {

--- a/packages/cli/src/typegen/render/manifest.ts
+++ b/packages/cli/src/typegen/render/manifest.ts
@@ -282,13 +282,30 @@ export function isSelfContainedType(typeText: string): boolean {
   return identifiers.every((id) => SELF_CONTAINED_NAMES.has(id))
 }
 
+/** Whitespace-insensitive comparison — `{ rpm: number }` and `{rpm:number}` are one type. */
+const normaliseType = (t: string | null): string => (t ?? 'true').replace(/\s+/g, '')
+
 export function renderRouteFlags(items: DiscoveredRouteFlag[]): string {
-  // Two calls with the same name are the same flag; first wins, and a
-  // conflicting value type is the author's problem to notice, not ours to
-  // guess at.
+  // Two calls with the same name are the same flag. Identical declarations are
+  // fine (a re-export, a duplicated import); DIFFERENT value types are not —
+  // keeping the first would type `flags.get(name)` from one declaration while
+  // `defineRouteFlag` at the other site stores the other shape, and nothing
+  // would report the mismatch. Fail generation instead, naming both files.
   const byName = new Map<string, DiscoveredRouteFlag>()
   for (const item of items) {
-    if (!byName.has(item.name)) byName.set(item.name, item)
+    const prior = byName.get(item.name)
+    if (!prior) {
+      byName.set(item.name, item)
+      continue
+    }
+    if (normaliseType(prior.valueType) !== normaliseType(item.valueType)) {
+      throw new Error(
+        `Route flag '${item.name}' is declared with two different value types:\n` +
+          `  ${prior.relativePath}: ${prior.valueType ?? 'true'}\n` +
+          `  ${item.relativePath}: ${item.valueType ?? 'true'}\n` +
+          `Declare the flag once and import it, or give the two flags different names.`,
+      )
+    }
   }
 
   const sorted = [...byName.values()].toSorted((a, b) => a.name.localeCompare(b.name))
@@ -304,8 +321,11 @@ export function renderRouteFlags(items: DiscoveredRouteFlag[]): string {
       // inside this `declare module` block — emitting it produces
       // `Cannot find name 'X'` and breaks every consumer's typecheck. Degrade
       // to `unknown` and say why, rather than emitting a file that won't compile.
+      // Collapse the type text onto one line: a multiline type would end the
+      // `//` comment early and put the rest of it into the file as code.
+      const oneLine = item.valueType.replace(/\s+/g, ' ').trim()
       return (
-        `    // '${item.valueType}' is declared in ${item.relativePath}, not in scope here.\n` +
+        `    // '${oneLine}' is declared in ${item.relativePath}, not in scope here.\n` +
         `    // Inline the type at the defineRouteFlag call, or declare this flag by hand.\n` +
         `    ${key}: unknown`
       )

--- a/packages/cli/src/typegen/scanner.ts
+++ b/packages/cli/src/typegen/scanner.ts
@@ -241,6 +241,27 @@ export interface DiscoveredPluginOrAdapter {
  * plugin, which emits the `ContextKeys` augmentation so `dependsOn`
  * typo-checking is automatic and complete.
  */
+/**
+ * A `defineRouteFlag('name')` call site.
+ *
+ * Cheaper to discover than a context key: the name is a positional string
+ * literal, there is no `dependsOn` graph to resolve and no per-route narrowing
+ * to compute — a flag is just a name, so scanning is one AST branch and the
+ * emitted registry is a flat map.
+ */
+export interface DiscoveredRouteFlag {
+  /** The literal name — `'auth.public'`. */
+  name: string
+  /**
+   * Source text of an explicit value type, when the call site writes one:
+   * `defineRouteFlag<{ rpm: number }>('rate.limit')` → `'{ rpm: number }'`.
+   * `null` for a bare flag, which is emitted as `true`.
+   */
+  valueType: string | null
+  filePath: string
+  relativePath: string
+}
+
 export interface DiscoveredContextKey {
   /** The literal `key:` value the contributor writes. */
   key: string
@@ -315,6 +336,8 @@ export interface ScanResult {
   augmentations: DiscoveredAugmentation[]
   /** Context keys from `define(Http)ContextDecorator({ key })` calls */
   contextKeys: DiscoveredContextKey[]
+  /** Route flags from `defineRouteFlag('name')` calls. */
+  routeFlags: DiscoveredRouteFlag[]
   /**
    * Decorated classes that sit inside a module directory but aren't
    * picked up by any of the module's `import.meta.glob(...)` patterns.
@@ -1699,6 +1722,7 @@ export interface FileExtract {
   pluginsAndAdapters: DiscoveredPluginOrAdapter[]
   augmentations: DiscoveredAugmentation[]
   contextKeys: DiscoveredContextKey[]
+  routeFlags: DiscoveredRouteFlag[]
   /** Routes with own-path `pathParams` only — mount prefix applied at join. */
   routes: DiscoveredRoute[]
   /** `{ controller, mountPath }` pairs from this file's `routes()` body. */
@@ -1780,6 +1804,8 @@ export function extractFileRegex(source: string, filePath: string, cwd: string):
     tokens: extractTokensFromSource(source, filePath, cwd),
     injects: extractInjectsFromSource(source, filePath, cwd),
     pluginsAndAdapters: extractPluginsAndAdaptersFromSource(source, filePath, cwd),
+    // The regex fallback does not scan flags — the AST extractor owns that.
+    routeFlags: [],
     augmentations: extractAugmentationsFromSource(source, filePath, cwd),
     contextKeys: extractContextKeysFromSource(source, filePath, cwd),
     // Empty mount map → own-path params only; prefix re-applied at join.
@@ -1979,6 +2005,7 @@ function joinExtracts(files: string[], extracts: (FileExtract | null)[]): Omit<S
   const pluginsAndAdapters: DiscoveredPluginOrAdapter[] = []
   const augmentations: DiscoveredAugmentation[] = []
   const contextKeys: DiscoveredContextKey[] = []
+  const routeFlags: DiscoveredRouteFlag[] = []
 
   // forinda/kick-js#235 §3 — build a `Controller → mountPath` map from every
   // module file's `routes()` body so per-route `pathParams` can include
@@ -2007,6 +2034,7 @@ function joinExtracts(files: string[], extracts: (FileExtract | null)[]): Omit<S
     pluginsAndAdapters.push(...extract.pluginsAndAdapters)
     augmentations.push(...extract.augmentations)
     contextKeys.push(...extract.contextKeys)
+    routeFlags.push(...extract.routeFlags)
     if (extract.globPatterns.length > 0) globPatternsByFile.set(files[i], extract.globPatterns)
 
     // Re-apply the cross-file mount prefix to each cached route's
@@ -2109,6 +2137,7 @@ function joinExtracts(files: string[], extracts: (FileExtract | null)[]): Omit<S
     pluginsAndAdapters,
     augmentations,
     contextKeys,
+    routeFlags,
     orphanedClasses,
   }
 }

--- a/packages/kickjs/__tests__/route-flag-registry.d.ts
+++ b/packages/kickjs/__tests__/route-flag-registry.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Declares the suite's route flags, mirroring `context-meta.d.ts` for
+ * contributors. Without it `KickRouteFlags` is empty in this program,
+ * `RouteFlagName` collapses to `string`, and the narrowing assertions below
+ * would pass while proving nothing.
+ */
+declare module '../src/index' {
+  interface KickRouteFlags {
+    'auth.public': true
+    'rate.limit': { rpm: number }
+  }
+}
+
+export {}

--- a/packages/kickjs/__tests__/route-flag-types.test.ts
+++ b/packages/kickjs/__tests__/route-flag-types.test.ts
@@ -72,7 +72,7 @@ describe('RouteFlag overloads', () => {
       @Public
       bare() {}
 
-      @Public(false)
+      @Public.off
       off() {}
 
       @Limit({ rpm: 10 })
@@ -85,7 +85,7 @@ describe('RouteFlag overloads', () => {
     @Limit({ rpm: 5 })
     class ValuedClass {}
 
-    @Public(false)
+    @Public.off
     class OffClass {}
 
     expectTypeOf<MethodTarget>().toBeObject()

--- a/packages/kickjs/__tests__/route-flag-types.test.ts
+++ b/packages/kickjs/__tests__/route-flag-types.test.ts
@@ -8,10 +8,48 @@
  * the factory discriminates on its arguments — so only a type test catches it.
  */
 import { describe, it, expectTypeOf } from 'vitest'
-import { defineRouteFlag, type RouteFlag } from '../src/index'
+import { defineRouteFlag, getRouteFlags, type RouteFlag, type RouteFlagTest } from '../src/index'
 
 const Public = defineRouteFlag('auth.public')
 const Limit = defineRouteFlag<{ rpm: number }>('rate.limit')
+
+describe('KickRouteFlags narrowing', () => {
+  it('infers a flag value from the registry, no explicit generic', () => {
+    const Limit = defineRouteFlag('rate.limit')
+    expectTypeOf(Limit).toEqualTypeOf<RouteFlag<{ rpm: number }>>()
+
+    const Pub = defineRouteFlag('auth.public')
+    expectTypeOf(Pub).toEqualTypeOf<RouteFlag<true>>()
+  })
+
+  it('rejects a name the registry does not declare', () => {
+    // @ts-expect-error 'auth.pubic' is a typo — the whole point of the registry
+    defineRouteFlag('auth.pubic')
+  })
+
+  it('types flags.get by name', () => {
+    const flags = getRouteFlags(class {}, 'x')
+    expectTypeOf(flags.get('rate.limit')).toEqualTypeOf<{ rpm: number } | undefined>()
+    expectTypeOf(flags.get('auth.public')).toEqualTypeOf<true | undefined>()
+  })
+
+  it('rejects a misspelt name in has() and in a flag test', () => {
+    const flags = getRouteFlags(class {}, 'x')
+    // @ts-expect-error not a declared flag
+    flags.has('nope')
+
+    // @ts-expect-error not a declared flag
+    const bad: RouteFlagTest = 'auth.pubic'
+    void bad
+  })
+
+  it('accepts a declared name, a list of them, and a predicate', () => {
+    expectTypeOf<'auth.public'>().toMatchTypeOf<RouteFlagTest>()
+    expectTypeOf<['auth.public', 'rate.limit']>().toMatchTypeOf<RouteFlagTest>()
+    const predicate: RouteFlagTest = ({ flags }) => flags.has('auth.public')
+    void predicate
+  })
+})
 
 describe('RouteFlag overloads', () => {
   it('applies bare and with a value, on both methods and classes', () => {

--- a/packages/kickjs/__tests__/route-flag-types.test.ts
+++ b/packages/kickjs/__tests__/route-flag-types.test.ts
@@ -22,6 +22,21 @@ describe('KickRouteFlags narrowing', () => {
     expectTypeOf(Pub).toEqualTypeOf<RouteFlag<true>>()
   })
 
+  it('refuses bare application on a flag whose value is not `true`', () => {
+    const Limit = defineRouteFlag('rate.limit')
+
+    class T {
+      // @ts-expect-error bare `@Limit` would store `true`, but the registry
+      // promises readers `{ rpm: number }`
+      @Limit
+      wrong() {}
+
+      @Limit({ rpm: 10 })
+      right() {}
+    }
+    expectTypeOf<T>().toBeObject()
+  })
+
   it('rejects a name the registry does not declare', () => {
     // @ts-expect-error 'auth.pubic' is a typo — the whole point of the registry
     defineRouteFlag('auth.pubic')
@@ -99,5 +114,25 @@ describe('RouteFlag overloads', () => {
       on() {}
     }
     expectTypeOf<T>().toBeObject()
+  })
+})
+
+describe('negated flag tests', () => {
+  it('accepts a negated name and a single-polarity list', () => {
+    expectTypeOf<'!auth.public'>().toMatchTypeOf<RouteFlagTest>()
+    expectTypeOf<['!auth.public', '!rate.limit']>().toMatchTypeOf<RouteFlagTest>()
+  })
+
+  it('rejects a misspelt negation', () => {
+    // @ts-expect-error 'auth.pubic' is not a declared flag, negated or not
+    const bad: RouteFlagTest = '!auth.pubic'
+    void bad
+  })
+
+  it('rejects a list that mixes polarities', () => {
+    // @ts-expect-error mixed polarity has no reading everyone agrees on —
+    // use a predicate
+    const mixed: RouteFlagTest = ['auth.public', '!rate.limit']
+    void mixed
   })
 })

--- a/packages/kickjs/__tests__/route-flags.test.ts
+++ b/packages/kickjs/__tests__/route-flags.test.ts
@@ -498,6 +498,24 @@ describe('route flags — false is a value, not a sentinel', () => {
     expect(byPath['/on'].get('feature.enabled')).toBe(true)
   })
 
+  it('a symbol-valued flag can hold any symbol, including a lookalike sentinel', () => {
+    const Marker = defineRouteFlag<symbol>('marker')
+    // A registry-global sentinel would be reachable here and would delete the
+    // flag instead of storing this value.
+    const lookalike = Symbol.for('kick.flagUnset')
+
+    @Controller()
+    class C {
+      @Marker(lookalike)
+      @Get('/x')
+      x(_ctx: RequestContext) {}
+    }
+
+    const flags = buildRouteTable(C)[0].meta.flags!
+    expect(flags.has('marker')).toBe(true)
+    expect(flags.get('marker')).toBe(lookalike)
+  })
+
   it('`.off` is what removes an inherited flag', () => {
     @Enabled(true)
     @Controller()

--- a/packages/kickjs/__tests__/route-flags.test.ts
+++ b/packages/kickjs/__tests__/route-flags.test.ts
@@ -389,3 +389,75 @@ describe('route flags — buildRoutes parity', () => {
     expect(buildRouteTable(C)[0].meta.flags?.has('auth.public')).toBe(true)
   })
 })
+
+describe('route flags — negated tests', () => {
+  beforeEach(() => Container.reset())
+
+  const Metered = defineRouteFlag('billing.metered')
+
+  const runsFor = async (skipWhen: unknown) => {
+    const ran: string[] = []
+    const Track = defineHttpContextDecorator({
+      key: 'user',
+      skipWhen: skipWhen as never,
+      resolve: (ctx: RequestContext) => {
+        ran.push(ctx.route?.path ?? '?')
+        return null
+      },
+    })
+
+    @Controller()
+    class C {
+      @Public
+      @Get('/pub')
+      pub(ctx: RequestContext) {
+        ctx.json({})
+      }
+
+      @Metered
+      @Get('/metered')
+      metered(ctx: RequestContext) {
+        ctx.json({})
+      }
+
+      @Public
+      @Metered
+      @Get('/both')
+      both(ctx: RequestContext) {
+        ctx.json({})
+      }
+
+      @Get('/plain')
+      plain(ctx: RequestContext) {
+        ctx.json({})
+      }
+    }
+
+    const app = await bootWith({ modules: [mod('/n', C)], contributors: [Track.registration] })
+    const h = app.handle.bind(app)
+    for (const p of ['/pub', '/metered', '/both', '/plain']) await request(h).get(`/api/v1/n${p}`)
+    return ran
+  }
+
+  it("'!flag' skips the routes that do NOT carry it", async () => {
+    // Skip where auth.public is absent → only the flagged routes run.
+    expect(await runsFor('!auth.public')).toEqual(['/pub', '/both'])
+  })
+
+  it('a negated list means "carries none of these"', async () => {
+    // Skip only where BOTH are absent → /plain is the only one skipped.
+    expect(await runsFor(['!auth.public', '!billing.metered'])).toEqual([
+      '/pub',
+      '/metered',
+      '/both',
+    ])
+  })
+
+  it('a positive list still means "carries any of these"', async () => {
+    expect(await runsFor(['auth.public', 'billing.metered'])).toEqual(['/plain'])
+  })
+
+  it('throws on a mixed-polarity list rather than guessing', async () => {
+    await expect(runsFor(['auth.public', '!billing.metered'])).rejects.toThrow(/mixes polarities/)
+  })
+})

--- a/packages/kickjs/__tests__/route-flags.test.ts
+++ b/packages/kickjs/__tests__/route-flags.test.ts
@@ -117,6 +117,18 @@ describe('route flags — resolution', () => {
   })
 })
 
+describe('route flags — reserved names', () => {
+  it("rejects a flag name starting with '!'", () => {
+    // '!x' as a NAME would be indistinguishable from the negation of 'x', so a
+    // test written as `exemptWhen: '!x'` would silently change meaning.
+    expect(() => defineRouteFlag('!csrf.exempt' as never)).toThrow(/cannot start with '!'/)
+  })
+
+  it('still accepts a name containing ! elsewhere', () => {
+    expect(() => defineRouteFlag('urgent!' as never)).not.toThrow()
+  })
+})
+
 describe('route flags — ctx.route', () => {
   beforeEach(() => Container.reset())
 

--- a/packages/kickjs/__tests__/route-flags.test.ts
+++ b/packages/kickjs/__tests__/route-flags.test.ts
@@ -2,7 +2,7 @@
  * Route flags (spec: `route-flags-design.md`).
  *
  * The load-bearing case is the last group: a class-level `@Public` with a
- * method-level `@Public(false)` must resolve with the flag ABSENT on that
+ * method-level `@Public.off` must resolve with the flag ABSENT on that
  * method, not present-and-false. Both directions are asserted, because a
  * resolver that dropped the key everywhere would pass a one-sided test.
  */
@@ -101,7 +101,7 @@ describe('route flags — resolution', () => {
     class C {
       @Get('/inherits') inherits(_ctx: RequestContext) {}
 
-      @Public(false)
+      @Public.off
       @Get('/overrides')
       overrides(_ctx: RequestContext) {}
     }
@@ -229,7 +229,7 @@ describe('route flags — contributor skipWhen', () => {
       ctx.json({ user: ctx.get('user') ?? null })
     }
 
-    @Public(false)
+    @Public.off
     @Get('/admin')
     admin(ctx: RequestContext) {
       ctx.json({ user: ctx.get('user') ?? null })
@@ -471,5 +471,46 @@ describe('route flags — negated tests', () => {
 
   it('throws on a mixed-polarity list rather than guessing', async () => {
     await expect(runsFor(['auth.public', '!billing.metered'])).rejects.toThrow(/mixes polarities/)
+  })
+})
+
+describe('route flags — false is a value, not a sentinel', () => {
+  beforeEach(() => Container.reset())
+
+  const Enabled = defineRouteFlag<boolean>('feature.enabled')
+
+  it('stores `false` as a value rather than deleting the flag', () => {
+    @Controller()
+    class C {
+      @Enabled(false)
+      @Get('/off')
+      off(_ctx: RequestContext) {}
+
+      @Enabled(true)
+      @Get('/on')
+      on(_ctx: RequestContext) {}
+    }
+
+    const byPath = Object.fromEntries(buildRouteTable(C).map((e) => [e.path, e.meta.flags!]))
+    // Present AND false — the old `false`-as-removal made this unreachable.
+    expect(byPath['/off'].has('feature.enabled')).toBe(true)
+    expect(byPath['/off'].get('feature.enabled')).toBe(false)
+    expect(byPath['/on'].get('feature.enabled')).toBe(true)
+  })
+
+  it('`.off` is what removes an inherited flag', () => {
+    @Enabled(true)
+    @Controller()
+    class C {
+      @Get('/keeps') keeps(_ctx: RequestContext) {}
+
+      @Enabled.off
+      @Get('/drops')
+      drops(_ctx: RequestContext) {}
+    }
+
+    const byPath = Object.fromEntries(buildRouteTable(C).map((e) => [e.path, e.meta.flags!]))
+    expect(byPath['/keeps'].get('feature.enabled')).toBe(true)
+    expect(byPath['/drops'].has('feature.enabled')).toBe(false)
   })
 })

--- a/packages/kickjs/src/core/context-decorator.ts
+++ b/packages/kickjs/src/core/context-decorator.ts
@@ -1,4 +1,4 @@
-import type { RouteFlagTest } from './route-flag'
+import { assertFlagTest, type RouteFlagTest } from './route-flag'
 import 'reflect-metadata'
 import { METADATA, type Constructor, type MaybePromise } from './interfaces'
 import { pushClassMeta, pushMethodMeta } from './metadata'
@@ -706,6 +706,10 @@ function defineContextDecoratorImpl<
       ctx: Ctx,
       deps: ResolvedDeps<D>,
     ) => spec.resolve(ctx, deps, frozenParams)
+    if (spec.skipWhen !== undefined)
+      assertFlagTest(spec.skipWhen, `contributor '${spec.key}' skipWhen`)
+    if (spec.onlyWhen !== undefined)
+      assertFlagTest(spec.onlyWhen, `contributor '${spec.key}' onlyWhen`)
     return Object.freeze({
       key: spec.key,
       deps: sharedDeps,

--- a/packages/kickjs/src/core/contributor-runner.ts
+++ b/packages/kickjs/src/core/contributor-runner.ts
@@ -2,7 +2,7 @@ import type { Container } from './container'
 import type { ContributorRegistration } from './context-decorator'
 import type { ExecutionContext } from './execution-context'
 import type { ContributorPipeline } from './contributor-pipeline'
-import { matchesFlagTest } from './route-flag'
+import { matchesFlagTest, type RouteFlags } from './route-flag'
 import type { MatchedRoute } from '../http/runtime'
 
 export interface RunContributorsOptions {
@@ -17,7 +17,7 @@ export interface RunContributorsOptions {
    * registration's `skipWhen` / `onlyWhen`. Omitted outside a route (the
    * pipeline then runs every contributor, as before).
    */
-  flags?: ReadonlyMap<string, unknown>
+  flags?: RouteFlags
 }
 
 /**
@@ -31,7 +31,7 @@ export interface RunContributorsOptions {
 function shouldRun(
   reg: ContributorRegistration,
   ctx: ExecutionContext,
-  flags?: ReadonlyMap<string, unknown>,
+  flags?: RouteFlags,
 ): boolean {
   if (reg.skipWhen === undefined && reg.onlyWhen === undefined) return true
   const resolved = flags ?? EMPTY_FLAGS
@@ -41,7 +41,7 @@ function shouldRun(
   return true
 }
 
-const EMPTY_FLAGS: ReadonlyMap<string, unknown> = new Map()
+const EMPTY_FLAGS: RouteFlags = new Map() as RouteFlags
 
 /**
  * Execute a built {@link ContributorPipeline} against an {@link ExecutionContext}.

--- a/packages/kickjs/src/core/index.ts
+++ b/packages/kickjs/src/core/index.ts
@@ -304,6 +304,7 @@ export type {
   RouteFlag,
   RouteFlagContext,
   RouteFlagDeclaration,
+  NegatedRouteFlagName,
   RouteFlagName,
   RouteFlagPredicate,
   RouteFlagTest,

--- a/packages/kickjs/src/core/index.ts
+++ b/packages/kickjs/src/core/index.ts
@@ -300,9 +300,13 @@ export {
 export { defineRouteFlag, getRouteFlags, matchesFlagTest, resolveRouteFlags } from './route-flag'
 export { RoutePolicyTable, bindRoutePolicy, offerRoutePolicy } from './route-policy'
 export type {
+  KickRouteFlags,
   RouteFlag,
   RouteFlagContext,
   RouteFlagDeclaration,
+  RouteFlagName,
   RouteFlagPredicate,
   RouteFlagTest,
+  RouteFlagValue,
+  RouteFlags,
 } from './route-flag'

--- a/packages/kickjs/src/core/route-flag.ts
+++ b/packages/kickjs/src/core/route-flag.ts
@@ -8,12 +8,11 @@
  * mark a security scheme — none of them needs to know about the others.
  *
  * The rule that makes presence checks safe: a flag resolves to **absent**, or
- * **present with a value defaulting to `true`**. There is no present-but-false
- * state, so `flags.has(name)` is always the right question for a boolean flag.
- * `@Public(false)` on a method does not store `false` — it removes the flag the
- * class put there. Without that, `has('auth.public')` would answer `true` for
- * the route that just opted back IN, which is an authorization bypass rather
- * than a papercut.
+ * **present with a value**. `@Public.off` on a method removes what the class
+ * set, rather than storing something falsy — so `flags.has(name)` is always the
+ * right question for a boolean flag. Without that, `has('auth.public')` could
+ * answer `true` for the route that just opted back IN, which is an
+ * authorization bypass rather than a papercut.
  */
 import { METADATA } from './interfaces'
 import { getClassMeta, getMethodMeta, pushClassMeta, pushMethodMeta } from './metadata'
@@ -45,10 +44,8 @@ import { getClassMeta, getMethodMeta, pushClassMeta, pushMethodMeta } from './me
  * Two constraints on what you can declare:
  * - A name cannot start with `!` — that prefix means "does not carry this flag"
  *   in a {@link RouteFlagTest}, and `defineRouteFlag` rejects it.
- * - A value type should not include `false`, which is the deletion sentinel:
- *   `@Flag(false)` removes the flag rather than storing `false`, so
- *   `flags.get()` can never return it (its result type excludes `false` to say
- *   so).
+ * - Removal is `@Flag.off`, not `@Flag(false)` — so `false` stays usable as a
+ *   real value for a flag declared `boolean`.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface KickRouteFlags {}
@@ -70,6 +67,17 @@ export type RouteFlagName = [keyof KickRouteFlags] extends [never]
 export type RouteFlagValue<K extends string, Fallback = unknown> = K extends keyof KickRouteFlags
   ? KickRouteFlags[K]
   : Fallback
+
+/**
+ * Marks a declaration as "remove this flag" during resolution.
+ *
+ * A dedicated sentinel rather than `false`: `false` is a perfectly good flag
+ * VALUE (a registry entry typed `boolean`), and overloading it meant
+ * `@Enabled(false)` deleted the flag while `flags.get('enabled')` could never
+ * return `false`. With the sentinel, `false` stores like any other value and
+ * removal is spelled `@Enabled.off`.
+ */
+export const FLAG_UNSET: unique symbol = Symbol.for('kick.flagUnset') as never
 
 /** One `@Flag` application, before precedence resolution. */
 export interface RouteFlagDeclaration {
@@ -105,9 +113,18 @@ export interface BareRouteFlag {
   (target: object, propertyKey: string | symbol, descriptor?: PropertyDescriptor): void
 }
 
-/** The called form — `@Public(false)`, `@Limit({ rpm: 10 })`. */
+/** The called form — `@Limit({ rpm: 10 })` — plus removal via `.off`. */
 export interface ValuedRouteFlag<V> {
-  (value: V | false): (target: object, propertyKey?: string | symbol) => void
+  (value: V): (target: object, propertyKey?: string | symbol) => void
+  /**
+   * Remove the flag on this route — `@Public.off` on a method drops what the
+   * controller set.
+   *
+   * Applied bare, like the flag itself. Spelled as its own member rather than
+   * `@Public(false)` so that `false` stays available as a real value: a flag
+   * declared `boolean` can store it, and `flags.get()` can return it.
+   */
+  readonly off: BareRouteFlag
   readonly flagName: string
 }
 
@@ -213,7 +230,15 @@ export function defineRouteFlag(name: string): RouteFlag<never> {
   }
 
   Object.defineProperty(flag, 'flagName', { value: name, enumerable: true })
-  return flag as RouteFlag<never>
+  // `.off` is the removal decorator: bare-applicable, and the only way to drop
+  // an inherited flag now that `false` is an ordinary value.
+  Object.defineProperty(flag, 'off', {
+    value: (target: object, propertyKey?: string | symbol): void => {
+      apply(FLAG_UNSET, target, propertyKey)
+    },
+    enumerable: true,
+  })
+  return flag as unknown as RouteFlag<never>
 }
 
 /**
@@ -234,7 +259,7 @@ export function resolveRouteFlags(
 
   // Lowest precedence first, so higher levels overwrite.
   for (const { name, value } of [...classDeclarations, ...methodDeclarations]) {
-    if (value === false) {
+    if (value === FLAG_UNSET) {
       resolved.delete(name)
       continue
     }
@@ -257,13 +282,7 @@ export function resolveRouteFlags(
  */
 export interface RouteFlags extends ReadonlyMap<string, unknown> {
   has(name: RouteFlagName): boolean
-  /**
-   * `false` is excluded from the result on purpose: it is the deletion
-   * sentinel, so a flag resolved to `false` is *absent*, and `get` returns
-   * `undefined` for it. A registry entry typed `boolean` would otherwise
-   * promise a `false` that can never arrive.
-   */
-  get<K extends RouteFlagName>(name: K): Exclude<RouteFlagValue<K>, false> | undefined
+  get<K extends RouteFlagName>(name: K): RouteFlagValue<K> | undefined
 }
 
 /**

--- a/packages/kickjs/src/core/route-flag.ts
+++ b/packages/kickjs/src/core/route-flag.ts
@@ -76,8 +76,13 @@ export type RouteFlagValue<K extends string, Fallback = unknown> = K extends key
  * `@Enabled(false)` deleted the flag while `flags.get('enabled')` could never
  * return `false`. With the sentinel, `false` stores like any other value and
  * removal is spelled `@Enabled.off`.
+ *
+ * Module-private and NOT `Symbol.for`: a registry-global symbol is reachable
+ * by application code, so a flag declared with a `symbol` value could be handed
+ * this exact sentinel and be deleted instead of stored. It is created and
+ * consumed in this module, so it never needs to cross a realm.
  */
-export const FLAG_UNSET: unique symbol = Symbol.for('kick.flagUnset') as never
+const FLAG_UNSET: unique symbol = Symbol('kick.flagUnset') as never
 
 /** One `@Flag` application, before precedence resolution. */
 export interface RouteFlagDeclaration {

--- a/packages/kickjs/src/core/route-flag.ts
+++ b/packages/kickjs/src/core/route-flag.ts
@@ -74,23 +74,47 @@ export interface RouteFlagDeclaration {
  * A flag decorator. Usable bare (`@Public`) or called with a value
  * (`@Public(false)`, `@RateLimit({ rpm: 10 })`), on a class or a method.
  */
-export interface RouteFlag<V = true> {
+/**
+ * The bare application forms — `@Public` with no call.
+ *
+ * Split out so they can be withheld from a flag whose declared value is not
+ * assignable from `true`: applying `@Limit` bare would store `true` while
+ * `flags.get('rate.limit')` promises `{ rpm: number }`, and nothing would catch
+ * the mismatch until a consumer read the wrong shape at runtime.
+ */
+export interface BareRouteFlag {
   /**
-   * Bare on a class — `@Public`. Typed against `Function` rather than `object`
-   * so a flag VALUE that happens to be an object (`@Limit({ rpm: 10 })`) cannot
-   * match this signature: overload resolution would otherwise pick it, return
+   * Bare on a class. Typed against `Function` rather than `object` so a flag
+   * VALUE that happens to be an object (`@Limit({ rpm: 10 })`) cannot match
+   * this signature: overload resolution would otherwise pick it, return
    * `void`, and fail with "Type 'void' has no call signatures".
    */
   (target: Function): void
   /**
-   * Bare on a method — `@Public`. `propertyKey` is required for the same
-   * reason: it makes a one-argument call unambiguous.
+   * Bare on a method. `propertyKey` is required for the same reason — it makes
+   * a one-argument call unambiguous.
    */
   (target: object, propertyKey: string | symbol, descriptor?: PropertyDescriptor): void
-  /** Called with a value — `@Public(false)`, `@Limit({ rpm: 10 })`. */
+}
+
+/** The called form — `@Public(false)`, `@Limit({ rpm: 10 })`. */
+export interface ValuedRouteFlag<V> {
   (value: V | false): (target: object, propertyKey?: string | symbol) => void
   readonly flagName: string
 }
+
+/**
+ * A flag decorator.
+ *
+ * Bare application is available only when `true` is a valid value for the flag
+ * — which is every flag until {@link KickRouteFlags} declares a value type for
+ * it. Declare `'rate.limit': { rpm: number }` and `@RateLimit` on its own stops
+ * compiling, because the value it would store is not the value the registry
+ * promises readers.
+ */
+export type RouteFlag<V = true> = true extends V
+  ? BareRouteFlag & ValuedRouteFlag<V>
+  : ValuedRouteFlag<V>
 
 /**
  * True when the arguments look like a decorator application rather than a
@@ -259,7 +283,35 @@ export type RouteFlagPredicate = (ctx: RouteFlagContext) => boolean
  * skipWhen: ({ flags }) => flags.has('a') && flags.has('b')   // both
  * ```
  */
-export type RouteFlagTest = RouteFlagName | readonly RouteFlagName[] | RouteFlagPredicate
+/**
+ * A flag name with `!` in front — matches routes that do **not** carry it.
+ *
+ * Narrows with the registry like the positive form: once `KickRouteFlags`
+ * declares `'auth.public'`, this is `'!auth.public' | …`, so a misspelt
+ * negation is a compile error too.
+ */
+export type NegatedRouteFlagName = `!${RouteFlagName}`
+
+/**
+ * How a consumer names the routes it cares about.
+ *
+ * - `'auth.public'` — carries the flag
+ * - `'!auth.public'` — does **not** carry it
+ * - `['a', 'b']` — carries **any** of them
+ * - `['!a', '!b']` — carries **none** of them
+ * - a predicate — anything else: all-of, a flag's value, the route's path
+ *
+ * Lists are single-polarity by construction: `['a', '!b']` matches neither
+ * array member of this union, so it is a compile error. Mixed polarity has no
+ * reading everyone agrees on — under any-of it means "a present OR b absent",
+ * which most readers parse as "and" — and a predicate says it unambiguously.
+ */
+export type RouteFlagTest =
+  | RouteFlagName
+  | NegatedRouteFlagName
+  | readonly RouteFlagName[]
+  | readonly NegatedRouteFlagName[]
+  | RouteFlagPredicate
 
 /**
  * Evaluate a {@link RouteFlagTest} against a route's resolved flags.
@@ -274,10 +326,60 @@ export function matchesFlagTest(
   route?: RouteFlagContext['route'],
 ): boolean {
   const resolved = flags ?? EMPTY_FLAGS
-  if (typeof test === 'string') return resolved.has(test)
   if (typeof test === 'function') return test({ flags: resolved, route })
-  return test.some((name) => resolved.has(name))
+
+  if (typeof test === 'string') {
+    return isNegated(test)
+      ? !resolved.has(stripNegation(test))
+      : resolved.has(test as RouteFlagName)
+  }
+
+  if (test.length === 0) return false
+
+  // Single polarity per list — the type forbids mixing, and this guards the
+  // untyped callers (plain JS, a value read from config) that the type cannot.
+  const negated = isNegated(test[0])
+  if (test.some((name) => isNegated(name) !== negated)) {
+    throw new Error(
+      `Route flag test mixes polarities: [${test.map((n) => `'${n}'`).join(', ')}]. ` +
+        `A list is either all names ("carries any of these") or all negated ` +
+        `("carries none of these") — for anything else, pass a predicate.`,
+    )
+  }
+
+  // Positive list is any-of; negated list is its complement, none-of. The two
+  // read as opposites, which is what makes flipping every entry do what a
+  // reader expects.
+  return negated
+    ? test.every((name) => !resolved.has(stripNegation(name)))
+    : test.some((name) => resolved.has(name as RouteFlagName))
 }
+
+/**
+ * Reject a mixed-polarity list at construction time.
+ *
+ * A list like `['auth.public', '!metered']` is a static mistake, so it fails
+ * where it is written — when the contributor or guard is built — rather than
+ * on the first request that reaches it. Same reasoning as the contributor
+ * pipeline failing a dependency cycle at boot.
+ *
+ * Call from every factory that accepts a {@link RouteFlagTest}; the check in
+ * {@link matchesFlagTest} stays as a backstop for direct callers.
+ */
+export function assertFlagTest(test: RouteFlagTest, site: string): void {
+  if (typeof test === 'function' || typeof test === 'string' || test.length === 0) return
+  const negated = isNegated(test[0])
+  if (test.some((name) => isNegated(name) !== negated)) {
+    throw new Error(
+      `${site}: route flag test mixes polarities: [${test.map((n) => `'${n}'`).join(', ')}]. ` +
+        `A list is either all names ("carries any of these") or all negated ` +
+        `("carries none of these") — for anything else, pass a predicate.`,
+    )
+  }
+}
+
+const isNegated = (name: string): boolean => name.startsWith('!')
+const stripNegation = (name: string): RouteFlagName => name.slice(1) as RouteFlagName
 
 const EMPTY_FLAGS: RouteFlags = new Map()
 

--- a/packages/kickjs/src/core/route-flag.ts
+++ b/packages/kickjs/src/core/route-flag.ts
@@ -41,6 +41,14 @@ import { getClassMeta, getMethodMeta, pushClassMeta, pushMethodMeta } from './me
  *
  * The framework itself declares nothing here: it ships the mechanism and names
  * no flags, so `auth.public` above is a name you chose.
+ *
+ * Two constraints on what you can declare:
+ * - A name cannot start with `!` — that prefix means "does not carry this flag"
+ *   in a {@link RouteFlagTest}, and `defineRouteFlag` rejects it.
+ * - A value type should not include `false`, which is the deletion sentinel:
+ *   `@Flag(false)` removes the flag rather than storing `false`, so
+ *   `flags.get()` can never return it (its result type excludes `false` to say
+ *   so).
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface KickRouteFlags {}
@@ -162,6 +170,19 @@ export function defineRouteFlag<const N extends RouteFlagName>(
 ): RouteFlag<RouteFlagValue<N, true>>
 export function defineRouteFlag<V>(name: RouteFlagName): RouteFlag<V>
 export function defineRouteFlag(name: string): RouteFlag<never> {
+  // `!` is reserved: a test string starting with it means "does NOT carry this
+  // flag", so a flag literally named '!x' would be indistinguishable from the
+  // negation of 'x' — `exemptWhen: '!x'` would silently stop meaning what the
+  // author wrote. Rejecting at definition is the only point where the two can
+  // still be told apart.
+  if (name.startsWith('!')) {
+    throw new Error(
+      `defineRouteFlag('${name}'): a flag name cannot start with '!' — that prefix is reserved ` +
+        `for negated tests ('!${name.slice(1)}' means "does not carry ${name.slice(1)}"). ` +
+        `Rename the flag.`,
+    )
+  }
+
   function apply(value: unknown, target: object, propertyKey?: string | symbol): void {
     const declaration: RouteFlagDeclaration = { name, value }
     if (propertyKey === undefined) {
@@ -236,7 +257,13 @@ export function resolveRouteFlags(
  */
 export interface RouteFlags extends ReadonlyMap<string, unknown> {
   has(name: RouteFlagName): boolean
-  get<K extends RouteFlagName>(name: K): RouteFlagValue<K> | undefined
+  /**
+   * `false` is excluded from the result on purpose: it is the deletion
+   * sentinel, so a flag resolved to `false` is *absent*, and `get` returns
+   * `undefined` for it. A registry entry typed `boolean` would otherwise
+   * promise a `false` that can never arrive.
+   */
+  get<K extends RouteFlagName>(name: K): Exclude<RouteFlagValue<K>, false> | undefined
 }
 
 /**

--- a/packages/kickjs/src/core/route-flag.ts
+++ b/packages/kickjs/src/core/route-flag.ts
@@ -18,6 +18,51 @@
 import { METADATA } from './interfaces'
 import { getClassMeta, getMethodMeta, pushClassMeta, pushMethodMeta } from './metadata'
 
+/**
+ * Augmentable route-flag registry — the flag counterpart of `ContextMeta`.
+ *
+ * Declare a project's flags here and every use of them narrows: a misspelt
+ * name is a compile error rather than a flag that silently never matches, and
+ * `flags.get('rate.limit')` comes back typed instead of `unknown`.
+ *
+ * ```ts
+ * declare module '@forinda/kickjs' {
+ *   interface KickRouteFlags {
+ *     'auth.public': true
+ *     'rate.limit': { rpm: number }
+ *   }
+ * }
+ * ```
+ *
+ * The interface is empty by default, and everything below falls back to plain
+ * `string` while it stays that way — a project that has not augmented anything
+ * keeps compiling exactly as before. The narrowing switches on with the first
+ * declaration.
+ *
+ * The framework itself declares nothing here: it ships the mechanism and names
+ * no flags, so `auth.public` above is a name you chose.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface KickRouteFlags {}
+
+/**
+ * A flag name. Narrows to the declared keys once {@link KickRouteFlags} is
+ * augmented, and stays `string` until then — the same
+ * `[Known] extends [never]` fallback `ContextMetaKey` uses, for the same
+ * reason: first-day code must keep compiling.
+ */
+export type RouteFlagName = [keyof KickRouteFlags] extends [never]
+  ? string
+  : keyof KickRouteFlags & string
+
+/**
+ * The value type declared for a flag, defaulting to `true` for a bare flag and
+ * `unknown` for a name the registry does not know.
+ */
+export type RouteFlagValue<K extends string, Fallback = unknown> = K extends keyof KickRouteFlags
+  ? KickRouteFlags[K]
+  : Fallback
+
 /** One `@Flag` application, before precedence resolution. */
 export interface RouteFlagDeclaration {
   readonly name: string
@@ -74,8 +119,25 @@ function isDecoratorApplication(args: unknown[]): boolean {
  * export const Public = defineRouteFlag('auth.public')
  * export const RateLimit = defineRouteFlag<{ rpm: number }>('rate.limit')
  * ```
+ *
+ * Once {@link KickRouteFlags} declares the name, the value type comes from the
+ * registry and the explicit generic is redundant:
+ *
+ * ```ts
+ * declare module '@forinda/kickjs' {
+ *   interface KickRouteFlags {
+ *     'rate.limit': { rpm: number }
+ *   }
+ * }
+ *
+ * const RateLimit = defineRouteFlag('rate.limit') // RouteFlag<{ rpm: number }>
+ * ```
  */
-export function defineRouteFlag<V = true>(name: string): RouteFlag<V> {
+export function defineRouteFlag<const N extends RouteFlagName>(
+  name: N,
+): RouteFlag<RouteFlagValue<N, true>>
+export function defineRouteFlag<V>(name: RouteFlagName): RouteFlag<V>
+export function defineRouteFlag(name: string): RouteFlag<never> {
   function apply(value: unknown, target: object, propertyKey?: string | symbol): void {
     const declaration: RouteFlagDeclaration = { name, value }
     if (propertyKey === undefined) {
@@ -106,7 +168,7 @@ export function defineRouteFlag<V = true>(name: string): RouteFlag<V> {
   }
 
   Object.defineProperty(flag, 'flagName', { value: name, enumerable: true })
-  return flag as RouteFlag<V>
+  return flag as RouteFlag<never>
 }
 
 /**
@@ -122,7 +184,7 @@ export function defineRouteFlag<V = true>(name: string): RouteFlag<V> {
 export function resolveRouteFlags(
   classDeclarations: readonly RouteFlagDeclaration[],
   methodDeclarations: readonly RouteFlagDeclaration[],
-): ReadonlyMap<string, unknown> {
+): RouteFlags {
   const resolved = new Map<string, unknown>()
 
   // Lowest precedence first, so higher levels overwrite.
@@ -134,7 +196,23 @@ export function resolveRouteFlags(
     resolved.set(name, value)
   }
 
-  return resolved
+  // The map is built from declarations, so its value types are whatever the
+  // registry says they are — this cast is the one place that knowledge crosses
+  // from runtime data into the type system.
+  return resolved as RouteFlags
+}
+
+/**
+ * The resolved flags for a route.
+ *
+ * A `ReadonlyMap` whose `has` is narrowed to known names and whose `get`
+ * returns the declared value type — so `flags.get('rate.limit')` is
+ * `{ rpm: number } | undefined` rather than `unknown`, once the registry
+ * declares it. Until then it behaves like `ReadonlyMap<string, unknown>`.
+ */
+export interface RouteFlags extends ReadonlyMap<string, unknown> {
+  has(name: RouteFlagName): boolean
+  get<K extends RouteFlagName>(name: K): RouteFlagValue<K> | undefined
 }
 
 /**
@@ -144,7 +222,7 @@ export function resolveRouteFlags(
  * which today means a non-HTTP transport running the same contributor pipeline.
  */
 export interface RouteFlagContext {
-  readonly flags: ReadonlyMap<string, unknown>
+  readonly flags: RouteFlags
   readonly route?: {
     readonly method: string
     readonly path: string
@@ -181,7 +259,7 @@ export type RouteFlagPredicate = (ctx: RouteFlagContext) => boolean
  * skipWhen: ({ flags }) => flags.has('a') && flags.has('b')   // both
  * ```
  */
-export type RouteFlagTest = string | readonly string[] | RouteFlagPredicate
+export type RouteFlagTest = RouteFlagName | readonly RouteFlagName[] | RouteFlagPredicate
 
 /**
  * Evaluate a {@link RouteFlagTest} against a route's resolved flags.
@@ -192,7 +270,7 @@ export type RouteFlagTest = string | readonly string[] | RouteFlagPredicate
  */
 export function matchesFlagTest(
   test: RouteFlagTest,
-  flags: ReadonlyMap<string, unknown> | undefined,
+  flags: RouteFlags | undefined,
   route?: RouteFlagContext['route'],
 ): boolean {
   const resolved = flags ?? EMPTY_FLAGS
@@ -201,7 +279,7 @@ export function matchesFlagTest(
   return test.some((name) => resolved.has(name))
 }
 
-const EMPTY_FLAGS: ReadonlyMap<string, unknown> = new Map()
+const EMPTY_FLAGS: RouteFlags = new Map()
 
 /**
  * Where the matched route is stashed for `ctx.route` to read.
@@ -235,10 +313,7 @@ export const ROUTE_SLOT: unique symbol = Symbol.for('kick.route') as never
  * })
  * ```
  */
-export function getRouteFlags(
-  controllerClass: object,
-  handlerName: string,
-): ReadonlyMap<string, unknown> {
+export function getRouteFlags(controllerClass: object, handlerName: string): RouteFlags {
   return resolveRouteFlags(
     getClassFlagDeclarations(controllerClass),
     getMethodFlagDeclarations(controllerClass, handlerName),

--- a/packages/kickjs/src/core/route-policy.ts
+++ b/packages/kickjs/src/core/route-policy.ts
@@ -15,14 +15,16 @@
  * an embedded admin app) each get their own.
  */
 
+import type { RouteFlags } from './route-flag'
+
 /** Flags for one mounted route, keyed for lookup by an incoming request. */
 interface PolicyEntry {
   /** Compiled from the mounted path — `/users/:id` → `^/users/([^/]+)$`. */
   readonly pattern: RegExp
-  readonly flags: ReadonlyMap<string, unknown>
+  readonly flags: RouteFlags
 }
 
-const EMPTY: ReadonlyMap<string, unknown> = new Map()
+const EMPTY: RouteFlags = new Map() as RouteFlags
 
 /**
  * Turn a mounted path into a matcher.
@@ -44,7 +46,7 @@ export class RoutePolicyTable {
   /** Bucketed by method: an incoming request only scans its own verb. */
   private readonly byMethod = new Map<string, PolicyEntry[]>()
 
-  add(method: string, path: string, flags: ReadonlyMap<string, unknown> | undefined): void {
+  add(method: string, path: string, flags: RouteFlags | undefined): void {
     if (!flags || flags.size === 0) return // nothing to say about this route
     const verb = method.toUpperCase()
     const bucket = this.byMethod.get(verb) ?? []
@@ -57,7 +59,7 @@ export class RoutePolicyTable {
    * matches no flagged route — including when it matches no route at all,
    * which is exactly the traffic this exists to keep visible.
    */
-  lookup(method: string, pathname: string): ReadonlyMap<string, unknown> {
+  lookup(method: string, pathname: string): RouteFlags {
     const bucket = this.byMethod.get(method.toUpperCase())
     if (!bucket) return EMPTY
     for (const entry of bucket) {

--- a/packages/kickjs/src/http/middleware/csrf.ts
+++ b/packages/kickjs/src/http/middleware/csrf.ts
@@ -3,7 +3,7 @@ import type { Request, Response, NextFunction } from 'express'
 import { resolvePathname, type ClientRequestLike } from '../client-ip'
 
 import { randomHex } from '../../core/web-crypto'
-import { matchesFlagTest, type RouteFlagTest } from '../../core/route-flag'
+import { assertFlagTest, matchesFlagTest, type RouteFlagTest } from '../../core/route-flag'
 import type { MiddlewareHandler } from '../../core/decorators'
 import type { RequestContext } from '../context'
 
@@ -170,6 +170,7 @@ export function csrfGuard(options: CsrfGuardOptions = {}): MiddlewareHandler {
   const ignorePaths = new Set(options.ignorePaths ?? [])
   const tokenLength = options.tokenLength ?? 32
   const exemptWhen = options.exemptWhen
+  if (exemptWhen !== undefined) assertFlagTest(exemptWhen, 'csrfGuard({ exemptWhen })')
   const cookieOpts = {
     // Same default as `csrf()` above, and for the same reason.
     httpOnly: false,

--- a/packages/kickjs/src/http/middleware/rate-limit-guard.ts
+++ b/packages/kickjs/src/http/middleware/rate-limit-guard.ts
@@ -3,7 +3,7 @@
 // entry (via `@Middleware()` or `createWebApp({ middleware })`), unlike the
 // connect-style `rateLimit()` which is node-only. Zero runtime imports —
 // part of the edge purity graph.
-import { matchesFlagTest, type RouteFlagTest } from '../../core/route-flag'
+import { assertFlagTest, matchesFlagTest, type RouteFlagTest } from '../../core/route-flag'
 import type { MiddlewareHandler } from '../../core/decorators'
 import type { RequestContext } from '../context'
 import type { RateLimitStore } from './rate-limit'
@@ -133,6 +133,7 @@ export function rateLimitGuard(options: RateLimitGuardOptions = {}): MiddlewareH
   const store = options.store ?? new LazyMemoryStore(windowMs)
 
   const exemptWhen = options.exemptWhen
+  if (exemptWhen !== undefined) assertFlagTest(exemptWhen, 'rateLimitGuard({ exemptWhen })')
 
   return async (ctx: RequestContext, next: () => void): Promise<void> => {
     if (options.skip?.(ctx)) return next()

--- a/packages/kickjs/src/http/middleware/rate-limit.ts
+++ b/packages/kickjs/src/http/middleware/rate-limit.ts
@@ -1,4 +1,4 @@
-import { matchesFlagTest, type RouteFlagTest } from '../../core/route-flag'
+import { assertFlagTest, matchesFlagTest, type RouteFlagTest } from '../../core/route-flag'
 import { bindRoutePolicy, type RoutePolicyTable } from '../../core/route-policy'
 import { sendJson } from './respond'
 import type { Request, Response, NextFunction } from 'express'
@@ -151,6 +151,7 @@ export function rateLimit(options: RateLimitOptions = {}) {
   const skip = options.skip
   const skipPaths = new Set(options.skipPaths ?? [])
   const exemptWhen = options.exemptWhen
+  if (exemptWhen !== undefined) assertFlagTest(exemptWhen, 'rateLimit({ exemptWhen })')
 
   // Filled in by the Application once routes are mounted, via the slot
   // declared below. Absent when this middleware runs outside an Application

--- a/packages/kickjs/src/http/runtime.ts
+++ b/packages/kickjs/src/http/runtime.ts
@@ -11,7 +11,7 @@
 // that lets `RequestContext` run engine-agnostically lands with them (M3), since
 // under Express the drivers ARE the Express request/response objects already.
 
-import { ROUTE_SLOT } from '../core/route-flag'
+import { ROUTE_SLOT, type RouteFlags } from '../core/route-flag'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type {
   RequestHandler,
@@ -99,7 +99,7 @@ export interface RouteMeta {
    * absent rather than present-and-false, so `has()` is always the right
    * question. See `core/route-flag.ts`.
    */
-  flags?: ReadonlyMap<string, unknown>
+  flags?: RouteFlags
 }
 
 /**
@@ -127,7 +127,7 @@ export function publishMatchedRoute(req: unknown, entry: RouteEntry): void {
   }
 }
 
-const EMPTY_FLAGS: ReadonlyMap<string, unknown> = new Map()
+const EMPTY_FLAGS: RouteFlags = new Map() as RouteFlags
 
 export interface MatchedRoute {
   method: RouteMethod
@@ -136,7 +136,7 @@ export interface MatchedRoute {
   controller?: Constructor
   handlerName?: string
   /** Enabled flags only — see {@link RouteMeta.flags}. */
-  flags: ReadonlyMap<string, unknown>
+  flags: RouteFlags
 }
 
 /** A controller's routes grouped under the module mount prefix. */

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -37,6 +37,7 @@ export type {
   KickRouteFlags,
   RouteFlag,
   RouteFlagContext,
+  NegatedRouteFlagName,
   RouteFlagName,
   RouteFlagPredicate,
   RouteFlagTest,

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -34,10 +34,14 @@ export { defineHttpContextDecorator } from './http/define-http-context-decorator
 export { defineRouteFlag, getRouteFlags } from './core/route-flag'
 export { bindRoutePolicy, type RoutePolicyTable } from './core/route-policy'
 export type {
+  KickRouteFlags,
   RouteFlag,
   RouteFlagContext,
+  RouteFlagName,
   RouteFlagPredicate,
   RouteFlagTest,
+  RouteFlagValue,
+  RouteFlags,
 } from './core/route-flag'
 export type { MatchedRoute } from './http/runtime'
 

--- a/packages/kickjs/tsconfig.typetests.json
+++ b/packages/kickjs/tsconfig.typetests.json
@@ -33,6 +33,7 @@
     // assertions below would pass while proving nothing.
     "__tests__/context-meta.d.ts",
     "__tests__/context-decorator-public-types.test.ts",
+    "__tests__/route-flag-registry.d.ts",
     "__tests__/route-flag-types.test.ts"
   ]
 }

--- a/packages/swagger/__tests__/swagger.test.ts
+++ b/packages/swagger/__tests__/swagger.test.ts
@@ -787,7 +787,7 @@ describe('buildOpenAPISpec — security (Swagger-owned, not coupled to any auth 
       @Get('/open')
       open() {}
 
-      @Public(false)
+      @Public.off
       @Get('/admin')
       admin() {}
     }
@@ -832,7 +832,7 @@ describe('buildOpenAPISpec — security (Swagger-owned, not coupled to any auth 
       @Get('/open')
       open() {}
 
-      @Public(false)
+      @Public.off
       @Get('/secret')
       secret() {}
     }


### PR DESCRIPTION
Three commits pushed to #634's branch after it merged, so they never landed. Rebased onto `main`,
unchanged.

## 1. `KickRouteFlags` — flags get the type safety contributors have

Flag names were plain strings, which the design doc's own risk section called out: a typo is a
flag that silently never matches, and `flags.get()` returned `unknown`.

```ts
declare module '@forinda/kickjs' {
  interface KickRouteFlags {
    'auth.public': true
    'rate.limit': { rpm: number }
  }
}
```

- `defineRouteFlag('auth.pubic')` → compile error, with TypeScript's *"Did you mean"* suggestion
- `defineRouteFlag('rate.limit')` infers `RouteFlag<{ rpm: number }>` from the registry
- `flags.get('rate.limit')` is typed; `has()` takes only declared names
- `skipWhen` / `onlyWhen` / `exemptWhen` narrow in **every** consumer

Opt-in by construction: empty registry → everything falls back to `string` / `unknown`, the same
`[Known] extends [never]` trick `ContextMetaKey` uses. Projects that declare nothing compile
unchanged.

`defineRouteFlag` is overloaded rather than re-parameterised, so the documented
`defineRouteFlag<{ rpm: number }>('rate.limit')` keeps working next to the inferred form — the
first draft made the value generic positional and quietly broke it, which the type tests caught.

## 2. `kick typegen` generates that registry

Declaring the flag becomes the only step — no hand-written `declare module`:

```ts
// src/flags.ts — all you write
export const Public = defineRouteFlag('auth.public')
export const Limit = defineRouteFlag<{ rpm: number }>('rate.limit')
```

The new `kick/route-flags` plugin emits `.kickjs/types/kick__route-flags.d.ts`, refreshed on every
`kick dev` save.

**It is the cheapest plugin in the set, and gets more for it.** A flag is a positional string
literal with no `dependsOn` graph and no per-route ordering, so discovery is one AST branch and the
output is a flat map — where the context-key registry must reason about the contributor pipeline
first. It also captures the *value type*, so `flags.get('rate.limit')` is typed rather than merely
known to exist, which `ContextKeys` cannot do for contributors.

## 3. `kick add` installs the engine peers you actually use

The catalog listed `express` as a static peer of `@forinda/kickjs`, so adding the framework to a
Fastify or h3 project installed Express. The engine is chosen at `bootstrap({ runtime })`;
`resolveAppRuntime()` already existed for `kick add upload` and the framework package just never
used it.

| Runtime | Installed with `@forinda/kickjs` |
| --- | --- |
| `express` | `express` |
| `fastify` | `fastify`, `@fastify/middie`, `serve-static` |
| `h3` | `h3`, `serve-static` |

A test asserts these match what `kick new` scaffolds — drift shows up as a missing peer at boot,
a poor place to learn about it.

Also `kick typegen --list`, the answer to "how do I know what I can disable", now prints the file
each plugin owns and a copy-pasteable `typegen: { disable: [...] }` snippet. Its code comment
claimed it printed the owning plugin; it printed neither owner nor output file.

## Verification

- `pnpm typecheck` clean, including the `tsconfig.typetests.json` guards
- Repo suite: **315 files, 3291 tests, all passing**
- Three changesets: `@forinda/kickjs` minor, `@forinda/kickjs-cli` minor + patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in type safety for route flags, including validated names and inferred value types.
  * Route-flag conditions now support negated names, with mixed-polarity lists rejected early.
  * Use `@Flag.off` or `@Public.off` to remove inherited flags while preserving `false` as a value.
  * `kick typegen` generates route-flag declarations and refreshes them during development.
  * `kick add` selects engine-specific peer packages for Express, Fastify, or h3.
  * `kick typegen --list` displays generated files, watched inputs, and plugin disable guidance.

* **Documentation**
  * Added guidance for typed route flags, negation, flag removal, runtime-specific dependencies, and enhanced type generation output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->