### PR TITLE
fix(docs): declare a canonical URL per page and collapse the duplicate host

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -224,6 +224,29 @@ export default defineConfig({
   sitemap: {
     hostname,
   },
+
+  /**
+   * Per-page canonical URL and `og:url`.
+   *
+   * The site is reachable on more than one host — `kickjs.netlify.app` serves
+   * the same build, and `www` resolves before it redirects — so without an
+   * explicit canonical a crawler picks its own winner and the chosen one may
+   * not be `kickjs.app`. `og:url` moved here for the same reason it was wrong
+   * in `head`: declared site-wide, every page claimed the homepage's URL.
+   *
+   * Paths mirror what `sitemap` emits (no `cleanUrls`, so `.html` stays, and a
+   * directory index collapses to its trailing slash) — a canonical that
+   * disagrees with the sitemap is worse than none.
+   */
+  transformPageData(pageData) {
+    const path = pageData.relativePath.replace(/(^|\/)index\.md$/, '$1').replace(/\.md$/, '.html')
+    const url = `${hostname}${path}`
+    pageData.frontmatter.head ??= []
+    pageData.frontmatter.head.push(
+      ['link', { rel: 'canonical', href: url }],
+      ['meta', { property: 'og:url', content: url }],
+    )
+  },
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: `${base}logo.svg` }],
     // Google Search Console site verification.
@@ -242,7 +265,6 @@ export default defineConfig({
           'Decorator-driven APIs that run on Express, Fastify, or h3. REST, WebSocket, queues, scheduled jobs — pick what you need.',
       },
     ],
-    ['meta', { property: 'og:url', content: hostname }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
   ],
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,11 @@
 ---
 layout: home
+# `<title>` is what a search result shows and what it ranks on, and the site
+# title alone loses "kickjs" to the streaming service. The custom home layout
+# does not read frontmatter `title`, so this only sets the document title;
+# `titleTemplate: false` stops VitePress appending " | KickJS" to it.
+title: KickJS — The Adaptive Node.js Framework
+titleTemplate: false
 
 features:
   - icon: 🔌

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,20 @@
 
 [build.environment]
   NODE_VERSION = "20"
+
+# The site answers on kickjs.netlify.app as well as kickjs.app, and an
+# identical copy of every page on a second host is a duplicate a crawler has to
+# pick between — one it can resolve in favour of the netlify.app subdomain,
+# which predates the custom domain and may have been indexed first. 301 it to
+# the canonical host so there is nothing to choose.
+#
+# `force = true` because the subdomain serves real files: without it the static
+# asset wins and the redirect never fires. Deploy previews and branch deploys
+# live on their own subdomains (deploy-preview-N--kickjs.netlify.app), so this
+# rule does not match them — and Netlify already sends `x-robots-tag: noindex`
+# there.
+[[redirects]]
+  from = "https://kickjs.netlify.app/*"
+  to = "https://kickjs.app/:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
## Summary

Google reporting `www.kickjs.app` as "Page with redirect" is **correct behaviour, not the bug** — www 301s to the apex by design, and a redirecting URL is never the one Google indexes. But chasing it turned up that nothing in the build ever declared which host is authoritative, and more than one host serves the same bytes.

What I checked on the live site first, all of it fine: `kickjs.app` answers 200 with no `x-robots-tag`, `robots.txt` allows everything and points at the sitemap, `sitemap.xml` is valid with 138 URLs and current `lastmod`, deploy previews already carry `x-robots-tag: noindex` from Netlify, and the HTML is pre-rendered (33KB with real `<h1>` and body copy, not a JS shell). So indexing was never blocked. What was missing is the part that tells a crawler which of several identical hosts to keep.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] CI / Tooling

## Changes

**1. Per-page `<link rel="canonical">`, via `transformPageData`.** There was none anywhere on the site. Paths mirror exactly what `sitemap` emits — no `cleanUrls`, so `.html` stays, and a directory index collapses to its trailing slash.

Verified against the whole build rather than spot-checked: 138 canonicals, 138 sitemap URLs, set difference empty in both directions. A canonical that disagrees with the sitemap is worse than having none.

**2. `og:url` moves into the same hook.** It was declared once in `head` as a constant, so all 138 pages claimed the homepage's URL.

**3. `netlify.toml` 301s `kickjs.netlify.app` to `kickjs.app`.** That subdomain answers 200 with `Allow: /` and no noindex — an identical twin of every page, on a host that predates the custom domain and may well have been crawled first. `force = true` because the static file otherwise wins over the redirect rule. Deploy previews live on `deploy-preview-N--kickjs.netlify.app`, so the rule does not match them and they keep the noindex Netlify already sends.

**4. A real `<title>` on the home page.** It was the bare site title, `KickJS` — which competes with the streaming service of the same name for that exact query. The `og:title` was already the good version; `<title>` is what ranks. The custom home layout does not read frontmatter `title`, so this changes the document title only.

## Not in this PR — the Search Console side

Worth checking there, since I cannot see it from here:

- **Which property has the sitemap.** If it was submitted under a `www.kickjs.app` property, every URL in it redirects, and "Page with redirect" is all that property will ever report. A **Domain** property (`kickjs.app`) covers apex, www and every subdomain at once; a URL-prefix property must be `https://kickjs.app/`.
- **Coverage → "Discovered – currently not indexed"** is the normal state for a young domain and resolves on its own. Under a week since submission, waiting is the correct action.
- After this deploys, `kickjs.netlify.app` will start 301ing; if it had accumulated any indexed pages, that redirect is what consolidates them onto the apex.

## Related Issues

None — reported directly.

## Checklist

- [x] `pnpm build` passes — `pnpm docs:build` clean, canonicals cross-checked against the sitemap
- [ ] `pnpm test` — not applicable, no package code changed
- [x] `pnpm format:check` passes
- [x] Docs updated — this is a docs-site config change
- [ ] New exports — not applicable

No changeset: docs site and deploy config only, no published package touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
