### PR TITLE
fix(cli): gitignore .env.test and commit a .env.test.example template

### DIFF
--- a/.changeset/quiet-lamps-untrack.md
+++ b/.changeset/quiet-lamps-untrack.md
@@ -1,0 +1,21 @@
+---
+'@forinda/kickjs-cli': patch
+---
+
+`kick new` no longer commits `.env.test`. It is gitignored like `.env`, and a
+committed `.env.test.example` carries the shared keys.
+
+Test values differ per machine — database names, ports — so a tracked
+`.env.test` turned each developer's local tweak into a diff and a merge
+conflict for everyone else. Isolation is unchanged: under a test run KickJS
+still reads `.env.test` instead of `.env`, a fresh clone has neither file, and
+a machine with `.env` but no `.env.test` still gets the backfill warning and a
+`kick doctor` warning, which now suggests `cp .env.test.example .env.test`.
+
+Existing projects that want the same split:
+
+```bash
+git mv .env.test .env.test.example   # keep the shared keys as the template
+cp .env.test.example .env.test
+echo .env.test >> .gitignore
+```

--- a/docs/guide/migration-from-express.md
+++ b/docs/guide/migration-from-express.md
@@ -289,7 +289,8 @@ unknown keys become type errors — that's the whole reason the file
 `dotenv` is loaded for you (it ships as a dependency of a scaffolded app). Keep
 your existing `.env`; add `.env.test` when you have a suite, because under a test
 run KickJS reads `.env.test` **instead of** `.env` — no layering, no fallback —
-so a test can't reach a live service through a var it forgot to override.
+so a test can't reach a live service through a var it forgot to override. Like
+`.env`, keep `.env.test` out of git and commit a `.env.test.example` template.
 
 See [Configuration](./configuration.md) for the full precedence rules and the
 `ConfigService` API.

--- a/docs/guide/project-structure.md
+++ b/docs/guide/project-structure.md
@@ -22,7 +22,8 @@ my-api/                           # Default layout — adopters can rearrange
 │   ├── GEMINI.md
 │   └── skills/<slug>/SKILL.md    # One folder per skill, auto-discovered by agents
 ├── .kickjs/types/                # kick typegen output (KickRoutes, KickEnv, …)
-├── .env / .env.example / .env.test
+├── .env / .env.example            # .env gitignored, .env.example committed
+├── .env.test / .env.test.example  # same split, for the test suite
 ├── .editorconfig
 ├── .gitattributes / .gitignore
 ├── .oxfmtrc.json                 # Formatter config

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -444,7 +444,7 @@ plus per-mode overrides) and there is no dev-resource-in-a-test failure mode to
 guard against, so those cascade normally.
 
 ```bash
-# .env.test — checked in; the whole environment your suite runs against
+# .env.test — gitignored; the whole environment your suite runs against
 NODE_ENV=test
 DATABASE_URL=postgresql://test@localhost/myapp_test
 LOG_LEVEL=silent
@@ -453,18 +453,27 @@ LOG_LEVEL=silent
 With no `.env.test` present, `.env` is read as before and KickJS prints a
 one-time warning naming what it backfilled.
 
-**Commit `.env.test`.** Unlike `.env`, it belongs in version control — that is
-the difference between _everyone_ on the team being isolated and only whoever
-wrote the file locally. It is shared, reviewable test configuration, so a
-teammate's fresh clone and CI get the same isolation you do. `kick new`
-gitignores `.env` and `*.local` and leaves `.env.test` tracked.
+**Don't commit `.env.test`; commit `.env.test.example`.** Test values differ per
+machine — one developer's database is `myapp_test`, another's runs on a
+different port — so a tracked `.env.test` turns every local tweak into a diff,
+and a merge conflict, for the whole team. `kick new` treats it like `.env`: it
+writes `.env.test` for you, gitignores it along with `.env` and `*.local`, and
+commits `.env.test.example` as the shared list of keys.
 
-The corollary is that it must not hold real credentials or live endpoints —
-point it at test doubles or throwaway containers. A shared database URL sitting
-in a committed `.env.test` rebuilds the trap: a whole team, and CI, quietly
-aimed at one box. Compute per-run values (a container's port, a worker-scoped
-database name) in your test config or setup file instead, where they stay out
-of the repo and `process.env` still outranks the file.
+```bash
+cp .env.test.example .env.test   # after cloning, next to cp .env.example .env
+```
+
+A fresh clone has neither `.env` nor `.env.test`, so nothing leaks. The one
+exposed shape is a machine with a `.env` but no `.env.test` — the one-time
+warning above and `kick doctor` both name it.
+
+When you add a key to `.env.test`, add it to `.env.test.example` with a
+placeholder value. Keep real credentials and live endpoints out of the example.
+In CI, set test env in the job (or with `KICKJS_ENV_FILE=off`) rather than
+relying on a file; `process.env` outranks every file. Compute per-run values (a
+container's port, a worker-scoped database name) in your test config or setup
+file, where they stay out of the repo.
 
 ### `KICKJS_ENV_FILE` — taking manual control
 

--- a/packages/cli/__tests__/scaffold-env-test.test.ts
+++ b/packages/cli/__tests__/scaffold-env-test.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect } from 'vitest'
 import {
   generateEnv,
   generateEnvTest,
+  generateEnvTestExample,
   generateGitIgnore,
   generateVitestConfig,
 } from '../src/generators/templates/project-config'
@@ -35,8 +36,9 @@ describe('scaffolded .env.test', () => {
     expect(generateEnv()).toContain('NODE_ENV=development')
   })
 
-  it('warns against committing real credentials', () => {
-    // It is a committed file, so the guidance has to be in the file.
+  it('warns against putting real credentials in the committed template', () => {
+    // Its keys are mirrored into the committed .env.test.example, so the
+    // guidance has to be in the file.
     expect(generateEnvTest().toLowerCase()).toContain('credentials')
   })
 
@@ -47,11 +49,18 @@ describe('scaffolded .env.test', () => {
     expect(generateVitestConfig()).not.toContain('env:')
   })
 
-  it('gitignores *.local but keeps .env.test committed', () => {
-    const ignore = generateGitIgnore()
+  it('gitignores .env.test and *.local; the committed template is .env.test.example', () => {
+    // Values differ per machine; a tracked .env.test turns every local
+    // tweak into a diff (and a conflict) for the whole team.
+    const ignore = generateGitIgnore().split('\n')
+    expect(ignore).toContain('.env.test')
     expect(ignore).toContain('*.local')
-    // A bare `.env.test` line would defeat the point — the suite's
-    // environment is meant to be shared and reviewable.
-    expect(ignore.split('\n')).not.toContain('.env.test')
+    expect(ignore).not.toContain('.env.test.example')
+  })
+
+  it('ships a .env.test.example with the same keys and copy instructions', () => {
+    const example = generateEnvTestExample()
+    expect(example).toContain('cp .env.test.example .env.test')
+    expect(example).toContain(generateEnvTest())
   })
 })

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -763,7 +763,8 @@ export function checkTestEnvIsolation(ctx: DoctorContext): DoctorResult | null {
       'those files, every var your test config does not pin resolves from your\n' +
       'development env — including DATABASE_URL and any third-party credentials.\n' +
       '\n' +
-      'Create .env.test holding the whole environment the suite should run against\n' +
+      'Create .env.test (cp .env.test.example .env.test, if the project has one)\n' +
+      'holding the whole environment the suite should run against\n' +
       '(a var you leave out is then missing, not inherited), or set KICKJS_ENV_FILE=off\n' +
       'and supply env from the test runner.',
   }

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -15,6 +15,7 @@ import {
   generateEnv,
   generateEnvExample,
   generateEnvTest,
+  generateEnvTestExample,
   generateVitestConfig,
 } from './templates/project-config'
 import {
@@ -327,8 +328,10 @@ export async function initProject(options: InitProjectOptions): Promise<void> {
   // it is what makes a new project isolated by default. Without it the
   // generated app ships the exact shape `kick doctor` warns about — a
   // `.env` plus a test runner — and its first test run prints the backfill
-  // warning rather than being isolated.
+  // warning rather than being isolated. It is gitignored like `.env` —
+  // values differ per machine — so the committed template is the example.
   await writeFileSafe(join(dir, '.env.test'), generateEnvTest())
+  await writeFileSafe(join(dir, '.env.test.example'), generateEnvTestExample())
 
   // ── src/config/index.ts — typed env schema (read by `kick typegen`) ─
   // Lives under `src/config/` so the framework's "config" concept has a

--- a/packages/cli/src/generators/templates/project-config.ts
+++ b/packages/cli/src/generators/templates/project-config.ts
@@ -302,8 +302,9 @@ export function generateGitIgnore(): string {
   return `node_modules/
 dist/
 .env
-# Personal machine overrides. \`.env.test\` itself is COMMITTED — it is the
-# suite's shared, reviewable environment — but \`*.local\` never is.
+# Machine-specific: each developer's test env differs (database names, ports).
+# The shared template is the committed \`.env.test.example\`.
+.env.test
 *.local
 coverage/
 .DS_Store
@@ -363,19 +364,29 @@ NODE_ENV=development
  *
  * `PORT=0` asks the OS for a free port, so a test run cannot collide with
  * a dev server already on 3000.
+ *
+ * Gitignored, like `.env`: values differ per machine, and a committed copy
+ * turns every local tweak into a diff for the whole team. The shared
+ * template is {@link generateEnvTestExample}.
  */
 export function generateEnvTest(): string {
   return `# Read INSTEAD of .env when NODE_ENV=test (or under vitest).
 # No fallback to .env — declare here everything the suite needs, so a
 # missing var fails the run instead of silently resolving to your dev value.
 #
-# Keep real endpoints and credentials OUT of this file. Point at test
-# doubles or throwaway containers; anything committed here is shared with
-# everyone who clones the repo.
+# Not committed. Add new keys to .env.test.example too, with placeholder
+# values — never real endpoints or credentials.
 NODE_ENV=test
 PORT=0
 LOG_LEVEL=silent
 `
+}
+
+/** Generate `.env.test.example` — the committed template a fresh clone copies to `.env.test`. */
+export function generateEnvTestExample(): string {
+  return `# Template for .env.test. Copy it and fill in your machine's values:
+#   cp .env.test.example .env.test
+${generateEnvTest()}`
 }
 
 /** Generate vitest.config.ts for test configuration */


### PR DESCRIPTION
## Why

`kick new` committed `.env.test` as the suite's shared environment. Test values differ per machine — one developer's database is `myapp_test`, another's is on a different port — so every local tweak became a diff for the whole team, and two people adjusting it for their own setups conflicted.

## What

`.env.test` now follows the same split as `.env` / `.env.example`:

| File | Before | After |
| --- | --- | --- |
| `.env.test` | written, **committed** | written, **gitignored** |
| `.env.test.example` | — | written, committed; same keys + `cp .env.test.example .env.test` |

- `generateGitIgnore()` adds `.env.test`
- `generateEnvTestExample()` wraps `generateEnvTest()` with copy instructions, so the two can't drift
- `kick doctor`'s isolation warning suggests copying the example
- docs: testing guide ("Don't commit `.env.test`; commit `.env.test.example`"), project structure, Express migration

## Isolation is unchanged

No runtime change in `@forinda/kickjs`. Under a test run it still reads `.env.test` **instead of** `.env`.

- fresh clone: neither `.env` nor `.env.test` exists → no file read, nothing leaks
- machine with `.env` but no `.env.test`: same one-time backfill warning and `kick doctor` warning as today
- CI: env from the job (`process.env` outranks files), or `KICKJS_ENV_FILE=off`

## Existing projects

In the changeset:

```bash
git mv .env.test .env.test.example
cp .env.test.example .env.test
echo .env.test >> .gitignore
```

## Verification

- scaffolded with the built CLI: initial commit tracks `.env.example` and `.env.test.example`; `git check-ignore` reports `.env` and `.env.test`
- CLI tests 819/819 (scaffold test now asserts `.env.test` is ignored and the example mirrors it), typecheck, format, docs build clean

Changeset: `@forinda/kickjs-cli` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wf3GNMSJUfME42a93d5j6
