### PR TITLE
fix(docs): declare vue so the site builds after a peer bump

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,8 @@
     "preview": "vitepress preview"
   },
   "devDependencies": {
-    "vitepress": "^1.6.4"
+    "vitepress": "^1.6.4",
+    "vue": "^3.5.13"
   },
   "engines": {
     "node": ">=20.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
         version: 7.0.2
       unplugin-swc:
         specifier: ^1.5.11
-        version: 1.5.11(@swc/core@1.16.1)(esbuild@0.27.4)(rolldown@1.2.5)(rollup@4.59.0)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.5.11(@swc/core@1.16.1)(esbuild@0.27.4)(rolldown@1.2.0)(rollup@4.59.0)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       vite:
         specifier: ^8.2.2
         version: 8.2.2(@types/node@26.4.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -90,6 +90,9 @@ importers:
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.49.2)(@types/node@26.4.0)(lightningcss@1.33.0)(postcss@8.5.26)(search-insights@2.17.3)(typescript@7.0.2)
+      vue:
+        specifier: ^3.5.13
+        version: 3.5.30(typescript@7.0.2)
 
   packages/ai:
     dependencies:
@@ -884,11 +887,6 @@ packages:
   '@babel/helpers@8.0.0':
     resolution: {integrity: sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==}
     engines: {node: ^22.18.0 || >=24.11.0}
-
-  '@babel/parser@7.29.7':
-    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.8':
     resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
@@ -5841,10 +5839,6 @@ snapshots:
       '@babel/template': 8.0.0
       '@babel/types': 8.0.0
 
-  '@babel/parser@7.29.7':
-    dependencies:
-      '@babel/types': 7.29.8
-
   '@babel/parser@7.29.8':
     dependencies:
       '@babel/types': 7.29.8
@@ -7442,7 +7436,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.30':
     dependencies:
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       '@vue/compiler-core': 3.5.30
       '@vue/compiler-dom': 3.5.30
       '@vue/compiler-ssr': 3.5.30
@@ -9921,6 +9915,23 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  unplugin-swc@1.5.11(@swc/core@1.16.1)(esbuild@0.27.4)(rolldown@1.2.0)(rollup@4.59.0)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@4.59.0)
+      '@swc/core': 1.16.1
+      load-tsconfig: 0.2.5
+      unplugin: 3.3.0(esbuild@0.27.4)(rolldown@1.2.0)(rollup@4.59.0)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
   unplugin-swc@1.5.11(@swc/core@1.16.1)(esbuild@0.27.4)(rolldown@1.2.5)(rollup@4.59.0)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.59.0)
@@ -9937,6 +9948,17 @@ snapshots:
       - unloader
       - vite
       - webpack
+
+  unplugin@3.3.0(esbuild@0.27.4)(rolldown@1.2.0)(rollup@4.59.0)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.5
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.27.4
+      rolldown: 1.2.0
+      rollup: 4.59.0
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   unplugin@3.3.0(esbuild@0.27.4)(rolldown@1.2.5)(rollup@4.59.0)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## The failure

```
$ pnpm docs:build
ENOENT: no such file or directory, stat 'docs/node_modules/vue'
    at linkVue (vitepress/dist/node/chunk-D3CUZ4fa.js:49671)
```

Confusing, because the path *is* there:

```
docs/node_modules/vue -> .../.pnpm/vue@3.5.30_typescript@6.0.3/node_modules/vue   # dangling
node_modules/.pnpm/vue@3.5.30_typescript@7.0.2                                    # what exists
```

A **stale symlink**. TypeScript moved 6.0.3 → 7.0.2, which changed vue's peer hash, so the store
path the link pointed at was pruned. VitePress creates that symlink itself in `linkVue()` and
`statSync`s it on the next run — a dangling one throws rather than being replaced.

## The fix

The docs package never declared `vue`, so the link was entirely VitePress's and `pnpm install`
never refreshed it. Declaring it hands ownership to pnpm:

```jsonc
// docs/package.json
"devDependencies": {
  "vitepress": "^1.6.4",
  "vue": "^3.5.13"   // the range vitepress itself depends on — no second copy
}
```

Any future peer bump now rewrites the link on install instead of leaving a stale one behind.

## Verification

`vitepress build` completes: client + server bundles, pages rendered, sitemap generated, 159s.

That matters beyond the error message — **link validation can now run locally** instead of waiting
for the Netlify preview. The two dead links I had to find by script (`framework-filed-issues/KICK-018.md`,
`examples/ws-api.md`) are fixed in #639; from here `vitepress build` catches that class itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
