### PR TITLE
docs: recover the ctx.download cross-links that missed #674

### DIFF
--- a/docs/guide/controllers.md
+++ b/docs/guide/controllers.md
@@ -194,7 +194,7 @@ rather than the body, so the typed client has no payload to offer.
 | `ctx.badRequest(message)`               | 400    | **Deprecated** — use `ctx.problem.badRequest()` |
 | `ctx.html(content, status?)`            | 200    | HTML response                                   |
 | `ctx.redirect(url, status?)`            | 302    | Redirect (works on every runtime)               |
-| `ctx.download(buffer, filename, type?)` | --     | File download                                   |
+| `ctx.download(buffer, filename, type?)` | --     | [File download](#returning-a-generated-file)    |
 | `ctx.render(template, data?)`           | 200    | Render a template (requires ViewAdapter)        |
 
 #### Returning a generated file

--- a/docs/guide/file-uploads.md
+++ b/docs/guide/file-uploads.md
@@ -341,3 +341,25 @@ Uploaded files are available on the `RequestContext`:
 - **`ctx.files`** — an array of uploaded files (when using `array` mode)
 
 Each file object follows the standard Multer file shape: `originalname`, `mimetype`, `size`, `buffer` (memory storage), or `path` and `filename` (disk storage).
+
+## Sending a file back out
+
+The other direction is [`ctx.download(buffer, filename, type?)`](./controllers.md#returning-a-generated-file)
+— the mirror of `@FileUpload`, and runtime-neutral for the same reason: it
+writes through the response driver rather than the engine's own response
+object.
+
+```ts
+@Get('/students.xlsx')
+async export(ctx: RequestContext) {
+  const file = await this.reports.buildStudentsWorkbook()
+  return ctx.download(
+    file,
+    'students.xlsx',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  )
+}
+```
+
+Setting the headers by hand on `ctx.res` works on Express and breaks on the
+others — `FastifyReply` has no `setHeader`, and h3's event has no `end`.


### PR DESCRIPTION
## Summary

Recovers two commits that were pushed to #674's branch but never reached the PR. GitHub kept reporting the branch head as the first commit (`670ffe32`) while `git ls-remote` showed `b754f684`, and #674 merged at the stale head — so these two changes are on the remote branch and not on `main`.

Same work as #674, cherry-picked onto current `main`. No new content beyond what that PR was meant to carry.

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Documentation
- [ ] Refactor
- [ ] CI / Tooling

## Changes

- `docs/guide/file-uploads.md` — a "Sending a file back out" section. This is the page someone with a file problem opens first, and it documented only the inbound half; `ctx.download` is the mirror of `@FileUpload` and runtime-neutral for the same reason.
- `docs/guide/controllers.md` — the response-helper table row now links to the example one heading below it. The row read "File download" with nothing to suggest the section existed, which is the same discoverability gap #674 was fixing one level up.

Before writing the capability claim I checked `send()` on every driver rather than just Express: it takes a Buffer on Fastify (`reply.send`, `fastify.ts:135`), on h3 (`res.end`, `h3.ts:88`), and on the web driver, which special-cases `Uint8Array` so a Buffer skips JSON serialization (`web/driver.ts:115-125`).

## Related Issues

Part of #672. Completes #674.

## Checklist

- [x] `pnpm build` passes — `pnpm docs:build` clean, so every cross-link and anchor resolves
- [ ] `pnpm test` — not applicable, no code changed
- [x] `pnpm format:check` passes
- [x] Docs updated — this is the change
- [ ] New exports — not applicable

No changeset: docs only, no package touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for returning generated files, including an example for downloading an `.xlsx` workbook.
  * Documented the runtime-neutral `ctx.download()` helper and its optional filename and content type parameters.
  * Clarified runtime-specific limitations when manually setting response headers.
  * Linked the response helpers table to the new generated-file guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->