### PR TITLE
feat(cli): teach kick explain the framework's own DI errors

### DIFF
--- a/.changeset/plain-pugs-explain.md
+++ b/.changeset/plain-pugs-explain.md
@@ -1,0 +1,7 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+`kick explain` now recognizes the framework's own DI errors: the REQUEST-into-SINGLETON scope violation, `Circular dependency detected`, `No provider for <token>` (KICK001), and the dev-server 404 that means the entry file exports no `app`.
+
+The scope entry notes what the runtime error cannot: `@Controller()` takes no `scope` option, so "use TRANSIENT or REQUEST scope for the parent" has no controller-shaped answer — `@Autowired` is the fix there.

--- a/packages/cli/__tests__/explain.test.ts
+++ b/packages/cli/__tests__/explain.test.ts
@@ -165,6 +165,57 @@ describe('known-issues registry', () => {
     expect(m?.diagnosis.id).not.toBe('test-env-leaked-from-dotenv')
   })
 
+  it('matches di-request-scope-into-singleton on the container error verbatim', () => {
+    const m = findBestMatch(
+      'Cannot inject REQUEST-scoped "TenantContext" into SINGLETON "ReceptionController". ' +
+        'Singletons outlive requests. Use TRANSIENT or REQUEST scope for the parent.',
+    )
+    expect(m).not.toBeNull()
+    expect(m!.diagnosis.id).toBe('di-request-scope-into-singleton')
+    expect(m!.confidence).toBe(100)
+  })
+
+  it('points a controller at @Autowired, since @Controller() takes no scope', () => {
+    // The framework's own message says "use TRANSIENT or REQUEST scope for the
+    // parent" — advice that does not exist for a controller. The diagnosis has
+    // to say so or it sends people looking for an option that isn't there.
+    const m = findBestMatch('Cannot inject REQUEST-scoped "X" into SINGLETON "YController"')
+    expect(m!.diagnosis.fix).toContain('@Autowired')
+    expect(m!.diagnosis.fix).toContain('@Controller() does NOT')
+  })
+
+  it('matches di-circular-dependency with the resolution chain', () => {
+    const m = findBestMatch(
+      'Error: Circular dependency detected: OrderService -> PaymentService -> OrderService',
+    )
+    expect(m).not.toBeNull()
+    expect(m!.diagnosis.id).toBe('di-circular-dependency')
+    expect(m!.confidence).toBe(100)
+  })
+
+  it('matches di-no-provider-for-token by message and by KICK001 code', () => {
+    const byMessage = findBestMatch('No provider for USER_REPOSITORY')
+    expect(byMessage!.diagnosis.id).toBe('di-no-provider-for-token')
+
+    const byCode = findBestMatch('KICK001 while resolving the container')
+    expect(byCode!.diagnosis.id).toBe('di-no-provider-for-token')
+    expect(byCode!.confidence).toBe(100)
+  })
+
+  it('matches vite-dev-app-not-exported ahead of module-not-registered', () => {
+    // Both matchers see this 404. The dev-server one has to win, or the fix
+    // sends someone to audit a modules array that is already correct.
+    const m = findBestMatch('kick dev: every route returns 404, src/index.ts has no app export')
+    expect(m).not.toBeNull()
+    expect(m!.diagnosis.id).toBe('vite-dev-app-not-exported')
+  })
+
+  it('leaves a 404 with no dev-server signal to module-not-registered', () => {
+    const m = findBestMatch('GET /tasks returns 404 in production')
+    expect(m).not.toBeNull()
+    expect(m!.diagnosis.id).toBe('module-not-registered')
+  })
+
   it('returns null for completely unrelated errors', () => {
     const m = findBestMatch('the rocket motor failed to ignite at T-minus 3')
     expect(m).toBeNull()

--- a/packages/cli/__tests__/explain.test.ts
+++ b/packages/cli/__tests__/explain.test.ts
@@ -210,6 +210,21 @@ describe('known-issues registry', () => {
     expect(m!.diagnosis.id).toBe('vite-dev-app-not-exported')
   })
 
+  it('matches vite-dev-app-not-exported when all routes fail, without the word export', () => {
+    // The shape someone actually types before they know the cause.
+    const m = findBestMatch('kick dev: every route 404s, even ones that definitely exist')
+    expect(m).not.toBeNull()
+    expect(m!.diagnosis.id).toBe('vite-dev-app-not-exported')
+  })
+
+  it('leaves an ordinary dev-server 404 to module-not-registered', () => {
+    // One route missing under Vite is a routing problem, not a missing export
+    // — diagnosing it as the latter sends people to an entry file that is fine.
+    const m = findBestMatch('vite dev: GET /typo returns 404')
+    expect(m).not.toBeNull()
+    expect(m!.diagnosis.id).toBe('module-not-registered')
+  })
+
   it('leaves a 404 with no dev-server signal to module-not-registered', () => {
     const m = findBestMatch('GET /tasks returns 404 in production')
     expect(m).not.toBeNull()

--- a/packages/cli/src/explain/known-issues.ts
+++ b/packages/cli/src/explain/known-issues.ts
@@ -665,13 +665,28 @@ const viteDevAppNotExported: KnownIssue = {
     if (!inDevServer) return null
 
     const has404 = includesAny(input, ['404', 'not found', 'cannot get', 'cannot post', 'no route'])
+    if (!has404) return null
+
+    // A dev-server 404 on its own is usually an ordinary missing route, so one
+    // of these has to corroborate before this diagnosis outranks
+    // `module-not-registered`: the user naming the export, or the giveaway
+    // that it is not one route failing but all of them.
     const mentionsApp = includesAll(input, ['app', 'export'])
-    if (!has404 && !mentionsApp) return null
+    // Deliberately not 'no routes' — 'no route' is already a `has404` signal,
+    // so it would make every single-route 404 look like a total failure.
+    const everyRoute = includesAny(input, [
+      'every route',
+      'all routes',
+      'every endpoint',
+      'all endpoints',
+      'none of the routes',
+    ])
+    if (!mentionsApp && !everyRoute) return null
 
     return {
       // Above `module-not-registered` (50), which matches the same 404 text
       // and would otherwise send people to inspect a modules array that is fine.
-      confidence: has404 && mentionsApp ? 80 : 70,
+      confidence: mentionsApp && everyRoute ? 85 : mentionsApp ? 80 : 70,
       diagnosis: {
         id: 'vite-dev-app-not-exported',
         title: 'Every route 404s in dev because the entry file exports no `app`',

--- a/packages/cli/src/explain/known-issues.ts
+++ b/packages/cli/src/explain/known-issues.ts
@@ -490,6 +490,220 @@ const testEnvLeakedFromDotenv: KnownIssue = {
   },
 }
 
+// ── Issue 9: REQUEST-scoped dependency injected into a SINGLETON ─────────
+
+const requestScopeIntoSingleton: KnownIssue = {
+  match(input, _ctx) {
+    // The framework's own wording (container.ts) is the certain signal.
+    const exact = includesAll(input, ['cannot inject', 'request-scoped', 'singleton'])
+    // A paraphrase still routes here — the pairing of both scope names in one
+    // error is specific enough to KickJS's DI that nothing else produces it.
+    const paraphrase = includesAll(input, ['request-scoped', 'singleton'])
+    if (!exact && !paraphrase) return null
+
+    return {
+      confidence: exact ? 100 : 70,
+      diagnosis: {
+        id: 'di-request-scope-into-singleton',
+        title: 'A SINGLETON cannot hold a REQUEST-scoped dependency',
+        explanation:
+          'Controllers are SINGLETON by default: one instance for the process, built\n' +
+          'the first time the container resolves it. A REQUEST-scoped binding is the\n' +
+          'opposite — one instance per request, discarded when the response ends.\n' +
+          '\n' +
+          'Injecting the second into the first would capture whichever request\n' +
+          'happened to build the singleton and hand that same instance to every\n' +
+          'later request, so the container refuses at resolve time instead.\n' +
+          '\n' +
+          'This surfaces on the first request that reaches the controller, not at\n' +
+          'boot, because the container builds lazily. The route mounts fine and then\n' +
+          'answers 500.',
+        fix:
+          'The error says "use TRANSIENT or REQUEST scope for the parent", and that\n' +
+          'is the fix when the parent is a @Service / @Repository / @Component —\n' +
+          'each takes `{ scope }`.\n' +
+          '\n' +
+          '@Controller() does NOT. It takes no options and always registers as a\n' +
+          'SINGLETON, so for a controller the advice in the message is not\n' +
+          'available. Switch that one dependency to @Autowired instead: property\n' +
+          'injection re-resolves per access, so each request reads its own instance\n' +
+          'and the singleton never captures one.\n' +
+          '\n' +
+          'If the dependency did not need request scope in the first place, the\n' +
+          'other direction also works — make it SINGLETON and pass the per-request\n' +
+          'values in as method arguments.',
+        docs: 'https://kickjs.app/guide/dependency-injection.html#scopes',
+      },
+    }
+  },
+}
+
+// ── Issue 10: circular dependency in the DI graph ────────────────────────
+
+const circularDependency: KnownIssue = {
+  match(input, _ctx) {
+    const exact = input.toLowerCase().includes('circular dependency detected')
+    const loose = includesAll(input, ['circular', 'dependency'])
+    if (!exact && !loose) return null
+
+    return {
+      confidence: exact ? 100 : 65,
+      diagnosis: {
+        id: 'di-circular-dependency',
+        title: 'Two services depend on each other, directly or through a chain',
+        explanation:
+          'The container resolves constructor dependencies depth-first. When a token\n' +
+          'is requested while it is already being resolved further up the stack, the\n' +
+          'graph has a cycle and there is no order that satisfies both ends.\n' +
+          '\n' +
+          'The error prints the whole chain, arrow-separated — read it as "A needed\n' +
+          'B, which needed C, which needed A again". The repeated name at both ends\n' +
+          'is where the cycle closes, and it is usually the pair in the middle that\n' +
+          'is worth splitting, not the class you were resolving.\n' +
+          '\n' +
+          'Constructor injection is what forces the ordering. Property injection\n' +
+          '(@Autowired) resolves after construction, so it tolerates a cycle the\n' +
+          'constructor form cannot.',
+        fix:
+          'Preferred: pull the shared behaviour into a third service both sides\n' +
+          'depend on. A cycle is usually a missing collaborator, and breaking it\n' +
+          'this way leaves both classes independently testable.\n' +
+          '\n' +
+          'If the cycle is genuine and the design is settled, switch ONE side from\n' +
+          'constructor injection to @Autowired so it resolves lazily.',
+        codeBefore:
+          '@Service()\n' +
+          'export class OrderService {\n' +
+          '  constructor(private readonly billing: BillingService) {}\n' +
+          '}\n\n' +
+          '@Service()\n' +
+          'export class BillingService {\n' +
+          '  constructor(private readonly orders: OrderService) {}  // ← closes the cycle\n' +
+          '}',
+        codeAfter:
+          '@Service()\n' +
+          'export class OrderService {\n' +
+          '  constructor(private readonly billing: BillingService) {}\n' +
+          '}\n\n' +
+          '@Service()\n' +
+          'export class BillingService {\n' +
+          '  @Autowired() private readonly orders!: OrderService  // ← resolved after construction\n' +
+          '}',
+        docs: 'https://kickjs.app/guide/dependency-injection.html#circular-dependency-detection',
+      },
+    }
+  },
+}
+
+// ── Issue 11: no provider registered for a token (KICK001) ───────────────
+
+const noProviderForToken: KnownIssue = {
+  match(input, _ctx) {
+    const hasCode = input.includes('KICK001')
+    const hasMessage = includesAny(input, [
+      'no provider for',
+      'no provider found for',
+      'no binding is registered',
+    ])
+    if (!hasCode && !hasMessage) return null
+
+    return {
+      confidence: hasCode ? 100 : 85,
+      diagnosis: {
+        id: 'di-no-provider-for-token',
+        title: 'A token was requested but nothing registers it',
+        explanation:
+          'Decorators register bindings as a side effect of the class being LOADED —\n' +
+          'and a class is only loaded if something imports it. A module that is not\n' +
+          'in the bootstrap array is never imported, so none of its @Service /\n' +
+          '@Repository / @Controller classes ever register, and the first thing that\n' +
+          'asks for one gets this error.\n' +
+          '\n' +
+          'That makes the failure almost always about the MODULE, not the class the\n' +
+          'error names — which is why the token in the message usually looks\n' +
+          'correctly decorated when you open it.\n' +
+          '\n' +
+          'The other two causes: a class with no decorator at all, or a\n' +
+          'createToken() handle that nothing binds. Tokens are inert values — they\n' +
+          'carry a type, never an implementation.',
+        fix:
+          'Check, in this order:\n' +
+          '  1. Is the enclosing module in `bootstrap({ modules })` (or in the array\n' +
+          '     exported from src/modules/index.ts)?\n' +
+          '  2. Does the class carry @Service() / @Repository() / @Controller()?\n' +
+          '  3. For a createToken() token — does some module bind it in `register()`?',
+        codeAfter:
+          "const TENANT_REPO = createToken<TenantRepo>('TENANT_REPO')\n\n" +
+          'export const TenantModule = defineModule({\n' +
+          "  name: 'TenantModule',\n" +
+          '  build: () => ({\n' +
+          '    register(container) {\n' +
+          '      container.register(TENANT_REPO, { useClass: PrismaTenantRepo })  // ← the binding\n' +
+          '    },\n' +
+          '    routes: () => null,\n' +
+          '  }),\n' +
+          '})',
+        docs: 'https://kickjs.app/guide/dependency-injection.html#registering-services',
+      },
+    }
+  },
+}
+
+// ── Issue 12: dev server 404s because the entry exports no `app` ─────────
+
+const viteDevAppNotExported: KnownIssue = {
+  match(input, _ctx) {
+    // Only fires with a dev-server signal present. Without one this is an
+    // ordinary 404 and `module-not-registered` is the better diagnosis.
+    const inDevServer = includesAny(input, [
+      'vite',
+      'kick dev',
+      'dev server',
+      'localhost:5173',
+      ':5173',
+    ])
+    if (!inDevServer) return null
+
+    const has404 = includesAny(input, ['404', 'not found', 'cannot get', 'cannot post', 'no route'])
+    const mentionsApp = includesAll(input, ['app', 'export'])
+    if (!has404 && !mentionsApp) return null
+
+    return {
+      // Above `module-not-registered` (50), which matches the same 404 text
+      // and would otherwise send people to inspect a modules array that is fine.
+      confidence: has404 && mentionsApp ? 80 : 70,
+      diagnosis: {
+        id: 'vite-dev-app-not-exported',
+        title: 'Every route 404s in dev because the entry file exports no `app`',
+        explanation:
+          'The Vite plugin does not start your server. It imports the entry module\n' +
+          'and reads `app` off it, then hands each request to that instance.\n' +
+          '\n' +
+          'When the entry runs `await bootstrap(...)` without assigning the result to\n' +
+          'an exported `app`, the plugin finds nothing to delegate to and falls\n' +
+          "through to Vite's own 404 handler. Your app booted; nothing is routing to\n" +
+          'it.\n' +
+          '\n' +
+          'The giveaway is that EVERY route 404s, including ones that clearly exist,\n' +
+          'and the failure is dev-only — `kick start` runs the entry directly and\n' +
+          'never needs the export.',
+        fix:
+          'Export the bootstrap result as `app` from your entry file. The name is\n' +
+          'load-bearing — the plugin looks up exactly that export.',
+        codeBefore:
+          "import './env'\n" +
+          "import { bootstrap } from '@forinda/kickjs'\n\n" +
+          'await bootstrap({ modules })  // ← nothing for the dev server to read',
+        codeAfter:
+          "import './env'\n" +
+          "import { bootstrap } from '@forinda/kickjs'\n\n" +
+          'export const app = await bootstrap({ modules })',
+        docs: 'https://kickjs.app/guide/project-structure.html',
+      },
+    }
+  },
+}
+
 // ── Registry ──────────────────────────────────────────────────────────────
 
 export const KNOWN_ISSUES: KnownIssue[] = [
@@ -501,6 +715,10 @@ export const KNOWN_ISSUES: KnownIssue[] = [
   reflectMetadataMissing,
   moduleNotRegistered,
   testEnvLeakedFromDotenv,
+  requestScopeIntoSingleton,
+  circularDependency,
+  noProviderForToken,
+  viteDevAppNotExported,
 ]
 
 /**


### PR DESCRIPTION
## Summary

`kick explain` now recognizes the four errors KickJS itself produces. Split out of #672 (item 2b) — the cheapest item in that list: data only, no framework change.

The registry worked (`kick explain "@Module is not a function"` matches `module-decorator-not-found`) but held eight matchers, none keyed on a string the framework throws. All four of these returned "No known-issue matched":

| Error | Source |
| --- | --- |
| `Cannot inject REQUEST-scoped "…" into SINGLETON "…"` | `core/container.ts:732` |
| `Circular dependency detected: A -> B -> A` | `core/container.ts:536` |
| `No provider for <token>` (KICK001) | `core/kick-errors.ts` |
| every route 404s in dev | not thrown at all — see below |

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] CI / Tooling

## Changes

- Four new entries in `packages/cli/src/explain/known-issues.ts`, registered in `KNOWN_ISSUES`.
- 8 new tests in `packages/cli/__tests__/explain.test.ts`, including ranking against `module-not-registered` in both directions.
- Patch changeset on `@forinda/kickjs-cli`.

### The 404 one is not an error string

`packages/vite/src/dev-server.ts:148` reads `mod.app`, finds no `.handle`, and falls through to Vite's own 404. Nothing is logged. Every route 404s, including ones that obviously exist, and only in dev — `kick start` runs the entry directly and never needs the export.

The existing `module-not-registered` entry matched that 404 at confidence 50, which is the wrong diagnosis: it sends someone to audit a modules array that is already correct.

Getting the boundary right took two passes. The first version fired on any dev-server 404, which CodeRabbit correctly flagged: `vite dev: GET /typo returns 404` would have been diagnosed as a missing `app` export. A 404 now needs corroboration from one of two signals — the user naming the export, or the giveaway that it is not one route failing but all of them. `'no routes'` is deliberately excluded from that second list, since `'no route'` is already a 404 signal and would make every single-route 404 read as a total failure.

### One thing the runtime error gets wrong

The scope message ends with:

> Singletons outlive requests. Use TRANSIENT or REQUEST scope for the parent.

Good advice when the parent is a `@Service` / `@Repository` / `@Component` / `@Injectable` — each takes `{ scope }`. It is not available for a controller: `@Controller()` takes no options at all and always registers SINGLETON (`core/decorators.ts:178`), which is the exact shape reported in #672.

The fix there is `@Autowired`. Its getter re-resolves on every access for REQUEST and TRANSIENT dependencies and memoizes only SINGLETON ones (`core/container.ts:862-885`), so each request reads its own instance and the singleton never captures one. The diagnosis says this outright rather than repeating advice the reader cannot act on. The docs already point the same way — `docs/guide/dependency-injection.md:436` says "resolve it explicitly inside a method call rather than injecting it as a dependency", and the request-scope example uses `@Autowired` on a controller.

Wording that hint by parent kind at the throw site is worth its own change, since the container knows whether the target is a controller. Noted in #676.

## Related Issues

Part of #672. Related: #676.

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm test` passes — `explain.test.ts` 31 passed; full CLI suite 816 passed / 76 files
- [x] `pnpm format:check` passes
- [ ] Docs updated — not applicable; every doc URL in the new entries points at an existing heading (`#scopes`, `#circular-dependency-detection`, `#registering-services`, `guide/project-structure`)
- [ ] New exports — not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `kick explain` now recognizes additional dependency-injection issues, including scope mismatches, circular dependencies, and missing providers.
  * Added guidance for development-server 404 errors caused by missing `app` exports.
  * Explanations include diagnoses and recommended fixes, including controller-scope and `@Autowired` guidance.

* **Tests**
  * Added coverage for the new diagnostics, overlapping error precedence, development-server 404 scenarios, and production 404 handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->