### PR TITLE
fix(swagger): emit security: [] on public routes under a global requirement

### DIFF
--- a/.changeset/silly-pumas-drum.md
+++ b/.changeset/silly-pumas-drum.md
@@ -1,0 +1,16 @@
+---
+'@forinda/kickjs-swagger': patch
+---
+
+Fix public routes still requiring auth in the spec when `bearerAuth: true` is set.
+
+`bearerAuth: true` installs a security requirement at the **root** of the
+OpenAPI document, and OpenAPI applies a root requirement to every operation
+that does not override it. `@ApiPublic`, a `securityResolver` returning `null`,
+and `publicFlag` all emitted no `security` key on the operation — which means
+"inherit the root requirement", so the spec documented those routes as needing
+a bearer token anyway.
+
+They now emit `security: []`, the only spelling OpenAPI has for an open
+operation. Specs built without a global requirement are unchanged: an empty
+array there would be noise, so `security` stays unset.

--- a/packages/swagger/__tests__/swagger.test.ts
+++ b/packages/swagger/__tests__/swagger.test.ts
@@ -750,6 +750,59 @@ describe('buildOpenAPISpec — security (Swagger-owned, not coupled to any auth 
     expect(spec.paths['/api/secret']?.get?.security).toEqual([{ BearerAuth: [] }])
   })
 
+  it('a public route overrides the global requirement bearerAuth installs', () => {
+    // `bearerAuth: true` sets `security` at the ROOT of the spec, and OpenAPI
+    // applies a root requirement to every operation that does not override it.
+    // Omitting `security` on a public operation therefore documents it as
+    // requiring a token — the opposite of what the flag said. An empty array
+    // is the only spelling of "open".
+    const Open = defineRouteFlag('probe.open')
+
+    @Controller()
+    class GlobalAuthController {
+      @Open
+      @Get('/live')
+      live() {}
+
+      @Get('/orders')
+      orders() {}
+    }
+
+    registerControllerForDocs(GlobalAuthController, '/api')
+    const spec = buildOpenAPISpec({ bearerAuth: true, publicFlag: 'probe.open' })
+
+    expect(spec.security).toEqual([{ BearerAuth: [] }])
+    expect(spec.paths['/api/live']?.get?.security).toEqual([])
+    // The protected one inherits the root requirement, so it stays unset.
+    expect(spec.paths['/api/orders']?.get?.security).toBeUndefined()
+  })
+
+  it('@ApiPublic overrides the global requirement too', () => {
+    @Controller()
+    class ApiPublicController {
+      @Get('/open')
+      @ApiPublic()
+      open() {}
+    }
+
+    registerControllerForDocs(ApiPublicController, '/api')
+    expect(buildOpenAPISpec({ bearerAuth: true }).paths['/api/open']?.get?.security).toEqual([])
+  })
+
+  it('leaves security unset on a public route when no global requirement exists', () => {
+    // Without `bearerAuth` there is nothing to override, and an empty array
+    // would be noise in every spec that documents no auth at all.
+    @Controller()
+    class NoGlobalController {
+      @Get('/open')
+      @ApiPublic()
+      open() {}
+    }
+
+    registerControllerForDocs(NoGlobalController, '/api')
+    expect(buildOpenAPISpec().paths['/api/open']?.get?.security).toBeUndefined()
+  })
+
   it('options.publicFlag accepts several names', () => {
     const A = defineRouteFlag('team.public')
     const B = defineRouteFlag('probe')

--- a/packages/swagger/src/openapi-builder.ts
+++ b/packages/swagger/src/openapi-builder.ts
@@ -777,7 +777,9 @@ function buildOpenAPISpecUncached(options: SwaggerOptions = {}): any {
       // generic — adopters must declare custom schemes via
       // `SwaggerOptions.securitySchemes` when using those paths.
       let bearerAuthSourced = false
-      if (isPublicMethod || resolverPublic || (flagPublic && resolverSecurity === undefined)) {
+      const explicitlyPublic =
+        isPublicMethod || resolverPublic || (flagPublic && resolverSecurity === undefined)
+      if (explicitlyPublic) {
         requirements = undefined
       } else if (resolverSecurity && resolverSecurity.length > 0) {
         requirements = resolverSecurity
@@ -791,6 +793,17 @@ function buildOpenAPISpecUncached(options: SwaggerOptions = {}): any {
       } else if (classAuth) {
         requirements = [{ name: classAuth, scopes: [] }]
         bearerAuthSourced = true
+      }
+
+      if (!requirements && explicitlyPublic && options.bearerAuth) {
+        // `bearerAuth: true` puts a security requirement at the ROOT of the
+        // spec, and OpenAPI applies a root requirement to every operation that
+        // does not override it. Omitting `security` therefore documents a
+        // public route as requiring a token — the opposite of what
+        // `@ApiPublic` / `securityResolver` / `publicFlag` just said.
+        //
+        // An empty array is the only way the spec spells "this one is open".
+        op.security = []
       }
 
       if (requirements) {


### PR DESCRIPTION
## The bug

`bearerAuth: true` installs a security requirement at the **root** of the OpenAPI document:

```json
{ "security": [{ "BearerAuth": [] }] }
```

OpenAPI applies a root requirement to every operation that does not override it. But `@ApiPublic`, a `securityResolver` returning `null`, and `publicFlag` all resolved to `requirements = undefined` and emitted **no `security` key at all** on the operation — which means "inherit the root requirement".

So every route those three declared public was still documented as requiring a bearer token. Swagger UI showed the padlock and sent an `Authorization` header; a client generated from the spec required a credential for an endpoint that takes none.

An empty array is the only spelling OpenAPI has for an open operation:

```json
{ "paths": { "/health/live": { "get": { "security": [] } } } }
```

## Fix

Emit `security: []` when a route is explicitly public **and** a global requirement exists. Without `bearerAuth` there is nothing to override, and an empty array on every operation would be noise — so that case stays unset, and the existing tests asserting `toBeUndefined()` still hold. Both behaviours are now covered.

## How it surfaced

Checking whether `bootstrap({ health: { flags: ['auth.public'] } })` (PR #653) actually reaches the spec. It does — `/health/live` and `/health/ready` appear at the root, outside `apiPrefix` — but with `bearerAuth: true` they were still marked as requiring auth, which would defeat the point of naming the flag.

## Tests

Three cases in `packages/swagger/__tests__/swagger.test.ts`:

- `publicFlag` under `bearerAuth: true` → `security: []`, and the sibling protected route stays unset so it inherits the root requirement
- `@ApiPublic` under `bearerAuth: true` → `security: []`
- `@ApiPublic` with no global requirement → still unset

65 passed in `packages/swagger`; lint and format clean. Patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVCyhU9ghEntXjQwzXvjhE
