### PR TITLE
docs: fix route-flag review findings, and correct the guard/contributor order

### DIFF
--- a/docs/api/swagger.md
+++ b/docs/api/swagger.md
@@ -16,16 +16,9 @@ interface SwaggerAdapterOptions extends SwaggerOptions {
   adapters?: any[] // peer adapters to discover (e.g. WsAdapter)
   disableInProd?: boolean // skip mounting when NODE_ENV === 'production'
 }
-
-interface SwaggerOptions {
-  bearerAuth?: boolean
-  /** Route flag(s) naming a public endpoint — those routes get `security: []`. */
-  publicFlag?: string | readonly string[]
-  /** Full control: return `null` for public, `undefined` to fall through. */
-  securityResolver?: (ctx: { controllerClass: any; handlerName: string }) => any
-  // …title, version, description, servers, tags
-}
 ```
+
+`SwaggerAdapterOptions` extends [`SwaggerOptions`](#types).
 
 ### Marking endpoints public from route flags
 
@@ -171,7 +164,13 @@ interface OpenAPIInfo {
 interface SwaggerOptions {
   info?: Partial<OpenAPIInfo>
   servers?: { url: string; description?: string }[]
+  /** Add the `BearerAuth` scheme and apply it as a GLOBAL security requirement. */
   bearerAuth?: boolean
+  /** Route flag(s) naming a public endpoint — those routes emit `security: []`. */
+  publicFlag?: string | readonly string[]
+  /** Full control: return `null` for public, requirements to set them, `undefined` to fall through. */
+  securityResolver?: (ctx: { controllerClass: any; handlerName: string }) => any
+  securitySchemes?: Record<string, OpenAPISecurityScheme>
   schemaParser?: SchemaParser
 }
 ```

--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -133,6 +133,7 @@ the generated file doubles as this reference — delete what you don't need.
 | `onHealthCheck()`          | on `GET /health/ready`                 | the built-in readiness endpoint                                      |
 | `shutdown()`               | real shutdown **and** every HMR reload | the framework, time-boxed and concurrent                             |
 | `introspect()`             | DevTools topology poll                 | the `/_debug` dashboard                                              |
+| `devtoolsTabs()`           | DevTools panel discovery               | the `/_debug` dashboard                                              |
 
 ### Reading route flags in `onRouteMount`
 
@@ -158,7 +159,6 @@ An adapter can also **consume** flags per request: `contributors()` registration
 accept `skipWhen` / `onlyWhen`, so a contributor an adapter ships can be exempted
 by an app that never edits the adapter — see
 [Context Decorators](./context-decorators.md#skipping-a-contributor-per-route-skipwhen-onlywhen).
-| `devtoolsTabs()` | DevTools panel discovery | the `/_debug` dashboard |
 
 Two are worth calling out because nothing else surfaces them:
 

--- a/docs/guide/authorization.md
+++ b/docs/guide/authorization.md
@@ -12,7 +12,7 @@ The role check below is a contributor — `kick g contributor <name> --params "r
 Full flag list: [Generators](./generators.md#kick-g-contributor).
 :::
 
-## BYO role checks — `@RequireRole`
+## BYO role checks — `@RequireRole` {#byo-role-checks}
 
 A role check is a contributor that depends on the auth user and throws 401/403.
 
@@ -57,7 +57,7 @@ dashboard(ctx: RequestContext) { /* ctx.get('user') is non-null here */ }
 
 Because `roles` is your own `AuthUser` type, literal-union role names give you compile-time typo checking with zero augmentation machinery — you declared the type yourself in Step 1.
 
-## Policies — bring your own engine via DI
+## Policies — bring your own engine via DI {#policies}
 
 There is no first-party `@Policy` / `@Can` to migrate to — but nothing about a policy engine needs framework support. Context decorators have everything required to compose one: **`deps` injects any DI token** (your engine service), **`dependsOn` orders it after `user`**, and **parameterised decorators carry the action**. The engine is just a service you register:
 
@@ -166,16 +166,21 @@ Prefer this to a pathname allow-list: a flag is declared on the route and surviv
 | A [route flag](./route-flags.md)  | Recording a fact about the route that several checks read        | `auth.public` on webhooks and health probes |
 | `rateLimit()`                     | Throttle specific endpoints                                      | Login endpoint, search API                  |
 
-The first two are code you own — see [BYO role checks](#byo-role-checks-requirerole) and [Policies](#policies-bring-your-own-engine-via-di) above. The framework ships the primitives they are built from, not the checks themselves.
+The first two are code you own — see [BYO role checks](#byo-role-checks) and [Policies](#policies) above. The framework ships the primitives they are built from, not the checks themselves.
 
 **Ordering is yours to set.** There is no built-in auth middleware imposing a precedence any more, so the order is simply the order you register things:
 
 1. Global middleware, in the order given to `bootstrap({ middlewares })` — no `ctx.route` yet
-2. Context contributors, topologically sorted by `dependsOn` — this is where the user is loaded, and where `skipWhen` lets a route flag opt out of loading one
-3. `@Middleware()` guards, class-level then method-level
-4. The handler
+2. Validation (`{ body, query, params }`), then `@FileUpload`
+3. `@Middleware()` guards — class-level, then method-level
+4. Context contributors, topologically sorted by `dependsOn` — this is where the user is loaded, and where `skipWhen` lets a route flag opt out of loading one
+5. The handler
 
-A role check that reads `ctx.get('user')` therefore has to run as a contributor that `dependsOn` the one loading the user, or as a guard mounted after it. See [Context Decorators](./context-decorators.md#ordering).
+::: warning A guard cannot read a contributor's value
+Guards run at step 3, contributors at step 4, so `ctx.get('user')` inside a `@Middleware()` guard is `undefined` — on Express, Fastify and h3 alike. A role check that reads the user has to **be** a contributor that `dependsOn` the one loading it, and reject from there. See [Context Decorators](./context-decorators.md#ordering-with-dependson).
+
+The same order is documented from the middleware side in [Middleware → Execution order](./middleware.md#execution-order).
+:::
 
 ## See Also
 

--- a/docs/guide/context-decorators.md
+++ b/docs/guide/context-decorators.md
@@ -543,7 +543,7 @@ The cost would only matter if you wrote code that relied on object identity (`ct
 The framework explicitly does NOT cache the ctx on `req` (e.g. `req.kickjsCtx`) because: (a) it would pollute Express's public `Request` type for non-kickjs middleware in the chain; (b) advanced adopters can layer in their own caching at the wrapper they own, but the framework shouldn't make the policy choice for them.
 :::
 
-### What survives the chain — and what doesn't
+### What survives the chain — and what doesn't {#what-survives-the-chain-and-what-doesnt}
 
 | Pattern                                                | Survives across instances? | Why                                                                                      |
 | ------------------------------------------------------ | -------------------------- | ---------------------------------------------------------------------------------------- |

--- a/docs/guide/edge-deployment.md
+++ b/docs/guide/edge-deployment.md
@@ -29,7 +29,7 @@ export const app = createWebApp({ h3, modules })
 `createWebApp` accepts the same module shapes as `bootstrap({ modules })`, plus
 `apiPrefix` (default `/api`), `defaultVersion` (default `1`),
 `contributors` (global context contributors), and `env` (see
-[Environment](#environment--config)).
+[Environment](#environment-config)).
 
 The h3 module is **passed in by you** rather than imported internally — edge
 bundlers have no `createRequire`, and this keeps the peer optional for everyone

--- a/docs/guide/migration-v3-to-v4.md
+++ b/docs/guide/migration-v3-to-v4.md
@@ -194,7 +194,7 @@ The `dependsOn` narrowing is one slice of the broader v4 push to make plugin/ada
 
 None of these break v3 source. They're all opt-in surfaces that light up when you adopt them.
 
-## Dropped packages — bring-your-own via `defineAdapter` / `definePlugin`
+## Dropped packages — bring-your-own via `defineAdapter` / `definePlugin` {#dropped-packages-bring-your-own-via-defineadapter-defineplugin}
 
 A handful of v3 packages were thin wrappers around fast-moving ecosystems where adopters consistently swapped the wrapper for direct upstream usage within weeks. v4 stops shipping them and replaces each with a guide page showing how to compose the same behaviour using `defineAdapter` / `definePlugin` / `defineHttpContextDecorator` / `getRequestValue` and the upstream library directly. The framework keeps the small, stable interfaces; adopters keep control of the ecosystem-specific glue.
 

--- a/docs/guide/roadmap.md
+++ b/docs/guide/roadmap.md
@@ -352,7 +352,7 @@ Only the **error-shape helpers** (`ctx.notFound()`, `ctx.badRequest()`) get a `@
 
 ---
 
-### B.6 Route flags — one vocabulary for per-route policy
+### B.6 Route flags — one vocabulary for per-route policy {#b-6-route-flags-one-vocabulary-for-per-route-policy}
 
 **Status:** `in design` — working spec at [`route-flags-design.md`](https://github.com/forinda/kick-js/blob/main/route-flags-design.md)
 **Effort:** 1–2 weeks for phase 1; phases 2–4 independently schedulable

--- a/packages/kickjs/__tests__/guard-contributor-order.test.ts
+++ b/packages/kickjs/__tests__/guard-contributor-order.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Where a `@Middleware()` guard sits relative to the contributor pipeline.
+ *
+ * The docs claimed contributors ran first, so a guard could read `ctx.get('user')`.
+ * They don't: the route entry runs validation → upload → class middleware →
+ * method middleware → contributorRunner → handler. A guard that reads a
+ * contributor's value therefore sees `undefined`, and a role check written that
+ * way fails open or throws depending on how it handles the missing value.
+ *
+ * Asserted on all three runtimes because the ordering lives in each runtime's
+ * materializer, not in one shared place.
+ */
+import 'reflect-metadata'
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import {
+  Application,
+  Container,
+  Controller,
+  Get,
+  Middleware,
+  defineHttpContextDecorator,
+  type AppModule,
+  type ModuleRoutes,
+  type RequestContext,
+} from '../src/index'
+import { fastifyRuntime } from '../src/http/runtimes/fastify'
+import { h3Runtime } from '../src/http/runtimes/h3'
+
+declare module '../src/index' {
+  interface ContextMeta {
+    orderUser: { id: string }
+  }
+}
+
+const trace: string[] = []
+
+const LoadUser = defineHttpContextDecorator({
+  key: 'orderUser',
+  resolve: () => {
+    trace.push('contributor')
+    return { id: 'u1' }
+  },
+})
+
+const guard = (ctx: RequestContext, next: () => void) => {
+  trace.push(ctx.get('orderUser') ? 'guard:sees-user' : 'guard:no-user')
+  next()
+}
+
+@LoadUser
+@Middleware(guard)
+@Controller()
+class OrderController {
+  @Get('/probe')
+  probe(ctx: RequestContext) {
+    trace.push('handler')
+    ctx.json({ user: ctx.get('orderUser') ?? null })
+  }
+}
+
+const mod = (): AppModule =>
+  ({ routes: (): ModuleRoutes => ({ path: '/order', controller: OrderController }) }) as AppModule
+
+beforeEach(() => {
+  Container.reset()
+  trace.length = 0
+})
+
+describe('guard vs contributor ordering', () => {
+  const runtimes = [
+    ['express', undefined],
+    ['fastify', fastifyRuntime],
+    ['h3', h3Runtime],
+  ] as const
+
+  for (const [name, runtime] of runtimes) {
+    it(`runs @Middleware() before contributors on ${name}`, async () => {
+      const app = new Application({
+        modules: [mod()],
+        apiPrefix: '/api',
+        defaultVersion: 1,
+        ...(runtime ? { runtime: runtime() } : {}),
+      } as never)
+      await app.setup()
+
+      const res = await request(app.handle.bind(app)).get('/api/v1/order/probe')
+
+      expect(trace).toEqual(['guard:no-user', 'contributor', 'handler'])
+      // The handler still gets the value — only the guard is too early for it.
+      expect(res.body.user).toEqual({ id: 'u1' })
+    })
+  }
+})


### PR DESCRIPTION
Follow-up to the review on #655. Four findings; three were real.

## 1. The ordering doc was wrong — and the wrong way round (major)

`authorization.md` listed the request order as global middleware → **contributors** → `@Middleware()` guards → handler, and told readers a role check reading `ctx.get('user')` could be "a guard mounted after it".

The runtime does the opposite. Each route entry runs:

```
publishMatchedRoute → validation → @FileUpload → class @Middleware → method @Middleware → contributorRunner → handler
```

So a guard runs *before* every contributor and `ctx.get('user')` is `undefined` inside it. Following that advice produces an auth check that silently fails open. Verified on all three engines:

```
ORDER[express]: guard(user=no) → contributor → handler
ORDER[fastify]: guard(user=no) → contributor → handler
ORDER[h3]:      guard(user=no) → contributor → handler
```

Corrected the list, added a warning box saying a role check has to *be* a contributor with `dependsOn`, and cross-linked `middleware.md#execution-order`, which had it right all along — the two pages contradicted each other.

`packages/kickjs/__tests__/guard-contributor-order.test.ts` pins it on express, fastify and h3, since the ordering lives in each runtime's materializer rather than one shared place.

## 2. A table row orphaned by the new section

The `onRouteMount` section I added to `adapters.md` was inserted mid-table, splitting `devtoolsTabs()` off into a stray pipe-delimited paragraph. Row rejoined; verified it renders as `<td>` in the built HTML.

## 3. Two disagreeing `SwaggerOptions` declarations

`api/swagger.md` had one under `## SwaggerAdapter` (mine, with the security fields) and one under `## Types` (without). `## Types` is now the single canonical declaration and carries `publicFlag`, `securityResolver` and `securitySchemes`; the adapter section links to it.

## 4. The anchor finding was wrong — but led somewhere

The claim that `#skipping-a-contributor-per-route-skipwhen-onlywhen` is invalid is incorrect; that is exactly the generated id.

Checking it did turn up four **pre-existing** broken anchors. VitePress keeps the em dash in a heading slug — `## BYO role checks — \`@RequireRole\`` becomes `#byo-role-checks-—-requirerole` — so every link written as `#byo-role-checks-requirerole` went nowhere. Percent-encoding the dash doesn't survive rendering, so the affected headings get explicit `{#ids}` instead:

- `authorization.md` — `{#byo-role-checks}`, `{#policies}`
- `roadmap.md` — B.6
- `context-decorators.md` — "What survives the chain"
- `migration-v3-to-v4.md` — "Dropped packages"
- `edge-deployment.md` — link typo (`#environment--config`)

A sweep of all 39 in-page anchors against the built HTML now reports **0 broken**, up from 6.

## Verification

936 passing in `packages/kickjs` (3 new), 65 in `packages/swagger`, VitePress build clean, lint and format clean. Docs + one test — no changeset.

Note: `pnpm build` serves a cached docs build, so verifying rendered output needs `npx vitepress build` from `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVCyhU9ghEntXjQwzXvjhE
