### PR TITLE
docs: document route flags on every surface they apply to

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -222,7 +222,16 @@ interface ModuleRoutes {
   version?: number | false
   /** `false` drops `apiPrefix` — for probes, fixed webhook URLs, `/.well-known`. Pair with `version: false` to mount at `path` exactly. */
   prefix?: false
+  /** [Route flags](#route-flags) applied to every route this mount produces. Lowest precedence: method > class > mount. */
+  flags?: readonly RouteFlagName[] | RouteFlagRecord
 }
+```
+
+`flags` is the **module registration site** — the only way to flag routes on a
+controller you do not own, since a decorator has to be written on the class:
+
+```ts
+routes: () => ({ path: '/webhooks', controller: WebhooksController, flags: ['auth.public'] })
 ```
 
 ## AppAdapter
@@ -509,6 +518,134 @@ type MetaValue<K extends string, Fallback = unknown> = K extends keyof ContextMe
 ```
 
 `RequestContext` (HTTP) implements `ExecutionContext`. Future `WsContext` / `QueueContext` / `CronContext` (V2) will too.
+
+## Route Flags
+
+A named, inheritable fact about a route — `this endpoint is public`, `this one is
+unmetered`. The core carries the fact; consumers decide what it means. Full guide
+at [Route Flags](../guide/route-flags.md); this section is the reference.
+
+The framework declares **no flag names**. Every name below is one an app chose.
+
+### defineRouteFlag
+
+```typescript
+function defineRouteFlag<const N extends RouteFlagName>(name: N): RouteFlag<RouteFlagValue<N, true>>
+function defineRouteFlag<V>(name: RouteFlagName): RouteFlag<V>
+```
+
+```ts
+const Public = defineRouteFlag('auth.public') // bare: @Public
+const Limit = defineRouteFlag<{ rpm: number }>('rate.limit') // valued: @Limit({ rpm: 10 })
+```
+
+Applicable to a class (every route below inherits it) or a method. `Flag.off`
+removes an inherited one; `Flag.flagName` is the string. A name starting with
+`!` throws — that prefix is reserved for negated tests.
+
+### Declaration sites and precedence
+
+| Site   | How                                            | Precedence |
+| ------ | ---------------------------------------------- | ---------- |
+| Method | `@Public` / `@Limit({ rpm: 10 })` on a handler | highest    |
+| Class  | `@Public` on the `@Controller()`               | middle     |
+| Mount  | `ModuleRoutes.flags`                           | lowest     |
+
+Resolved at boot, so the per-request cost is a map lookup. A resolved flag is
+present or absent — `@Flag.off` deletes the key rather than storing `false`, so
+`false` stays usable as a real value.
+
+### Reading flags
+
+```typescript
+interface MatchedRoute {
+  readonly method: string
+  readonly path: string
+  readonly controller: string
+  readonly handlerName: string
+  readonly flags: RouteFlags
+}
+
+interface RouteFlags extends ReadonlyMap<string, unknown> {
+  has(name: RouteFlagName): boolean
+  get<K extends RouteFlagName>(name: K): RouteFlagValue<K> | undefined
+}
+```
+
+`ctx.route` is the in-request reader — available to handlers, `@Middleware()`,
+guards and contributors. It is `undefined` in **global** middleware, which runs
+before a route is matched.
+
+```typescript
+function getRouteFlags(controllerClass: object, handlerName: string): RouteFlags
+```
+
+The out-of-request reader, for consumers that see a controller and a method name
+rather than a live request — an adapter's `onRouteMount`, an OpenAPI generator, a
+DevTools listing. It resolves all three sites, so it cannot disagree with
+`ctx.route.flags`.
+
+### Flag tests
+
+Every consumer option that takes a flag condition (`skipWhen`, `onlyWhen`,
+`exemptWhen`) accepts the same type:
+
+```typescript
+type RouteFlagTest =
+  | RouteFlagName // carries this flag
+  | NegatedRouteFlagName // '!name' — does NOT carry it
+  | readonly RouteFlagName[] // any-of
+  | readonly NegatedRouteFlagName[] // none-of
+  | ((ctx: RouteFlagContext) => boolean) // anything else
+```
+
+A list is **single-polarity**: `['a', '!b']` is a compile error, because any-of
+would read it as "a present or b absent" while most readers expect "and". Mixing
+them at runtime throws where the consumer is constructed, not on the first
+request. All-of and value checks go through a predicate.
+
+### Consumers
+
+| Surface                | Option                             |
+| ---------------------- | ---------------------------------- |
+| Context contributors   | `skipWhen` / `onlyWhen`            |
+| `csrfGuard()`          | `exemptWhen`                       |
+| `rateLimitGuard()`     | `exemptWhen`                       |
+| `rateLimit()` (global) | `exemptWhen`, via the policy table |
+| `SwaggerAdapter()`     | `publicFlag`, `securityResolver`   |
+| DevTools               | `GET /_debug/routes` → `flags`     |
+| Health module          | `bootstrap({ health: { flags } })` |
+
+### Pre-match middleware: the policy table
+
+Middleware mounted app-wide runs before routing, so it has no `ctx.route`. The
+flags come to it instead: every mounted route registers its method, path and
+flags in a per-application table.
+
+```typescript
+class RoutePolicyTable {
+  lookup(method: string, pathname: string): RouteFlags
+}
+
+function bindRoutePolicy<T extends object>(handler: T, receive: (t: RoutePolicyTable) => void): T
+```
+
+The Application hands the table to any middleware that declared the slot, once
+routes are mounted. A request matching no route matches no flags and stays
+subject to the middleware — which is why an abuse control belongs here rather
+than in a route-scoped guard.
+
+### Type safety
+
+```typescript
+interface KickRouteFlags {} // augment to narrow every flag name
+```
+
+Empty by default, so flag names are plain `string` and everything compiles. Once
+augmented, `defineRouteFlag`, `has`, `get`, and every consumer option narrow to
+the declared names and value types. `kick typegen` writes the augmentation from
+your `defineRouteFlag()` calls into `.kickjs/types/kick__route-flags.d.ts` — see
+[Typegen](../guide/typegen.md).
 
 ## Logger
 

--- a/docs/api/swagger.md
+++ b/docs/api/swagger.md
@@ -16,7 +16,47 @@ interface SwaggerAdapterOptions extends SwaggerOptions {
   adapters?: any[] // peer adapters to discover (e.g. WsAdapter)
   disableInProd?: boolean // skip mounting when NODE_ENV === 'production'
 }
+
+interface SwaggerOptions {
+  bearerAuth?: boolean
+  /** Route flag(s) naming a public endpoint — those routes get `security: []`. */
+  publicFlag?: string | readonly string[]
+  /** Full control: return `null` for public, `undefined` to fall through. */
+  securityResolver?: (ctx: { controllerClass: any; handlerName: string }) => any
+  // …title, version, description, servers, tags
+}
 ```
+
+### Marking endpoints public from route flags
+
+`publicFlag` names the [route flag](../guide/route-flags.md) your app already uses
+for open endpoints, so the spec reads the same declaration the runtime does
+instead of a second annotation that can drift from it:
+
+```ts
+SwaggerAdapter({ bearerAuth: true, publicFlag: 'auth.public' })
+SwaggerAdapter({ bearerAuth: true, publicFlag: ['auth.public', 'health.probe'] })
+```
+
+Resolution order per route: `@ApiPublic` → `securityResolver()` → `publicFlag` →
+`bearerAuth`. The name is configuration because the framework names no flags.
+
+For anything richer than a name — a flag's value, two flags combined — use
+`securityResolver` with `getRouteFlags`, which resolves method, class **and**
+mount declarations:
+
+```ts
+import { getRouteFlags } from '@forinda/kickjs'
+
+SwaggerAdapter({
+  bearerAuth: true,
+  securityResolver: ({ controllerClass, handlerName }) =>
+    getRouteFlags(controllerClass, handlerName).has('auth.public') ? null : undefined,
+})
+```
+
+Because mount flags resolve here too, `bootstrap({ health: { flags: ['auth.public'] } })`
+marks both health probes public in the spec with no extra wiring.
 
 Built with `defineAdapter()` — call it as `SwaggerAdapter({ … })` and pass the result to `bootstrap({ adapters: [...] })`. The factory wires `onRouteMount` (route metadata collection) and `beforeMount` (mount the docs UI) internally.
 

--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -122,18 +122,43 @@ one — those methods don't exist, or don't mean the same thing, elsewhere.
 All ten are optional. `kick g adapter <name>` scaffolds every one of them, so
 the generated file doubles as this reference — delete what you don't need.
 
-| Hook                       | Runs when                              | Consumed by                                                |
-| -------------------------- | -------------------------------------- | ---------------------------------------------------------- |
-| `middleware()`             | during setup                           | the pipeline, at the phase each entry names                |
-| `contributors()`           | during setup                           | the [context-contributor](./context-decorators.md) chain   |
-| `beforeMount(ctx)`         | before routes mount                    | you — early routes, docs, static assets                    |
-| `onRouteMount(ctrl, path)` | per controller mounted                 | you — route metadata, spec building                        |
-| `beforeStart(ctx)`         | inside `app.setup()`                   | you — also fires under `createTestApp`                     |
-| `afterStart(ctx)`          | once the server listens                | you — needs a live `server`; **not** under `createTestApp` |
-| `onHealthCheck()`          | on `GET /health/ready`                 | the built-in readiness endpoint                            |
-| `shutdown()`               | real shutdown **and** every HMR reload | the framework, time-boxed and concurrent                   |
-| `introspect()`             | DevTools topology poll                 | the `/_debug` dashboard                                    |
-| `devtoolsTabs()`           | DevTools panel discovery               | the `/_debug` dashboard                                    |
+| Hook                       | Runs when                              | Consumed by                                                          |
+| -------------------------- | -------------------------------------- | -------------------------------------------------------------------- |
+| `middleware()`             | during setup                           | the pipeline, at the phase each entry names                          |
+| `contributors()`           | during setup                           | the [context-contributor](./context-decorators.md) chain             |
+| `beforeMount(ctx)`         | before routes mount                    | you — early routes, docs, static assets                              |
+| `onRouteMount(ctrl, path)` | per controller mounted                 | you — route metadata, spec building, [route flags](./route-flags.md) |
+| `beforeStart(ctx)`         | inside `app.setup()`                   | you — also fires under `createTestApp`                               |
+| `afterStart(ctx)`          | once the server listens                | you — needs a live `server`; **not** under `createTestApp`           |
+| `onHealthCheck()`          | on `GET /health/ready`                 | the built-in readiness endpoint                                      |
+| `shutdown()`               | real shutdown **and** every HMR reload | the framework, time-boxed and concurrent                             |
+| `introspect()`             | DevTools topology poll                 | the `/_debug` dashboard                                              |
+
+### Reading route flags in `onRouteMount`
+
+`onRouteMount` sees a controller class and a mount path, not a live request, so
+`ctx.route` is not available. `getRouteFlags(controllerClass, handlerName)` is
+the out-of-request resolver — it returns the same method-over-class-over-mount
+result the runtime computes, which is how `SwaggerAdapter` marks flagged routes
+public in the spec and how DevTools fills its Flags column:
+
+```ts
+import { getRouteFlags } from '@forinda/kickjs'
+
+onRouteMount(controllerClass, mountPath) {
+  for (const route of getRoutes(controllerClass)) {
+    if (getRouteFlags(controllerClass, route.handlerName).has('auth.public')) {
+      this.publicRoutes.push(`${mountPath}${route.path}`)
+    }
+  }
+}
+```
+
+An adapter can also **consume** flags per request: `contributors()` registrations
+accept `skipWhen` / `onlyWhen`, so a contributor an adapter ships can be exempted
+by an app that never edits the adapter — see
+[Context Decorators](./context-decorators.md#skipping-a-contributor-per-route-skipwhen-onlywhen).
+| `devtoolsTabs()` | DevTools panel discovery | the `/_debug` dashboard |
 
 Two are worth calling out because nothing else surfaces them:
 

--- a/docs/guide/authorization.md
+++ b/docs/guide/authorization.md
@@ -133,6 +133,29 @@ class InternalController {
 }
 ```
 
+### Exempting routes: flags, not path lists
+
+A guard that must let some routes through should read a [route flag](./route-flags.md). `ctx.route` is populated for any `@Middleware()`, because it runs inside the matched route:
+
+```ts
+export async function ipWhitelistGuard(ctx: RequestContext, next: () => void) {
+  if (ctx.route?.flags.has('ops.internal')) return next()
+  // …check as above
+}
+```
+
+The built-in `csrfGuard()` and `rateLimitGuard()` take `exemptWhen`, which accepts a flag name, `'!name'`, a single-polarity list, or a predicate:
+
+```ts
+@Middleware(rateLimitGuard({ max: 60, exemptWhen: 'auth.public' }))
+@Controller()
+export class ApiController {}
+```
+
+Prefer this to a pathname allow-list: a flag is declared on the route and survives an `apiPrefix` or version change that voids `/api/v1/...` strings.
+
+**Global** middleware is the exception — it runs before a route is matched, so it has no `ctx.route`. `rateLimit()` mounted in `bootstrap()` reads flags from the route policy table instead; see [Route Flags → Middleware that runs before routing](./route-flags.md#middleware-that-runs-before-routing).
+
 ### When to Use What
 
 | Mechanism                         | Use when                                                         | Example                                     |
@@ -140,14 +163,15 @@ class InternalController {
 | `@RequireRole('admin')` (yours)   | The user needs a string role                                     | Admin panel access                          |
 | A policy resolved from DI (yours) | The check depends on the specific resource                       | "Can this user edit THIS post?"             |
 | `@Middleware(guard)`              | Logic not tied to roles or resources, or that must short-circuit | IP whitelist, feature flags, API versioning |
+| A [route flag](./route-flags.md)  | Recording a fact about the route that several checks read        | `auth.public` on webhooks and health probes |
 | `rateLimit()`                     | Throttle specific endpoints                                      | Login endpoint, search API                  |
 
 The first two are code you own — see [BYO role checks](#byo-role-checks-requirerole) and [Policies](#policies-bring-your-own-engine-via-di) above. The framework ships the primitives they are built from, not the checks themselves.
 
 **Ordering is yours to set.** There is no built-in auth middleware imposing a precedence any more, so the order is simply the order you register things:
 
-1. Global middleware, in the order given to `bootstrap({ middlewares })`
-2. Context contributors, topologically sorted by `dependsOn` — this is where the user is loaded
+1. Global middleware, in the order given to `bootstrap({ middlewares })` — no `ctx.route` yet
+2. Context contributors, topologically sorted by `dependsOn` — this is where the user is loaded, and where `skipWhen` lets a route flag opt out of loading one
 3. `@Middleware()` guards, class-level then method-level
 4. The handler
 

--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -400,6 +400,9 @@ A `defineContextDecorator(...)` call returns a function that works as both a dec
 
 Same-precedence collisions on the same key throw `DuplicateContributorError` at boot. Cross-level collisions are silent overrides — the higher-precedence contributor wins.
 
+To exempt one route from a contributor registered above it — including one you
+don't own — see [`skipWhen` / `onlyWhen`](#skipping-a-contributor-per-route-skipwhen-onlywhen) below.
+
 ```ts
 // Method-level
 class C {
@@ -442,6 +445,73 @@ bootstrap({
 ```
 
 The `.registration` property on the returned function is the immutable `ContributorRegistration` the runner consumes. Decorator usage hides this; non-decorator usage exposes it.
+
+## Skipping a contributor per route: `skipWhen` / `onlyWhen`
+
+Precedence answers "which contributor wins for this key". It does not answer
+"don't run this one here at all" — and overriding a key you don't own is not an
+option when a plugin or adapter registered it.
+
+That is what [route flags](./route-flags.md) are for. A flag is a named fact
+declared on the route; a contributor states the flag condition under which it
+steps aside:
+
+```ts
+const LoadAuthUser = defineHttpContextDecorator({
+  key: 'user',
+  skipWhen: 'auth.public', // don't run on routes carrying this flag
+  resolve: (ctx) => verify(ctx.headers.authorization),
+})
+```
+
+```ts
+const Public = defineRouteFlag('auth.public')
+
+@Public // the whole controller opts out
+@Controller()
+export class WebhooksController {
+  @Get('/stripe')
+  stripe(ctx: RequestContext) {} // LoadAuthUser does not run
+
+  @Public.off // this one opts back in
+  @Post('/admin')
+  admin(ctx: RequestContext) {} // LoadAuthUser runs
+}
+```
+
+`onlyWhen` is the inverse — run **only** where the flag is present.
+
+This is what makes exemption composable across ownership. Without it, the only
+way to opt out of a contributor is to register a permissive twin under the same
+key, which requires owning that key. A flag lives on the route, so the app can
+exempt a contributor an adapter shipped without touching it.
+
+### What the condition accepts
+
+`skipWhen` and `onlyWhen` take the same `RouteFlagTest` every flag consumer does:
+
+| Form                              | Means                 |
+| --------------------------------- | --------------------- |
+| `'auth.public'`                   | carries this flag     |
+| `'!auth.public'`                  | does **not** carry it |
+| `['auth.public', 'health.probe']` | carries any of these  |
+| `['!a', '!b']`                    | carries none of these |
+| `({ flags, route }) => boolean`   | anything else         |
+
+A list is single-polarity — `['a', '!b']` is a compile error, because "any-of"
+would read it as "a present **or** b absent" while most readers expect "and". Use
+a predicate to say it unambiguously. Keep predicates cheap: they run per request,
+per contributor.
+
+Flags are resolved from the route's method, class and mount declarations before
+the pipeline runs, so a skipped contributor costs a map lookup, not a resolve.
+
+### Skipping and `ctx.require()`
+
+A skipped contributor sets no key, so `ctx.require('user')` throws on a route
+where it was skipped. That is the intended pairing: use `ctx.get('user')` on
+routes that can be public, and `ctx.require('user')` only where the flag
+guarantees the contributor ran.
 
 ## How values flow: instances, ALS, and what survives
 

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -122,6 +122,23 @@ export class AdminController { ... }
 
 **Reach for a contributor instead when the job is to produce a value** rather than to reject — see below.
 
+### Exempting routes with flags
+
+A guard that has to let some routes through should read a [route flag](./route-flags.md), not a list of pathnames. `ctx.route` is available to any `@Middleware()`, because it runs inside the matched route:
+
+```ts
+export async function adminGuard(ctx: RequestContext, next: () => void): Promise<void> {
+  if (ctx.route?.flags.has('auth.public')) return next()
+  if (!ctx.headers.authorization) {
+    ctx.problem.unauthorized({ detail: 'Missing or invalid authorization header' })
+    return
+  }
+  next()
+}
+```
+
+`ctx.route` also carries `method`, `path`, `controller` and `handlerName`. The built-in `csrfGuard()` and `rateLimitGuard()` take an `exemptWhen` option that accepts the same flag tests — a name, `'!name'`, a single-polarity list, or a predicate.
+
 ## Middleware vs context decorators
 
 KickJS has two ways to "do something before the handler runs". Picking the right one matters for type safety, ordering, and reusability.
@@ -132,6 +149,7 @@ KickJS has two ways to "do something before the handler runs". Picking the right
 | Short-circuit the response                  | Yes (`return ctx.notFound()`)  | Not the right tool                            |
 | Mutate the response stream                  | Yes (compression, etc.)        | No                                            |
 | Run before route matching                   | Yes (global middleware)        | No (per-route only)                           |
+| Read `ctx.route.flags`                      | Yes — unless mounted globally  | Yes, plus `skipWhen` / `onlyWhen`             |
 | Declare ordering against another middleware | Manual array position          | `dependsOn: ['otherKey']` enforced at startup |
 | Reusable across plugins/adapters            | Pass closures around           | Built-in `contributors?()` hook               |
 | Errors abort boot if misconfigured          | No (silent until requests hit) | Yes (cycles/missing deps fail `app.setup()`)  |

--- a/docs/guide/modules.md
+++ b/docs/guide/modules.md
@@ -84,12 +84,36 @@ interface ModuleRoutes {
   controller?: any // Controller class — framework derives the router via buildRoutes(controller)
   router?: any // Express Router — only when you need to hand-build the router
   version?: number | false // API version override (false = no /v{n} segment)
+  prefix?: false // drop apiPrefix — pair with version: false to mount at `path` exactly
+  flags?: readonly RouteFlagName[] | RouteFlagRecord // route flags for every route in this mount
 }
 ```
 
 Either `controller` **or** `router` is required. Pass `controller` for the common case — the framework calls `buildRoutes(controller)` internally to produce the Express Router and uses the same controller for OpenAPI spec generation through `SwaggerAdapter`. Pass `router` directly only when you need to compose multiple controllers under one path or hand-build the router yourself.
 
 Routes mount at `/{apiPrefix}/v{version}{path}`. With the defaults (`apiPrefix: '/api'`, `defaultVersion: 1`), a module returning `path: '/todos'` mounts at `/api/v1/todos`.
+
+### Flagging every route in a mount
+
+`flags` is the module-level declaration site for [route flags](./route-flags.md) — the one place you can flag routes on a controller you don't own, since a decorator has to be written on the class:
+
+```ts
+routes: () => ({
+  path: '/webhooks',
+  controller: WebhooksController,
+  flags: ['auth.public'], // bare flags, each stored as `true`
+})
+```
+
+Use the record form for flags that carry a value:
+
+```ts
+flags: { 'auth.public': true, 'rate.limit': { rpm: 10 } }
+```
+
+Precedence is **method > class > mount**, so a `@Flag` on the controller or handler wins and `@Flag.off` on a method still drops an inherited one. A name starting with `!` throws at boot — a declaration has no negative form; remove the flag instead.
+
+The built-in health module is the framework's own use of this: `bootstrap({ health: { flags: ['auth.public'] } })` puts your flag on both probes, whose controller belongs to the framework.
 
 ## Multiple route sets + versioning
 


### PR DESCRIPTION
## The gap

`guide/route-flags.md` is a solid dedicated page. The problem is everywhere else — the pages an adopter actually lands on had nothing:

| Page | Flag mentions before |
| --- | --- |
| `guide/context-decorators.md` | 0 |
| `guide/middleware.md` | 0 |
| `guide/authorization.md` | 0 |
| `guide/modules.md` | 0 |
| `guide/adapters.md` | 0 |
| `api/core.md` | 0 |
| `api/swagger.md` | 0 |

The worst of these is `context-decorators.md`. It is the canonical 1,250-line contributor reference, and it never mentioned `skipWhen` / `onlyWhen` — so the one mechanism for exempting a contributor you *don't own* was undiscoverable from the exact page where you'd look for it. `api/core.md` had no route-flags entry at all, and `api/swagger.md` documented neither `publicFlag` nor `securityResolver`.

## What each page got

**`api/core.md`** — a full Route Flags reference section: `defineRouteFlag`, the declaration-site precedence table (method > class > mount), `MatchedRoute` / `RouteFlags`, `getRouteFlags`, the `RouteFlagTest` type with the single-polarity rule, a consumer table naming every surface and its option, the `RoutePolicyTable` / `bindRoutePolicy` pre-match path, and `KickRouteFlags`. `ModuleRoutes` gains `flags`.

**`api/swagger.md`** — `SwaggerOptions` now shows `publicFlag` and `securityResolver`, with the per-route resolution order (`@ApiPublic` → `securityResolver()` → `publicFlag` → `bearerAuth`) and the `getRouteFlags` escape hatch.

**`guide/context-decorators.md`** — a new section on `skipWhen` / `onlyWhen`: why precedence doesn't substitute for it (you can't override a key you don't own), the full condition table, and the `ctx.require()` interaction — a skipped contributor sets no key, so a route that can be public must use `ctx.get()`.

**`guide/modules.md`** — `ModuleRoutes.flags` as the module declaration site, both input forms, precedence, and the `!name` boot rejection.

**`guide/middleware.md`** — guards read `ctx.route.flags`; the middleware-vs-contributor comparison table gains a flags row.

**`guide/authorization.md`** — exempting with flags rather than path lists, `exemptWhen` on the built-in guards, and the global-middleware exception (no `ctx.route` pre-match).

**`guide/adapters.md`** — `getRouteFlags` in `onRouteMount`, and the note that an adapter-shipped contributor is exemptable by an app that never edits the adapter.

## Verification

VitePress build passes (it fails on dead links, and several of these are new cross-page anchors). `pnpm format:check` clean. Docs only — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVCyhU9ghEntXjQwzXvjhE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive guidance for route flags, including declaration, precedence, lookup, testing, and route-policy usage.
  - Documented applying flags to all routes in a module and mounting routes without the API prefix.
  - Added Swagger configuration guidance for identifying public endpoints and customizing security decisions.
  - Expanded adapter, authorization, middleware, and context decorator documentation with route-based exemptions and conditional contributor behavior.
  - Clarified testing lifecycle behavior and adapter hook consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->