### PR TITLE
docs(cli,kickjs): correct generator docblocks that misstate the runtime

### DIFF
--- a/.changeset/tidy-pans-warn.md
+++ b/.changeset/tidy-pans-warn.md
@@ -1,0 +1,23 @@
+---
+'@forinda/kickjs-cli': patch
+'@forinda/kickjs': patch
+---
+
+Correct three generator/API docblock claims that did not match runtime behaviour.
+
+`kick g middleware` emits a connect-style `(req, res, next)` factory, but its
+docblock recommended `@Middleware(<factory>())`. That decorator invokes its
+handler as `(ctx, next)` — two arguments — so the factory's `next` binds to the
+response slot, no third argument arrives, and the first `next()` throws
+`TypeError: next is not a function` from inside the middleware. The docblock now
+names the mismatch and points at `kick g guard` for the ctx-style shape.
+
+`kick g plugin` listed a lifecycle order that did not match `Application`:
+`adapters()` is read during construction and `middleware()` mounts before
+`modules()`, so a plugin middleware handler cannot resolve anything a plugin
+module registers. It also did not mention that `.async()` resolves config inside
+`onReady`, past every contribution point.
+
+`KickPlugin.middleware()` and the generated hook both described their return as
+"Express middleware". The handlers are mounted through each runtime's
+`useConnect` seam and work on Express, Fastify and h3 alike.

--- a/packages/cli/__tests__/generators-engine-neutral.test.ts
+++ b/packages/cli/__tests__/generators-engine-neutral.test.ts
@@ -89,6 +89,19 @@ describe('kick g middleware', () => {
     expect(src).toContain('next: NextFunction')
     expect(src).not.toContain("from 'node:http'")
   })
+
+  it('does not tell the reader to pass the factory to @Middleware()', async () => {
+    // The template emits a connect-style `(req, res, next)` factory, but
+    // `@Middleware()` calls its handler as `(ctx, next)` — two arguments. The
+    // factory's `next` binds to the response slot, its third parameter stays
+    // undefined, and the first `next()` throws `next is not a function`. The
+    // docblock used to recommend exactly that.
+    const dir = tempDir()
+    await generateMiddleware({ name: 'audit', outDir: dir, runtime: 'express' })
+    const src = readOnly(dir)
+    expect(src).not.toMatch(/@Middleware\(\w+\(\)\)/)
+    expect(src).toMatch(/guard/i)
+  })
 })
 
 describe('kick g guard', () => {

--- a/packages/cli/src/generators/middleware.ts
+++ b/packages/cli/src/generators/middleware.ts
@@ -95,8 +95,12 @@ export interface ${toPascalCase(name)}Options {
  *     }]
  *   }
  *
- * Usage with @Middleware decorator:
- *   @Middleware(${camel}())
+ * NOT for \`@Middleware()\`. That decorator takes a ctx-style handler —
+ * \`(ctx, next)\`, see \`MiddlewareHandler\` — and the runtime calls it with
+ * exactly two arguments. Passing this connect-style factory there binds
+ * \`next\` to the response slot and passes no third argument at all, so the
+ * first \`next()\` throws \`TypeError: next is not a function\`. Generate a
+ * guard instead (\`kick g guard\`) for the per-route, ctx-style shape.
  */
 export function ${camel}(options: ${toPascalCase(name)}Options = {}) {
 ${

--- a/packages/cli/src/generators/plugin.ts
+++ b/packages/cli/src/generators/plugin.ts
@@ -54,17 +54,26 @@ export interface ${pascal}PluginConfig {
  * A plugin bundles DI bindings, modules, adapters, and middleware
  * into one object that can be added to \`bootstrap({ plugins })\`.
  *
- * Lifecycle order (each hook is optional — delete the ones you don't
- * need and keep only the surface your plugin actually uses):
+ * Call order (each hook is optional — delete the ones you don't need and
+ * keep only the surface your plugin actually uses). This is the order the
+ * hooks are INVOKED in, which is not the order they read in below:
  *
- *   1. \`register(container)\` — runs before user modules load. Use
- *      it to bind services that modules depend on.
- *   2. \`modules()\`            — plugin modules load before user modules.
- *   3. \`adapters()\`           — plugin adapters mount before user adapters.
- *   4. \`middleware()\`         — plugin middleware runs before user middleware.
+ *   1. \`adapters()\`           — read first, while the app is still being
+ *      constructed; the returned adapters mount before user adapters.
+ *   2. \`register(container)\`  — runs before user modules load. Use it to
+ *      bind services that modules depend on.
+ *   3. \`middleware()\`         — mounts BEFORE \`modules()\` is read, so a
+ *      handler here cannot resolve anything a plugin module registers.
+ *   4. \`modules()\` / \`setup(registry)\` — plugin modules load before user
+ *      modules.
  *   5. \`contributors()\`       — Context Contributors merged into every route.
  *   6. \`onReady(container)\`   — runs after the app has fully bootstrapped.
  *   7. \`shutdown()\`           — on shutdown AND every HMR reload.
+ *
+ * \`.async()\` resolves its config inside \`onReady\`, which is past every
+ * contribution point above: only \`register()\`, \`onReady()\` and
+ * \`shutdown()\` still run. Use the bare or \`.scoped()\` form when the plugin
+ * ships modules, adapters, middleware, or contributors.
  *
  * @example
  * \`\`\`ts
@@ -119,8 +128,11 @@ export const ${pascal}Plugin = definePlugin<${pascal}PluginConfig>({
     },
 
     /**
-     * Return Express middleware entries to be added to the global
-     * pipeline. Plugin middleware runs before user-defined middleware.
+     * Return connect-style handlers — \`(req, res, next)\` — for the global
+     * pipeline. Every runtime accepts them: each one is mounted through the
+     * engine's \`useConnect\` seam, so this is NOT Express-only. Plugin
+     * middleware runs before user-defined middleware, and takes no
+     * \`phase\` / \`path\` — use an adapter's \`middleware()\` for those.
      */
     middleware(): unknown[] {
       return [

--- a/packages/kickjs/src/core/plugin.ts
+++ b/packages/kickjs/src/core/plugin.ts
@@ -137,8 +137,12 @@ export interface KickPlugin {
   adapters?(): AppAdapter[]
 
   /**
-   * Return Express middleware to be added to the global pipeline.
-   * Plugin middleware runs before user-defined middleware.
+   * Return connect-style handlers — `(req, res, next)` — for the global
+   * pipeline. Each is mounted through the runtime's `useConnect` seam, so
+   * these work on Express, Fastify and h3 alike; only the `req` / `res`
+   * shapes differ per engine. Plugin middleware runs before user-defined
+   * middleware, and carries no `phase` / `path` — use an adapter's
+   * {@link AppAdapter.middleware} for scoped or phased entries.
    */
   middleware?(): any[]
 


### PR DESCRIPTION
## What was wrong

Three docblock claims that the runtime does not honour. The first was reported from a real probe on 8.3.0, the other two were found checking its neighbours.

### 1. `kick g middleware` recommends a call that always throws

The template emits a connect-style factory:

```ts
export function uploadProbe(options: UploadProbeOptions = {}) {
  return (req: Request, res: Response, next: NextFunction) => {
    next()
  }
}
```

and its docblock said:

```
 * Usage with @Middleware decorator:
 *   @Middleware(uploadProbe())
```

But `@Middleware` takes a `MiddlewareHandler` — `(ctx, next)` — and the runtimes call it with exactly two arguments (`packages/kickjs/src/http/runtimes/express.ts:66-70`, and the same shape under Fastify and h3):

```ts
for (const mw of entry.middlewares) {
  handlers.push((req, res, next) => {
    const ctx = new RequestContext(req, res, next)
    Promise.resolve(mw(ctx, next)).catch(next)
  })
}
```

So the generated handler binds `req` to the context, `res` to `next`, and never receives a third argument. The first `next()` throws `TypeError: next is not a function`, and the stack points at the generated middleware rather than at the mismatch.

The docblock now names the mismatch and points at `kick g guard`, which already emits the correct `(ctx, next)` shape.

### 2. `kick g plugin` lists a lifecycle order that isn't the real one

Claimed `register → modules → adapters → middleware → contributors → onReady → shutdown`. Against `packages/kickjs/src/http/application.ts` the hooks are actually read in this order:

| # | hook | site |
|---|---|---|
| 1 | `adapters()` | `:556` — during construction |
| 2 | `register()` | `:729` |
| 3 | `middleware()` | `:735` |
| 4 | `modules()` / `setup()` | `:812-813` |
| 5 | `contributors()` | `:888` |
| 6 | `onReady()` | `:1123` |
| 7 | `shutdown()` | `:1326` |

`middleware()` mounting before `modules()` is the one that can bite: a plugin middleware handler cannot resolve anything a plugin module registered. The template also never mentioned that `.async()` resolves its config inside `onReady` — past every contribution point — which `define-plugin.ts:44-46` documents but the scaffold did not.

### 3. "Express middleware" on an engine-neutral hook

`KickPlugin.middleware()` and the generated hook both said "Return Express middleware". They are mounted via `this.runtime.useConnect(this.app, handler)` (`application.ts:737`) and work on all three engines. Fixed at the interface, which is where the generator copied the wording from.

## Guard template: checked, correct

`kick g guard` emits `(ctx, next)` and passes the function itself — `@Middleware(adminOnlyGuard)` — so it is right as written. No change.

## Test

One regression test in `packages/cli/__tests__/generators-engine-neutral.test.ts` asserting the middleware template never recommends `@Middleware(<factory>())` again.

Note: the new prose originally tripped the existing `not.toContain('undefined')` guard on that template — reworded rather than loosening the guard, since that assertion exists to catch `runtime: undefined` leaking into an interpolated comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected middleware guidance to distinguish connect-style handlers from context-style handlers used with decorators.
  * Clarified that guards should be generated for context-style handler patterns.
  * Updated plugin lifecycle documentation to reflect the actual invocation order and asynchronous configuration timing.
  * Clarified middleware mounting behavior and runtime-specific request/response handling across supported runtimes.
* **Tests**
  * Added coverage verifying generated middleware documentation no longer recommends incompatible decorator usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->