### PR TITLE
fix(cli): reject pre-route-flags scanner cache entries

### DIFF
--- a/.changeset/tidy-jars-shake.md
+++ b/.changeset/tidy-jars-shake.md
@@ -1,0 +1,15 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+Fix `typegen failed (routeFlags is not iterable)` on projects with a warm scanner cache.
+
+Adding `routeFlags` to `FileExtract` did not bump `CACHE_VERSION` or extend the
+cached-entry validator, so every project that had run typegen before route flags
+shipped served v2 entries lacking the field and crashed in the join phase. The
+only workaround was deleting `.kickjs/cache/scan.json` by hand.
+
+The cache version is bumped (stale entries are ignored), the validator now
+rejects an entry missing `routeFlags`, and a compile-time check makes the key
+list impossible to forget: adding an array field to `FileExtract` now fails to
+build until the validator lists it.

--- a/packages/cli/__tests__/scanner-cache.test.ts
+++ b/packages/cli/__tests__/scanner-cache.test.ts
@@ -111,6 +111,38 @@ export class UsersService {}
     expect(healed).toEqual(truth)
   })
 
+  it('rejects an entry written before a FileExtract field existed', async () => {
+    // The real upgrade path: a project whose cache predates `routeFlags`.
+    // Every entry validated fine under the old key list and then crashed the
+    // join phase with `routeFlags is not iterable`. Deleting the field
+    // reproduces exactly what an older CLI wrote.
+    const truth = await scanProject({ root: src, cwd: root })
+    await scanProject(opts())
+
+    const cacheFile = join(cacheDir, 'scan.json')
+    const doc = JSON.parse(await readFile(cacheFile, 'utf-8'))
+    for (const key of Object.keys(doc.files)) {
+      delete doc.files[key].extract.routeFlags
+    }
+    await writeFile(cacheFile, JSON.stringify(doc))
+
+    // Must re-scan rather than throw, and produce the same result as cold.
+    const healed = await scanProject(opts())
+    expect(healed).toEqual(truth)
+  })
+
+  it('ignores a cache written under an older CACHE_VERSION', async () => {
+    const truth = await scanProject({ root: src, cwd: root })
+    await scanProject(opts())
+
+    const cacheFile = join(cacheDir, 'scan.json')
+    const doc = JSON.parse(await readFile(cacheFile, 'utf-8'))
+    doc.version = doc.version - 1
+    await writeFile(cacheFile, JSON.stringify(doc))
+
+    expect(await scanProject(opts())).toEqual(truth)
+  })
+
   it('re-extracts a file whose signature changed', async () => {
     await scanProject(opts()) // cold
     const changed = join(src, 'users', 'users.service.ts')

--- a/packages/cli/src/typegen/scanner-cache.ts
+++ b/packages/cli/src/typegen/scanner-cache.ts
@@ -31,7 +31,11 @@ import type { FileExtract } from './scanner'
 // v2: per-file extraction switched to AST-first (extract-ast.ts) — v1
 // entries hold regex-era results that can differ (template-literal
 // paths, aliased schema-ref resolution), so they must not be served.
-const CACHE_VERSION = 2
+// v3: `FileExtract` gained `routeFlags`. A v2 entry has no such field, and
+// the join phase spreads it — every upgraded project with a warm cache hit
+// `routeFlags is not iterable` on the first typegen until the cache was
+// deleted by hand.
+const CACHE_VERSION = 3
 
 /** The array-valued keys every `FileExtract` must carry. */
 const EXTRACT_ARRAY_KEYS = [
@@ -41,10 +45,31 @@ const EXTRACT_ARRAY_KEYS = [
   'pluginsAndAdapters',
   'augmentations',
   'contextKeys',
+  'routeFlags',
   'routes',
   'moduleMounts',
   'globPatterns',
 ] as const
+
+/**
+ * Compile-time coverage: every required array field of `FileExtract` must be
+ * listed above.
+ *
+ * `routeFlags` was added to `FileExtract` without touching this list, so the
+ * validator below happily served entries that lacked it and the join phase
+ * spread `undefined`. The list is now derived-checked rather than remembered —
+ * adding an array field to `FileExtract` fails to compile here until it is
+ * listed, which is the only moment anyone is looking at this file.
+ */
+type RequiredArrayKeys<T> = {
+  [K in keyof T]-?: undefined extends T[K] ? never : T[K] extends readonly unknown[] ? K : never
+}[keyof T]
+
+type MissingArrayKeys = Exclude<RequiredArrayKeys<FileExtract>, (typeof EXTRACT_ARRAY_KEYS)[number]>
+
+// If this errors, add the named key(s) to EXTRACT_ARRAY_KEYS and bump CACHE_VERSION.
+const _extractKeysCovered: MissingArrayKeys extends never ? true : MissingArrayKeys = true
+void _extractKeysCovered
 
 /**
  * Structurally validate a cached extract before trusting it. The join


### PR DESCRIPTION
## The bug

Any project that had run `kick typegen` before route flags shipped hit this on the first run after upgrading:

```
kick/modules: typegen failed (p.routeFlags is not iterable (cannot read property undefined)) — keeping previous output
```

The only workaround was `rm -rf .kickjs/cache` by hand.

## Cause

`routeFlags` was added to `FileExtract`, but the persistent scanner cache in `packages/cli/src/typegen/scanner-cache.ts` has two guards that both had to be updated and neither was:

- `CACHE_VERSION` — still `2`, so entries written before the field existed were still served.
- `EXTRACT_ARRAY_KEYS` — the validator's key list, so `isFileExtract()` accepted an entry with no `routeFlags` at all.

The join phase then does `routeFlags.push(...extract.routeFlags)` (`scanner.ts:2037`) and spreads `undefined`.

Confirmed against a real affected project: `cache version: 2 | entries: 2151 | entries missing routeFlags: 2151`.

## Fix

- Bump `CACHE_VERSION` to `3` — stale entries are ignored, the scan behaves like a cold first run.
- Add `'routeFlags'` to `EXTRACT_ARRAY_KEYS` so the validator self-heals even if a version bump is missed.
- Add a type-level coverage assertion so this cannot recur:

```ts
type MissingArrayKeys = Exclude<RequiredArrayKeys<FileExtract>, (typeof EXTRACT_ARRAY_KEYS)[number]>
const _extractKeysCovered: MissingArrayKeys extends never ? true : MissingArrayKeys = true
```

Removing `'routeFlags'` from the list now fails the build with `Type 'true' is not assignable to type '"routeFlags"'` — it names the forgotten key.

## Tests

Two regression cases in `packages/cli/__tests__/scanner-cache.test.ts`, both asserting the scan self-heals to the cold-scan result instead of throwing:

- an entry written before `routeFlags` existed (field deleted from a real cache file)
- a cache written under an older `CACHE_VERSION`

`796 passed (796)` in `packages/cli`; lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVCyhU9ghEntXjQwzXvjhE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a type generation failure that could occur when using a warm scanner cache.
  * Outdated or incomplete scanner cache entries are now ignored and automatically rebuilt, ensuring consistent type generation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->