### PR TITLE
docs: bring the request lifecycle and auth recipes up to what ships

### DIFF
--- a/docs/api/ws.md
+++ b/docs/api/ws.md
@@ -145,7 +145,7 @@ bootstrap({
 ## Related
 
 - [WebSocket Guide](../guide/websockets.md) — full walkthrough with rooms, auth, heartbeat
-- [WebSocket Example](../examples/ws-api.md) — chat app with notifications
+- [Examples](../examples/) — runnable reference apps, in the examples archive
 - [DevTools `/_debug/ws`](../guide/devtools.md) — live WebSocket metrics
 - [@forinda/kickjs-core](./core.md) — DI container, decorators
 - [@forinda/kickjs-http](./http.md) — HTTP server that WsAdapter attaches to

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -32,19 +32,40 @@ export const LoadAuthUser = defineHttpContextDecorator.withParams<{
 }>()({
   key: 'user',
   deps: { strategies: AUTH_STRATEGIES },
+  skipWhen: 'auth.public', // ← routes flagged @Public never reach the resolver
   paramDefaults: { on401: 'reject' },
   resolve: async (ctx, { strategies }, params) => {
     /* try strategies in order */
   },
 })
 
-// 4. `@Public` is sugar: LoadAuthUser({ on401: 'allow' }).
-export const Public = LoadAuthUser({ on401: 'allow' })
+// 4. `@Public` is a route flag the contributor skips on. The flag is a fact
+//    about the route; `skipWhen` on the contributor reads it (see below).
+export const Public = defineRouteFlag('auth.public')
 
 // 5. AuthAdapter (defineAdapter) registers the strategy list in DI and
 //    ships LoadAuthUser as a GLOBAL contributor when defaultPolicy is
 //    'protected' — every route requires a user unless marked @Public.
 ```
+
+::: tip Why a flag rather than a permissive twin
+`@Public` used to be `LoadAuthUser({ on401: 'allow' })` — a second instance of the same
+contributor, registered at higher precedence. That works, and still does, but it only composes if
+you own the contributor's key: you cannot exempt a contributor a plugin shipped, and no other
+consumer (CSRF, rate limiting, the OpenAPI spec) can tell the route is public.
+
+A [route flag](./route-flags.md) puts the fact on the route instead, so every consumer reads the
+same declaration:
+
+```ts
+csrfGuard({ exemptWhen: 'csrf.exempt' })
+rateLimitGuard({ max: 60, exemptWhen: 'auth.public' })
+SwaggerAdapter({ bearerAuth: true, publicFlag: 'auth.public' })
+```
+
+Declared on a controller it covers every route below; `@Public.off` on one method opts that
+route back in.
+:::
 
 Usage reads the same as the old package:
 

--- a/docs/guide/byo-recipes.md
+++ b/docs/guide/byo-recipes.md
@@ -142,6 +142,10 @@ type LoadAuthUserParams = {
 export const LoadAuthUser = defineHttpContextDecorator.withParams<LoadAuthUserParams>()({
   key: 'user',
   deps: { strategies: AUTH_STRATEGIES },
+  // Routes flagged @Public (step 5) never reach the resolver. Without this the
+  // adapter's global registration runs here on every route and the default
+  // `on401: 'reject'` answers 401 — including on the routes you marked public.
+  skipWhen: 'auth.public',
   paramDefaults: { on401: 'reject' },
   resolve: async (ctx, { strategies }, params) => {
     for (const strategy of strategies) {
@@ -202,11 +206,8 @@ import { defineRouteFlag } from '@forinda/kickjs'
 export const Public = defineRouteFlag('auth.public')
 ```
 
-The contributor from step 4 skips it by name:
-
-```ts
-defineHttpContextDecorator({ key: 'user', skipWhen: 'auth.public', resolve })
-```
+The contributor in step 4 already skips it by name — `skipWhen: 'auth.public'` is what connects
+the two halves, and the flag does nothing without it.
 
 The older shim — `export const Public = LoadAuthUser({ on401: 'allow' })` — still works, and
 relies on method-level precedence beating class-level. Prefer the flag: it composes.

--- a/docs/guide/byo-recipes.md
+++ b/docs/guide/byo-recipes.md
@@ -190,18 +190,37 @@ export const RequireRole = defineHttpContextDecorator.withParams<RequireRolePara
 })
 ```
 
-### Step 5 — `@Public` shim (just sugar over `LoadAuthUser({on401: 'allow'})`)
+### Step 5 — `@Public` as a route flag
 
 ```ts
-// src/auth/public.ts
-import { LoadAuthUser } from './load-auth-user'
+// src/auth/flags.ts
+import { defineRouteFlag } from '@forinda/kickjs'
 
-// `@Public` is just `@LoadAuthUser({ on401: 'allow' })` — pass through
-// without rejecting unauthenticated requests. Method-level decorators
-// have higher precedence than class-level, so a `@Public()` method on
-// a `@LoadAuthUser` controller wins.
-export const Public = LoadAuthUser({ on401: 'allow' })
+// A fact about the route, not a second copy of the auth contributor.
+// Declared on a controller it covers every route below; `@Public.off` on
+// one method opts that route back in.
+export const Public = defineRouteFlag('auth.public')
 ```
+
+The contributor from step 4 skips it by name:
+
+```ts
+defineHttpContextDecorator({ key: 'user', skipWhen: 'auth.public', resolve })
+```
+
+The older shim — `export const Public = LoadAuthUser({ on401: 'allow' })` — still works, and
+relies on method-level precedence beating class-level. Prefer the flag: it composes.
+Registering a permissive twin requires owning the contributor's key, so it cannot exempt a
+contributor a plugin shipped, and no other consumer can see that the route is public. With a
+flag, CSRF, rate limiting and the OpenAPI spec read the same declaration:
+
+```ts
+csrfGuard({ exemptWhen: 'csrf.exempt' })
+rateLimitGuard({ max: 60, exemptWhen: 'auth.public' })
+SwaggerAdapter({ bearerAuth: true, publicFlag: 'auth.public' })
+```
+
+See [Route Flags](./route-flags.md).
 
 ### Step 6 — `AuthAdapter` factory
 
@@ -334,7 +353,7 @@ parameterised contributor over the primitives the framework ships.
       decorator).
 - [ ] Replace `@Authenticated()` with adapter-level
       `defaultPolicy: 'protected'`.
-- [ ] Replace `@Public()` with `@LoadAuthUser({ on401: 'allow' })`
+- [ ] Replace `@Public()` with a route flag (`defineRouteFlag('auth.public')` + `skipWhen`)
       (or the `Public` shim re-export).
 - [ ] Replace `@Roles('admin')` with `@RequireRole({ roles: ['admin'] })`.
 - [ ] Run your existing auth tests — they should pass without changes.

--- a/docs/guide/decorators.md
+++ b/docs/guide/decorators.md
@@ -159,8 +159,19 @@ class WebhooksController {
 }
 ```
 
-Read them from anything holding a context — `ctx.route.flags.has('auth.public')` —
-or let a consumer do it for you: contributors take `skipWhen` / `onlyWhen`, and
+Read them anywhere a route has been matched — a guard, `@Middleware()`, a
+contributor, the handler:
+
+```ts
+if (ctx.route?.flags.has('auth.public')) return next()
+```
+
+`ctx.route` is optional because it is `undefined` before route matching: global
+middleware runs too early to have one. Pre-match middleware that needs flags
+(the connect-style `rateLimit()`) reads them from the boot-built policy table
+instead.
+
+Or let a consumer do the reading: contributors take `skipWhen` / `onlyWhen`, and
 the ctx-style guards take `exemptWhen`. Full surface in
 [Route Flags](./route-flags.md).
 

--- a/docs/guide/decorators.md
+++ b/docs/guide/decorators.md
@@ -134,6 +134,36 @@ class TxService {
 
 ## Method & Class Decorators
 
+### Route flags — `defineRouteFlag(name)`
+
+A flag is a decorator you define, recording a fact about the route that other
+things read — auth, CSRF, rate limiting, the OpenAPI spec:
+
+```ts
+import { defineRouteFlag } from '@forinda/kickjs'
+
+export const Public = defineRouteFlag('auth.public')
+export const RateLimit = defineRouteFlag<{ rpm: number }>('rate.limit')
+```
+
+```ts
+@Public // class level — every route below inherits it
+@Controller()
+class WebhooksController {
+  @Get('/health') health(ctx: RequestContext) {}
+
+  @Public.off // this one opts back in
+  @RateLimit({ rpm: 10 }) // flags can carry a value
+  @Post('/admin')
+  admin(ctx: RequestContext) {}
+}
+```
+
+Read them from anything holding a context — `ctx.route.flags.has('auth.public')` —
+or let a consumer do it for you: contributors take `skipWhen` / `onlyWhen`, and
+the ctx-style guards take `exemptWhen`. Full surface in
+[Route Flags](./route-flags.md).
+
 ### @Middleware(...handlers)
 
 Attach middleware to a class (all routes) or a specific method. Handlers receive `(ctx: RequestContext, next: () => void)`.
@@ -453,6 +483,7 @@ class TaskController {
 | `@PostConstruct`             | Method               | core    | Post-instantiation hook                             |
 | `@PreDestroy`                | Method               | core    | Teardown hook (request-scope close)                 |
 | `@Middleware`                | Class/Method         | core    | Attach middleware                                   |
+| flags via `defineRouteFlag`  | Class/Method         | core    | Per-route facts read by guards, contributors, docs  |
 | `@FileUpload`                | Method               | core    | Configure file upload                               |
 | `@Autowired`                 | Property / Parameter | core    | Dependency injection — either position works        |
 | `@Value`                     | Property             | core    | Env variable injection                              |

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -29,56 +29,85 @@ Steps 5 and 11 are where most adapter logic runs. Adapters that resolve cross-cu
 
 ## Request Flow
 
-Every incoming request flows through this pipeline:
+Every incoming request flows through this pipeline. The step numbers match the
+`── n.` markers in `Application.setup()`, so the code and this diagram stay
+readable against each other.
 
-```
+```text
 Request In
   │
-  ├─ Request tracking (in-flight counter)
-  ├─ Health check? (/health, /ready) → 200 OK (short-circuit)
-  ├─ AsyncLocalStorage scope opened
+  ├─ In-flight request tracking (drains on shutdown)
+  ├─ AsyncLocalStorage scope opened  ← the per-request bag every layer shares
   │
-  ├─ ▸ beforeGlobal adapters
-  │   └─ Example: a tracing adapter writes `requestStartedAt` into the request bag
-  │
+  ├─ ▸ adapter middleware: beforeGlobal
   ├─ Plugin middleware
-  ├─ Security headers (helmet)
-  ├─ User middleware (cors, json, session, etc.)
-  ├─ ▸ afterGlobal adapters
+  ├─ Global middleware (helmet, cors, requestId, body parsers, your own)
+  │   └─ Runs BEFORE a route is matched, so `ctx.route` is undefined here.
+  │      Pre-match middleware that needs route flags (rateLimit) reads them
+  │      from the boot-built policy table instead.
+  ├─ ▸ adapter middleware: afterGlobal
+  ├─ ▸ adapter middleware: beforeRoutes
   │
-  ├─ ▸ beforeRoutes adapters
-  │   └─ Example: AuthAdapter
-  │       ├─ Resolve controller + method from URL
-  │       ├─ @Public → LoadAuthUser({ on401: 'allow' }), user may be null
-  │       ├─ @LoadAuthUser → try strategies in order (BYO)
-  │       │   ├─ No user → throw, 401
-  │       │   └─ User found → ctx.set('user', user)
-  │       ├─ @RequireRole check (BYO) → 403 on missing role
-  │       ├─ @Can / policy engine via DI (BYO) → 403 on deny
-  │       └─ CSRF check (cookie auth + mutating method)
-  │
-  ├─ Express Router matches route
-  │   ├─ Validation middleware (Zod schemas)
+  ├─ The runtime matches a route  (Express / Fastify / h3 — same table, own engine)
+  │   │
+  │   ├─ Publish the matched route → `ctx.route` is now readable
+  │   │   └─ method, path, controller, handlerName, and flags resolved at boot
+  │   ├─ Validation middleware (schema on the route decorator)
   │   ├─ File-upload middleware (@FileUpload)
-  │   ├─ @Middleware() handlers (class then method)
-  │   ├─ ▸ Context Contributor pipeline (#107)
+  │   ├─ @Middleware() handlers — class first, then method
+  │   │   └─ guards live here: read `ctx.route.flags`, answer with ctx.problem.*
+  │   ├─ ▸ Context Contributor pipeline
   │   │   ├─ topo-sorted at boot — method > class > module > adapter > global
+  │   │   ├─ `skipWhen` / `onlyWhen` consult the route's flags first
   │   │   ├─ each contributor's resolve() runs sequentially (await)
   │   │   ├─ return value → runner does ctx.set(reg.key, value)
   │   │   └─ on throw: optional skip / onError fallback / propagate
-  │   │     (architecture.md §20.9)
   │   │
   │   └─ Controller method executes
   │       ├─ ctx.get(key)      → typed via ContextMeta
   │       ├─ getRequestValue() → same lookup from a service (no ctx)
-  │       └─ ctx.json(data)    → response (or .created / .noContent / etc.)
+  │       └─ return payload, or ctx.json(data) / .created / .noContent
   │
-  ├─ ▸ afterRoutes adapters
-  │
+  ├─ ▸ adapter middleware: afterRoutes
+  ├─ Error + not-found handlers
   └─ Response complete
 ```
 
-Three layers each construct their own `RequestContext` — `@Middleware`, the contributor wrapper, and the main handler. They all share the same per-request bag through the `AsyncLocalStorage` frame opened in step 4. See [Context Decorators → How values flow](./context-decorators.md#how-values-flow-instances-als-and-what-survives) for the per-instance details and the why.
+::: tip `/health` is not special
+The built-in health endpoints are an **ordinary module, mounted last** — not a
+short-circuit at the top of the pipeline. They pass through global middleware
+like any other route, which means app-wide auth applies to them unless you
+exempt the path. That is deliberate: a framework route quietly bypassing your
+middleware is the bigger surprise. Mounting last also means your own `/health`
+module wins if you declare one, and `health: false` skips the built-in entirely.
+:::
+
+### Where a value can be read
+
+| You are in                        | `ctx.route`  | Route flags             | Per-request bag        |
+| --------------------------------- | ------------ | ----------------------- | ---------------------- |
+| Global middleware (`middlewares`) | ❌ pre-match | via policy table        | ✅                     |
+| Adapter middleware (any phase)    | ❌ pre-match | via policy table        | ✅                     |
+| `@Middleware()` / guards          | ✅           | `ctx.route.flags`       | ✅                     |
+| Context contributors              | ✅           | `skipWhen` / `onlyWhen` | ✅                     |
+| Controller handler                | ✅           | `ctx.route.flags`       | ✅                     |
+| A service with no `ctx`           | —            | —                       | ✅ `getRequestValue()` |
+
+The split is route matching: everything after it knows which handler it is
+headed for, everything before it does not. See [Route Flags](./route-flags.md)
+for the flags themselves and the policy table that carries them across that line.
+
+### One context, or several
+
+Under Express the framework constructs a **new `RequestContext` per layer**
+(middleware step, contributor wrapper, handler); Fastify and h3 build one per
+request. Both are correct, because per-request state does not live on the ctx
+instance — `ctx.get` / `ctx.set` read the `AsyncLocalStorage` frame opened at the
+top of the pipeline, and `ctx.route` is published on the request object.
+
+It matters when you write a framework-level feature: state stashed on a `ctx`
+instance survives on Fastify and h3 and vanishes on Express. See
+[Context Decorators → How values flow](./context-decorators.md#how-values-flow-instances-als-and-what-survives).
 
 ## Adapter Lifecycle Hooks
 
@@ -125,30 +154,36 @@ Adapter middleware runs at specific phases in the pipeline:
 | -------------- | ---------------------- | ---------------------------------------------------------------- |
 | `beforeGlobal` | Before user middleware | Cross-cutting scope adapters (tracing, locale, tenant/workspace) |
 | `afterGlobal`  | After user middleware  | —                                                                |
-| `beforeRoutes` | Before Express router  | AuthAdapter, rate limiters, request validators                   |
-| `afterRoutes`  | After Express router   | SwaggerAdapter (serve OpenAPI spec), tail-end logging            |
+| `beforeRoutes` | Before route matching  | Rate limiters, request validators                                |
+| `afterRoutes`  | After route matching   | SwaggerAdapter (serve OpenAPI spec), tail-end logging            |
 
 Phases execute in order. Within a phase, adapters run in the order they appear in the `adapters` array — order matters when one adapter writes a value the next one reads. For most cases prefer a Context Contributor with `dependsOn` over relying on adapter ordering, since `dependsOn` validates at boot.
 
 ## RequestContext
 
-The `RequestContext` (alias `Ctx<T>`) wraps Express `req`/`res` and is constructed per middleware/handler layer that needs it. The `get` / `set` accessors read and write the same per-request bag every layer shares (via the `AsyncLocalStorage` frame):
+The `RequestContext` (alias `Ctx<T>`) is the engine-neutral request surface — it wraps whatever the active runtime hands it (Express `req`/`res`, a Fastify request/reply, an h3 event) and is constructed per layer that needs one. The `get` / `set` accessors read and write the same per-request bag every layer shares (via the `AsyncLocalStorage` frame):
 
 ```
 RequestContext
+├─ ctx.route           ← matched route + its flags (undefined pre-match)
 ├─ ctx.user            ← reads from request bag, falls back to req.user
 ├─ ctx.body            ← parsed request body
 ├─ ctx.params          ← route parameters
 ├─ ctx.query           ← query string
+├─ ctx.qs(config)      ← parsed filters / sort / pagination
 ├─ ctx.headers         ← request headers
+├─ ctx.ip              ← client IP, resolved per runtime
 ├─ ctx.session         ← session data (if session middleware)
 ├─ ctx.requestId       ← X-Request-Id header
+├─ ctx.file / ctx.files ← uploads (@FileUpload)
 ├─ ctx.get(key)        ← typed read via augmented ContextMeta
 ├─ ctx.set(key, value) ← typed write via augmented ContextMeta
+├─ ctx.setHeader(k, v) ← response header, runtime-neutral
 ├─ ctx.json(data)      ← 200 response
 ├─ ctx.created(data)   ← 201 response
 ├─ ctx.noContent()     ← 204 response
 ├─ ctx.notFound()      ← 404 response
+├─ ctx.problem.*       ← RFC 9457 problem responses
 └─ ctx.paginate(fn)    ← auto-paginated response
 ```
 
@@ -174,3 +209,5 @@ Services that don't hold a `ctx` reference read the same bag via `getRequestValu
 - [Authorization](./authorization.md) — BYO role checks + policy engine via DI
 - [Multi-Tenancy](./multi-tenancy.md) — TenantAdapter and database switching
 - [Middleware](./middleware.md) — custom middleware
+- [Route Flags](./route-flags.md) — per-route facts read by guards, contributors and pre-match middleware
+- [HTTP Runtimes](./http-runtimes.md) — what changes when the engine does

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -6,26 +6,32 @@ KickJS processes every request through a deterministic pipeline of middleware ph
 
 When `bootstrap()` is called, the application is assembled in this order:
 
-```
+```text
  1. Adapter beforeMount hooks            (mount early routes that bypass middleware)
  2. Hardened defaults                    (disable x-powered-by, trust proxy)
- 3. Request tracking + health endpoints
+ 3. In-flight request tracking           (drains on shutdown)
  4. Request scope (AsyncLocalStorage)    (requestScopeMiddleware)
  5. Adapter middleware: beforeGlobal     (e.g. tracing / scope-resolving adapters)
  6. Plugin registration + middleware
  7. Security defaults (auto-helmet)
  8. User middleware (cors, json, session, etc.)
  9. Adapter middleware: afterGlobal
-10. Module registration + DI bootstrap
-11. Adapter middleware: beforeRoutes     (e.g. AuthAdapter, rate limit)
+10. Module registration + DI bootstrap   (incl. the built-in health module)
+11. Adapter middleware: beforeRoutes     (e.g. rate limit, request validators)
 12. Mount module routes                  (onRouteMount notifies adapters per controller)
 13. Adapter middleware: afterRoutes
-14. Error handlers (404 + global)
-15. Adapter beforeStart hooks            (final DI registrations, log banner)
+14. Adapter beforeStart hooks            (final DI registrations, log banner)
+15. Error handlers (404 + global)
 16. HTTP server listen                   (then afterStart hooks fire)
 ```
 
-Steps 5 and 11 are where most adapter logic runs. Adapters that resolve cross-cutting per-request state (locale, tenant/workspace scope, geo, feature flags) typically run at `beforeGlobal`; auth / RBAC / rate limit run at `beforeRoutes` so they only protect matched routes.
+Steps 5 and 11 are where most adapter logic runs. Adapters resolving cross-cutting per-request
+state (locale, tenant/workspace scope, geo, feature flags) typically run at `beforeGlobal`.
+
+Note what step 11 is **not**: `beforeRoutes` runs before route _matching_, so middleware there sees
+every request including ones that match no route. That is right for an abuse control and wrong for
+anything that needs to know which handler it is protecting — those belong in `@Middleware()` or a
+contributor, where `ctx.route` exists.
 
 ## Request Flow
 

--- a/docs/guide/tutorial-typed-client.md
+++ b/docs/guide/tutorial-typed-client.md
@@ -444,9 +444,9 @@ Decorator-driven frameworks — KickJS, NestJS, Ts.ED, Hono — are increasingly
 
 The frameworks that win the next wave of TypeScript adoption will be the ones that close this loop. tRPC proved the DX is possible. The question is whether decorator-driven frameworks can offer the same safety without requiring developers to abandon their preferred patterns.
 
-KickJS already collects the metadata. It already has `SpaAdapter` for serving frontends. It already has `SwaggerAdapter` for API documentation. A typed client generator would be the third leg of the full-stack stool — turning a backend framework into a full-stack platform.
+KickJS already collects the metadata. It already has `SpaAdapter` for serving frontends. It already has `SwaggerAdapter` for API documentation. A typed client generator was the third leg of the full-stack stool — turning a backend framework into a full-stack platform.
 
-I've filed this as [KICK-018](./framework-filed-issues/KICK-018.md) in the framework issue tracker. If you're building with KickJS and want this feature, add a thumbs up on the GitHub issue.
+**This shipped.** `kick typegen` emits the route map, [`@forinda/kickjs-client`](./typed-client.md) consumes it, and `createRpc(api, kickRpc)` gives the tRPC-style namespace on top. The rest of this article is the argument that led there, kept as written.
 
 ---
 

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -608,16 +608,17 @@ export class Application {
 
   /**
    * Full setup pipeline:
-   * 1. Adapter beforeMount hooks (early routes — docs, health)
+   * 1. Adapter beforeMount hooks (early routes — e.g. docs UI)
    * 2. Adapter middleware (phase: beforeGlobal)
    * 3. Global middleware (user-declared or defaults)
    * 4. Adapter middleware (phase: afterGlobal)
-   * 5. Module registration + DI bootstrap
+   * 5. Module registration + DI bootstrap (the built-in health module mounts
+   *    here with everything else — it is NOT an early route)
    * 6. Adapter middleware (phase: beforeRoutes)
    * 7. Module route mounting
    * 8. Adapter middleware (phase: afterRoutes)
-   * 9. Error handlers (notFound + global)
-   * 10. Adapter beforeStart hooks
+   * 9. Adapter beforeStart hooks
+   * 10. Error handlers (notFound + global)
    */
   /** Build the adapter context object (shared across all hooks) */
   private adapterCtx(server?: any): AdapterContext {


### PR DESCRIPTION
Fresh branch off `main`, with everything merged.

I checked each pipeline step against `Application.setup()` and the runtime route chain rather than
against the previous version of the page.

## The correction that matters most

`/health` was documented as a short-circuit at the top of the pipeline:

```
├─ Health check? (/health, /ready) → 200 OK (short-circuit)
```

It is an **ordinary module mounted last** (`application.ts:811`). It passes through global
middleware like every other route, which means app-wide auth applies to it unless you exempt the
path. People configure auth around this assumption, so having it backwards in the docs is worse
than having it missing.

## Other drift in the same diagram

- **"Express Router matches route"**, "Before/After Express router" — the engine is pluggable.
  The runtime matches; the route table is shared.
- **`ctx.route` was absent entirely**, though publishing it is the first step of the matched-route
  chain (`express.ts:51`).
- **No `skipWhen` / `onlyWhen` step** in the contributor pipeline.

## Added: where a value can be read

The split people actually trip on is route matching — `ctx.route` and its flags exist after it and
not before, which is exactly why the pre-match `rateLimit()` reads flags from the boot-built policy
table instead. That is now a table rather than something you infer.

Also documented: Express constructs a `RequestContext` **per layer** while Fastify and h3 build one
per request. Both are fine because state lives in the ALS frame and on the request — but it means
state stashed on a ctx instance survives on two engines and vanishes on the third, which cost me a
debugging cycle when building route flags.

## The auth recipes

`authentication.md` and `byo-recipes.md` still taught:

```ts
export const Public = LoadAuthUser({ on401: 'allow' })   // a permissive twin
```

That works and is kept as the alternative, but it only composes if you own the contributor's key:
you cannot exempt a contributor a plugin shipped, and no other consumer can tell the route is
public. Both now lead with the flag and name the consumers that read the same declaration —
`csrfGuard`, `rateLimitGuard`, `SwaggerAdapter({ publicFlag })`.

## Swept up along the way

- Route flags were missing from the **decorator reference** entirely — added a section and a
  summary-table row, since someone scanning that page would otherwise never learn they exist.
- `tutorial-typed-client.md` still called the typed client a proposal ("would be the third leg")
  and linked `./framework-filed-issues/KICK-018.md`, which does not exist. It shipped; the page
  now says so and keeps the argument that led there.
- `api/ws.md` linked `../examples/ws-api.md`, which moved to the examples archive.

## Verification

Every relative link across `docs/guide`, `docs/api`, `docs/guide/database` and `docs/*.md`
resolves (script — `vitepress build` fails locally on a missing `docs/node_modules/vue`,
unrelated). `pnpm format:check` clean. Docs only, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated WebSocket API related links to point to the consolidated examples section.
  - Expanded guidance for route flags, including authentication, inheritance, opt-out behavior, and access by other request components.
  - Revised authentication recipes and migration guidance for public routes.
  - Updated request lifecycle documentation across supported runtimes, including route and request-context details.
  - Clarified that typed client generation and RPC namespace support are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->