### PR TITLE
fix(kickjs): export BareRouteFlag and ValuedRouteFlag (#641)

### DIFF
--- a/.changeset/route-flag-dts-export.md
+++ b/.changeset/route-flag-dts-export.md
@@ -1,0 +1,20 @@
+---
+'@forinda/kickjs': patch
+---
+
+Export `BareRouteFlag` and `ValuedRouteFlag` so a consumer can export a flag (#641).
+
+`RouteFlag<V>` is a conditional over those two interfaces, and only the alias was exported. A consumer writing the documented shape:
+
+```ts
+export const Public = defineRouteFlag('auth.public')
+```
+
+failed to emit declarations:
+
+```
+error TS4023: Exported variable 'Public' has or is using name 'BareRouteFlag'
+from external module ".../dist/route-flag-GzEeUmws" but cannot be named.
+```
+
+Flags are meant to be shared across controllers, so `export const` in a small module is the natural usage — and there was no non-exported way to use one across files. Both interfaces are now re-exported from the entry; the `RouteFlag` annotation workaround is no longer needed.

--- a/.changeset/route-flag-dts-export.md
+++ b/.changeset/route-flag-dts-export.md
@@ -12,7 +12,7 @@ export const Public = defineRouteFlag('auth.public')
 
 failed to emit declarations:
 
-```
+```text
 error TS4023: Exported variable 'Public' has or is using name 'BareRouteFlag'
 from external module ".../dist/route-flag-GzEeUmws" but cannot be named.
 ```

--- a/packages/kickjs/__tests__/dts-consumer-emit.test.ts
+++ b/packages/kickjs/__tests__/dts-consumer-emit.test.ts
@@ -31,7 +31,15 @@
 
 import { describe, expect, it } from 'vitest'
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -42,7 +50,7 @@ const DTS_ENTRY = join(PKG_ROOT, 'dist', 'index.d.mts')
 
 /** Mirrors what `kick g contributor` emits, including the `export`. */
 const CONSUMER = `
-import { defineContextDecorator } from '@forinda/kickjs'
+import { defineContextDecorator, defineRouteFlag } from '@forinda/kickjs'
 
 export const Tenant = defineContextDecorator({
   key: 'tenant',
@@ -63,6 +71,13 @@ export const Audit = defineContextDecorator.withParams<{ actorId: string }>()({
   key: 'audit',
   resolve: (_ctx, _deps, params) => ({ actor: params.actorId }),
 })
+
+// Route flags are shared across controllers, so \`export const\` in a small
+// module is the documented shape. \`RouteFlag<V>\` is a conditional over two
+// interfaces, and BOTH must be nameable through the entry — issue #641 shipped
+// because only the alias was exported.
+export const Public = defineRouteFlag('auth.public')
+export const RateLimit = defineRouteFlag<{ rpm: number }>('rate.limit')
 `
 
 // The documented \`src/middleware/index.ts\` layout: export the array and let
@@ -82,6 +97,20 @@ describe('a consumer can emit declarations for an exported contributor', () => {
     const dir = mkdtempSync(join(tmpdir(), 'kick-dts-'))
     try {
       writeFileSync(join(dir, 'consumer.ts'), CONSUMER)
+
+      // Install the built package into a real node_modules layout rather than
+      // pointing `paths` at dist/index.d.mts. That distinction is load-bearing:
+      // with `paths`, TypeScript can name a hashed chunk by RELATIVE path
+      // (`import("../dist/route-flag-XXXX")`) and emits happily — so the test
+      // passed against a package whose entry did not re-export the type, while
+      // a real dependant failed. Through node_modules the `exports` map has no
+      // subpath for the chunk, so the entry's re-exports are genuinely the only
+      // way to name anything. That is what consumers get.
+      const installed = join(dir, 'node_modules', '@forinda', 'kickjs')
+      mkdirSync(installed, { recursive: true })
+      cpSync(join(PKG_ROOT, 'dist'), join(installed, 'dist'), { recursive: true })
+      cpSync(join(PKG_ROOT, 'package.json'), join(installed, 'package.json'))
+
       writeFileSync(
         join(dir, 'tsconfig.json'),
         JSON.stringify(
@@ -99,9 +128,6 @@ describe('a consumer can emit declarations for an exported contributor', () => {
               target: 'es2022',
               skipLibCheck: true,
               experimentalDecorators: true,
-              // Resolve by NAME, the way a real dependant does, so the
-              // entry's re-exports are the only path to a type.
-              paths: { '@forinda/kickjs': [DTS_ENTRY] },
             },
             files: ['consumer.ts'],
           },
@@ -131,6 +157,9 @@ describe('a consumer can emit declarations for an exported contributor', () => {
       // Both union branches must be present, or this guard only covers one.
       expect(declaration).toContain('ContextDecoratorWithDefaults')
       expect(declaration).toContain('ContextDecoratorRequiringParams')
+      // Both branches of the RouteFlag conditional (issue #641).
+      expect(declaration).toContain('BareRouteFlag')
+      expect(declaration).toContain('ValuedRouteFlag')
 
       // Assert on TS4023 specifically rather than a clean exit: unrelated
       // config noise in a throwaway project should not fail this, but a

--- a/packages/kickjs/src/core/index.ts
+++ b/packages/kickjs/src/core/index.ts
@@ -301,7 +301,9 @@ export { defineRouteFlag, getRouteFlags, matchesFlagTest, resolveRouteFlags } fr
 export { RoutePolicyTable, bindRoutePolicy, offerRoutePolicy } from './route-policy'
 export type {
   KickRouteFlags,
+  BareRouteFlag,
   RouteFlag,
+  ValuedRouteFlag,
   RouteFlagContext,
   RouteFlagDeclaration,
   NegatedRouteFlagName,

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -35,7 +35,9 @@ export { defineRouteFlag, getRouteFlags } from './core/route-flag'
 export { bindRoutePolicy, type RoutePolicyTable } from './core/route-policy'
 export type {
   KickRouteFlags,
+  BareRouteFlag,
   RouteFlag,
+  ValuedRouteFlag,
   RouteFlagContext,
   NegatedRouteFlagName,
   RouteFlagName,


### PR DESCRIPTION
Fixes #641.

## The bug

`RouteFlag<V>` is a conditional over `BareRouteFlag` and `ValuedRouteFlag`, and only the alias was
exported. So the shape `defineRouteFlag`'s own docblock demonstrates fails downstream:

```ts
export const Public = defineRouteFlag('auth.public')
```
```
error TS4023: Exported variable 'Public' has or is using name 'BareRouteFlag'
from external module ".../dist/route-flag-GzEeUmws" but cannot be named.
```

The interfaces live in a hashed chunk the entry never re-exports, so a consumer has no path to
name them. Flags are meant to be shared across controllers — `export const` in a small module is
the natural usage, and there was no non-exported way to use one across files.

Both are now re-exported. The `RouteFlag` annotation workaround in the issue is no longer needed.

## The more useful half: the guard that should have caught it

`dts-consumer-emit.test.ts` exists for exactly this class of bug. It passed.

It pointed `paths` at `dist/index.d.mts`, and with a path mapping TypeScript can name a hashed
chunk by **relative** path (`import("../dist/route-flag-XXXX")`) and emits happily. Through a real
`node_modules` install the `exports` map has no subpath for that chunk, so the entry's re-exports
are genuinely the only way to name anything.

The guard now installs the built package into a temp `node_modules` instead — what a dependant
actually sees. Verified both directions:

- against the **unfixed** build it reproduces the issue verbatim, all three diagnostics
- against the **fixed** build it passes, and the emitted `.d.ts` names both types through the
  package entry:

```ts
export declare const Public: import("@forinda/kickjs").BareRouteFlag &
  import("@forinda/kickjs").ValuedRouteFlag<true>
```

The new case asserts **both** branches of the conditional, since a regression that un-exported
only one would otherwise sail through — the same reasoning the contributor cases in that file
already carry.

## Verification

- Repro reproduced by hand first, then through the hardened guard
- Full suite: **315 files, 3317 tests** passing
- `tsconfig.typetests.json` guards clean, `pnpm lint` and `pnpm format:check` clean
- Changeset: `@forinda/kickjs` patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVCyhU9ghEntXjQwzXvjhE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `BareRouteFlag` and `ValuedRouteFlag` are now publicly available from the package entry point.
  - Exported route flags now provide complete type information for consumers using `defineRouteFlag`.
  - Existing `RouteFlag` exports remain available.

- **Bug Fixes**
  - Improved generated declaration compatibility for projects that export route flags, removing the need for an additional `RouteFlag` annotation workaround.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->