### PR TITLE
feat(kickjs): module-level route flags, and health probes that accept them

### DIFF
--- a/.changeset/olive-cameras-heal.md
+++ b/.changeset/olive-cameras-heal.md
@@ -1,0 +1,28 @@
+---
+'@forinda/kickjs': minor
+---
+
+Route flags can now be declared at the module mount, and the built-in health probes accept them.
+
+`ModuleRoutes.flags` applies flags to every route a mount produces — the site a
+decorator cannot reach, because a module mounts controllers it may not own.
+Precedence is method > class > mount, so a class or method declaration still
+wins and `@Flag.off` still removes an inherited flag.
+
+```ts
+routes: () => ({ path: '/webhooks', controller: WebhooksController, flags: ['auth.public'] })
+```
+
+The health module is the first consumer. Its two probes sit inside the
+middleware chain, so app-wide auth applies to them, and until now the only way
+out was exempting `/health/live` and `/health/ready` by pathname:
+
+```ts
+bootstrap({ health: { flags: ['auth.public'] } })
+```
+
+The framework still names no flags — the name is yours, and every consumer that
+already reads it (`skipWhen`, `exemptWhen`, `SwaggerAdapter({ publicFlag })`)
+covers the probes with no further wiring. `getRouteFlags()` reports mount flags
+too, so an OpenAPI spec or DevTools listing cannot disagree with what the
+runtime resolved.

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -21,7 +21,7 @@ Inversion-of-Control container, decorators, logger, and error types shared by al
 | `trustProxy`      | `boolean \| number \| string \| fn`   | `false`                         | Express `trust proxy` setting.                                                                                                                                   |
 | `jsonLimit`       | `string \| number`                    | `'1mb'`                         | Max JSON body size — only applied when `middlewares` is omitted.                                                                                                 |
 | `security`        | `{ helmet?: boolean }`                | `{ helmet: true }`              | Auto-inject helmet headers unless opted out.                                                                                                                     |
-| `health`          | `boolean`                             | `true`                          | Mount the built-in [health module](#health-endpoints). `false` leaves `/health/*` to you.                                                                        |
+| `health`          | `boolean \| { flags }`                | `true`                          | Mount the built-in [health module](#health-endpoints). `false` leaves `/health/*` to you; `{ flags: ['auth.public'] }` puts your own route flags on both probes. |
 | `contextStore`    | `'auto' \| 'manual'`                  | `'auto'`                        | ALS frame for `RequestContext.set/get` + REQUEST-scoped DI. `'manual'` only if you own the frame.                                                                |
 | `processHooks`    | `'auto' \| 'errors-only' \| 'manual'` | `'auto'`                        | Process-level error loggers + SIGINT/SIGTERM → shutdown. Use `'errors-only'` when an SDK owns shutdown.                                                          |
 | `cluster`         | `boolean \| { workers?: number }`     | `false`                         | Fork workers across CPU cores (shared port).                                                                                                                     |
@@ -689,7 +689,13 @@ They ship as an ordinary module — `healthModule()`, registered automatically �
 ::: warning They run INSIDE the middleware chain
 Before v8 these were mounted straight onto the engine, ahead of every middleware. They are now mounted with your other modules, which means **global auth applies to them**. An app with app-wide authentication will require it on its probes.
 
-That is the intended default — your app controls its own auth, and a framework route quietly bypassing it is the surprise — but it will fail a liveness check the first time it runs. Exempt the path as you would any other, or pass `health: false` and mount your own.
+That is the intended default — your app controls its own auth, and a framework route quietly bypassing it is the surprise — but it will fail a liveness check the first time it runs. Flag both probes with whatever name your app already treats as public:
+
+```ts
+bootstrap({ health: { flags: ['auth.public'] } })
+```
+
+The flags land on the mount, not on `HealthController` — the class is the framework's, the names are yours — and every consumer that reads them (an auth contributor's `skipWhen`, a guard's `exemptWhen`, `SwaggerAdapter({ publicFlag })`) covers health with no further wiring. See [Route Flags](../guide/route-flags.md#the-built-in-health-probes). You can still exempt the pathnames instead, or pass `health: false` and mount your own module.
 :::
 
 `version: false` **and** `prefix: false` on their `ModuleRoutes` is what keeps them at the root: a probe URL an orchestrator is configured against must not move when `apiPrefix` or the API version changes. The two flags are independent — `prefix: false` alone drops `/api` but keeps `/v1`, mounting at `/v1/health`.

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -243,7 +243,7 @@ interface HealthProbe {
 }
 ```
 
-Mounted automatically at `/health/live` and `/health/ready`; pass `bootstrap({ health: false })` to replace it. It reads draining state and adapter checks through `HEALTH_PROBE` rather than Application internals, so a replacement module can satisfy the same contract. Behaviour and the v8 mounting change are documented in the [core reference](./core.md#health-endpoints).
+Mounted automatically at `/health/live` and `/health/ready`; pass `bootstrap({ health: false })` to replace it, or `bootstrap({ health: { flags: ['auth.public'] } })` to put your own [route flags](../guide/route-flags.md) on both probes. It reads draining state and adapter checks through `HEALTH_PROBE` rather than Application internals, so a replacement module can satisfy the same contract. Behaviour and the v8 mounting change are documented in the [core reference](./core.md#health-endpoints).
 
 ## Query String Parsing
 

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -83,9 +83,20 @@ Request In
 The built-in health endpoints are an **ordinary module, mounted last** — not a
 short-circuit at the top of the pipeline. They pass through global middleware
 like any other route, which means app-wide auth applies to them unless you
-exempt the path. That is deliberate: a framework route quietly bypassing your
+exempt them. That is deliberate: a framework route quietly bypassing your
 middleware is the bigger surprise. Mounting last also means your own `/health`
 module wins if you declare one, and `health: false` skips the built-in entirely.
+
+To exempt them, put your own [route flag](./route-flags.md) on both probes:
+
+```ts
+bootstrap({ health: { flags: ['auth.public'] } })
+```
+
+Whatever already skips on that flag — an auth contributor's `skipWhen`, a
+guard's `exemptWhen`, `SwaggerAdapter({ publicFlag })` — now covers health too.
+Prefer it to exempting the pathnames, which stop matching if the probe paths
+ever move.
 :::
 
 ### Where a value can be read

--- a/docs/guide/route-flags.md
+++ b/docs/guide/route-flags.md
@@ -165,8 +165,9 @@ tab shows them in a Flags column — so "why does this endpoint not require auth
 the route list rather than by reading the controller.
 
 `getRouteFlags(controllerClass, handlerName)` is the out-of-request resolver behind both: the same
-method-over-class result `ctx.route.flags` carries, for consumers that see a controller and a
-method name rather than a live request.
+method-over-class-over-mount result `ctx.route.flags` carries, for consumers that see a controller
+and a method name rather than a live request. Mount flags are recorded against the controller when
+it mounts, so a spec cannot report a route public that the runtime protects.
 
 ## Matching: name, list, or predicate
 
@@ -265,7 +266,43 @@ Two constraints on what a flag can be:
 
 ## Where flags can be declared
 
-Method and class today, resolved method-over-class. Module, adapter and global registration sites are planned, matching the [context contributor](./context-decorators.md) precedence chain.
+Method, class, and module mount — resolved **method > class > mount**, the top
+three levels of the [context contributor](./context-decorators.md) precedence
+chain. Adapter and global sites are planned.
+
+The mount site is where a module flags routes on a controller it does not own,
+which no decorator can do:
+
+```ts
+routes: () => ({ path: '/webhooks', controller: WebhooksController, flags: ['auth.public'] })
+```
+
+A list stores each flag as `true`. Use the record form for flags that carry a
+value:
+
+```ts
+flags: { 'auth.public': true, 'rate.limit': { rpm: 10 } }
+```
+
+Both narrow against `KickRouteFlags`, and a name starting with `!` is rejected
+at boot — a declaration has no negative form; remove the flag instead.
+
+Since it is the lowest level, a class or method declaration of the same flag
+wins and `@Flag.off` on a method still removes it.
+
+### The built-in health probes
+
+`GET /health/live` and `GET /health/ready` are an ordinary module inside the
+middleware chain, so app-wide auth applies to them. The controller is the
+framework's and the flag names are yours, so the flag goes on the mount:
+
+```ts
+bootstrap({ health: { flags: ['auth.public'] } })
+```
+
+That is the whole wiring — every consumer already reading `auth.public` now
+exempts the probes, including the OpenAPI spec. Exempting `/health/live` and
+`/health/ready` by pathname does the same thing until the paths move.
 
 ## Naming
 

--- a/packages/kickjs/__tests__/route-flags-mount.test.ts
+++ b/packages/kickjs/__tests__/route-flags-mount.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Module-level route flags — the third registration site.
+ *
+ * A decorator can only flag a controller you own. A module mounts controllers
+ * it may not own (the framework's own health controller is the case that forced
+ * this), so the flags belong on the mount.
+ *
+ * The load-bearing cases: mount flags reach a controller carrying no flag
+ * decorator at all, a method still wins over them, `@Flag.off` still removes
+ * them, and `getRouteFlags()` — which sees no mount — reports the same answer
+ * the runtime resolved, so Swagger and DevTools cannot drift from it.
+ */
+import 'reflect-metadata'
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import {
+  Application,
+  Container,
+  Controller,
+  Get,
+  HttpException,
+  defineHttpContextDecorator,
+  defineRouteFlag,
+  getRouteFlags,
+  type AppModule,
+  type ModuleRoutes,
+  type RequestContext,
+} from '../src/index'
+
+const Public = defineRouteFlag('ops.public')
+const Limit = defineRouteFlag<{ rpm: number }>('ops.limit')
+
+@Controller()
+class PlainController {
+  @Get('/open')
+  open(ctx: RequestContext) {
+    ctx.json({ flags: [...(ctx.route?.flags.keys() ?? [])] })
+  }
+
+  @Public.off
+  @Get('/closed')
+  closed(ctx: RequestContext) {
+    ctx.json({ flags: [...(ctx.route?.flags.keys() ?? [])] })
+  }
+}
+
+@Controller()
+@Limit({ rpm: 1 })
+class DecoratedController {
+  @Get('/')
+  index(ctx: RequestContext) {
+    ctx.json({ limit: ctx.route?.flags.get('ops.limit') })
+  }
+}
+
+const mod = (path: string, controller: unknown, flags?: ModuleRoutes['flags']): AppModule =>
+  ({ routes: (): ModuleRoutes => ({ path, controller, flags }) }) as AppModule
+
+const boot = async (modules: AppModule[]) => {
+  const app = new Application({ modules, apiPrefix: '/api', defaultVersion: 1 } as never)
+  await app.setup()
+  return app.getExpressApp()
+}
+
+beforeEach(() => {
+  Container.reset()
+})
+
+describe('ModuleRoutes.flags', () => {
+  it('applies to every route the mount produces', async () => {
+    const http = await boot([mod('/x', PlainController, ['ops.public'])])
+    const res = await request(http).get('/api/v1/x/open').expect(200)
+    expect(res.body.flags).toEqual(['ops.public'])
+  })
+
+  it('is removable per method with @Flag.off', async () => {
+    const http = await boot([mod('/x', PlainController, ['ops.public'])])
+    const res = await request(http).get('/api/v1/x/closed').expect(200)
+    expect(res.body.flags).toEqual([])
+  })
+
+  it('loses to a class declaration of the same flag', async () => {
+    const http = await boot([mod('/y', DecoratedController, { 'ops.limit': { rpm: 99 } })])
+    const res = await request(http).get('/api/v1/y').expect(200)
+    expect(res.body.limit).toEqual({ rpm: 1 })
+  })
+
+  it('accepts values through the record form', async () => {
+    const http = await boot([mod('/y', PlainController, { 'ops.limit': { rpm: 5 } })])
+    const res = await request(http).get('/api/v1/y/open').expect(200)
+    expect(res.body.flags).toEqual(['ops.limit'])
+  })
+
+  it('is visible to getRouteFlags, so out-of-request readers agree', async () => {
+    await boot([mod('/x', PlainController, ['ops.public'])])
+    expect(getRouteFlags(PlainController, 'open').has('ops.public')).toBe(true)
+    // The method-level `.off` must win here too — a spec that marked
+    // /x/closed public while the runtime protected it is the failure mode.
+    expect(getRouteFlags(PlainController, 'closed').has('ops.public')).toBe(false)
+  })
+
+  it('rejects a negated name at boot rather than never matching', async () => {
+    await expect(boot([mod('/x', PlainController, ['!ops.public'] as never)])).rejects.toThrow(
+      /cannot start with '!'/,
+    )
+  })
+})
+
+describe('health: { flags }', () => {
+  // The reason the mount site exists: HealthController is the framework's, the
+  // flag name is the app's, and no decorator can bridge that.
+  //
+  // Registered app-wide as a contributor rather than as a global middleware:
+  // global middleware runs before a route is matched and has no `ctx.route`,
+  // so it is structurally unable to read flags. A contributor runs in-route.
+  const RequireAuth = defineHttpContextDecorator({
+    key: 'user',
+    skipWhen: 'ops.public',
+    resolve: (ctx: RequestContext) => {
+      if (!ctx.headers.authorization) throw new HttpException(401, 'Unauthorized')
+      return { id: 'u1' }
+    },
+  })
+
+  const bootApp = async (health?: unknown) => {
+    const app = new Application({
+      modules: [],
+      contributors: [RequireAuth.registration],
+      ...(health === undefined ? {} : { health }),
+    } as never)
+    await app.setup()
+    return app.getExpressApp()
+  }
+
+  it('leaves the probes guarded by default', async () => {
+    await request(await bootApp())
+      .get('/health/live')
+      .expect(401)
+  })
+
+  it('exempts both probes once the app names its flag', async () => {
+    const http = await bootApp({ flags: ['ops.public'] })
+    await request(http).get('/health/live').expect(200)
+    await request(http).get('/health/ready').expect(200)
+  })
+
+  it('still honours health: false', async () => {
+    await request(await bootApp(false))
+      .get('/health/live')
+      .expect(404)
+  })
+})

--- a/packages/kickjs/src/core/app-module.ts
+++ b/packages/kickjs/src/core/app-module.ts
@@ -1,5 +1,6 @@
 import type { Container } from './container'
 import type { ContributorRegistrations } from './context-decorator'
+import type { RouteFlagDeclarations } from './route-flag'
 
 /**
  * Route set returned by a module's routes() method.
@@ -49,6 +50,23 @@ export interface ModuleRoutes {
    * for OpenAPI spec generation via `SwaggerAdapter`.
    */
   controller?: any
+
+  /**
+   * Route flags applied to every route this mount produces.
+   *
+   * The module-level registration site: a flag stated here reaches routes on a
+   * controller the module does not own, which is what a decorator cannot do.
+   * The built-in health module uses it to let an app name its own "public"
+   * flag without the framework picking one.
+   *
+   * ```ts
+   * routes: () => ({ path: '/webhooks', controller: WebhooksController, flags: ['auth.public'] })
+   * ```
+   *
+   * Lowest precedence — method > class > mount, matching the contributor
+   * chain. A method can drop an inherited one with `@Flag.off`.
+   */
+  flags?: RouteFlagDeclarations
 }
 
 /**

--- a/packages/kickjs/src/core/index.ts
+++ b/packages/kickjs/src/core/index.ts
@@ -298,6 +298,7 @@ export {
 } from './asset-keys'
 
 export { defineRouteFlag, getRouteFlags, matchesFlagTest, resolveRouteFlags } from './route-flag'
+export type { RouteFlagDeclarations, RouteFlagRecord } from './route-flag'
 export { RoutePolicyTable, bindRoutePolicy, offerRoutePolicy } from './route-policy'
 export type {
   KickRouteFlags,

--- a/packages/kickjs/src/core/route-flag.ts
+++ b/packages/kickjs/src/core/route-flag.ts
@@ -249,9 +249,9 @@ export function defineRouteFlag(name: string): RouteFlag<never> {
 /**
  * Resolve the flags in force for one route.
  *
- * Precedence is method > class, matching the contributor pipeline's top two
- * levels. Within a level the last declaration wins (decorators apply bottom-up,
- * so the one nearest the handler is applied last).
+ * Precedence is method > class > mount, matching the contributor pipeline's top
+ * three levels. Within a level the last declaration wins (decorators apply
+ * bottom-up, so the one nearest the handler is applied last).
  *
  * A resolved `false` deletes the key rather than storing it — see the module
  * docblock.
@@ -259,11 +259,18 @@ export function defineRouteFlag(name: string): RouteFlag<never> {
 export function resolveRouteFlags(
   classDeclarations: readonly RouteFlagDeclaration[],
   methodDeclarations: readonly RouteFlagDeclaration[],
+  mountDeclarations: readonly RouteFlagDeclaration[] = [],
 ): RouteFlags {
   const resolved = new Map<string, unknown>()
 
-  // Lowest precedence first, so higher levels overwrite.
-  for (const { name, value } of [...classDeclarations, ...methodDeclarations]) {
+  // Lowest precedence first, so higher levels overwrite. Mount comes first
+  // despite being the last parameter — it was added after the other two, and
+  // moving it to the front would break every existing caller for no gain.
+  for (const { name, value } of [
+    ...mountDeclarations,
+    ...classDeclarations,
+    ...methodDeclarations,
+  ]) {
     if (value === FLAG_UNSET) {
       resolved.delete(name)
       continue
@@ -470,6 +477,7 @@ export function getRouteFlags(controllerClass: object, handlerName: string): Rou
   return resolveRouteFlags(
     getClassFlagDeclarations(controllerClass),
     getMethodFlagDeclarations(controllerClass, handlerName),
+    getMountFlagDeclarations(controllerClass),
   )
 }
 
@@ -489,4 +497,89 @@ export function getMethodFlagDeclarations(
     handlerName,
     [],
   )
+}
+
+/**
+ * Flags declared as data rather than as a decorator, keyed by name.
+ *
+ * ```ts
+ * { 'auth.public': true, 'rate.limit': { rpm: 10 } }
+ * ```
+ */
+export type RouteFlagRecord = { [K in RouteFlagName]?: RouteFlagValue<K, true> }
+
+/**
+ * What a non-decorator registration site accepts.
+ *
+ * A list is the common case — bare flags, each stored as `true`:
+ * `flags: ['auth.public']`. The record form exists for flags that carry a
+ * value. Both narrow against {@link KickRouteFlags} once it is augmented.
+ */
+export type RouteFlagDeclarations = readonly RouteFlagName[] | RouteFlagRecord
+
+/**
+ * Normalise either input form into declarations.
+ *
+ * @param site Where the flags came from, for the error message — a name is
+ * validated here rather than at read time so a typo'd `!` fails at boot.
+ */
+export function toFlagDeclarations(
+  flags: RouteFlagDeclarations | undefined,
+  site: string,
+): RouteFlagDeclaration[] {
+  if (!flags) return []
+  const entries: [string, unknown][] = Array.isArray(flags)
+    ? flags.map((name) => [name as string, true])
+    : Object.entries(flags as Record<string, unknown>)
+
+  return entries.map(([name, value]) => {
+    // Same reservation as `defineRouteFlag`: `!name` is a negated *test*, and a
+    // flag named that way could never be tested for. Declaring one is always a
+    // mistake — usually someone reaching for "not public" on the wrong side.
+    if (name.startsWith('!')) {
+      throw new Error(
+        `${site}: a flag name cannot start with '!' — that prefix is reserved for negated ` +
+          `tests, and a declaration has no negative form. Remove the flag instead of ` +
+          `declaring '${name}'.`,
+      )
+    }
+    return { name, value }
+  })
+}
+
+/**
+ * Mount-level declarations, keyed by controller class.
+ *
+ * A module declares flags for every route it mounts (`ModuleRoutes.flags`), so
+ * unlike class and method declarations they are not written by a decorator and
+ * have nowhere on the class to live. They are recorded here at mount time so
+ * that {@link getRouteFlags} — which sees only a controller and a method name —
+ * reports the same flags the runtime resolved. Without it an OpenAPI spec or a
+ * DevTools route listing would disagree with `ctx.route.flags`.
+ *
+ * A `WeakMap`, so a controller from a torn-down app (a test, an HMR reload) is
+ * collectable. Mounting the same controller twice replaces rather than appends:
+ * a reload re-declares the same flags, and appending would grow without bound.
+ */
+const MOUNT_FLAGS = new WeakMap<object, RouteFlagDeclaration[]>()
+
+/**
+ * Record the flags a mount declares for `controllerClass`.
+ *
+ * @internal Called by the route-table builder; not part of the app-facing API.
+ */
+export function registerMountFlags(
+  controllerClass: object,
+  declarations: readonly RouteFlagDeclaration[],
+): void {
+  if (declarations.length === 0) {
+    MOUNT_FLAGS.delete(controllerClass)
+    return
+  }
+  MOUNT_FLAGS.set(controllerClass, [...declarations])
+}
+
+/** Read the mount-level declarations recorded for a controller. */
+export function getMountFlagDeclarations(controllerClass: object): RouteFlagDeclaration[] {
+  return MOUNT_FLAGS.get(controllerClass) ?? []
 }

--- a/packages/kickjs/src/http/application.ts
+++ b/packages/kickjs/src/http/application.ts
@@ -40,7 +40,7 @@ import {
   assertRouteUnique,
   buildRouteTable,
 } from './router-builder'
-import { HEALTH_PROBE, healthModule } from './health-module'
+import { HEALTH_PROBE, healthModule, type HealthModuleConfig } from './health-module'
 import { expressRuntime } from './runtimes/express'
 import type {
   ActiveRuntime,
@@ -234,9 +234,15 @@ export interface ApplicationOptions {
    *
    * They mount as an ordinary module, which means they sit inside the
    * middleware chain: whatever guards the rest of the app guards these too.
-   * Exempt the path if your orchestrator must reach them unauthenticated.
+   * Pass `{ flags: [...] }` to put your own route flags on both probes — the
+   * way to make them reachable unauthenticated without exempting a pathname
+   * that can move:
+   *
+   * ```ts
+   * bootstrap({ health: { flags: ['auth.public'] } })
+   * ```
    */
-  health?: boolean
+  health?: boolean | HealthModuleConfig
 
   runtime?: HttpRuntime
 
@@ -830,7 +836,7 @@ export class Application {
           )
         },
       })
-      moduleRegistry.mount(healthModule())
+      moduleRegistry.mount(healthModule(this.options.health === true ? {} : this.options.health))
     }
     const allModuleEntries: AppModuleEntry[] = moduleRegistry.entries
     const modules = allModuleEntries.map((entry) => {
@@ -971,7 +977,7 @@ export class Application {
           if (route.router) {
             this.runtime.useConnect(this.app, route.router, { path: mountPath })
           } else if (route.controller) {
-            const routeTable = buildRouteTable(route.controller)
+            const routeTable = buildRouteTable(route.controller, { mountFlags: route.flags })
             const ctrl = route.controller.name ?? 'controller'
             for (const entry of routeTable) {
               // Per-handler owner so intra-controller duplicates name both methods.

--- a/packages/kickjs/src/http/health-module.ts
+++ b/packages/kickjs/src/http/health-module.ts
@@ -19,8 +19,9 @@
  * Mounting it with the other modules also puts it INSIDE the middleware chain,
  * where it was previously ahead of it. That is deliberate: an app controls its
  * own auth, and a framework route quietly bypassing it is the surprise, not the
- * other way round. An app that wants its probes unauthenticated exempts the
- * path the same way it would any other.
+ * other way round. An app that wants its probes unauthenticated exempts them —
+ * `health: { flags: ['auth.public'] }` puts the app's own flag on both routes,
+ * and whatever already skips on that flag skips these too.
  *
  * @module @forinda/kickjs/http/health-module
  */
@@ -28,6 +29,7 @@ import { Controller, Get } from '../core/decorators'
 import { createToken } from '../core/token'
 import { defineModule } from '../core/define-module'
 import type { Container } from '../core/container'
+import type { RouteFlagDeclarations } from '../core/route-flag'
 import { reply } from './reply'
 
 /** One adapter's answer to `onHealthCheck()`. */
@@ -51,6 +53,27 @@ export interface HealthProbe {
 }
 
 export const HEALTH_PROBE = createToken<HealthProbe>('kick/Health/probe')
+
+/** Config for {@link healthModule}. */
+export interface HealthModuleConfig {
+  /**
+   * Route flags to put on `GET /health/live` and `GET /health/ready`.
+   *
+   * The framework names no flags, so it cannot decide these probes are
+   * "public" on your behalf — the name is yours, and every consumer that
+   * already reads it (an auth contributor's `skipWhen`, a guard's
+   * `exemptWhen`, `SwaggerAdapter({ publicFlag })`) then covers health with no
+   * further wiring:
+   *
+   * ```ts
+   * bootstrap({ health: { flags: ['auth.public'] } })
+   * ```
+   *
+   * This replaces exempting `/health/live` and `/health/ready` by pathname,
+   * which silently stops matching if the probe paths ever move.
+   */
+  flags?: RouteFlagDeclarations
+}
 
 @Controller()
 export class HealthController {
@@ -87,11 +110,12 @@ export class HealthController {
  * shape only the framework can produce.
  *
  * Registered automatically unless the app passes `health: false` or supplies a
- * module of its own.
+ * module of its own. Pass `health: { flags: [...] }` to `bootstrap()` to flag
+ * both probes — see {@link HealthModuleConfig}.
  */
-export const healthModule = defineModule({
+export const healthModule = defineModule<HealthModuleConfig>({
   name: 'HealthModule',
-  build: () => ({
+  build: (config) => ({
     register(container: Container) {
       // Resolve through the token so a replacement probe — or a test double —
       // can be bound before this runs.
@@ -103,7 +127,15 @@ export const healthModule = defineModule({
     routes() {
       // Root-mounted and unversioned: the probe URL an orchestrator is
       // configured against must not move when the API prefix or version does.
-      return { path: '/health', controller: HealthController, version: false, prefix: false }
+      return {
+        path: '/health',
+        controller: HealthController,
+        version: false,
+        prefix: false,
+        // Declared at the mount rather than on HealthController: the class is
+        // the framework's, the flag names are the app's.
+        flags: config.flags,
+      }
     },
   }),
 })

--- a/packages/kickjs/src/http/router-builder.ts
+++ b/packages/kickjs/src/http/router-builder.ts
@@ -11,7 +11,10 @@ import { getClassMeta, getMethodMeta, getMethodMetaOrUndefined } from '../core/m
 import {
   getClassFlagDeclarations,
   getMethodFlagDeclarations,
+  registerMountFlags,
   resolveRouteFlags,
+  toFlagDeclarations,
+  type RouteFlagDeclarations,
 } from '../core/route-flag'
 import { duplicateRouteError } from '../core/kick-errors'
 import type { CtxHandler, RouteEntry, RouteMethod } from './runtime'
@@ -70,6 +73,12 @@ export interface BuildRoutesOptions {
    * falls back to the slot set by Application.setup().
    */
   externalSources?: readonly SourcedRegistration[]
+  /**
+   * Flags the mounting module declares for every route on this controller
+   * (`ModuleRoutes.flags`). Lowest precedence — a class or method declaration
+   * of the same name wins, and `@Flag.off` on a method removes it.
+   */
+  mountFlags?: RouteFlagDeclarations
 }
 
 /**
@@ -123,6 +132,15 @@ export function buildRouteTable(
   // unless a method declares the same flag `false` (see core/route-flag.ts).
   const classFlagDeclarations = getClassFlagDeclarations(controllerClass)
 
+  // Flags the module declared for this whole mount. Recorded against the class
+  // so `getRouteFlags()` — the resolver Swagger and DevTools use, which sees no
+  // mount — reports what the runtime actually resolved.
+  const mountFlagDeclarations = toFlagDeclarations(
+    options.mountFlags,
+    `${controllerClass?.name ?? 'controller'} mount flags`,
+  )
+  registerMountFlags(controllerClass, mountFlagDeclarations)
+
   const entries: RouteEntry[] = []
 
   for (const route of routes) {
@@ -158,6 +176,7 @@ export function buildRouteTable(
     const flags = resolveRouteFlags(
       classFlagDeclarations,
       getMethodFlagDeclarations(controllerClass, route.handlerName),
+      mountFlagDeclarations,
     )
 
     let contributorRunner: CtxHandler | null = null

--- a/packages/kickjs/src/index.ts
+++ b/packages/kickjs/src/index.ts
@@ -16,6 +16,7 @@ export {
   HEALTH_PROBE,
   type HealthProbe,
   type HealthCheckResult,
+  type HealthModuleConfig,
 } from './http/health-module'
 
 export { bootstrap } from './http/bootstrap'
@@ -41,7 +42,9 @@ export type {
   RouteFlagContext,
   NegatedRouteFlagName,
   RouteFlagName,
+  RouteFlagDeclarations,
   RouteFlagPredicate,
+  RouteFlagRecord,
   RouteFlagTest,
   RouteFlagValue,
   RouteFlags,

--- a/packages/kickjs/src/web.ts
+++ b/packages/kickjs/src/web.ts
@@ -185,7 +185,7 @@ export function createWebApp(options: CreateWebAppOptions): WebApp {
         }
         const version = route.version ?? defaultVersion
         const mountPath = buildMountPath(apiPrefix, version, route.path)
-        for (const entry of buildRouteTable(route.controller)) {
+        for (const entry of buildRouteTable(route.controller, { mountFlags: route.flags })) {
           const url = joinPath(mountPath, entry.path)
           // Per-handler owner so intra-controller duplicates name both methods.
           const owner = `${route.controller.name ?? 'controller'}.${String(entry.meta.handlerName ?? '?')}`


### PR DESCRIPTION
## The gap

The built-in health probes mount as an ordinary module *inside* the middleware chain — deliberately, so a framework route never quietly bypasses app auth. But that left no good way to exempt them. A route flag can only be declared by a decorator, and `HealthController` is the framework's class, so the only option was exempting `/health/live` and `/health/ready` by pathname — exactly the brittle thing route flags were introduced to replace.

`health: false` isn't an escape either: it also skips the `HEALTH_PROBE` binding, so a replacement module can't reuse the draining/adapter-check logic.

## The module registration site

`ModuleRoutes.flags` applies flags to every route a mount produces — the site a decorator structurally cannot reach, because a module mounts controllers it may not own. This is the third level of the precedence chain the [roadmap already named](https://kickjs.app/guide/route-flags):

```ts
routes: () => ({ path: '/webhooks', controller: WebhooksController, flags: ['auth.public'] })
```

- **Precedence: method > class > mount.** A class declaration of the same flag wins, and `@Flag.off` on a method still removes an inherited one.
- **Two input forms.** A list stores each flag as `true` (`['auth.public']`); the record form carries values (`{ 'rate.limit': { rpm: 10 } }`). Both narrow against `KickRouteFlags`.
- **`!name` is rejected at boot.** A declaration has no negative form — remove the flag instead of declaring `'!x'`, which could never be tested for.

### `getRouteFlags` parity

Mount flags have nowhere on the class to live, so `getRouteFlags(controllerClass, handlerName)` — the resolver `SwaggerAdapter({ publicFlag })` and DevTools' route listing both use — would not have seen them. That would mean a spec marking a route public while the runtime protects it. Mount declarations are recorded against the controller (a `WeakMap`, replaced not appended, so HMR doesn't grow it) and folded in at the lowest precedence, so all three readers give the same answer.

## Health

```ts
bootstrap({ health: { flags: ['auth.public'] } })
```

That's the whole wiring. The framework still names no flags — `auth.public` is yours — and every consumer already reading it (an auth contributor's `skipWhen`, a guard's `exemptWhen`, `SwaggerAdapter({ publicFlag })`) now covers both probes. `health: true` / `health: false` behave exactly as before.

## Tests

`packages/kickjs/__tests__/route-flags-mount.test.ts` — 9 cases:

- mount flags reach a controller carrying no flag decorator
- `@Flag.off` on a method removes one
- a class declaration of the same flag wins
- the record form carries values
- `getRouteFlags()` agrees with the runtime, including the `.off` case
- `'!name'` throws at boot
- the probes are guarded by default, exempt with `health: { flags }`, and `health: false` still 404s

The health group uses an app-wide **contributor** rather than a global middleware, because global middleware runs pre-match and has no `ctx.route` — the same distinction the docs draw.

933 passed in `packages/kickjs`; swagger (62), devtools (94) and testing (229) green; lint and format clean.

## Docs

`guide/route-flags.md` (mount site + a health section), `guide/lifecycle.md` (the `/health` tip now shows the flag instead of "exempt the path"), `api/core.md`, `api/http.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVCyhU9ghEntXjQwzXvjhE
