### PR TITLE
docs: pre-match middleware does not mean no flags

### DIFF
--- a/docs/guide/csrf.md
+++ b/docs/guide/csrf.md
@@ -126,9 +126,16 @@ with HTTP status **403**.
 
 ## Exempting routes by flag
 
-`csrf()` runs before route matching, so its only handle on "not this endpoint" is
-`ignorePaths` — an exact pathname. That cannot express `/webhooks/:provider`, and
-it keeps parsing after an `apiPrefix` or `version` change that silently voids it.
+`csrf()` takes `ignorePaths` — an exact pathname — which cannot express
+`/webhooks/:provider` and keeps parsing after an `apiPrefix` or `version` change
+that silently voids it.
+
+Running before route matching is **not** the reason it has no flag option: the
+connect-style `rateLimit()` runs there too and takes `exemptWhen`, reading a
+policy table built at boot. CSRF has no equivalent because the check itself is
+meaningless off a matched route — a token mismatch on a path that routes nowhere
+is a 404, not a 403 — so exempting one was never the useful half. The flag-aware
+path is the guard below.
 
 `csrfGuard()` is the ctx-style counterpart. It runs inside the matched route, so
 it reads [route flags](./route-flags.md) and works on every runtime including the

--- a/docs/guide/decorators.md
+++ b/docs/guide/decorators.md
@@ -167,9 +167,9 @@ if (ctx.route?.flags.has('auth.public')) return next()
 ```
 
 `ctx.route` is optional because it is `undefined` before route matching: global
-middleware runs too early to have one. Pre-match middleware that needs flags
-(the connect-style `rateLimit()`) reads them from the boot-built policy table
-instead.
+middleware runs too early to have one. That is about `ctx.route`, not about
+flags — pre-match middleware can still read a route's flags through the boot-built
+policy table, which is how `rateLimit({ exemptWhen })` works.
 
 Or let a consumer do the reading: contributors take `skipWhen` / `onlyWhen`, and
 the ctx-style guards take `exemptWhen`. Full surface in

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -90,18 +90,24 @@ module wins if you declare one, and `health: false` skips the built-in entirely.
 
 ### Where a value can be read
 
-| You are in                        | `ctx.route`  | Route flags             | Per-request bag        |
-| --------------------------------- | ------------ | ----------------------- | ---------------------- |
-| Global middleware (`middlewares`) | ❌ pre-match | via policy table        | ✅                     |
-| Adapter middleware (any phase)    | ❌ pre-match | via policy table        | ✅                     |
-| `@Middleware()` / guards          | ✅           | `ctx.route.flags`       | ✅                     |
-| Context contributors              | ✅           | `skipWhen` / `onlyWhen` | ✅                     |
-| Controller handler                | ✅           | `ctx.route.flags`       | ✅                     |
-| A service with no `ctx`           | —            | —                       | ✅ `getRequestValue()` |
+| You are in                        | `ctx.route`  | Route flags                 | Per-request bag        |
+| --------------------------------- | ------------ | --------------------------- | ---------------------- |
+| Global middleware (`middlewares`) | ❌ pre-match | policy table, if it opts in | ✅                     |
+| Adapter middleware (any phase)    | ❌ pre-match | policy table, if it opts in | ✅                     |
+| `@Middleware()` / guards          | ✅           | `ctx.route.flags`           | ✅                     |
+| Context contributors              | ✅           | `skipWhen` / `onlyWhen`     | ✅                     |
+| Controller handler                | ✅           | `ctx.route.flags`           | ✅                     |
+| A service with no `ctx`           | —            | —                           | ✅ `getRequestValue()` |
 
 The split is route matching: everything after it knows which handler it is
-headed for, everything before it does not. See [Route Flags](./route-flags.md)
-for the flags themselves and the policy table that carries them across that line.
+headed for, everything before it does not.
+
+"Pre-match" does not mean "no flags", though — it means no `ctx.route`. Middleware
+that runs before matching can still read a route's flags by opting into the
+**policy table**, which records every mounted route's flags at boot;
+`rateLimit({ exemptWhen })` does exactly that, and your own middleware can via
+`bindRoutePolicy`. What it cannot do is know which handler it is headed for,
+because nothing has matched yet. See [Route Flags](./route-flags.md).
 
 ### One context, or several
 


### PR DESCRIPTION
Caught by review: the docs state a rule and then demonstrate breaking it.

## The contradiction

Three pages gave **"runs before route matching"** as the *reason* a middleware cannot use route
flags:

> `csrf()` runs before route matching, so its only handle on "not this endpoint" is `ignorePaths`

…while `rate-limiting.md` and `route-flags.md` show:

```ts
bootstrap({ middlewares: [rateLimit({ max: 60, exemptWhen: 'auth.public' })] })
```

`rateLimit()` is mounted exactly the same way, runs at exactly the same point, and takes a flag
test. So the stated rule was wrong, not the example.

## Why it drifted

That wording was accurate when `csrfGuard` landed — at that point nothing pre-match could read
flags. The next phase added the boot-built **policy table**, which is precisely the mechanism for
crossing that line, and `rateLimit` opted into it. I updated the pages that gained the feature and
left the ones that had asserted the old rule.

## What's true

Pre-match costs you **`ctx.route`** — nothing has matched, so there is no handler to point at.
Flags are a separate question, answered by whether the middleware opts into the policy table.

- **csrf.md** — gave the wrong reason for its own limitation. `csrf()` has no flag option because a
  token check off a matched route is meaningless (a mismatch on a path that routes nowhere is a
  404, not a 403), not because of where it runs. It now says that, and points at `csrfGuard()`.
- **lifecycle.md** — the "where a value can be read" table said flags reach pre-match middleware
  "via policy table" flatly. It is *"if it opts in"*: `rateLimit` does, `csrf` does not.
- **decorators.md** — drew the same false equivalence between `ctx.route` being undefined and
  flags being unavailable.

## Verification

`vitepress build` completes (36s), `pnpm format:check` clean. Docs only, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVCyhU9ghEntXjQwzXvjhE
