### PR TITLE
docs(cli): stop naming Express on engine-neutral generator surfaces

### DIFF
--- a/.changeset/olive-moons-tap.md
+++ b/.changeset/olive-moons-tap.md
@@ -1,0 +1,18 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+Correct three more generator claims that name Express on engine-neutral surfaces.
+
+`kick g adapter`'s `beforeMount` example used `ctx.app.get(…)` with
+`res.json(…)` — both Express-only — directly below a docblock promising the
+adapter "works on every runtime". It now uses `ctx.http.route(…)`, the seam the
+Application builds over whichever runtime is active, and says when reaching for
+the engine-native `ctx.app` is the right call. The same hook's `path` option
+accepts a string prefix, a RegExp, or an array of either; the docblock described
+only the prefix.
+
+`kick --help` described `kick g middleware` as "Express middleware", and the
+generated AGENTS.md called adapter middleware "raw Express". Both are
+connect-style handlers mounted through the runtime seam, and work under Express,
+Fastify and h3 alike.

--- a/packages/cli/__tests__/generators-engine-neutral.test.ts
+++ b/packages/cli/__tests__/generators-engine-neutral.test.ts
@@ -24,6 +24,7 @@ import { join } from 'node:path'
 
 import { generateGuard } from '../src/generators/guard'
 import { generateMiddleware } from '../src/generators/middleware'
+import { generateAdapter } from '../src/generators/adapter'
 
 const dirs: string[] = []
 function tempDir(): string {
@@ -107,5 +108,19 @@ describe('kick g guard', () => {
     const dir = tempDir()
     await generateGuard({ name: 'adminOnly', outDir: dir })
     expect(readOnly(dir)).toMatch(/ENGINE-NATIVE/)
+  })
+})
+
+describe('kick g adapter', () => {
+  it('shows the engine-neutral http seam, not the Express-native app', async () => {
+    // The template's own middleware() docblock promises the adapter works on
+    // every runtime, so its beforeMount example must not reach for
+    // `ctx.app.get(...)` + `res.json(...)` — both Express-only. `ctx.http` is
+    // the seam the Application builds over whichever runtime is active.
+    const dir = tempDir()
+    await generateAdapter({ name: 'metrics', outDir: dir })
+    const src = readOnly(dir)
+    expect(src).toContain('_ctx.http.route(')
+    expect(codeOf(src)).not.toMatch(/_ctx\.app\.get\(/)
   })
 })

--- a/packages/cli/src/generators/adapter.ts
+++ b/packages/cli/src/generators/adapter.ts
@@ -97,7 +97,8 @@ export const ${pascal}Adapter = defineAdapter<${pascal}AdapterConfig>({
        * \`phase\` controls where each handler sits in the pipeline:
        *   'beforeGlobal' | 'afterGlobal' | 'beforeRoutes' | 'afterRoutes'.
        *
-       * \`path\` (optional) scopes the entry to a path prefix.
+       * \`path\` (optional) scopes the entry — a string prefix, a RegExp,
+       * or an array mixing both. See \`MiddlewarePath\`.
        *
        * Delete this hook entirely if you don't add middleware.
        */
@@ -129,8 +130,13 @@ export const ${pascal}Adapter = defineAdapter<${pascal}AdapterConfig>({
        * Delete this hook if you have no early routes.
        */
       beforeMount(_ctx: AdapterContext): void {
-        // Example:
-        // _ctx.app.get('/${kebab}/status', (_req, res) => res.json({ status: 'ok' }))
+        // Example — \`ctx.http\` is the engine-neutral seam, so this route
+        // works under Express, Fastify and h3 alike:
+        // _ctx.http.route('GET', '/${kebab}/status', (ctx) => ctx.json({ status: 'ok' }))
+        //
+        // \`ctx.app\` is the engine-native instance (an Express app only under
+        // the default runtime). Reach for it when what you're wiring is
+        // genuinely engine-specific, and accept the lock-in.
       },
 
       /**

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -448,7 +448,7 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
   log('  kick g scaffold <n> <f..> CRUD module from field definitions')
   log('  kick g controller <name>  Standalone controller')
   log('  kick g service <name>     @Service() class')
-  log('  kick g middleware <name>   Express middleware')
+  log('  kick g middleware <name>   Global connect-style middleware')
   log('  kick g guard <name>       Route guard (auth, roles, etc.)')
   log('  kick g adapter <name>     AppAdapter with lifecycle hooks')
   log('  kick g dto <name>         Zod DTO schema')

--- a/packages/cli/src/generators/templates/project-docs.ts
+++ b/packages/cli/src/generators/templates/project-docs.ts
@@ -1003,7 +1003,7 @@ plugins: [
 
 **Red flags**:
 - Any \`new SomeAdapter()\` / \`SomePlugin()\` literal inside \`bootstrap({ ... })\` instead of imported from a category folder.
-- Mixing middleware signatures: \`bootstrap({ middlewares })\` is **raw Express** \`(req, res, next)\`; \`@Middleware()\` decorators are \`(ctx, next)\`; adapter middleware is raw Express again. Wrong shape in the wrong slot throws "Cannot read properties of undefined".
+- Mixing middleware signatures: \`bootstrap({ middlewares })\` is **raw Express** \`(req, res, next)\`; \`@Middleware()\` decorators are \`(ctx, next)\`; adapter middleware is connect-style too (mounted through the runtime seam, so it is not Express-only). Wrong shape in the wrong slot throws "Cannot read properties of undefined".
 - \`bootstrap({ register: ... })\` — that option doesn't exist. Use an inline plugin.`,
     },
     {


### PR DESCRIPTION
Follow-up to #667 — same audit continued across the remaining generators. Every claim below was checked against the framework source, not read for plausibility.

## Fixed here

### `kick g adapter` — Express-only example under an "every runtime" promise

The `middleware()` docblock says the entries work on Express, Fastify and h3. Twenty lines later `beforeMount` demonstrated:

```ts
// _ctx.app.get('/metrics/status', (_req, res) => res.json({ status: 'ok' }))
```

`ctx.app` is `ActiveRuntime['app']` — an Express app only under the default runtime — and `res.json()` exists on none of the others. `AdapterContext` documents the fix in its own JSDoc ("Prefer `http` over `app`: `http` is the same on every runtime"), so the template now shows:

```ts
// _ctx.http.route('GET', '/metrics/status', (ctx) => ctx.json({ status: 'ok' }))
```

matching `AdapterHttp.route(method, path, handler)` in `packages/kickjs/src/http/runtime.ts:303`, plus a note on when `ctx.app` is the right escape hatch.

### `kick g adapter` — `path` described as prefix-only

Template said "scopes the entry to a path prefix". `MiddlewarePath` is `string | RegExp | ReadonlyArray<string | RegExp>`. The middleware template already documented all three shapes; the adapter one now does too.

### Two stale "Express" labels

- `kick --help`: `kick g middleware <name>   Express middleware` → "Global connect-style middleware".
- The generated AGENTS.md: "adapter middleware is raw Express again" → connect-style, mounted through the runtime seam.

## Audited and correct — no change

| Generator | Claim checked | Result |
|---|---|---|
| `kick g guard` | emits `(ctx, next)`, passes the function itself to `@Middleware` | matches `MiddlewareHandler` |
| `kick g contributor` | `.with({…}).registration`, `withParams<P>()` curried form, `requiredParams`, `ctx.require()` | all match `context-decorator.ts`, including the split between `ContextDecoratorWithDefaults` and `ContextDecoratorRequiringParams` |
| `kick g controller` | `reply.created()` / `reply.noContent()` alongside a `reply(status, body)` claim | `reply` is a function with those statics (`http/reply.ts:40-51`) |
| `kick g service` | `@Inject(TOKEN)` on a constructor parameter | `Inject` returns `PropertyOrParameterDecorator` |
| `kick g test` | `Container.reset()` in `beforeEach` | static, `core/container.ts:228` |
| `kick g adapter` (rest) | `onHealthCheck` feeding `GET /health/ready`; `shutdown` run concurrently and time-boxed | both hold (`application.ts:830-831`, `:1329`) |

## Found, NOT fixed here — needs a decision

**`kick g dto` and `kick g module` hardcode Zod on scaffolds that don't have it.**

`kick new --schema valibot` (or `yup`) installs only the chosen library — `project-config.ts:81` writes `[schemaDep.name]: schemaDep.range`, one entry — and generates the env file through `fromValibot` / `fromYup` accordingly. But `dto.ts:35` and `templates/dtos.ts:5,26` both emit:

```ts
import { z } from 'zod'
```

so the generated file imports a package the project never installed. `kick g module` is the wider blast radius, since it emits DTOs as part of every module.

This is the same shape as the bug #667 fixes: the scaffold knows the answer, the generator can't see it. The runtime case was solved by recording `runtime` in `kick.config.ts` and passing `config?.runtime` into the generator (`commands/generate.ts:477`). Nothing records the schema library today, so the fix is the same three moves — a `schemaLib` field on `KickConfig`, emitted by the project template, read by the DTO generators.

Left out of this PR because it changes the config schema and generated output rather than a comment. Happy to do it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
