### PR TITLE
docs(ws): add realtime load test and publish reference numbers

### DIFF
--- a/docs/guide/benchmarks.md
+++ b/docs/guide/benchmarks.md
@@ -55,3 +55,54 @@ Key takeaways:
 - Middleware overhead is minimal (~5% for 3 layers)
 - JSON serialization is the main cost for large responses
 - KickJS's decorator/DI layer adds negligible overhead over raw Express 5
+
+## WebSockets
+
+`@forinda/kickjs-ws` ships a load test in `packages/ws/bench/`. It starts one or more server instances and several client processes, so clients never share the server's event loop. Each run has two phases:
+
+- **echo** — every connection sends at a fixed rate and the server replies; measures round-trip latency.
+- **fan-out** — one connection broadcasts to a room every other connection has joined; measures delivery latency and **reach** (deliveries received ÷ deliveries expected).
+
+```bash
+pnpm --filter @forinda/kickjs-ws build
+cd packages/ws
+
+pnpm bench                                             # 1 instance, 2,000 connections
+CONNS=10000 WORKERS=8 ECHO_RATE=0 FAN_RATE=5 pnpm bench
+INSTANCES=2 CONNS=10000 WORKERS=8 pnpm bench
+```
+
+| Variable    | Default | Meaning                                         |
+| ----------- | ------- | ----------------------------------------------- |
+| `INSTANCES` | `1`     | Server processes; connections are spread evenly |
+| `CONNS`     | `2000`  | Total connections                               |
+| `WORKERS`   | `4`     | Client processes                                |
+| `SECONDS`   | `10`    | Length of the measured phase                    |
+| `ECHO_RATE` | `1`     | Messages per second, per connection             |
+| `FAN_RATE`  | `20`    | Broadcasts per second from the single sender    |
+| `BASE_PORT` | `4600`  | First server port                               |
+
+The output includes client CPU. If it approaches 100%, the clients are the bottleneck — raise `WORKERS` before reading the server numbers.
+
+### Reference numbers
+
+Node 24.20, Linux, 12 cores. Each server process is one event loop, so it saturates at ~100% CPU. Client CPU stayed under 25% in every run.
+
+| Scenario (1 instance)                    | Throughput       | p50    | p99   | Memory |
+| ---------------------------------------- | ---------------- | ------ | ----- | ------ |
+| 10,000 connections, echo                 | 9,000 msg/s      | 0.17ms | 14ms  | 299MB  |
+| 20,000 connections, echo                 | 18,000 msg/s     | 1ms    | 128ms | 428MB  |
+| 20,000 connections, echo (overloaded)    | 38,000 msg/s     | 1.0s   | 2.1s  | 481MB  |
+| 10,000-member room, fan-out              | 50,000 frames/s  | 142ms  | 255ms | 269MB  |
+| 10,000-member room, fan-out (overloaded) | 100,000 frames/s | 1.8s   | 4.1s  | 270MB  |
+
+No run lost a message; overloaded runs delivered late. Once a process is past its ceiling, latency grows with the backlog rather than frames being dropped.
+
+### Running more than one instance
+
+| Scenario                             | Reach | p50   | p99   |
+| ------------------------------------ | ----- | ----- | ----- |
+| 1 instance, 10,000-member room, 5/s  | 1.0   | 142ms | 255ms |
+| 2 instances, 10,000-member room, 5/s | 0.5   | 44ms  | 97ms  |
+
+A second instance halves the per-process load, but rooms are process-local: a broadcast reaches only the sockets connected to the instance that sent it. Until a cross-instance broker exists, run one instance per realtime workload, or put connections behind a service that owns them — see [WebSockets](./websockets.md).

--- a/packages/ws/bench/client.mjs
+++ b/packages/ws/bench/client.mjs
@@ -1,0 +1,102 @@
+/** One client process for bench/run.mjs: open connections, wait for "go", run echo + fan-out. */
+import { WebSocket } from 'ws'
+
+const cfg = JSON.parse(process.argv[2])
+const clock = () => performance.timeOrigin + performance.now()
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+const percentile = (xs, p) => {
+  if (!xs.length) return 0
+  xs.sort((a, b) => a - b)
+  return +xs[Math.min(xs.length - 1, Math.floor(xs.length * p))].toFixed(2)
+}
+
+const echoLat = []
+const fanLat = []
+let echoSent = 0
+let fanSent = 0
+
+function open(i) {
+  const port = cfg.ports[(cfg.offset * cfg.conns + i) % cfg.ports.length]
+  return new Promise((resolve) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws/bench`)
+    ws.on('message', (raw) => {
+      const { event, data } = JSON.parse(raw)
+      if (event === 'echo') echoLat.push(clock() - data.t)
+      else if (event === 'fan') fanLat.push(clock() - data.t)
+    })
+    ws.once('open', () => resolve(ws))
+    ws.once('error', () => resolve(null))
+  })
+}
+
+const started = performance.now()
+const sockets = []
+for (let i = 0; i < cfg.conns; i += 100) {
+  const batch = await Promise.all(
+    Array.from({ length: Math.min(100, cfg.conns - i) }, (_, j) => open(i + j)),
+  )
+  sockets.push(...batch.filter(Boolean))
+}
+const connectMs = Math.round(performance.now() - started)
+
+process.send({ connected: sockets.length })
+await new Promise((r) => process.once('message', r))
+
+const timers = []
+if (cfg.echoRate > 0) {
+  for (const ws of sockets) {
+    const every = 1000 / cfg.echoRate
+    setTimeout(() => {
+      timers.push(
+        setInterval(() => {
+          echoSent++
+          ws.send(JSON.stringify({ event: 'echo', data: { t: clock() } }))
+        }, every),
+      )
+    }, Math.random() * every)
+  }
+}
+if (cfg.fanRate > 0) {
+  timers.push(
+    setInterval(() => {
+      fanSent++
+      sockets[0].send(JSON.stringify({ event: 'fan', data: { t: clock() } }))
+    }, 1000 / cfg.fanRate),
+  )
+}
+
+// Client CPU, so a saturated client is not mistaken for a slow server.
+const cpuStart = process.cpuUsage()
+const phaseStart = performance.now()
+
+await sleep(cfg.seconds * 1000)
+timers.forEach(clearInterval)
+const cpu = process.cpuUsage(cpuStart)
+const clientCpuPct = Math.round(
+  ((cpu.user + cpu.system) / 1e3 / (performance.now() - phaseStart)) * 100,
+)
+
+// Drain until the backlog stops arriving (1s quiet, 20s cap): a frame that is
+// merely late must not be counted as lost.
+let seen = -1
+for (let waited = 0; waited < 20000 && seen !== echoLat.length + fanLat.length; waited += 1000) {
+  seen = echoLat.length + fanLat.length
+  await sleep(1000)
+}
+
+process.send({
+  done: true,
+  connected: sockets.length,
+  connectMs,
+  clientCpuPct,
+  echoSent,
+  echoReceived: echoLat.length,
+  echoP50: percentile(echoLat, 0.5),
+  echoP99: percentile(echoLat, 0.99),
+  fanSent,
+  fanReceived: fanLat.length,
+  fanP50: percentile(fanLat, 0.5),
+  fanP99: percentile(fanLat, 0.99),
+})
+for (const ws of sockets) ws.terminate()
+process.exit(0)

--- a/packages/ws/bench/run.mjs
+++ b/packages/ws/bench/run.mjs
@@ -1,0 +1,108 @@
+/**
+ * Realtime load test: N server instances, K client processes.
+ *
+ *   node bench/run.mjs                     # defaults
+ *   INSTANCES=2 CONNS=4000 node bench/run.mjs
+ *
+ * Servers and clients run in separate processes so neither steals the other's
+ * event loop. Each phase prints one JSON line per client worker, then a summary.
+ */
+import { fork } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const here = (f) => fileURLToPath(new URL(f, import.meta.url))
+const env = (k, d) => Number(process.env[k] ?? d)
+
+const INSTANCES = env('INSTANCES', 1)
+const WORKERS = env('WORKERS', 4)
+const CONNS = env('CONNS', 2000)
+const SECONDS = env('SECONDS', 10)
+const ECHO_RATE = env('ECHO_RATE', 1) // msgs/sec per connection
+const FAN_RATE = env('FAN_RATE', 20) // broadcasts/sec from one sender
+const BASE_PORT = env('BASE_PORT', 4600)
+
+const servers = []
+const serverStats = new Map()
+for (let i = 0; i < INSTANCES; i++) {
+  const port = BASE_PORT + i
+  const child = fork(here('./server.mjs'), [String(port)], {
+    stdio: ['ignore', 'pipe', 'inherit', 'ipc'],
+  })
+  servers.push(
+    new Promise((resolve) =>
+      child.on('message', (m) => {
+        if (m.ready) resolve(child)
+        if (m.stats) serverStats.set(port, m.stats)
+      }),
+    ),
+  )
+}
+const children = await Promise.all(servers)
+const ports = children.map((_, i) => BASE_PORT + i)
+
+// Every worker connects first; the phase starts for all of them at once, so the
+// fan-out sender never broadcasts to a room that is still filling.
+let ready = 0
+const workers = []
+const results = await Promise.all(
+  Array.from(
+    { length: WORKERS },
+    (_, w) =>
+      new Promise((resolve, reject) => {
+        const child = fork(here('./client.mjs'), [
+          JSON.stringify({
+            ports,
+            conns: Math.ceil(CONNS / WORKERS),
+            offset: w,
+            seconds: SECONDS,
+            echoRate: ECHO_RATE,
+            // one sender in the whole run, on instance 0
+            fanRate: w === 0 ? FAN_RATE : 0,
+          }),
+        ])
+        workers.push(child)
+        child.on('message', (m) => {
+          if (m.done) return resolve(m)
+          if (m.connected !== undefined && ++ready === WORKERS)
+            for (const c of workers) c.send('go')
+        })
+        child.on('exit', (code) => code && reject(new Error(`client ${w} exited ${code}`)))
+      }),
+  ),
+)
+
+const sum = (k) => results.reduce((a, r) => a + (r[k] ?? 0), 0)
+const pct = (k) => Math.max(...results.map((r) => r[k] ?? 0))
+const fanSent = results[0].fanSent
+const connected = sum('connected')
+
+console.log(
+  JSON.stringify(
+    {
+      instances: INSTANCES,
+      conns: connected,
+      connectMs: pct('connectMs'),
+      peakClientCpuPct: pct('clientCpuPct'),
+      echo: {
+        msgsPerSec: Math.round(sum('echoReceived') / SECONDS),
+        p50: pct('echoP50'),
+        p99: pct('echoP99'),
+        lost: sum('echoSent') - sum('echoReceived'),
+      },
+      fan: {
+        broadcasts: fanSent,
+        expectedDeliveries: fanSent * connected,
+        delivered: sum('fanReceived'),
+        reach: +(sum('fanReceived') / (fanSent * connected || 1)).toFixed(3),
+        p50: pct('fanP50'),
+        p99: pct('fanP99'),
+      },
+      servers: Object.fromEntries(serverStats),
+    },
+    null,
+    2,
+  ),
+)
+
+for (const c of children) c.kill()
+process.exit(0)

--- a/packages/ws/bench/server.mjs
+++ b/packages/ws/bench/server.mjs
@@ -1,0 +1,50 @@
+/** One realtime server instance for bench/run.mjs. Reports CPU and RSS to the parent. */
+import 'reflect-metadata'
+import http from 'node:http'
+import { Container } from '@forinda/kickjs'
+import { WsAdapter, WsController, OnConnect, OnMessage } from '@forinda/kickjs-ws'
+
+class BenchController {
+  connect(ctx) {
+    ctx.join('room')
+  }
+  echo(ctx) {
+    ctx.send('echo', ctx.data)
+  }
+  fan(ctx) {
+    ctx.to('room').send('fan', ctx.data)
+  }
+}
+// Decorators applied by hand so this runs as plain node, no TS transform.
+OnConnect()(BenchController.prototype, 'connect')
+OnMessage('echo')(BenchController.prototype, 'echo')
+OnMessage('fan')(BenchController.prototype, 'fan')
+WsController('/bench')(BenchController)
+
+const port = Number(process.argv[2])
+const server = http.createServer()
+const adapter = WsAdapter({ heartbeatInterval: 0 })
+await adapter.beforeStart({ container: Container.getInstance() })
+await adapter.afterStart({ server })
+await new Promise((resolve) => server.listen(port, resolve))
+
+let last = process.cpuUsage()
+let lastAt = performance.now()
+let peakCpu = 0
+let peakRssMb = 0
+setInterval(() => {
+  // Divide by real elapsed time: a saturated loop fires this late, and a fixed
+  // 1s denominator then reports several seconds of CPU as one.
+  const now = process.cpuUsage()
+  const at = performance.now()
+  const cpu = Math.round(
+    ((now.user - last.user + now.system - last.system) / 1e3 / (at - lastAt)) * 100,
+  )
+  last = now
+  lastAt = at
+  peakCpu = Math.max(peakCpu, cpu)
+  peakRssMb = Math.max(peakRssMb, Math.round(process.memoryUsage.rss() / 1048576))
+  if (process.connected) process.send({ stats: { peakCpuPct: peakCpu, peakRssMb } })
+}, 1000).unref()
+
+process.send({ ready: true })

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -33,6 +33,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
+    "bench": "node bench/run.mjs",
     "clean": "rm -rf dist .wireit"
   },
   "dependencies": {


### PR DESCRIPTION
## Why

We need WebSocket numbers on the docs, and a repeatable way to check the realtime ceiling before and after scaling work (cross-instance broker, socket.io / Centrifugo transports).

## What

- `packages/ws/bench/` — `run.mjs` starts `INSTANCES` server processes and `WORKERS` client processes, then runs:
  - **echo**: each connection sends at `ECHO_RATE`/s, server replies; round-trip p50/p99
  - **fan-out**: one sender broadcasts to a room everyone joined at `FAN_RATE`/s; delivery p50/p99 and **reach** (received ÷ expected)
  - reports server peak CPU/RSS and client CPU, so a saturated client isn't read as a slow server
- `pnpm bench` script in `packages/ws`. Not published (`files: ["dist"]`).
- `docs/guide/benchmarks.md` — new **WebSockets** section: how to run, variables, reference numbers.

## Reference numbers (Node 24.20, Linux, 12 cores)

| Scenario (1 instance) | Throughput | p50 | p99 |
| --- | --- | --- | --- |
| 20k connections, echo | 18,000 msg/s | 1ms | 128ms |
| 20k connections, echo | 38,000 msg/s | 1.0s | 2.1s |
| 10k-member room, fan-out | 50,000 frames/s | 142ms | 255ms |
| 10k-member room, fan-out | 100,000 frames/s | 1.8s | 4.1s |

Two instances: reach **0.5** — rooms are process-local.

## Measurement notes

- CPU is divided by real elapsed time; a saturated loop fires the sampler late, and a fixed 1s denominator reported >100% for one thread.
- Drain waits until frames stop arriving (1s quiet, 20s cap), so late frames are not counted as lost.

## Verification

- smoke run `CONNS=200 SECONDS=2 pnpm bench`: reach 1, 0 lost
- `format:check` clean, `docs:build` clean

No changeset — nothing published changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wf3GNMSJUfME42a93d5j6
