### PR TITLE
docs(db): make setup followable end to end, and cover existing databases

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -94,19 +94,15 @@ const guideSidebar = [
     text: 'Database',
     items: [
       { text: 'Overview & Getting Started', link: '/guide/database/' },
+      { text: 'Adopting on an Existing DB', link: '/guide/database/adopting' },
       { text: 'Schema', link: '/guide/database/schema' },
+      { text: 'Schema Types', link: '/guide/db-schema-types' },
       { text: 'Queries', link: '/guide/database/queries' },
+      { text: 'Relational Queries', link: '/guide/db-relational-query' },
       { text: 'Migrations', link: '/guide/database/migrations' },
       { text: 'CLI', link: '/guide/database/cli' },
       { text: 'Drivers', link: '/guide/database/drivers' },
       { text: 'Repositories', link: '/guide/database/repositories' },
-    ],
-  },
-  {
-    text: 'Database (kickjs-db)',
-    items: [
-      { text: 'Schema Types', link: '/guide/db-schema-types' },
-      { text: 'Relational Queries', link: '/guide/db-relational-query' },
       { text: 'Extensions', link: '/guide/db-extensions' },
     ],
   },

--- a/docs/guide/database/adopting.md
+++ b/docs/guide/database/adopting.md
@@ -1,0 +1,138 @@
+# Adopting kick/db on an Existing Database
+
+The [getting started](./index) path assumes an empty database: you write a schema, generate a migration, apply it. Adopting `@forinda/kickjs-db` on a database that already exists — with data, and usually with another ORM's migration history — is a different job.
+
+The order matters. Introspect first, baseline second, and only then let the differ near your database.
+
+## The one thing that will bite you
+
+`kick db generate` diffs your schema against the **last snapshot it wrote**, not against the live database. With no snapshot, every table you have is "new", so the generated `up.sql` is full of `CREATE TABLE` statements for tables that already exist. Running it fails — and if it half-succeeds you have a real mess.
+
+So the first migration on an existing database is never applied. It is **recorded as already applied**, which is what "baselining" means below.
+
+## 1. Introspect the live database
+
+Point the CLI at the database and let it write the schema for you:
+
+```bash
+kick db introspect
+```
+
+That reads the live schema and writes TypeScript to `db.schemaPath` (`--out` to send it elsewhere, `--json` to inspect the raw snapshot without writing anything). The migration tracking tables (`kick_migrations`, `kick_migrations_lock`) are excluded automatically, as is anything your old ORM keeps — check for its journal table (`_prisma_migrations`, `knex_migrations`, `typeorm_metadata`) and exclude it from the schema file if it came through.
+
+## 2. Read what it produced
+
+Introspection recovers what the database knows, which is less than what you know. Expect to fix up:
+
+- **Names.** Column and table names come back exactly as they are in SQL. If your old ORM mapped `created_at` to `createdAt`, that mapping lived in the ORM, not the database.
+- **Enums.** Postgres enums come through; a `varchar` with a `CHECK` constraint, or an int-backed enum, comes back as its storage type.
+- **Defaults.** A default expression the differ cannot represent is dropped with a comment rather than guessed at.
+- **Relations.** Foreign keys are recovered; the `relations()` declarations that drive `db.query` are not — the database has no idea you call them "author's posts". Add those by hand ([Schema](./schema#relations)).
+
+Do this now rather than later: everything below treats this file as the truth.
+
+## 3. Baseline the migration history
+
+Generate a migration that describes the schema as it stands:
+
+```bash
+kick db generate baseline
+```
+
+Now record it as applied **without running its SQL**. There is no `--fake` flag; `recordApplied()` on the migration adapter is the supported way, and a ten-line script is clearer than a flag would be about what it does:
+
+```ts
+// scripts/baseline.ts — run once, then delete it
+import { computeMigrationHash, readJournal } from '@forinda/kickjs-db'
+import { migrationAdapter } from '../src/db/client'
+
+const migrationsDir = 'db/migrations'
+const journal = await readJournal(migrationsDir, migrationAdapter.dialect)
+const entry = journal.entries.at(-1)
+if (!entry) throw new Error('No migration to baseline — run `kick db generate baseline` first.')
+
+await migrationAdapter.ensureMigrationTables()
+await migrationAdapter.recordApplied({
+  id: entry.id,
+  name: entry.tag,
+  hash: await computeMigrationHash(`${migrationsDir}/${entry.id}`),
+  batch: 1,
+  direction: 'up',
+})
+await migrationAdapter.close()
+console.log(`Baselined ${entry.id} — its SQL was NOT executed.`)
+```
+
+Confirm it took:
+
+```bash
+kick db migrate status   # baseline: applied, nothing pending
+```
+
+From here the normal loop works: edit the schema, `kick db generate <name>`, read the SQL, `kick db migrate latest`. The second migration is a real diff against the baseline snapshot, so it contains only your actual change.
+
+::: warning Baseline against every environment
+The tracking table lives in the database, so each environment needs the row. Run the script once per environment (dev, staging, production) before the first real migration reaches it — otherwise production sees the baseline as pending and, under `migrationsOnBoot: 'fail-if-pending'`, refuses to boot.
+:::
+
+## 4. Verify the schema really matches
+
+After editing the introspected file you want one question answered: does it still describe the live database? `migrate status` does not answer it — that lists applied and pending migrations only. Compare the snapshot directly:
+
+```bash
+kick db introspect --json > /tmp/live.json
+diff <(jq -S . /tmp/live.json) <(jq -S . db/migrations/<baseline-id>/snapshot.json)
+```
+
+An empty diff means the baseline snapshot and the database agree, so the next `kick db generate` will produce a diff of your change and nothing else. A non-empty diff is usually step 2 edited a little too enthusiastically — fix the schema file rather than generating SQL to change a database that is already correct.
+
+Drift detection covers this from then on, but it runs when migrations are **applied** (`migrate latest` / `up`), not on `status`. Configure it in the `db` block:
+
+```ts
+db: {
+  driftCheck: 'error', // 'error' | 'warn' | 'ignore'
+}
+```
+
+## Running alongside your current ORM
+
+You do not have to cut over in one commit. Two clients can read and write the same database — they are just connections.
+
+What you cannot do is let both own the schema. Pick one migration tool from the day you baseline:
+
+| Concern            | During transition                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------------------- |
+| Migrations         | **One owner.** Freeze the old ORM's migrations; all schema changes go through `kick db generate`. |
+| Reads/writes       | Both, freely. Migrate module by module.                                                           |
+| Connection pooling | Two pools means two limits. Halve each, or share a pool if the drivers allow.                     |
+| Transactions       | A transaction cannot span both clients. Keep a unit of work inside one of them.                   |
+
+The reason for the first row: if both tools write their own journal tables, each will happily generate a migration that undoes the other's change, and neither has any idea the other exists.
+
+## Cutover checklist
+
+- [ ] `kick db introspect` output reviewed, names and enums corrected, `relations()` added
+- [ ] Baseline generated and recorded in **every** environment
+- [ ] `kick db migrate status` clean, no drift
+- [ ] Old ORM's migration tool frozen — schema changes go through one tool only
+- [ ] One real migration generated and applied end to end, in a non-production environment first
+- [ ] Old ORM's journal table left alone until you are certain (it is small; dropping it is not urgent)
+
+## Coming from a specific ORM
+
+The mechanics above are the same regardless; these are the mapping notes that catch people out.
+
+**Prisma.** `schema.prisma` names are the ORM's, not the database's — `@map`/`@@map` mean your introspected names may differ from the model names you are used to. Prisma's `_prisma_migrations` table is unrelated to `kick_migrations`; leave it until cutover is done.
+
+**Drizzle.** Closest in shape — both are code-first, both build on a query builder — so schema translation is mostly mechanical. Drizzle's `drizzle-kit` snapshots are not interchangeable with kick/db snapshots, so baseline rather than trying to convert history.
+
+**TypeORM / Sequelize.** Entity decorators and model definitions carry behaviour (hooks, cascades, lifecycle events) that has no schema equivalent. Introspection recovers the tables; the behaviour is application code you port to services or [context contributors](../context-decorators).
+
+**Knex / raw SQL.** The easiest case: there are no ORM semantics to unwind. Introspect, baseline, and keep your existing query code running while you move call sites onto the typed client at whatever pace suits.
+
+## See also
+
+- [Database CLI](./cli) — every `kick db` command, including `introspect` flags
+- [Migrations](./migrations) — the review gate, batches, rollback, drift detection
+- [Schema](./schema) — the builders you will be editing in step 2
+- [Repositories](./repositories) — a useful seam while two clients coexist

--- a/docs/guide/database/index.md
+++ b/docs/guide/database/index.md
@@ -1,51 +1,75 @@
 # Database
 
-`@forinda/kickjs-db` is the first-party database layer for KickJS — a code-first ORM built on top of [Kysely](https://kysely.dev). You declare your schema as TypeScript, get fully typed queries with zero codegen, and ship reversible migrations through the `kick db` CLI.
+`@forinda/kickjs-db` is the first-party database layer for KickJS — a code-first ORM built on [Kysely](https://kysely.dev). You declare your schema in TypeScript, get typed queries with no codegen step, and ship reversible migrations through the `kick db` CLI.
 
-::: tip This is the database story for KickJS
-`@forinda/kickjs-db` and its driver packages (`@forinda/kickjs-db/pg`, `@forinda/kickjs-db/sqlite`, `@forinda/kickjs-db/mysql`) are the supported, first-party way to talk to a SQL database from a KickJS app.
-:::
+This page is one continuous path: install → schema → migration → query, with nothing assumed between the steps. It uses **SQLite** so you can finish it without provisioning anything; the only lines that change for Postgres or MySQL are called out at the end.
+
+The deeper references — every column type, the relational query layer, the full migration command set — are linked from [Where to go next](#where-to-go-next).
 
 ## What you get
 
-- **Code-first schema** — `table()`, typed column builders (`uuid()`, `varchar()`, `timestamp()`, …), `pgEnum()`, foreign keys, indexes, and `relations()`. One declaration drives both runtime SQL and TypeScript inference.
-- **Typed client** — `createDbClient({ schema, dialect })` returns a `KickDbClient` whose `selectFrom` / `insertInto` / `updateTable` / `deleteFrom` are typed against your schema. No hand-written `interface DB`.
-- **Relational queries** — `db.query.users.findMany({ with: { posts: true } })` compiles to a single JSON-aggregated query (no N+1).
-- **Reversible migrations** — `kick db generate` diffs your schema and writes `up.sql` + `down.sql` + a snapshot; `kick db migrate latest` applies them with a lock table, batch tracking, and drift detection.
-- **Lifecycle adapter** — `kickDbAdapter()` plugs migrations into `bootstrap()` and decides what to do about pending migrations on boot.
-- **DI tokens** — inject the client anywhere with `@Inject(DB_PRIMARY)`.
+- **Code-first schema** — `table()`, typed column builders (`uuid()`, `varchar()`, `timestamp()`, …), enums, foreign keys, indexes, and `relations()`. One declaration drives both the SQL and the TypeScript types.
+- **Typed client** — `createDbClient({ schema, dialect })` returns a client whose `selectFrom` / `insertInto` / `updateTable` / `deleteFrom` are typed from your schema. No hand-written `interface DB`.
+- **Relational queries** — `db.query.users.findMany({ with: { posts: true } })` compiles to one JSON-aggregated query, not N+1.
+- **Reversible migrations** — `kick db generate` diffs the schema and writes `up.sql` + `down.sql` + a snapshot; `kick db migrate latest` applies them with a lock table, batch tracking and drift detection.
+- **Lifecycle adapter** — `kickDbAdapter()` decides what happens to pending migrations on boot and drains the pool on shutdown.
 
-## Install
+## 1. Install
 
-`kick add` pulls the core package **and** the database client for your dialect in one step:
-
-**PostgreSQL**
-
-<PmCommand exec="kick add pg" />
-
-**SQLite**
+`kick add` installs the core package and the driver for your dialect together:
 
 <PmCommand exec="kick add sqlite" />
 
-**MySQL / MariaDB**
+| Dialect         | `kick add` | Packages installed                      |
+| --------------- | ---------- | --------------------------------------- |
+| SQLite          | `sqlite`   | `@forinda/kickjs-db` + `better-sqlite3` |
+| PostgreSQL      | `pg`       | `@forinda/kickjs-db` + `pg`             |
+| MySQL / MariaDB | `mysql`    | `@forinda/kickjs-db` + `mysql2`         |
 
-<PmCommand exec="kick add mysql" />
+Everything ships from the one package — the dialects are subpath exports (`@forinda/kickjs-db/sqlite`), not separate installs.
 
-Or install the pair yourself — this is exactly what `kick add` does:
+## 2. Mount the db CLI
 
-| dialect         | packages                                |
-| --------------- | --------------------------------------- |
-| PostgreSQL      | `@forinda/kickjs-db` + `pg`             |
-| SQLite          | `@forinda/kickjs-db` + `better-sqlite3` |
-| MySQL / MariaDB | `@forinda/kickjs-db` + `mysql2`         |
+::: warning Do this before reaching for `kick db`
+The `kick db` command tree ships inside `@forinda/kickjs-db`, not the base CLI, and is **opt-in**. Until you mount it, `kick db generate` is not a command — this is the most common "why doesn't this work" in the setup.
+:::
 
-<PmCommand add="@forinda/kickjs-db pg" />
+```ts
+// kick.config.ts
+import { defineConfig } from '@forinda/kickjs-cli'
+import { dbCliPlugin } from '@forinda/kickjs-db/cli'
 
-See [Drivers](./drivers) for the differences between dialects.
+export default defineConfig({
+  plugins: [dbCliPlugin], // ← adds the `kick db` commands
+  db: {
+    schemaPath: 'src/db/schema.ts',
+    migrationsDir: 'db/migrations',
+    dialect: 'sqlite',
+  },
+})
+```
 
-## 1. Declare a schema
+Check it took:
 
-A schema is a plain module that exports `table()` declarations:
+```bash
+kick db --help
+```
+
+The `db` block is read by both the CLI and the migration tooling, so it is configured once:
+
+| Field              | Default              | Purpose                                                          |
+| ------------------ | -------------------- | ---------------------------------------------------------------- |
+| `schemaPath`       | `'src/db/schema.ts'` | Module exporting your `table()` declarations                     |
+| `migrationsDir`    | `'db/migrations'`    | Where `kick db generate` writes migrations                       |
+| `dialect`          | `'postgres'`         | `'postgres' \| 'sqlite' \| 'mysql'`                              |
+| `connectionString` | `$DATABASE_URL`      | Used by the built-in Postgres adapter                            |
+| `adapter`          | —                    | Factory returning a custom `MigrationAdapter` (see [CLI](./cli)) |
+
+If you would rather not mount a plugin, the same commands ship as a standalone `kickjs-db` binary — see [Database CLI](./cli).
+
+## 3. Declare the schema
+
+A schema is a plain module of `table()` declarations:
 
 ```ts
 // src/db/schema.ts
@@ -59,136 +83,96 @@ export const users = table('users', {
 })
 ```
 
-The phantom type on each column flows through to the client, so `name` is `string | null` (nullable, no `.notNull()`) and `createdAt` is a generated `Date`. The full builder surface is covered in [Schema](./schema).
+Each column's type flows through to the client: `name` is `string | null` because it has no `.notNull()`, and `createdAt` is a generated `Date` you never pass on insert. Every builder is in [Schema](./schema).
 
-## 2. Add the `db:` config block
+## 4. Generate and apply the first migration
 
-`kick.config.ts` carries a `db` block that the CLI reads for `kick db generate` and `kick db migrate*`:
-
-```ts
-// kick.config.ts
-import { defineConfig } from '@forinda/kickjs-cli'
-
-export default defineConfig({
-  db: {
-    schemaPath: 'src/db/schema.ts',
-    migrationsDir: 'db/migrations',
-    dialect: 'postgres',
-    connectionString: process.env.DATABASE_URL,
-  },
-})
+```bash
+kick db generate init
 ```
 
-| Field              | Default              | Purpose                                                      |
-| ------------------ | -------------------- | ------------------------------------------------------------ |
-| `schemaPath`       | `'src/db/schema.ts'` | Module that exports your `table()` / `pgEnum()` declarations |
-| `migrationsDir`    | `'db/migrations'`    | Where `kick db generate` writes migration directories        |
-| `dialect`          | `'postgres'`         | `'postgres' \| 'sqlite' \| 'mysql'`                          |
-| `connectionString` | `$DATABASE_URL`      | Connection string for the built-in Postgres CLI adapter      |
-| `adapter`          | —                    | Escape-hatch factory returning a custom `MigrationAdapter`   |
+That diffs the schema against the last snapshot — there isn't one yet, so everything is new — and writes a migration directory containing `up.sql`, `down.sql`, a snapshot, and `meta.json`. **Read the SQL before applying it.** Generation is a diff, not an oracle; the review gate exists because a rename and a drop+add look identical to a differ.
 
-See [Migrations](./migrations) for the full workflow.
+```bash
+kick db migrate status    # what's pending
+kick db migrate latest    # apply
+```
 
-## 3. Create the client
+Later changes are the same two commands: edit the schema, `kick db generate <name>`, read the SQL, `kick db migrate latest`. [Migrations](./migrations) covers rollback, batches, drift detection and the review gate.
 
-`createDbClient` infers the database shape straight from the `schema` parameter — no manual generic:
+## 5. Create the client
 
 ```ts
 // src/db/client.ts
-import { Pool } from 'pg'
+import Database from 'better-sqlite3'
 import { createDbClient } from '@forinda/kickjs-db'
-import { pgAdapter, pgDialect } from '@forinda/kickjs-db/pg'
+import { sqliteAdapter, sqliteDialect } from '@forinda/kickjs-db/sqlite'
 import * as schema from './schema'
 
-export const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+const database = new Database('dev.db')
 
 export const db = createDbClient({
   schema,
-  dialect: pgDialect({ pool }),
-  events: true,
-  slowQueryThresholdMs: 100,
+  dialect: sqliteDialect({ database }),
 })
 
-// The same pool feeds the migration adapter — one pool, no duplicate connections.
-export const migrationAdapter = pgAdapter({ pool })
+// The same handle feeds the migration adapter — one connection, not two.
+export const migrationAdapter = sqliteAdapter({ database })
 ```
 
-## 4. Register the adapter in `bootstrap`
+`createDbClient` infers the database shape from `schema`, so there is no generic to pass and nothing to regenerate when the schema changes.
 
-`kickDbAdapter()` is a standard KickJS adapter. It checks for pending migrations on boot and registers a shutdown hook that drains the pool:
+## 6. Make it injectable
+
+The client is a value you own — register it under **your own token**:
 
 ```ts
-// src/index.ts
-import { bootstrap } from '@forinda/kickjs'
-import { kickDbAdapter } from '@forinda/kickjs-db'
-import { migrationAdapter } from './db/client'
-import { modules } from './modules'
+// src/db/token.ts
+import { createToken } from '@forinda/kickjs'
+import type { db } from './client'
 
-export const app = await bootstrap({
-  modules,
-  adapters: [
-    kickDbAdapter({
-      migrationAdapter,
-      migrationsDir: 'db/migrations',
-      // Apply automatically in dev; fail fast everywhere else so a
-      // deploy never silently mutates the schema.
-      migrationsOnBoot: process.env.NODE_ENV === 'development' ? 'apply' : 'fail-if-pending',
-    }),
-  ],
-})
+export const APP_DB = createToken<typeof db>('app/db')
 ```
 
-`migrationsOnBoot` is one of:
-
-- `'fail-if-pending'` (default) — throw on boot if any migration is pending. Operators run `kick db migrate latest` explicitly before a deploy lands.
-- `'apply'` — run `migrateLatest()` automatically. Handy for dev / preview environments.
-- `'ignore'` — boot regardless.
-
-## 5. Make the client injectable
-
-Register the client under the [DI token](#di-tokens) so any `@Service` / `@Repository` can inject it. The cleanest spot is a small module `register()`:
-
 ```ts
+// src/modules/db.module.ts
 import { defineModule } from '@forinda/kickjs'
-import { DB_PRIMARY } from '@forinda/kickjs-db'
-import { db } from './db/client'
+import { APP_DB } from '../db/token'
+import { db } from '../db/client'
 
 export const DbModule = defineModule({
-  name: 'db',
+  name: 'DbModule',
   build: () => ({
     register(container) {
-      container.registerFactory(DB_PRIMARY, () => db)
+      container.registerFactory(APP_DB, () => db)
     },
   }),
 })
 ```
 
-To make the bare `KickDbClient` type resolve to your schema everywhere, augment `KickDbRegister` once (the `kick typegen` plugin can emit this for you — see [Schema Types](../db-schema-types)):
+Typing the token with `typeof db` means `@Inject(APP_DB)` hands back your exact schema — no augmentation needed.
 
-```ts
-declare module '@forinda/kickjs-db' {
-  interface KickDbRegister {
-    db: typeof db
-  }
-}
-```
+::: tip The shipped tokens are a shortcut, not a requirement
+`@forinda/kickjs-db` also exports `DB_PRIMARY`, `DB_REPLICA` and `DB_CLIENT`. Nothing in the framework resolves them — the db adapter registers only what you hand it — so they are pre-made tokens for the common primary/replica shape, not an interface you have to adopt.
 
-## 6. First query
+Use them if that shape fits. Define your own when it doesn't: sharding, per-tenant clients, an analytics connection, or simply a name that reads better in your codebase. The `kick/` prefix is reserved for first-party tokens, so name yours under your own scope (`app/db/tenants`).
+:::
 
-Inject the client and run a typed query. The query surface is Kysely's — `selectFrom`, `insertInto`, `updateTable`, `deleteFrom`:
+## 7. Query
 
 ```ts
 import { Service, Inject } from '@forinda/kickjs'
-import { DB_PRIMARY, type KickDbClient } from '@forinda/kickjs-db'
+import { APP_DB } from '../db/token'
+import type { db } from '../db/client'
 
 @Service()
 export class UsersService {
-  @Inject(DB_PRIMARY) private db!: KickDbClient
+  @Inject(APP_DB) private db!: typeof db
 
   create(email: string, name: string) {
     return this.db
       .insertInto('users')
-      .values({ email, name }) // id + createdAt are generated — omit them
+      .values({ email, name }) // id and createdAt are generated — omit them
       .returningAll()
       .executeTakeFirstOrThrow()
   }
@@ -199,26 +183,61 @@ export class UsersService {
 }
 ```
 
-`row.email` is `string`, `row.createdAt` is `Date` — all inferred from the schema. See [Queries](./queries) for filtering, the relational `db.query` layer, transactions, and pagination.
+`row.email` is `string`, `row.createdAt` is `Date`, and a typo in a column name is a compile error. [Queries](./queries) covers filtering, the relational `db.query` layer, transactions and pagination.
 
-## DI tokens
+## 8. Decide what happens on boot
 
-`@forinda/kickjs-db` ships three injection tokens in the reserved `kick/` namespace:
+`kickDbAdapter()` checks for pending migrations at startup and closes the connection on shutdown:
 
 ```ts
-import { DB_PRIMARY, DB_REPLICA, DB_CLIENT } from '@forinda/kickjs-db'
+// src/index.ts
+export const app = await bootstrap({
+  modules,
+  adapters: [
+    kickDbAdapter({
+      migrationAdapter,
+      migrationsDir: 'db/migrations',
+      migrationsOnBoot: process.env.NODE_ENV === 'development' ? 'apply' : 'fail-if-pending',
+    }),
+  ],
+})
 ```
 
-- `DB_PRIMARY` — `kick/db/primary`. The default write client.
-- `DB_REPLICA` — `kick/db/replica`. For read-replica setups.
-- `DB_CLIENT` — an alias for `DB_PRIMARY`. Inject this if you only have one database and don't want to remember primary vs replica.
+- `'fail-if-pending'` (default) — refuse to boot with migrations pending, so a deploy never silently mutates the schema.
+- `'apply'` — run them. Convenient in dev and preview environments.
+- `'ignore'` — boot regardless.
 
-For sharded / multi-tenant setups, define your own token under your app's scope (e.g. `createToken<KickDbClient>('app/db/tenants')`) — the `kick/` prefix is reserved for first-party tokens.
+## Using Postgres or MySQL instead
+
+Only three things differ from the SQLite path above:
+
+| Step             | SQLite                        | PostgreSQL                          |
+| ---------------- | ----------------------------- | ----------------------------------- |
+| install (step 1) | `kick add sqlite`             | `kick add pg`                       |
+| `db.dialect`     | `'sqlite'`                    | `'postgres'` (+ `connectionString`) |
+| client (step 5)  | `sqliteDialect({ database })` | `pgDialect({ pool })`               |
+
+```ts
+import { Pool } from 'pg'
+import { pgAdapter, pgDialect } from '@forinda/kickjs-db/pg'
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+export const db = createDbClient({ schema, dialect: pgDialect({ pool }) })
+export const migrationAdapter = pgAdapter({ pool })
+```
+
+Schema, migrations, queries and DI are identical. [Drivers](./drivers) covers the capability differences that do exist — enum support, returning clauses, and what each dialect does with `defaultRandom()`.
 
 ## Where to go next
 
+In rough reading order:
+
 - [Schema](./schema) — tables, columns, enums, foreign keys, indexes, relations, custom types.
-- [Queries](./queries) — the typed query builder, `db.query` relational layer, transactions, lifecycle events, pagination.
-- [Migrations](./migrations) — `kick db generate`, the review gate, `kick db migrate latest/up/down/rollback/status`.
-- [Drivers](./drivers) — Postgres vs SQLite vs MySQL, connection config, capability differences.
-- [Repositories](./repositories) — implementing a generated `I<Name>Repository` interface against the client.
+- [Schema Types](../db-schema-types) — how the inference works, and the `kick db typegen` route to a typed `KickDbClient` everywhere.
+- [Queries](./queries) — the query builder, transactions, lifecycle events, pagination.
+- [Relational Queries](../db-relational-query) — `db.query.<table>.findMany({ with })` in depth.
+- [Migrations](./migrations) — the review gate, batches, rollback, drift detection.
+- [Database CLI](./cli) — every `kick db` command, plus the standalone binary.
+- [Drivers](./drivers) — per-dialect connection config and capabilities.
+- [Repositories](./repositories) — putting the client behind a repository interface.
+- [Extensions](../db-extensions) — custom column types and dialect-level extensions.

--- a/docs/guide/database/repositories.md
+++ b/docs/guide/database/repositories.md
@@ -47,7 +47,7 @@ export const users = table('users', {
 
 ## A database-backed repository
 
-Implement `IUserRepository` against the injected `KickDbClient`. Inject the client through `DB_PRIMARY` and use the typed query builder:
+Implement `IUserRepository` against the injected client. Inject it through whichever token you registered the client under — the examples here use the shipped `DB_PRIMARY`, but an app-owned token (`createToken<typeof db>('app/db')`) types better because it carries your schema without an augmentation. See [Getting started](./index#_6-make-it-injectable).
 
 ```ts
 // src/modules/users/infrastructure/repositories/db-user.repository.ts


### PR DESCRIPTION
Branched fresh off `main`.

## What was actually wrong

I walked the setup as a newcomer — scaffolded a project, followed `guide/database/index.md` line
by line — and hit a wall the docs describe but never sequence:

```
$ kick db --help
# not a command
```

`kick db` ships inside `@forinda/kickjs-db` as an **opt-in CLI plugin**. `cli.md` documents
mounting `dbCliPlugin`; the getting-started page that tells you to run `kick db generate` never
mentions it. That is the "second-guessing" moment.

## Getting started, rewritten as one path

Install → mount the CLI → schema → generate + apply → client → DI → query → boot policy, with
nothing assumed between steps. It uses **SQLite** so a reader can finish it without provisioning
anything, and ends with a three-row table of the only lines that change for Postgres or MySQL.
Every deep page is linked once, in reading order, from "where to go next".

## New: adopting kick/db on an existing database

The missing guide, and the one with a real trap in it. `kick db generate` diffs against the last
**snapshot**, not the live database — so on an existing schema the first migration is full of
`CREATE TABLE` for tables that already exist. Applying it fails; half-applying it is worse.

That migration has to be *recorded* rather than run. There is no `--fake` flag, but
`recordApplied()` is public on `MigrationAdapter`, so the guide gives the baseline script built
from the exported `readJournal` + `computeMigrationHash`. Then:

- verifying the schema really matches (compare `introspect --json` against the baseline snapshot)
- running alongside your current ORM — two clients on one database is fine, **two migration owners
  is not**
- a cutover checklist
- per-ORM notes: Prisma (`@map` names differ from the database), Drizzle (closest shape, but
  snapshots aren't interchangeable), TypeORM/Sequelize (hooks and cascades have no schema
  equivalent), Knex/raw SQL (easiest case)

## Consolidation

The db docs were split across two sidebar sections — `Database` and `Database (kickjs-db)` — so
Schema Types, Relational Queries and Extensions sat apart from the pages they extend. Merged into
one section in reading order.

## The DI tokens

> "restricting people to use our db tokens is a bit absurd… people should have flexibility"

Checked whether it was real: it isn't, but the docs made it look real. Nothing in the framework
resolves `DB_PRIMARY` — `adapter.ts:98` registers only the token *you* hand it, and client
registration is your own `registerFactory`. Every example just happened to use the shipped token,
which reads as the required interface.

Getting started now leads with an app-owned token, which types better anyway:

```ts
export const APP_DB = createToken<typeof db>('app/db')   // carries your schema, no augmentation
```

…and presents `DB_PRIMARY` / `DB_REPLICA` as a shortcut for the common primary/replica shape, with
the cases where you want your own (sharding, per-tenant, analytics) named explicitly.

## Verification

Both claims I could not verify from docs alone, I checked against source — and both were wrong in
my first draft:

- `migrate status` does **not** run drift detection; that happens on apply (`migrate latest`/`up`).
  Rewrote that step to compare `introspect --json` against the snapshot instead.
- `driftCheck` takes `'ignore'`, not `'off'`.

Also confirmed: the dialects are subpath exports of one package (`packages/db-pg` and `db-sqlite`
on disk are stale `dist` folders with no source), `introspect` excludes the migration tracking
tables by default, and `JournalEntry` is `{ id, tag, hash, createdAt }` as the baseline script uses.

All relative links in the touched pages resolve (checked with a script — `vitepress build` fails
locally on a missing `docs/node_modules/vue`, unrelated to this change). `pnpm format:check` clean.

Docs only, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
