### PR TITLE
docs: close the swagger reference gaps, and correct what "public" emits

### DIFF
--- a/docs/api/swagger.md
+++ b/docs/api/swagger.md
@@ -15,6 +15,8 @@ interface SwaggerAdapterOptions extends SwaggerOptions {
   specPath?: string // default: '/openapi.json'
   adapters?: any[] // peer adapters to discover (e.g. WsAdapter)
   disableInProd?: boolean // skip mounting when NODE_ENV === 'production'
+  renderSwaggerUI?: UIRenderer // swap the Swagger UI shell
+  renderReDoc?: UIRenderer // swap the ReDoc shell
 }
 ```
 
@@ -144,6 +146,35 @@ Mark an endpoint or controller as requiring Bearer token authentication.
 function ApiBearerAuth(name?: string): ClassDecorator & MethodDecorator
 ```
 
+### ApiSecurity
+
+Require a named security scheme on an endpoint or controller. Accepts a scheme
+name, a `{ name, scopes }` requirement, or a list of either.
+
+```typescript
+function ApiSecurity(
+  requirement: string | ApiSecurityRequirement | (string | ApiSecurityRequirement)[],
+): ClassDecorator & MethodDecorator
+```
+
+A method-level requirement replaces the class-level one rather than adding to
+it. Reference a scheme declared in [`securitySchemes`](#swaggeradapter); only
+the literal name `BearerAuth` is auto-synthesised.
+
+### ApiPublic
+
+Mark a single method as public — it opts out of any class-level requirement.
+
+```typescript
+function ApiPublic(): MethodDecorator
+```
+
+Method-only, and the highest-precedence answer in the [resolution
+order](../guide/swagger.md#resolution-order). When the spec carries a global
+requirement (`bearerAuth: true`), the operation emits `security: []`, which is
+how OpenAPI spells "this one is open" — omitting the key would mean "inherit the
+global requirement".
+
 ### ApiExclude
 
 Exclude a controller or method from the generated OpenAPI spec.
@@ -161,6 +192,19 @@ interface OpenAPIInfo {
   description?: string
 }
 
+interface SecurityResolverContext {
+  controllerClass: any
+  handlerName: string
+}
+
+interface ApiSecurityRequirement {
+  name: string
+  scopes?: string[]
+}
+
+/** Renders the HTML for a docs UI — `swaggerUIHtml` and `redocHtml` implement it. */
+type UIRenderer = (specUrl: string, title?: string, assetsPath?: string) => string
+
 interface SwaggerOptions {
   info?: Partial<OpenAPIInfo>
   servers?: { url: string; description?: string }[]
@@ -168,8 +212,10 @@ interface SwaggerOptions {
   bearerAuth?: boolean
   /** Route flag(s) naming a public endpoint — those routes emit `security: []`. */
   publicFlag?: string | readonly string[]
-  /** Full control: return `null` for public, requirements to set them, `undefined` to fall through. */
-  securityResolver?: (ctx: { controllerClass: any; handlerName: string }) => any
+  /** Full control: `null` is public, `undefined` falls through, anything else sets the requirement. */
+  securityResolver?: (
+    ctx: SecurityResolverContext,
+  ) => string | ApiSecurityRequirement | (string | ApiSecurityRequirement)[] | null | undefined
   securitySchemes?: Record<string, OpenAPISecurityScheme>
   schemaParser?: SchemaParser
 }

--- a/docs/guide/swagger.md
+++ b/docs/guide/swagger.md
@@ -169,6 +169,8 @@ class InternalController {
 
 Use when the controller is mostly secured but exposes a health-check / login / public-stats endpoint that shouldn't carry the inherited security requirement in the OpenAPI spec.
 
+Under `bearerAuth: true` the operation emits `security: []` rather than omitting the key — see [Resolution order](#resolution-order).
+
 ### @ApiExclude
 
 Hide a controller or method from the spec.
@@ -266,13 +268,30 @@ The resolver runs **after** `@ApiPublic()` (which short-circuits to public) but 
 
 When the spec builder picks security for a route, the first match wins:
 
-1. `@ApiPublic()` on the method → no security emitted.
+1. `@ApiPublic()` on the method → public.
 2. `securityResolver({ controllerClass, handlerName })` returns a value (or `null` for public).
-3. `publicFlag` — the route carries one of the named flags → no security emitted.
+3. `publicFlag` — the route carries one of the named flags → public.
 4. `@ApiSecurity` on the method.
 5. `@ApiBearerAuth` on the method.
 6. `@ApiSecurity` on the class.
 7. `@ApiBearerAuth` on the class.
+
+::: tip What "public" emits
+It depends on whether the spec carries a **global** requirement.
+
+`bearerAuth: true` sets `security` at the root of the document, and OpenAPI
+applies a root requirement to every operation that does not override it — so
+omitting the key there would document the route as _requiring_ a token. A public
+operation therefore emits `security: []`, which is the only way OpenAPI spells
+"this one is open":
+
+```json
+{ "paths": { "/health/live": { "get": { "security": [] } } } }
+```
+
+With no global requirement there is nothing to override, so `security` is left
+off entirely rather than adding an empty array to every operation.
+:::
 
 ## Schema-Driven Documentation
 


### PR DESCRIPTION
Audited `docs/api/swagger.md` and `docs/guide/swagger.md` against the package's actual exports. Three gaps and one stale claim.

## The reference named decorators it never defined

`packages/swagger` exports seven `Api*` decorators. The API reference documented five:

| Exported | Documented before |
| --- | --- |
| ApiOperation, ApiResponse, ApiTags, ApiBearerAuth, ApiExclude | ✅ |
| **ApiSecurity** | ❌ |
| **ApiPublic** | ❌ |

Both are named in the security resolution order that same page describes, so the reference pointed at decorators a reader couldn't look up. Added, with their real signatures.

## `securityResolver` was typed `=> any`

The reference declared it as returning `any`, which loses the whole contract — `null` is "explicitly public", `undefined` falls through, anything else sets the requirement. Replaced with the real signature, plus the two supporting types it references (`SecurityResolverContext`, `ApiSecurityRequirement`), neither of which was documented anywhere.

## `SwaggerAdapterOptions` was incomplete

Missing `renderSwaggerUI` / `renderReDoc`, and the `UIRenderer` type they take was undocumented. Worth noting I got its signature wrong on the first pass — I wrote `(specUrl, title)` from memory; it is `(specUrl, title?, assetsPath?)`. Corrected against source.

## The guide was stale against #656

The resolution order said a public route emits **no** security. Since #656 that is only true when the spec has no global requirement. With `bearerAuth: true`, `security` sits at the root of the document and OpenAPI applies it to every operation that doesn't override it — so a public operation emits `security: []`, the only spelling OpenAPI has for "open". Omitting the key would document it as requiring a token, which was the bug.

Stated in the resolution order and on `@ApiPublic`, including the "no global requirement → key left off" half so the two cases don't read as contradictory.

## Verification

VitePress build clean, all 39 in-page anchors resolve, `pnpm format:check` clean. Docs only — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVCyhU9ghEntXjQwzXvjhE
