### PR TITLE
fix(cli): emit DTO schemas for the project's validation library

### DIFF
--- a/.changeset/spotty-jars-smile.md
+++ b/.changeset/spotty-jars-smile.md
@@ -1,0 +1,21 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+Generate DTO schemas against the validation library the project actually installed.
+
+`kick new --schema valibot` (or `yup`) installs exactly one validation library —
+the chosen one and no other. But `kick g dto` and the DTOs `kick g module` emits
+both hardcoded `import { z } from 'zod'`, so every generated schema on such a
+project imported a package that was never installed.
+
+Both now resolve the library from the project's dependencies and emit the
+matching source: `v.pipe(v.string(), …)` with `v.InferOutput` for Valibot,
+`yup.string().required()` with `yup.InferType` for Yup, unchanged Zod otherwise.
+Reading it from the dependency rather than a new config field means projects
+scaffolded before this fix are covered without a config migration; a project
+with none declared still gets Zod, as before.
+
+The schemas stay unwrapped — no `fromZod` / `fromValibot` — because
+`detectSchema()` sniffs the library at runtime and `InferSchemaOutput` reads all
+three for typegen.

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -37,7 +37,7 @@ cd packages/cli && pnpm link --global
 | `kick generate guard <name>`                | `kick g guard`                                 | Generate a route guard                                            |
 | `kick generate service <name>`              | `kick g service`                               | Generate a `@Service()` class                                     |
 | `kick generate controller <name>`           | `kick g controller`                            | Generate a `@Controller()` class with routes                      |
-| `kick generate dto <name>`                  | `kick g dto`                                   | Generate a Zod DTO schema                                         |
+| `kick generate dto <name>`                  | `kick g dto`                                   | Generate a DTO schema for the project's validation library        |
 | `kick generate test <name>`                 | `kick g test`                                  | Generate a Vitest test scaffold                                   |
 | `kick generate config`                      | `kick g config`                                | Generate `kick.config.ts`                                         |
 | `kick generate agents`                      | `kick g agents` (also `agent-docs`, `ai-docs`) | Regenerate `.agents/*` + root `CLAUDE.md` from upstream templates |

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -493,7 +493,9 @@ Plugins are the canonical place to wire DI bindings, contribute modules or adapt
 
 <PmCommand exec="kick g dto create-user" />
 
-Generates a Zod schema with inferred TypeScript type. Default output: `src/dtos/`.
+Generates a schema with its inferred TypeScript type. Default output: `src/dtos/`.
+
+The schema is written against whichever validation library the project depends on — Zod, Valibot, or Yup — so a scaffold created with `--schema valibot` gets a Valibot schema rather than an import it cannot resolve. Same for the DTOs `kick g module` emits.
 
 ### kick g test
 

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -7,7 +7,7 @@ Under the hood the validate middleware calls `detectSchema(schema).safeParse(pay
 :::
 
 ::: tip Scaffold one
-`kick g dto <name>` writes a Zod schema plus its inferred type, in the shape the route decorators below expect.
+`kick g dto <name>` writes a schema plus its inferred type, in the shape the route decorators below expect — in whichever of the three libraries the project depends on.
 
 <PmCommand exec="kick g dto create-user" />
 

--- a/packages/cli/__tests__/generators-schema-lib.test.ts
+++ b/packages/cli/__tests__/generators-schema-lib.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Generated schema files must import the validation library the project
+ * actually installed.
+ *
+ * `kick new --schema valibot|yup` writes exactly one of zod / valibot / yup
+ * into package.json, so a hardcoded `import { z } from 'zod'` in a DTO is an
+ * import that cannot resolve. Same rule the swagger / testHarness flags already
+ * follow: never emit an import the project cannot satisfy.
+ */
+import { describe, expect, it, afterEach } from 'vitest'
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { generateDto } from '../src/generators/dto'
+import { generateCreateDTO, generateUpdateDTO } from '../src/generators/templates/dtos'
+import { resolveSchemaLib } from '../src/config'
+
+const dirs: string[] = []
+function tempDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'kick-schema-'))
+  dirs.push(d)
+  return d
+}
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+function readOnly(dir: string): string {
+  const files = readdirSync(dir, { recursive: true, withFileTypes: true }).filter((e) => e.isFile())
+  expect(files).toHaveLength(1)
+  return readFileSync(join(files[0]!.parentPath ?? dir, files[0]!.name), 'utf8')
+}
+
+/** A project root declaring `deps` as runtime dependencies. */
+function projectWith(deps: Record<string, string>): string {
+  const dir = tempDir()
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'app', dependencies: deps }))
+  return dir
+}
+
+const EXPECTED = {
+  zod: { import: `import { z } from 'zod'`, infer: 'z.infer<' },
+  valibot: { import: `import * as v from 'valibot'`, infer: 'v.InferOutput<' },
+  yup: { import: `import * as yup from 'yup'`, infer: 'yup.InferType<' },
+} as const
+
+describe('resolveSchemaLib', () => {
+  it('reads the library from the project dependencies', () => {
+    expect(resolveSchemaLib(projectWith({ valibot: '^1.0.0' }))).toBe('valibot')
+    expect(resolveSchemaLib(projectWith({ yup: '^1.4.0' }))).toBe('yup')
+    expect(resolveSchemaLib(projectWith({ zod: '^4.3.6' }))).toBe('zod')
+  })
+
+  it('falls back to zod when no validation library is declared', () => {
+    // Covers a bare project and an unreadable package.json alike — emitting
+    // today's default is the non-breaking answer when nothing proves otherwise.
+    expect(resolveSchemaLib(projectWith({}))).toBe('zod')
+    expect(resolveSchemaLib(tempDir())).toBe('zod')
+  })
+
+  it('prefers the deliberately chosen library when zod is also present', () => {
+    // `kick new --schema valibot` is an explicit pick; zod turning up beside it
+    // is more likely incidental than a second scaffold choice.
+    expect(resolveSchemaLib(projectWith({ valibot: '^1.0.0', zod: '^4.3.6' }))).toBe('valibot')
+  })
+
+  it('ignores a devDependency-only install', () => {
+    // A DTO schema is evaluated when its module loads, so `npm install
+    // --omit=dev` would break the app in production.
+    const dir = tempDir()
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: 'app', devDependencies: { valibot: '^1.0.0' } }),
+    )
+    expect(resolveSchemaLib(dir)).toBe('zod')
+  })
+})
+
+describe('kick g dto', () => {
+  for (const [lib, expected] of Object.entries(EXPECTED)) {
+    it(`writes the schema against ${lib}`, async () => {
+      const dir = tempDir()
+      await generateDto({
+        name: 'createUser',
+        outDir: dir,
+        schemaLib: lib as keyof typeof EXPECTED,
+      })
+      const src = readOnly(dir)
+      expect(src).toContain(expected.import)
+      expect(src).toContain(expected.infer)
+      for (const [other, shape] of Object.entries(EXPECTED)) {
+        if (other !== lib) expect(src).not.toContain(shape.import)
+      }
+    })
+  }
+
+  it('still emits zod when the caller says nothing', async () => {
+    const dir = tempDir()
+    await generateDto({ name: 'createUser', outDir: dir })
+    expect(readOnly(dir)).toContain(EXPECTED.zod.import)
+  })
+})
+
+describe('kick g module DTOs', () => {
+  for (const [lib, expected] of Object.entries(EXPECTED)) {
+    it(`writes create + update against ${lib}`, () => {
+      const ctx = { pascal: 'User', kebab: 'user', schemaLib: lib as keyof typeof EXPECTED }
+      for (const src of [generateCreateDTO(ctx), generateUpdateDTO(ctx)]) {
+        expect(src).toContain(expected.import)
+        expect(src).toContain(expected.infer)
+      }
+    })
+  }
+
+  it('names the library it wrote, so the field examples match the import', () => {
+    // The docblock lists library-specific builders; naming Zod above a valibot
+    // schema is how the hardcoded version misled readers.
+    expect(generateCreateDTO({ pascal: 'User', kebab: 'user', schemaLib: 'valibot' })).toContain(
+      'Valibot schema for validating POST request bodies',
+    )
+  })
+})

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -17,7 +17,7 @@ import { generateContributor, type ContributorType } from '../generators/contrib
 import { generateService } from '../generators/service'
 import { generateController } from '../generators/controller'
 import { generateDto } from '../generators/dto'
-import { hasDependency, hasSwagger } from '../config'
+import { hasDependency, hasSwagger, resolveSchemaLib } from '../config'
 import { findProjectRoot } from '../utils/project-root'
 import { generateConfig } from '../generators/config'
 import { generateAgentDocs } from '../generators/agent-docs'
@@ -241,6 +241,9 @@ async function runModuleGeneration(
   // so a project that HAS swagger silently generates controllers without it.
   // The extension guide warns generator authors about exactly this trap.
   const swagger = hasSwagger(findProjectRoot())
+  // Same findProjectRoot reasoning: a DTO schema importing a validation library
+  // the project never installed is a file that cannot resolve.
+  const schemaLib = resolveSchemaLib(findProjectRoot())
   // Both are devDependencies — a test harness is not needed in a production
   // install — so this asks for 'any' rather than 'runtime'.
   const projectRoot = findProjectRoot()
@@ -307,6 +310,7 @@ async function runModuleGeneration(
       pluralize: shouldPluralize,
       tokenScope,
       swagger,
+      schemaLib,
       style: mc.style,
     })
     allFiles.push(...files)
@@ -607,7 +611,7 @@ export function registerGenerateCommand(program: Command, ctx?: KickCliPluginCon
   gen
     .command('dto <name>')
     .description(
-      'Generate a Zod DTO schema\n' +
+      'Generate a DTO schema for the project\u2019s validation library\n' +
         '  Use -m to scope it to a module: kick g dto create-user -m users',
     )
     .option('-o, --out <dir>', 'Output directory (overrides --module)')
@@ -625,6 +629,7 @@ export function registerGenerateCommand(program: Command, ctx?: KickCliPluginCon
         modulesDir,
         pattern: config?.pattern,
         pluralize: mc.pluralize ?? true,
+        schemaLib: resolveSchemaLib(findProjectRoot()),
       })
       printGenerated(files, dryRun)
     })

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -638,6 +638,34 @@ export function hasSwagger(cwd: string): boolean {
   return hasDependency(cwd, '@forinda/kickjs-swagger', 'runtime')
 }
 
+/** Schema library a generated schema file is written against. */
+export type SchemaLib = 'zod' | 'valibot' | 'yup'
+
+/**
+ * Which validation library the project actually depends on, so generated
+ * schema files import something that is installed.
+ *
+ * `kick new --schema valibot|yup` installs exactly one of these — the chosen
+ * library and no other — so an emitted `import { z } from 'zod'` is a file that
+ * cannot resolve. Read from package.json rather than `kick.config.ts` because
+ * the dependency IS the fact; nothing has to be declared twice, and projects
+ * scaffolded before this existed are covered without a config migration.
+ *
+ * Valibot and Yup are checked first: `kick new` installs one deliberately,
+ * whereas `zod` is common enough to appear alongside it for unrelated reasons.
+ * A project that genuinely needs to override the pick can gain a config field
+ * when someone hits that; until then the dependency answers it.
+ *
+ * Runtime scope, same reasoning as {@link hasSwagger}: a DTO schema is
+ * evaluated when the module loads, so a devDependency-only install would break
+ * in production.
+ */
+export function resolveSchemaLib(cwd: string): SchemaLib {
+  if (hasDependency(cwd, 'valibot', 'runtime')) return 'valibot'
+  if (hasDependency(cwd, 'yup', 'runtime')) return 'yup'
+  return 'zod'
+}
+
 export function resolveTokenScope(config: KickConfig | null, cwd: string): string {
   if (config?.tokenScope && typeof config.tokenScope === 'string' && config.tokenScope.length > 0) {
     const sanitised = sanitizeScope(config.tokenScope)

--- a/packages/cli/src/generators/dto.ts
+++ b/packages/cli/src/generators/dto.ts
@@ -2,7 +2,8 @@ import { join } from 'node:path'
 import { writeFileSafe } from '../utils/fs'
 import { toPascalCase, toKebabCase, toCamelCase } from '../utils/naming'
 import { resolveOutDir } from '../utils/resolve-out-dir'
-import type { ProjectPattern } from '../config'
+import { SCHEMA_SHAPES, objectSchema } from './templates/dtos'
+import type { ProjectPattern, SchemaLib } from '../config'
 
 interface GenerateDtoOptions {
   name: string
@@ -11,6 +12,13 @@ interface GenerateDtoOptions {
   modulesDir?: string
   pattern?: ProjectPattern
   pluralize?: boolean
+  /**
+   * Validation library to write the schema against. Defaults to `'zod'`.
+   * The command resolves it from the project's dependencies — a scaffold
+   * created with `--schema valibot` never installs zod, so emitting a zod
+   * import there produces a file that cannot resolve.
+   */
+  schemaLib?: SchemaLib
 }
 
 export async function generateDto(options: GenerateDtoOptions): Promise<string[]> {
@@ -27,19 +35,18 @@ export async function generateDto(options: GenerateDtoOptions): Promise<string[]
   const kebab = toKebabCase(name)
   const pascal = toPascalCase(name)
   const camel = toCamelCase(name)
+  const lib = options.schemaLib ?? 'zod'
+  const shape = SCHEMA_SHAPES[lib]
   const files: string[] = []
 
   const filePath = join(outDir, `${kebab}.dto.ts`)
   await writeFileSafe(
     filePath,
-    `import { z } from 'zod'
+    `${shape.import}
 
-export const ${camel}Schema = z.object({
-  // Define your schema fields here
-  name: z.string().min(1).max(200),
-})
+export const ${camel}Schema = ${objectSchema(lib, `// Define your schema fields here\n  name: ${shape.required}`)}
 
-export type ${pascal}DTO = z.infer<typeof ${camel}Schema>
+export type ${pascal}DTO = ${shape.infer(`${camel}Schema`)}
 `,
   )
   files.push(filePath)

--- a/packages/cli/src/generators/module.ts
+++ b/packages/cli/src/generators/module.ts
@@ -5,7 +5,7 @@ import { colors } from '../utils/colors'
 import { toPascalCase, toKebabCase, pluralize, pluralizePascal } from '../utils/naming'
 import { escapeRegex } from '../utils/regex'
 import { readFile, writeFile } from 'node:fs/promises'
-import type { ProjectPattern, RepoTypeConfig } from '../config'
+import type { ProjectPattern, RepoTypeConfig, SchemaLib } from '../config'
 import type { ModuleStyle } from './templates/types'
 import { generateMinimalFiles, generateRestFiles } from './patterns'
 import type { ModuleContext } from './patterns'
@@ -42,6 +42,8 @@ interface GenerateModuleOptions {
   tokenScope?: string
   /** Project depends on @forinda/kickjs-swagger — gates @ApiTags emission. */
   swagger?: boolean
+  /** Validation library the emitted DTO schemas import. Default `'zod'`. */
+  schemaLib?: SchemaLib
   /**
    * Project has `@forinda/kickjs-testing` and `supertest` — gates the
    * generated controller test booting the module for real. Without them the
@@ -110,6 +112,7 @@ export async function generateModule(options: GenerateModuleOptions): Promise<st
     noTests: noTests ?? false,
     tokenScope: options.tokenScope ?? 'app',
     swagger: options.swagger ?? false,
+    schemaLib: options.schemaLib ?? 'zod',
     testHarness: options.testHarness ?? false,
     style: options.style ?? 'define',
     write,

--- a/packages/cli/src/generators/patterns/rest.ts
+++ b/packages/cli/src/generators/patterns/rest.ts
@@ -26,6 +26,7 @@ export async function generateRestFiles(ctx: ModuleContext): Promise<void> {
     write,
   } = ctx
   const swagger = ctx.swagger ?? false
+  const schemaLib = ctx.schemaLib ?? 'zod'
 
   // Module file (named `<kebab>.module.ts` so Vite's module-discovery plugin picks it up)
   await write(`${kebab}.module.ts`, generateRestModuleIndex({ pascal, kebab, plural, repo, style }))
@@ -43,8 +44,8 @@ export async function generateRestFiles(ctx: ModuleContext): Promise<void> {
   await write(`${kebab}.service.ts`, generateRestService({ pascal, kebab }))
 
   // DTOs
-  await write(`dtos/create-${kebab}.dto.ts`, generateCreateDTO({ pascal, kebab }))
-  await write(`dtos/update-${kebab}.dto.ts`, generateUpdateDTO({ pascal, kebab }))
+  await write(`dtos/create-${kebab}.dto.ts`, generateCreateDTO({ pascal, kebab, schemaLib }))
+  await write(`dtos/update-${kebab}.dto.ts`, generateUpdateDTO({ pascal, kebab, schemaLib }))
   await write(`dtos/${kebab}-response.dto.ts`, generateResponseDTO({ pascal, kebab }))
 
   // ONE repository file: factory, contract, token. The factory's return type

--- a/packages/cli/src/generators/patterns/types.ts
+++ b/packages/cli/src/generators/patterns/types.ts
@@ -1,3 +1,4 @@
+import type { SchemaLib } from '../../config'
 import type { RepoType } from '../module'
 import type { ModuleStyle } from '../templates/types'
 
@@ -27,6 +28,8 @@ export interface ModuleContext {
   files: string[]
   /** Project depends on @forinda/kickjs-swagger — gates @ApiTags. */
   swagger?: boolean
+  /** Validation library the emitted DTO schemas import. Default `'zod'`. */
+  schemaLib?: SchemaLib
   /** Project has kickjs-testing + supertest — gates the real controller test. */
   testHarness?: boolean
 }

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -451,7 +451,7 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
   log('  kick g middleware <name>   Express middleware')
   log('  kick g guard <name>       Route guard (auth, roles, etc.)')
   log('  kick g adapter <name>     AppAdapter with lifecycle hooks')
-  log('  kick g dto <name>         Zod DTO schema')
+  log('  kick g dto <name>         DTO schema (Zod / Valibot / Yup)')
   log('  kick g config             Generate kick.config.ts')
   log('')
   log('Add packages:')

--- a/packages/cli/src/generators/templates/dtos.ts
+++ b/packages/cli/src/generators/templates/dtos.ts
@@ -1,35 +1,96 @@
+import type { SchemaLib } from '../../config'
 import type { TemplateContext } from './types'
+
+/**
+ * Body-schema source for one field, per library.
+ *
+ * The schemas are emitted RAW — no `fromZod` / `fromValibot` wrapper. Both
+ * consumers already handle that: `detectSchema()` sniffs the library at
+ * runtime, and `InferSchemaOutput<T>` reads Standard Schema / `_output` /
+ * `__outputType` for typegen. Wrapping would only add an import.
+ */
+export const SCHEMA_SHAPES: Record<
+  SchemaLib,
+  {
+    import: string
+    /** Required field, 1-200 chars. */
+    required: string
+    /** Same field, optional — the update DTO. */
+    optional: string
+    infer: (schema: string) => string
+    hint: string
+  }
+> = {
+  zod: {
+    import: `import { z } from 'zod'`,
+    required: `z.string().min(1, 'Name is required').max(200)`,
+    optional: `z.string().min(1).max(200).optional()`,
+    infer: (schema) => `z.infer<typeof ${schema}>`,
+    hint: [
+      ' *   z.string(), z.number(), z.boolean(), z.enum([...]),',
+      ' *   z.array(), z.object(), .optional(), .default(), .transform()',
+    ].join('\n'),
+  },
+  valibot: {
+    import: `import * as v from 'valibot'`,
+    required: `v.pipe(v.string(), v.minLength(1, 'Name is required'), v.maxLength(200))`,
+    optional: `v.optional(v.pipe(v.string(), v.minLength(1), v.maxLength(200)))`,
+    infer: (schema) => `v.InferOutput<typeof ${schema}>`,
+    hint: [
+      ' *   v.string(), v.number(), v.boolean(), v.picklist([...]),',
+      ' *   v.array(), v.object(), v.optional(), and v.pipe(...) to chain checks',
+    ].join('\n'),
+  },
+  yup: {
+    import: `import * as yup from 'yup'`,
+    required: `yup.string().required('Name is required').min(1).max(200)`,
+    optional: `yup.string().min(1).max(200).optional()`,
+    infer: (schema) => `yup.InferType<typeof ${schema}>`,
+    hint: [
+      ' *   yup.string(), yup.number(), yup.boolean(), .oneOf([...]),',
+      ' *   yup.array(), yup.object(), .required(), .optional(), .default()',
+    ].join('\n'),
+  },
+}
+
+/** Object-schema wrapper differs only in the callee. */
+export function objectSchema(lib: SchemaLib, body: string): string {
+  const callee = lib === 'zod' ? 'z.object' : lib === 'valibot' ? 'v.object' : 'yup.object'
+  return `${callee}({\n  ${body},\n})`
+}
 
 export function generateCreateDTO(ctx: TemplateContext): string {
   const { pascal } = ctx
-  return `import { z } from 'zod'
+  const lib = ctx.schemaLib ?? 'zod'
+  const shape = SCHEMA_SHAPES[lib]
+  const name = `create${pascal}Schema`
+  const libName = lib === 'zod' ? 'Zod' : lib === 'valibot' ? 'Valibot' : 'Yup'
+  return `${shape.import}
 
 /**
- * Create ${pascal} DTO — Zod schema for validating POST request bodies.
- * This schema is passed to @Post('/', { body: create${pascal}Schema }) for automatic validation.
+ * Create ${pascal} DTO — ${libName} schema for validating POST request bodies.
+ * This schema is passed to @Post('/', { body: ${name} }) for automatic validation.
  * It also generates OpenAPI request body docs when SwaggerAdapter is used.
  *
- * Add more fields as needed. Supported Zod types:
- *   z.string(), z.number(), z.boolean(), z.enum([...]),
- *   z.array(), z.object(), .optional(), .default(), .transform()
+ * Add more fields as needed. Supported ${libName} types:
+${shape.hint}
  */
-export const create${pascal}Schema = z.object({
-  name: z.string().min(1, 'Name is required').max(200),
-})
+export const ${name} = ${objectSchema(lib, `name: ${shape.required}`)}
 
-export type Create${pascal}DTO = z.infer<typeof create${pascal}Schema>
+export type Create${pascal}DTO = ${shape.infer(name)}
 `
 }
 
 export function generateUpdateDTO(ctx: TemplateContext): string {
   const { pascal } = ctx
-  return `import { z } from 'zod'
+  const lib = ctx.schemaLib ?? 'zod'
+  const shape = SCHEMA_SHAPES[lib]
+  const name = `update${pascal}Schema`
+  return `${shape.import}
 
-export const update${pascal}Schema = z.object({
-  name: z.string().min(1).max(200).optional(),
-})
+export const ${name} = ${objectSchema(lib, `name: ${shape.optional}`)}
 
-export type Update${pascal}DTO = z.infer<typeof update${pascal}Schema>
+export type Update${pascal}DTO = ${shape.infer(name)}
 `
 }
 

--- a/packages/cli/src/generators/templates/project-config.ts
+++ b/packages/cli/src/generators/templates/project-config.ts
@@ -1,13 +1,10 @@
 type ProjectTemplate = 'rest' | 'minimal'
 
-/**
- * Supported schema libraries — passed through to `fromZod` /
- * `fromValibot` / `fromYup` in the generated env file. `zod` is the
- * default for `--yes` because it has the deepest ecosystem
- * compatibility (OpenAPI generation, Standard Schema brand for
- * `kick typegen`).
- */
-export type SchemaLib = 'zod' | 'valibot' | 'yup'
+// `SchemaLib` is defined next to `resolveSchemaLib` in ../../config, so the
+// scaffold that installs the library and the generators that import from it
+// read the same list. Re-exported here for existing importers.
+export type { SchemaLib } from '../../config'
+import type { SchemaLib } from '../../config'
 
 /** Map of optional package names to their npm package identifiers */
 const PACKAGE_DEPS: Record<string, string> = {
@@ -17,7 +14,14 @@ const PACKAGE_DEPS: Record<string, string> = {
   devtools: '@forinda/kickjs-devtools',
 }
 
-/** Schema-lib runtime dependency ranges. Pinned to a recent release. */
+/**
+ * Schema-lib runtime dependency ranges. Pinned to a recent release.
+ *
+ * Exactly one of these is installed, chosen by `--schema`; `zod` is the `--yes`
+ * default for its ecosystem reach (OpenAPI generation, the Standard Schema
+ * brand `kick typegen` reads). Whichever lands here is what `resolveSchemaLib`
+ * later detects when generating DTO schemas.
+ */
 const SCHEMA_LIB_DEPS: Record<SchemaLib, { name: string; range: string }> = {
   zod: { name: 'zod', range: '^4.3.6' },
   valibot: { name: 'valibot', range: '^1.4.1' },

--- a/packages/cli/src/generators/templates/types.ts
+++ b/packages/cli/src/generators/templates/types.ts
@@ -1,3 +1,5 @@
+import type { SchemaLib } from '../../config'
+
 /**
  * Module declaration style emitted by the module-index templates.
  *
@@ -58,6 +60,14 @@ export interface TemplateContext {
    * test with every case as `it.todo` and no extra imports.
    */
   testHarness?: boolean
+  /**
+   * Validation library the emitted DTO schemas are written against.
+   * Defaults to `'zod'`. Resolved from the project's dependencies by the
+   * orchestrating generator (`resolveSchemaLib`) — same rule as
+   * {@link TemplateContext.swagger}: importing a package the project does not
+   * install produces a file that cannot compile.
+   */
+  schemaLib?: SchemaLib
   /**
    * Module declaration style emitted for the module-index file.
    * Defaults to `'define'`. Resolved from `kick.config.ts > modules.style`


### PR DESCRIPTION
Third in the generator audit series, after #667 (merged) and #669. This one is a functional bug rather than a doc claim.

## The bug

`kick new --schema valibot` installs exactly one validation library — `project-config.ts` writes a single entry, `[schemaDep.name]: schemaDep.range` — and generates `src/config/index.ts` through `fromValibot` accordingly. The scaffold gets this right.

The generators did not. Both `kick g dto` and the DTOs `kick g module` emits opened with:

```ts
import { z } from 'zod'
```

So on a Valibot or Yup project, every generated schema imported a package that was never installed. `kick g module` is the wider path, since it writes three DTO files per module.

Same shape as the bug #667 fixed: the scaffold knows the answer, the generator can't see it.

## The fix

`resolveSchemaLib(cwd)` in `config.ts`, next to `hasSwagger`, reading the project's `dependencies`:

```ts
export function resolveSchemaLib(cwd: string): SchemaLib {
  if (hasDependency(cwd, 'valibot', 'runtime')) return 'valibot'
  if (hasDependency(cwd, 'yup', 'runtime')) return 'yup'
  return 'zod'
}
```

**Read from package.json, not a new `kick.config.ts` field.** The runtime case needed a config field because the engine is a bootstrap argument, not a dependency — nothing in `package.json` distinguishes an Express app from one that merely has Express installed. A validation library is different: the dependency *is* the fact. That also means every project scaffolded before this fix is covered without a config migration.

Two ordering decisions worth stating:

- **Valibot and Yup are checked first.** Each is a deliberate `--schema` pick, while `zod` shows up as a direct dependency for unrelated reasons often enough. A project that genuinely needs to override can gain a config field when someone hits it.
- **Runtime scope, not `'any'`** — same reasoning `hasSwagger` documents. A DTO schema is evaluated when its module loads, so a devDependency-only install would break under `npm install --omit=dev`.

## Generated output

```ts
// valibot
import * as v from 'valibot'
export const createUserSchema = v.object({
  name: v.pipe(v.string(), v.minLength(1, 'Name is required'), v.maxLength(200)),
})
export type CreateUserDTO = v.InferOutput<typeof createUserSchema>

// yup
import * as yup from 'yup'
export const createUserSchema = yup.object({
  name: yup.string().required('Name is required').min(1).max(200),
})
export type CreateUserDTO = yup.InferType<typeof createUserSchema>
```

Zod output is unchanged. The per-library docblock follows the import, so a Valibot schema no longer lists `z.string(), z.enum([...])` as its field examples.

**Schemas stay unwrapped** — no `fromZod` / `fromValibot`. Both consumers already handle raw schemas: `detectSchema()` sniffs the library at runtime (`packages/schema/src/detect.ts:95-99`), and `InferSchemaOutput<T>` reads Standard Schema, then `~output` / `_output`, then Yup's `__outputType` (`packages/schema/src/infer.ts`), which is what `typegen.schemaValidator: 'kickjs-schema'` renders into the route types. A wrapper would only add an import.

## Also

- `SchemaLib` now has one definition, in `config.ts` beside the resolver, re-exported from `project-config.ts` for existing importers.
- `kick --help` and `kick g dto --help` said "Zod DTO schema"; the docs pages said the same. Both now name the project's library.

## Tests

12 in a new `generators-schema-lib.test.ts` — detection (each library, both-present tiebreak, devDependency-only, missing package.json), and emitted output per library for both `kick g dto` and the module DTOs, each asserting the other two libraries' imports are absent.

Full CLI suite: 809 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
