### PR TITLE
docs: add Google Analytics gtag behind DOCS_GA_ID

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,6 +31,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm docs:build
+        env:
+          DOCS_GA_ID: ${{ vars.DOCS_GA_ID }}
 
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitepress'
+import { defineConfig, type HeadConfig } from 'vitepress'
 // Docs track the latest release only — older versions are not snapshotted.
 
 const guideSidebar = [
@@ -205,6 +205,20 @@ const hostname = process.env.DOCS_HOSTNAME ?? DEFAULT_HOSTNAME
 
 // A subpath base without a matching hostname would emit a wrong sitemap/og:url
 // (pointing at kickjs.app). Fail loud so the deploy is fixed, not shipped.
+// Google Analytics. Only wired when DOCS_GA_ID is set at build time, so no
+// measurement ID lives in the repo and local/preview builds stay untracked.
+const gaId = process.env.DOCS_GA_ID
+const gaHead: HeadConfig[] = gaId
+  ? [
+      ['script', { async: '', src: `https://www.googletagmanager.com/gtag/js?id=${gaId}` }],
+      [
+        'script',
+        {},
+        `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','${gaId}')`,
+      ],
+    ]
+  : []
+
 if (base !== DEFAULT_BASE && hostname === DEFAULT_HOSTNAME) {
   throw new Error(
     `DOCS_BASE is overridden (${base}) but DOCS_HOSTNAME is unset — ` +
@@ -244,6 +258,7 @@ export default defineConfig({
     ],
     ['meta', { property: 'og:url', content: hostname }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+    ...gaHead,
   ],
 
   themeConfig: {


### PR DESCRIPTION
## Why

The docs site had no analytics. Adding a measurement ID straight into `config.mts` would commit it to the repo and also track every local `pnpm docs:dev` / preview build.

## What

- `docs/.vitepress/config.mts` — build `gaHead` from `process.env.DOCS_GA_ID`. Set: two head entries (the async `gtag/js` loader plus the inline `gtag('config', …)` bootstrap). Unset: empty array, so the rendered HTML contains no analytics markup at all.
- `.github/workflows/deploy-docs.yml` — pass `DOCS_GA_ID: ${{ vars.DOCS_GA_ID }}` to the `pnpm docs:build` step.

```ts
const gaId = process.env.DOCS_GA_ID
const gaHead: HeadConfig[] = gaId
  ? [
      ['script', { async: '', src: `https://www.googletagmanager.com/gtag/js?id=${gaId}` }],
      ['script', {}, `window.dataLayer=window.dataLayer||[];…gtag('config','${gaId}')`],
    ]
  : []
```

## One manual step before this does anything

Repo Settings → Secrets and variables → Actions → Variables → add `DOCS_GA_ID = G-XXXXXXXXXX`. Until that variable exists, deploys build exactly as they do today.

## Verification

`DOCS_GA_ID=G-TEST123 pnpm docs:build` → `dist/index.html` contains `googletagmanager.com/gtag/js?id=G-TEST123`.

## Not included

Cookie consent gating and GA4 custom events — worth adding if EU traffic or funnel tracking become a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKVJfNeYv7g4bSsXwDKnUZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Google Analytics tracking to the documentation site when configured.
  - Documentation builds can now receive an analytics measurement ID through deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->