### PR TITLE
feat(ws): relay broadcasts across instances through a pluggable broker

### DIFF
--- a/.changeset/bright-sockets-bridge.md
+++ b/.changeset/bright-sockets-bridge.md
@@ -1,0 +1,29 @@
+---
+'@forinda/kickjs-ws': minor
+---
+
+`@forinda/kickjs-ws/socket.io` serves the same `@WsController` classes over
+Socket.IO, so choosing a transport no longer means rewriting controllers.
+
+```ts
+import { SocketIoAdapter } from '@forinda/kickjs-ws/socket.io'
+
+bootstrap({ modules, adapters: [SocketIoAdapter({ cors: { origin: 'https://app.example.com' } })] })
+```
+
+Namespaces map to `io.of(namespace)`, `@OnMessage('x')` handles the client's
+`socket.emit('x', data)`, and `SocketIoContext` mirrors `WsContext` (`send`,
+`broadcast`, `broadcastAll`, `join`, `to(room).send`, `get`/`set`, `cookies`).
+`auth.resolveUser` runs as namespace middleware and rejects with a
+`connect_error` of `Unauthorized`; authenticated sockets join `user:<id>`, and
+`WS_USER_BROADCASTER` reaches a user in every namespace. An async `@OnConnect`
+is awaited before events are delivered, as with `WsAdapter`.
+
+Every Socket.IO server option passes through, including `adapter` — with
+`@socket.io/redis-adapter`, emits and per-user sends cross instances. Shutdown
+disconnects sockets and closes the engine but leaves the HTTP server to KickJS,
+where `io.close()` would close it too.
+
+`socket.io` is an optional peer dependency, needed only for this subpath.
+Differences from `WsAdapter`: rooms are per namespace, `WS_ROOM_MANAGER` is not
+registered (inject `SOCKET_IO`), and acknowledgements go through `ctx.socket`.

--- a/.changeset/calm-hubs-centrifugo.md
+++ b/.changeset/calm-hubs-centrifugo.md
@@ -1,0 +1,22 @@
+---
+'@forinda/kickjs-ws': minor
+---
+
+Add `@forinda/kickjs-ws/centrifugo` for apps that hand client connections to
+[Centrifugo](https://centrifugal.dev) instead of holding them in Node.
+
+- `centrifugoClient({ url, apiKey })` — `publish`, `broadcast`, `subscribe`,
+  `disconnect` over Centrifugo's server API. Throws `CentrifugoApiError` on a
+  non-2xx reply or on the `error` object Centrifugo returns with HTTP 200.
+- `connectionToken({ secret, sub, expiresInSeconds, info, channels })` — an
+  HS256 connection JWT signed with `node:crypto`; no JWT dependency.
+- `centrifugoConnect(request, resolveUser)` — the reply body for Centrifugo's
+  connect proxy, from the same `resolveUser` a `WsAdapter` uses: a user
+  connects, `null` disconnects with `4401`, a throwing resolver answers
+  internal error `100`.
+- `CentrifugoAdapter({ url, apiKey, personalChannelNamespace? })` — registers
+  the `CENTRIFUGO` client and a `WS_USER_BROADCASTER` that publishes to the
+  user's personal channel (`#<user>`), so services written against
+  `WsAdapter`'s broadcaster keep working unchanged.
+
+`@WsController` / `@OnMessage` do not apply: Centrifugo owns the sockets.

--- a/.changeset/wide-rooms-relay.md
+++ b/.changeset/wide-rooms-relay.md
@@ -1,0 +1,31 @@
+---
+'@forinda/kickjs-ws': minor
+---
+
+Broadcasts can now reach sockets on every instance, not only the one that sent
+them. Pass a `broker` to `WsAdapter`; `@forinda/kickjs-ws/redis` ships one over
+Redis pub/sub.
+
+```ts
+import Redis from 'ioredis'
+import { WsAdapter } from '@forinda/kickjs-ws'
+import { redisBroker } from '@forinda/kickjs-ws/redis'
+
+const redis = new Redis(process.env.REDIS_URL!)
+
+WsAdapter({ broker: redisBroker({ publisher: redis, subscriber: redis.duplicate() }) })
+```
+
+Room broadcasts (`ctx.to()`, `WS_ROOM_MANAGER.broadcast`), per-user sends
+(`WS_USER_BROADCASTER`, `broadcastToUser`) and namespace broadcasts
+(`ctx.broadcast`, `ctx.broadcastAll`) are delivered to local sockets straight
+away, then published; other instances deliver them to theirs, and each
+instance skips its own messages so no socket gets a frame twice. A failed
+publish is logged and never thrown into the handler. Membership queries
+(`getStats().rooms`, `getSockets`, `getAllRooms`) still describe the local
+instance.
+
+The Redis subpath types the client by shape, so `ioredis` is not a dependency
+of the package — any client with `publish` / `subscribe` / `on('message')`
+works, and `WsBroker` can be implemented over another pub/sub. Without a
+`broker` nothing changes.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -52,6 +52,7 @@ const guideSidebar = [
       { text: 'Configuration', link: '/guide/configuration' },
       { text: 'WebSockets', link: '/guide/websockets' },
       { text: 'Socket.IO', link: '/guide/socketio' },
+      { text: 'Centrifugo', link: '/guide/centrifugo' },
       { text: 'Server-Sent Events', link: '/guide/sse' },
       { text: 'GraphQL (BYO adapter)', link: '/guide/graphql' },
       { text: 'gRPC / Connect RPC', link: '/guide/grpc' },

--- a/docs/guide/benchmarks.md
+++ b/docs/guide/benchmarks.md
@@ -72,15 +72,16 @@ CONNS=10000 WORKERS=8 ECHO_RATE=0 FAN_RATE=5 pnpm bench
 INSTANCES=2 CONNS=10000 WORKERS=8 pnpm bench
 ```
 
-| Variable    | Default | Meaning                                         |
-| ----------- | ------- | ----------------------------------------------- |
-| `INSTANCES` | `1`     | Server processes; connections are spread evenly |
-| `CONNS`     | `2000`  | Total connections                               |
-| `WORKERS`   | `4`     | Client processes                                |
-| `SECONDS`   | `10`    | Length of the measured phase                    |
-| `ECHO_RATE` | `1`     | Messages per second, per connection             |
-| `FAN_RATE`  | `20`    | Broadcasts per second from the single sender    |
-| `BASE_PORT` | `4600`  | First server port                               |
+| Variable    | Default | Meaning                                              |
+| ----------- | ------- | ---------------------------------------------------- |
+| `INSTANCES` | `1`     | Server processes; connections are spread evenly      |
+| `CONNS`     | `2000`  | Total connections                                    |
+| `WORKERS`   | `4`     | Client processes                                     |
+| `SECONDS`   | `10`    | Length of the measured phase                         |
+| `ECHO_RATE` | `1`     | Messages per second, per connection                  |
+| `FAN_RATE`  | `20`    | Broadcasts per second from the single sender         |
+| `BASE_PORT` | `4600`  | First server port                                    |
+| `REDIS_URL` | unset   | When set, instances share rooms via the Redis broker |
 
 The output includes client CPU. If it approaches 100%, the clients are the bottleneck — raise `WORKERS` before reading the server numbers.
 
@@ -100,9 +101,24 @@ No run lost a message; overloaded runs delivered late. Once a process is past it
 
 ### Running more than one instance
 
-| Scenario                             | Reach | p50   | p99   |
-| ------------------------------------ | ----- | ----- | ----- |
-| 1 instance, 10,000-member room, 5/s  | 1.0   | 142ms | 255ms |
-| 2 instances, 10,000-member room, 5/s | 0.5   | 44ms  | 97ms  |
+Set `REDIS_URL` to run the instances with the [Redis broker](./websockets.md#scaling-across-instances):
 
-A second instance halves the per-process load, but rooms are process-local: a broadcast reaches only the sockets connected to the instance that sent it. Until a cross-instance broker exists, run one instance per realtime workload, or put connections behind a service that owns them — see [WebSockets](./websockets.md).
+```bash
+docker run -d --rm -p 6379:6379 redis
+REDIS_URL=redis://127.0.0.1:6379 INSTANCES=2 CONNS=10000 WORKERS=8 ECHO_RATE=0 FAN_RATE=5 pnpm bench
+```
+
+One 10,000-member room, spread evenly across instances, local Redis. These rows were measured in one session, so they compare with each other rather than with the table above.
+
+| Scenario                | Frames/s | Reach   | p50   | p99   |
+| ----------------------- | -------- | ------- | ----- | ----- |
+| 1 instance              | 50,000   | 1.0     | 125ms | 178ms |
+| 1 instance + Redis      | 50,000   | 1.0     | 141ms | 184ms |
+| 2 instances, no broker  | 50,000   | **0.5** | 44ms  | 92ms  |
+| 2 instances + Redis     | 50,000   | 1.0     | 85ms  | 201ms |
+| 1 instance (overloaded) | 100,000  | 1.0     | 1.8s  | 2.7s  |
+| 4 instances + Redis     | 100,000  | 1.0     | 58ms  | 203ms |
+
+- Without a broker, each instance reaches only its own sockets, so half the room never gets the message.
+- The broker costs one Redis round trip per broadcast, not per recipient — ~16ms p50 in the single-instance runs here.
+- A load that swamps one process is handled by four with room to spare: server CPU stayed under 70% per instance.

--- a/docs/guide/centrifugo.md
+++ b/docs/guide/centrifugo.md
@@ -1,0 +1,184 @@
+# Centrifugo
+
+[Centrifugo](https://centrifugal.dev) is a standalone real-time server. Clients connect to it, not to your Node process; your KickJS app authenticates those connections and publishes through Centrifugo's server API. `@forinda/kickjs-ws/centrifugo` covers the KickJS side.
+
+## When to choose it
+
+|                                          | `WsAdapter` + Redis broker | Centrifugo                                                      |
+| ---------------------------------------- | -------------------------- | --------------------------------------------------------------- |
+| Who holds the sockets                    | Your Node instances        | Centrifugo (Go)                                                 |
+| Client → server messages                 | `@OnMessage` handlers      | Your HTTP routes, or Centrifugo's RPC/publish proxies           |
+| Extra infrastructure                     | Redis                      | Centrifugo (plus its own Redis/NATS when you run several nodes) |
+| History, presence, recovery on reconnect | Build it yourself          | Built in                                                        |
+
+Start with [`WsAdapter`](./websockets.md) — it keeps handlers in your code and scales out with a [broker](./websockets.md#scaling-across-instances). Move to Centrifugo when connection count or delivery features outgrow what you want to run in Node.
+
+## What does not carry over
+
+Centrifugo owns the connections, so nothing that acts on a socket applies: `@WsController`, `@OnConnect`, `@OnMessage`, `@OnDisconnect`, `WsContext`, rooms (`ctx.join`, `ctx.to`) and `WS_ROOM_MANAGER`. Channels replace rooms; clients subscribe to them, or you subscribe users server-side with `subscribe(user, channel)`.
+
+`WS_USER_BROADCASTER` does carry over — see [Publishing from services](#publishing-from-services).
+
+## Centrifugo config
+
+Keys as Centrifugo v6 reads them (`config.json`, or `CENTRIFUGO_`-prefixed environment variables such as `CENTRIFUGO_HTTP_API_KEY`):
+
+```json
+{
+  "http_api": { "key": "<api key>" },
+  "client": {
+    "allowed_origins": ["https://app.example.com"],
+    "token": { "hmac_secret_key": "<hmac secret>" },
+    "subscribe_to_user_personal_channel": { "enabled": true },
+    "proxy": {
+      "connect": {
+        "enabled": true,
+        "endpoint": "http://api:3000/centrifugo/connect",
+        "http_headers": ["Cookie"]
+      }
+    }
+  },
+  "channel": {
+    "without_namespace": { "allow_subscribe_for_client": true }
+  }
+}
+```
+
+- `http_api.key` — what `CentrifugoAdapter` sends as `X-API-Key`.
+- `client.token.hmac_secret_key` — what `connectionToken` signs with. Needed only for the token flow.
+- `client.proxy.connect` — needed only for the proxy flow. Centrifugo forwards **only** the headers listed in `http_headers`; without `Cookie` your resolver sees no session.
+- `client.subscribe_to_user_personal_channel` — subscribes each user to `#<user>` on connect, which is where `WS_USER_BROADCASTER` publishes.
+
+## Register the adapter
+
+```ts
+import { bootstrap } from '@forinda/kickjs'
+import { CentrifugoAdapter } from '@forinda/kickjs-ws/centrifugo'
+
+bootstrap({
+  modules,
+  adapters: [
+    CentrifugoAdapter({
+      url: process.env.CENTRIFUGO_URL!, // e.g. http://centrifugo:8000
+      apiKey: process.env.CENTRIFUGO_API_KEY!,
+    }),
+  ],
+})
+```
+
+If you set `client.subscribe_to_user_personal_channel.personal_channel_namespace`, pass the same value as `personalChannelNamespace` so the broadcaster publishes to `<namespace>:#<user>`.
+
+## Authenticating connections
+
+Pick one of two flows.
+
+### Connection token
+
+Your app signs a short-lived JWT; the client passes it to Centrifugo.
+
+```ts
+import { Controller, Get, type RequestContext } from '@forinda/kickjs'
+import { connectionToken } from '@forinda/kickjs-ws/centrifugo'
+
+@Controller()
+export class RealtimeController {
+  @Get('/token')
+  async token(ctx: RequestContext) {
+    const user = await sessions.fromRequest(ctx.req) // your session lookup
+    if (!user) return ctx.json({ error: 'unauthorized' }, 401)
+
+    ctx.json({
+      token: connectionToken({
+        secret: process.env.CENTRIFUGO_HMAC_SECRET!,
+        sub: user.id,
+        expiresInSeconds: 15 * 60,
+        info: { name: user.name }, // visible to others in presence
+      }),
+    })
+  }
+}
+```
+
+`connectionToken` signs HS256 with `node:crypto` and sets the `sub`, `exp`, `info` and `channels` claims Centrifugo reads.
+
+### Connect proxy
+
+Centrifugo calls your app on every connection and uses the reply. Reuse the `resolveUser` you would give `WsAdapter`:
+
+```ts
+import { Controller, Post, type RequestContext } from '@forinda/kickjs'
+import { centrifugoConnect } from '@forinda/kickjs-ws/centrifugo'
+
+// Mount under /centrifugo so the path matches client.proxy.connect.endpoint
+@Controller()
+export class CentrifugoProxyController {
+  @Post('/connect')
+  async connect(ctx: RequestContext) {
+    ctx.json(await centrifugoConnect(ctx.req, resolveUser))
+  }
+}
+
+// The same shape as WsAuthConfig.resolveUser
+async function resolveUser(req: { headers: Record<string, string | string[] | undefined> }) {
+  const sid = parseCookie(req.headers.cookie).sid
+  return sid ? await sessions.verify(sid) : null
+}
+```
+
+| `resolveUser`               | Reply                                                        | Client sees                                      |
+| --------------------------- | ------------------------------------------------------------ | ------------------------------------------------ |
+| returns `{ id }`            | `{ result: { user: id } }`                                   | connected as that user                           |
+| returns `null` (or no `id`) | `{ disconnect: { code: 4401, reason: 'unauthorized' } }`     | socket closed with `4401`                        |
+| throws                      | `{ error: { code: 100, message: 'internal server error' } }` | connect error (Centrifugo's internal error code) |
+
+The route must be reachable from Centrifugo, and exempt from `csrf()` if you use it — Centrifugo sends no CSRF token.
+
+## Publishing from services
+
+`CentrifugoAdapter` registers two tokens:
+
+```ts
+import { Inject, Service } from '@forinda/kickjs'
+import { WS_USER_BROADCASTER, type WsUserBroadcaster } from '@forinda/kickjs-ws'
+import { CENTRIFUGO, type CentrifugoClient } from '@forinda/kickjs-ws/centrifugo'
+
+@Service()
+export class OrderEvents {
+  constructor(
+    @Inject(CENTRIFUGO) private readonly centrifugo: CentrifugoClient,
+    @Inject(WS_USER_BROADCASTER) private readonly users: WsUserBroadcaster,
+  ) {}
+
+  async shipped(order: { id: string; userId: string }) {
+    await this.centrifugo.publish(`orders:${order.id}`, { status: 'shipped' })
+    this.users.toUser(order.userId).send('order:shipped', { id: order.id })
+  }
+}
+```
+
+- `CENTRIFUGO` — `publish(channel, data)`, `broadcast(channels, data)`, `subscribe(user, channel)`, `disconnect(user)`. Each returns a promise and throws `CentrifugoApiError` (with `method` and `code`) when Centrifugo rejects the call.
+- `WS_USER_BROADCASTER` — the same interface `WsAdapter` registers. It publishes `{ event, data }` to the user's personal channel. Code written against `WsAdapter` works unchanged; like `WsAdapter`'s broker relay, a failed publish is logged rather than thrown.
+
+## Client
+
+Use Centrifugo's client SDK:
+
+<PmCommand add="centrifuge" />
+
+```ts
+import { Centrifuge } from 'centrifuge'
+
+const centrifuge = new Centrifuge('wss://realtime.example.com/connection/websocket', {
+  // Token flow; omit for the connect proxy flow
+  getToken: async () => (await fetch('/token').then((r) => r.json())).token,
+})
+
+// Server-side subscriptions, including the personal channel
+centrifuge.on('publication', (ctx) => console.log(ctx.channel, ctx.data))
+
+const orders = centrifuge.newSubscription('orders:42')
+orders.on('publication', (ctx) => console.log(ctx.data))
+orders.subscribe()
+
+centrifuge.connect()
+```

--- a/docs/guide/socketio.md
+++ b/docs/guide/socketio.md
@@ -1,245 +1,179 @@
 # Socket.IO Integration
 
-KickJS ships with a `ws`-based WebSocket adapter (`@forinda/kickjs-ws`), but you can integrate **Socket.IO** for features like automatic reconnection, rooms, acknowledgements, and binary support.
+`SocketIoAdapter` serves your `@WsController` classes over [Socket.IO](https://socket.io) instead of raw WebSockets. The decorators are the same; the transport brings client reconnection, a long-polling fallback, and Socket.IO's own adapters for running more than one instance.
 
 ## Setup
 
-<PmCommand add="socket.io" />
-
-## Create a Socket.IO Adapter
-
-```ts
-// src/adapters/socketio.adapter.ts
-import { Server, type Socket } from 'socket.io'
-import {
-  createToken,
-  defineAdapter,
-  Logger,
-  type AdapterContext,
-  type Container,
-} from '@forinda/kickjs'
-
-const log = Logger.for('SocketIOAdapter')
-
-export interface SocketIOAdapterOptions {
-  /** CORS configuration */
-  cors?: {
-    origin: string | string[]
-    methods?: string[]
-    credentials?: boolean
-  }
-  /** Path for the Socket.IO endpoint (default: '/socket.io') */
-  path?: string
-  /** Custom namespaces to register */
-  namespaces?: SocketIONamespace[]
-}
-
-export interface SocketIONamespace {
-  /** Namespace path (e.g. '/chat', '/notifications') */
-  namespace: string
-  /** Handler setup function — receives the namespace and DI container */
-  setup: (nsp: any, container: Container) => void
-}
-
-/**
- * Typed DI token for injecting the Socket.IO server.
- * `container.resolve(SOCKET_IO)` returns `Server` without a manual generic.
- */
-export const SOCKET_IO = createToken<Server>('kick/socketio/server')
-
-export const SocketIOAdapter = defineAdapter<SocketIOAdapterOptions>({
-  name: 'SocketIOAdapter',
-  defaults: { path: '/socket.io' },
-  build: (options) => {
-    let io: Server | undefined
-
-    return {
-      afterStart({ server, container }: AdapterContext): void {
-        io = new Server(server, {
-          cors: options.cors ?? { origin: '*' },
-          path: options.path,
-        })
-
-        // Default namespace
-        io.on('connection', (socket: Socket) => {
-          log.info(`Connected: ${socket.id}`)
-          socket.on('disconnect', (reason) => {
-            log.info(`Disconnected: ${socket.id} (${reason})`)
-          })
-        })
-
-        // Custom namespaces
-        for (const ns of options.namespaces ?? []) {
-          const nsp = io.of(ns.namespace)
-          ns.setup(nsp, container)
-          log.info(`Namespace registered: ${ns.namespace}`)
-        }
-
-        // Register io instance in DI for injection
-        container.registerInstance(SOCKET_IO, io)
-        log.info(`Socket.IO listening at ${options.path}`)
-      },
-
-      async shutdown(): Promise<void> {
-        if (io) {
-          await new Promise<void>((resolve) => io!.close(() => resolve()))
-          log.info('Socket.IO server closed')
-        }
-      },
-    }
-  },
-})
-```
-
-## Register in Bootstrap
+<PmCommand add="@forinda/kickjs-ws socket.io" />
 
 ```ts
 import { bootstrap } from '@forinda/kickjs'
-import { SocketIOAdapter } from './adapters/socketio.adapter'
+import { SocketIoAdapter } from '@forinda/kickjs-ws/socket.io'
 import { modules } from './modules'
 
 bootstrap({
   modules,
   adapters: [
-    SocketIOAdapter({
+    SocketIoAdapter({
+      // Any Socket.IO server option: cors, path, pingInterval, adapter, …
       cors: { origin: 'http://localhost:5173', credentials: true },
-      namespaces: [
-        {
-          namespace: '/chat',
-          setup: (nsp, container) => {
-            nsp.on('connection', (socket) => {
-              console.log(`Chat connected: ${socket.id}`)
-
-              socket.on('message', (data) => {
-                // Broadcast to room or all
-                nsp.emit('message', {
-                  from: socket.id,
-                  ...data,
-                  timestamp: new Date().toISOString(),
-                })
-              })
-
-              socket.on('join-room', (room) => {
-                socket.join(room)
-                socket.to(room).emit('user-joined', { userId: socket.id })
-              })
-
-              socket.on('leave-room', (room) => {
-                socket.leave(room)
-                socket.to(room).emit('user-left', { userId: socket.id })
-              })
-            })
-          },
-        },
-        {
-          namespace: '/notifications',
-          setup: (nsp, container) => {
-            nsp.on('connection', (socket) => {
-              // Join user-specific room for targeted notifications
-              const userId = socket.handshake.auth?.userId
-              if (userId) socket.join(`user:${userId}`)
-            })
-          },
-        },
-      ],
     }),
   ],
 })
 ```
 
-## Inject Socket.IO in Services
+Use `SocketIoAdapter` **instead of** `WsAdapter`, not alongside it — both would serve the same controllers.
 
-Use the `SOCKET_IO` token to inject the io server anywhere:
+## Controllers
+
+```ts
+import { WsController, OnConnect, OnDisconnect, OnMessage } from '@forinda/kickjs-ws'
+import type { SocketIoContext } from '@forinda/kickjs-ws/socket.io'
+
+@WsController('/chat')
+export class ChatController {
+  @OnConnect()
+  connect(ctx: SocketIoContext) {
+    ctx.join('general')
+  }
+
+  @OnMessage('message')
+  message(ctx: SocketIoContext) {
+    ctx.to('general').send('message', { from: ctx.id, text: ctx.data.text })
+  }
+
+  @OnMessage('*')
+  unknown(ctx: SocketIoContext) {
+    ctx.send('error', { message: `Unknown event: ${ctx.event}` })
+  }
+
+  @OnDisconnect()
+  disconnect(ctx: SocketIoContext) {}
+}
+```
+
+How the pieces map:
+
+| KickJS                                   | Socket.IO                                                      |
+| ---------------------------------------- | -------------------------------------------------------------- |
+| `@WsController('/chat')`                 | `io.of('/chat')` — `@WsController()` is the main namespace `/` |
+| `@OnMessage('message')`                  | the client's `socket.emit('message', data)`                    |
+| `@OnMessage('*')`                        | any event no other handler claims                              |
+| `ctx.send(event, data)`                  | `socket.emit`                                                  |
+| `ctx.broadcast(event, data)`             | `socket.broadcast.emit` — the namespace, sender excluded       |
+| `ctx.broadcastAll(event, data)`          | `socket.nsp.emit` — the namespace, sender included             |
+| `ctx.join(room)` / `ctx.to(room).send()` | `socket.join` / `socket.nsp.to(room).emit` — sender included   |
+| `ctx.socket` / `ctx.server`              | the Socket.IO `Socket` / `Server`, for anything not mapped     |
+
+`SocketIoContext` mirrors `WsContext` (`id`, `data`, `event`, `namespace`, `request`, `cookies`, `get`/`set`, `rooms()`), so a controller written for one runs on the other — with the differences below.
+
+::: warning Differences from `WsAdapter`
+
+- **Rooms belong to a namespace.** With `ws`, `lobby` joined from `/chat` and from `/admin` is one room; with Socket.IO they are two.
+- **No `WS_ROOM_MANAGER`.** Socket.IO keeps its own rooms — inject `SOCKET_IO` to reach them from a service.
+- **Acknowledgements are not mapped.** A client callback arrives as an extra argument the handler does not see; use `ctx.socket.on(...)` for events that need one.
+
+:::
+
+As with `WsAdapter`, an `async` `@OnConnect` is awaited: events that arrive meanwhile are held (up to 64, then the socket is disconnected) and delivered once it settles.
+
+## Authentication
+
+`auth` takes the same `resolveUser` hook as `WsAdapter`, run as namespace middleware before the connection is accepted:
+
+```ts
+SocketIoAdapter({
+  auth: {
+    resolveUser: async (request) => {
+      const token = parseCookie(request.headers.cookie).sid
+      return token ? await sessions.verify(token) : null
+    },
+  },
+})
+```
+
+- Returning `null` or throwing rejects the connection; the client gets `connect_error` with `err.message === 'Unauthorized'`.
+- The user is available as `ctx.get('user')` and `ctx.get('userId')`.
+- Each authenticated socket joins `user:<id>` in its namespace (`autoJoinUserRoom: false` to opt out, `userRoomPrefix` to rename).
+
+`resolveUser` receives the handshake request, so it reads cookies, headers and the query string. A token sent through the client's `auth` option is on `ctx.socket.handshake.auth`, not the request.
+
+## Services
 
 ```ts
 import { Service, Inject } from '@forinda/kickjs'
-import { SOCKET_IO } from '../adapters/socketio.adapter'
+import { WS_USER_BROADCASTER, type WsUserBroadcaster } from '@forinda/kickjs-ws'
+import { SOCKET_IO } from '@forinda/kickjs-ws/socket.io'
 import type { Server } from 'socket.io'
 
 @Service()
-export class NotificationPushService {
-  constructor(@Inject(SOCKET_IO) private io: Server) {}
+export class NotificationService {
+  constructor(
+    @Inject(WS_USER_BROADCASTER) private users: WsUserBroadcaster,
+    @Inject(SOCKET_IO) private io: Server,
+  ) {}
 
-  /** Send a notification to a specific user */
-  notifyUser(userId: string, event: string, data: any) {
-    this.io.of('/notifications').to(`user:${userId}`).emit(event, data)
+  notify(userId: string, data: unknown) {
+    // Every namespace the user is connected to.
+    this.users.broadcastToUser(userId, 'notification', data)
   }
 
-  /** Broadcast to all connected clients */
-  broadcast(event: string, data: any) {
-    this.io.emit(event, data)
-  }
-
-  /** Send to a specific room */
-  toRoom(room: string, event: string, data: any) {
-    this.io.to(room).emit(event, data)
+  announce(data: unknown) {
+    this.io.of('/chat').to('general').emit('announcement', data)
   }
 }
 ```
 
-## Client-Side
+`WS_USER_BROADCASTER` is the same token `WsAdapter` registers, so code written against it does not change when you switch transports.
+
+## Running more than one instance
+
+Pass a Socket.IO adapter. With [`@socket.io/redis-adapter`](https://socket.io/docs/v4/redis-adapter/), room emits, namespace broadcasts and `WS_USER_BROADCASTER` reach sockets on every instance:
+
+<PmCommand add="@socket.io/redis-adapter ioredis" />
+
+```ts
+import Redis from 'ioredis'
+import { createAdapter } from '@socket.io/redis-adapter'
+import { SocketIoAdapter } from '@forinda/kickjs-ws/socket.io'
+
+const pub = new Redis(process.env.REDIS_URL!)
+
+SocketIoAdapter({ adapter: createAdapter(pub, pub.duplicate()) })
+```
+
+Unlike `WsAdapter`, Socket.IO's long-polling fallback needs **sticky sessions** at the load balancer — or `transports: ['websocket']` on the client to skip polling.
+
+## Client
 
 ```ts
 import { io } from 'socket.io-client'
 
-// Connect to default namespace
-const socket = io('http://localhost:3000')
+const chat = io('http://localhost:3000/chat', { withCredentials: true })
 
-// Connect to a specific namespace
-const chat = io('http://localhost:3000/chat')
-const notifications = io('http://localhost:3000/notifications', {
-  auth: { userId: 'user-123' },
+chat.on('connect_error', (err) => {
+  if (err.message === 'Unauthorized') redirectToLogin()
 })
-
-// Listen for events
-chat.on('message', (msg) => console.log('New message:', msg))
-notifications.on('alert', (alert) => console.log('Alert:', alert))
-
-// Send events
+chat.on('message', (msg) => console.log(msg))
 chat.emit('message', { text: 'Hello everyone!' })
-chat.emit('join-room', 'general')
 ```
 
-## Socket.IO vs ws
+## Socket.IO or ws?
 
-|                      | `@forinda/kickjs-ws`           | Socket.IO                              |
-| -------------------- | ------------------------------ | -------------------------------------- |
-| **Protocol**         | Raw WebSocket                  | Custom protocol over WebSocket/polling |
-| **Reconnection**     | Manual                         | Automatic                              |
-| **Rooms**            | Via `RoomManager`              | Built-in                               |
-| **Acknowledgements** | Manual                         | Built-in callbacks                     |
-| **Binary**           | Manual                         | Automatic                              |
-| **Fallback**         | WebSocket only                 | Long-polling fallback                  |
-| **Bundle size**      | ~50KB                          | ~300KB (client + server)               |
-| **Decorators**       | `@WsController`, `@OnMessage`  | Use adapter pattern above              |
-| **Best for**         | Lightweight, low-level control | Full-featured real-time apps           |
-
-## With Authentication
-
-```ts
-// Middleware for Socket.IO authentication
-io.use((socket, next) => {
-  const token = socket.handshake.auth?.token
-  if (!token) return next(new Error('Authentication required'))
-
-  try {
-    const user = jwt.verify(token, JWT_SECRET)
-    socket.data.user = user
-    next()
-  } catch {
-    next(new Error('Invalid token'))
-  }
-})
-
-// Access user in handlers
-io.on('connection', (socket) => {
-  console.log(`Authenticated user: ${socket.data.user.email}`)
-})
-```
+|                       | `WsAdapter` (`ws`)                                           | `SocketIoAdapter`                              |
+| --------------------- | ------------------------------------------------------------ | ---------------------------------------------- |
+| **Client**            | Any WebSocket client, `{ event, data }` JSON                 | `socket.io-client` only                        |
+| **Reconnection**      | Yours to write                                               | Built in                                       |
+| **Fallback**          | WebSocket only                                               | Long-polling                                   |
+| **Rooms**             | Shared across namespaces                                     | Per namespace                                  |
+| **Acknowledgements**  | —                                                            | Via `ctx.socket`                               |
+| **Several instances** | `broker` ([Redis](./websockets.md#scaling-across-instances)) | Socket.IO adapter (`@socket.io/redis-adapter`) |
+| **Sticky sessions**   | Not needed                                                   | Needed for polling                             |
+| **Decorators**        | `@WsController`, `@OnMessage`, …                             | The same                                       |
 
 ## Sharing auth with your HTTP routes
 
-Auth is [bring-your-own](./byo-recipes.md#auth), so the piece to share is a plain function you own — not a framework strategy. Keep token verification separate from the transport, and both sides call it:
+Auth is [bring-your-own](./byo-recipes.md#auth), so the piece to share is a plain function you own. Keep token verification separate from the transport, and both sides call it:
 
 ```ts
 // src/auth/verify-token.ts — no HTTP, no socket, just the token
@@ -256,16 +190,13 @@ export function verifyToken(token: string | undefined): AuthUser | null {
 }
 ```
 
-The HTTP side calls it from the `user` contributor ([Step 3 of the recipe](./byo-recipes.md#auth)); the socket side calls it from `io.use`:
+The HTTP side calls it from the `user` contributor ([Step 3 of the recipe](./byo-recipes.md#auth)); the socket side calls it from `resolveUser`:
 
 ```ts
-import { verifyToken } from './auth/verify-token'
-
-io.use((socket, next) => {
-  const user = verifyToken(socket.handshake.auth?.token)
-  if (!user) return next(new Error('Unauthorized'))
-  socket.data.user = user
-  next()
+SocketIoAdapter({
+  auth: {
+    resolveUser: (request) => verifyToken(parseCookie(request.headers.cookie).token),
+  },
 })
 ```
 

--- a/docs/guide/websockets.md
+++ b/docs/guide/websockets.md
@@ -250,11 +250,54 @@ handleConnect(ctx: WsContext) {
 }
 ```
 
+## Scaling across instances
+
+Without a broker, a broadcast reaches only the sockets connected to the instance that sent it. With `bootstrap({ cluster })` or a second instance behind a load balancer, users on different nodes stop seeing each other the moment the second node takes traffic. Pass a `broker` to relay broadcasts between instances:
+
+<PmCommand add="ioredis" />
+
+```ts
+import Redis from 'ioredis'
+import { WsAdapter } from '@forinda/kickjs-ws'
+import { redisBroker } from '@forinda/kickjs-ws/redis'
+
+const redis = new Redis(process.env.REDIS_URL!)
+
+bootstrap({
+  modules,
+  adapters: [
+    WsAdapter({
+      // The subscriber must be its own connection: a Redis connection in
+      // subscribe mode cannot run other commands.
+      broker: redisBroker({ publisher: redis, subscriber: redis.duplicate() }),
+    }),
+  ],
+})
+```
+
+Each instance delivers a broadcast to its own sockets straight away, then publishes it; every other instance delivers it to theirs. No socket gets a frame twice.
+
+| Crosses instances                                    | Stays local                                    |
+| ---------------------------------------------------- | ---------------------------------------------- |
+| `ctx.to(room).send()`, `WS_ROOM_MANAGER.broadcast()` | `ctx.send()` — the socket is on this instance  |
+| `WS_USER_BROADCASTER`, `broadcastToUser()`           | `ctx.rooms()`, `getSockets()`, `getAllRooms()` |
+| `ctx.broadcast()`, `ctx.broadcastAll()`              | `getStats()` counts and room sizes             |
+
+Things to know:
+
+- **At-most-once.** Redis pub/sub does not store messages. An instance that is restarting or disconnected from Redis misses what was published meanwhile. Clients that must not miss events should re-fetch state on reconnect.
+- **A failed publish is logged, not thrown.** Local sockets still get the broadcast; the handler keeps running.
+- **One channel per app.** Instances share `kickjs:ws` by default. Give each app its own `channel` when several apps share a Redis.
+- **No sticky sessions needed** for WebSockets — the connection stays on the instance that accepted it. Your load balancer must allow the upgrade.
+- **Other pub/sub.** `redisBroker` accepts any client with `publish`, `subscribe`, `unsubscribe` and `on('message')`. For NATS or anything else, implement `WsBroker` (`publish`, `subscribe`, optional `close`).
+
+See [Benchmarks → WebSockets](./benchmarks.md#websockets) for measured numbers with and without a broker.
+
 ## Limits
 
 Know these before you design around the adapter:
 
-- **One process.** Rooms, `WS_ROOM_MANAGER` and `WS_USER_BROADCASTER` reach sockets in the process that holds them. With `bootstrap({ cluster })` or a second instance behind a load balancer, users on different nodes stop seeing each other — not gradually, but the moment the second node takes traffic. If you expect to scale out, put your own transport interface in front of the adapter so a broker-backed implementation can replace it without touching callers.
+- **One process without a broker.** Rooms, `WS_ROOM_MANAGER` and `WS_USER_BROADCASTER` reach only the process holding the sockets unless you configure a [broker](#scaling-across-instances).
 - **Node `bootstrap()` only.** Adapters do not run on the `@forinda/kickjs/web` entry, so there is no WebSocket support on Workers, Bun or Deno through it.
 - **Coexists with other upgrade handlers.** Devtools, a GraphQL subscription server or Vite's HMR socket can share the port; the adapter ignores upgrade paths it does not own. It answers `404` only when it is the sole upgrade listener.
 - **No context contributors.** A socket is not a request, so the per-request contributor chain does not run for WebSocket handlers. Resolve what a handler needs in `@OnConnect` and store it with `ctx.set()`.

--- a/docs/guide/websockets.md
+++ b/docs/guide/websockets.md
@@ -293,6 +293,8 @@ Things to know:
 
 See [Benchmarks → WebSockets](./benchmarks.md#websockets) for measured numbers with and without a broker.
 
+To take connections out of Node entirely, see [Centrifugo](./centrifugo.md): clients connect to Centrifugo, and your app issues tokens and publishes through its API. `WS_USER_BROADCASTER` keeps working; `@WsController` handlers do not apply.
+
 ## Limits
 
 Know these before you design around the adapter:

--- a/docs/guide/websockets.md
+++ b/docs/guide/websockets.md
@@ -16,6 +16,10 @@ bootstrap({
 
 Clients connect to: `ws://localhost:3000/ws/chat`
 
+::: tip Prefer Socket.IO?
+The same `@WsController` classes run on Socket.IO through `SocketIoAdapter` from `@forinda/kickjs-ws/socket.io` — see [Socket.IO Integration](./socketio.md).
+:::
+
 ## Decorators
 
 ### @WsController

--- a/packages/ws/README.md
+++ b/packages/ws/README.md
@@ -54,6 +54,19 @@ import { redisBroker } from '@forinda/kickjs-ws/redis'
 WsAdapter({ broker: redisBroker({ publisher: redis, subscriber: redis.duplicate() }) })
 ```
 
+## Socket.IO
+
+The same controllers run on Socket.IO (install `socket.io`):
+
+```ts
+import { SocketIoAdapter } from '@forinda/kickjs-ws/socket.io'
+
+bootstrap({ modules, adapters: [SocketIoAdapter({ cors: { origin: 'https://app.example.com' } })] })
+```
+
+Rooms are per namespace there, and `WS_ROOM_MANAGER` is replaced by the `SOCKET_IO` token.
+See [kickjs.app/guide/socketio](https://kickjs.app/guide/socketio).
+
 ## Documentation
 
 [kickjs.app/guide/websockets](https://kickjs.app/guide/websockets)

--- a/packages/ws/README.md
+++ b/packages/ws/README.md
@@ -44,9 +44,15 @@ Clients connect to `ws://localhost:3000/ws/chat`.
 
 ## Limits
 
-Runs in **one Node process** under `bootstrap()`. Rooms and per-user broadcasts
-reach sockets in that process only, so a second instance is a second island. It
-does not run on the `@forinda/kickjs/web` edge entry (Workers, Bun, Deno).
+Runs under Node `bootstrap()`, not the `@forinda/kickjs/web` edge entry
+(Workers, Bun, Deno). Rooms and broadcasts reach sockets in one process unless
+you pass a `broker`:
+
+```ts
+import { redisBroker } from '@forinda/kickjs-ws/redis'
+
+WsAdapter({ broker: redisBroker({ publisher: redis, subscriber: redis.duplicate() }) })
+```
 
 ## Documentation
 

--- a/packages/ws/__tests__/broker.integration.test.ts
+++ b/packages/ws/__tests__/broker.integration.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Cross-instance fan-out: two WsAdapter instances, each on its own HTTP
+ * server, joined by a broker. An in-memory hub stands in for pub/sub; the last
+ * suite runs the same checks over real Redis when REDIS_URL is set.
+ *
+ * @module @forinda/kickjs-ws/__tests__/broker.integration.test
+ */
+import 'reflect-metadata'
+import http from 'node:http'
+import { EventEmitter } from 'node:events'
+import type { AddressInfo } from 'node:net'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { WebSocket } from 'ws'
+import Redis from 'ioredis'
+import { Container } from '@forinda/kickjs'
+import {
+  WsAdapter,
+  WsController,
+  OnConnect,
+  OnMessage,
+  type WsBroker,
+  type WsBrokerMessage,
+  type WsContext,
+} from '@forinda/kickjs-ws'
+import { redisBroker } from '../src/redis'
+
+@WsController('/chat')
+class ChatController {
+  @OnConnect()
+  connect(ctx: WsContext) {
+    ctx.join('lobby')
+  }
+
+  @OnMessage('room')
+  room(ctx: WsContext) {
+    ctx.to('lobby').send('room', ctx.data)
+  }
+
+  @OnMessage('others')
+  others(ctx: WsContext) {
+    ctx.broadcast('others', ctx.data)
+  }
+
+  @OnMessage('all')
+  all(ctx: WsContext) {
+    ctx.broadcastAll('all', ctx.data)
+  }
+}
+void ChatController
+
+const cleanups: Array<() => unknown> = []
+beforeEach(() => {
+  Container.reset()
+})
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()!()
+})
+
+/** Pub/sub in one process. Round-trips through JSON like a real broker. */
+function memoryHub(): () => WsBroker {
+  const subscribers: Array<(message: WsBrokerMessage) => void> = []
+  return () => ({
+    publish(message) {
+      for (const deliver of subscribers) deliver(JSON.parse(JSON.stringify(message)))
+    },
+    subscribe(onMessage) {
+      subscribers.push(onMessage)
+    },
+  })
+}
+
+async function instance(options: Record<string, unknown>) {
+  const server = http.createServer()
+  const adapter = WsAdapter({ heartbeatInterval: 0, ...options }) as any
+  await adapter.beforeStart({ container: Container.getInstance() })
+  await adapter.afterStart({ server })
+  await new Promise<void>((resolve) => server.listen(0, resolve))
+  const port = (server.address() as AddressInfo).port
+  cleanups.push(async () => {
+    await adapter.shutdown()
+    server.close()
+  })
+  return { adapter, url: (path: string) => `ws://127.0.0.1:${port}${path}` }
+}
+
+/** A client that records every `event:data` it receives. */
+async function client(url: string) {
+  const ws = new WebSocket(url)
+  const got: string[] = []
+  ws.on('message', (raw) => {
+    const { event, data } = JSON.parse(String(raw))
+    got.push(`${event}:${data}`)
+  })
+  cleanups.push(() => ws.terminate())
+  await new Promise((resolve, reject) => {
+    ws.once('open', resolve)
+    ws.once('error', reject)
+  })
+  return {
+    ws,
+    got,
+    send: (event: string, data: string) => ws.send(JSON.stringify({ event, data })),
+  }
+}
+
+async function waitFor(check: () => boolean, ms = 2000): Promise<void> {
+  const until = Date.now() + ms
+  while (!check()) {
+    if (Date.now() > until) throw new Error('condition not met in time')
+    await new Promise((r) => setTimeout(r, 10))
+  }
+}
+const settle = () => new Promise((r) => setTimeout(r, 100))
+
+/** Two instances; `a` and `b` on the first, `c` on the second, all in `lobby`. */
+async function cluster(brokerFor: () => WsBroker, options: Record<string, unknown> = {}) {
+  const one = await instance({ broker: brokerFor(), ...options })
+  const two = await instance({ broker: brokerFor(), ...options })
+  const a = await client(one.url('/ws/chat'))
+  const b = await client(one.url('/ws/chat'))
+  const c = await client(two.url('/ws/chat'))
+  await waitFor(
+    () => one.adapter.getStats().rooms.lobby === 2 && two.adapter.getStats().rooms.lobby === 1,
+  )
+  return { one, two, a, b, c }
+}
+
+function crossInstanceSuite(name: string, brokerFor: () => () => WsBroker) {
+  describe(name, () => {
+    it('delivers a room broadcast to members on every instance, once each', async () => {
+      const { a, b, c } = await cluster(brokerFor())
+      a.send('room', 'hi')
+      await waitFor(() => c.got.length === 1)
+      await settle()
+      expect([a.got, b.got, c.got]).toEqual([['room:hi'], ['room:hi'], ['room:hi']])
+    })
+
+    it('ctx.broadcast skips the sender everywhere; broadcastAll includes it', async () => {
+      const { a, b, c } = await cluster(brokerFor())
+      a.send('others', 'x')
+      a.send('all', 'y')
+      await waitFor(() => c.got.length === 2)
+      await settle()
+      expect(a.got).toEqual(['all:y'])
+      expect(b.got).toEqual(['others:x', 'all:y'])
+      expect(c.got).toEqual(['others:x', 'all:y'])
+    })
+
+    it('broadcastToUser from one instance reaches the user on another', async () => {
+      const auth = {
+        resolveUser: (req: http.IncomingMessage) => ({
+          id: new URL(req.url!, 'http://x').searchParams.get('user')!,
+        }),
+      }
+      const make = brokerFor()
+      const one = await instance({ broker: make(), auth })
+      const two = await instance({ broker: make(), auth })
+      const alice = await client(one.url('/ws/chat?user=alice'))
+      await waitFor(() => one.adapter.getStats().rooms['user:alice'] === 1)
+
+      two.adapter.broadcastToUser('alice', 'ping', 'from-two')
+      await waitFor(() => alice.got.length === 1)
+      await settle()
+      expect(alice.got).toEqual(['ping:from-two'])
+    })
+  })
+}
+
+crossInstanceSuite('WsAdapter broker (in-memory hub)', () => memoryHub())
+
+describe('WsAdapter broker failures', () => {
+  it('logs a failed publish instead of throwing out of the handler', async () => {
+    const failing: WsBroker = {
+      publish: () => Promise.reject(new Error('redis down')),
+      subscribe: () => {},
+    }
+    const { url } = await instance({ broker: failing })
+    const a = await client(url('/ws/chat'))
+    const b = await client(url('/ws/chat'))
+    await new Promise((r) => setTimeout(r, 30))
+    a.send('room', 'still-local')
+    await waitFor(() => b.got.length === 1)
+    expect(b.got).toEqual(['room:still-local'])
+  })
+})
+
+describe('redisBroker', () => {
+  function fakeRedis() {
+    const bus = new EventEmitter()
+    const subscriber = Object.assign(bus, {
+      subscribe: vi.fn(async () => {}),
+      unsubscribe: vi.fn(async () => {}),
+    })
+    const publisher = {
+      publish: vi.fn(async (channel: string, message: string) => {
+        bus.emit('message', channel, message)
+      }),
+    }
+    return { publisher, subscriber }
+  }
+
+  it('publishes JSON on its channel and ignores other channels and non-JSON', async () => {
+    const { publisher, subscriber } = fakeRedis()
+    const broker = redisBroker({ publisher: publisher as any, subscriber: subscriber as any })
+    const seen: WsBrokerMessage[] = []
+    await broker.subscribe((m) => seen.push(m))
+    expect(subscriber.subscribe).toHaveBeenCalledWith('kickjs:ws')
+
+    const message = { origin: 'i1', room: 'lobby', event: 'e', data: 1 }
+    await broker.publish(message)
+    subscriber.emit('message', 'other-app', JSON.stringify(message))
+    subscriber.emit('message', 'kickjs:ws', 'not json')
+    expect(seen).toEqual([message])
+
+    await broker.close!()
+    expect(subscriber.unsubscribe).toHaveBeenCalledWith('kickjs:ws')
+    await broker.publish(message)
+    expect(seen).toHaveLength(1)
+  })
+})
+
+const REDIS_URL = process.env.REDIS_URL
+describe.skipIf(!REDIS_URL)('WsAdapter broker (real Redis)', () => {
+  // One channel per run so a parallel run against the same Redis cannot cross.
+  const channel = `kickjs:ws:test:${process.pid}`
+  crossInstanceSuite('over ioredis', () => () => {
+    const publisher = new Redis(REDIS_URL!)
+    const subscriber = publisher.duplicate()
+    // Queued before the adapter's own cleanup, so it runs after shutdown has
+    // unsubscribed — disconnecting first made `unsubscribe` hit a closed socket.
+    cleanups.push(() => {
+      publisher.disconnect()
+      subscriber.disconnect()
+    })
+    return redisBroker({ publisher, subscriber, channel })
+  })
+})

--- a/packages/ws/__tests__/centrifugo.test.ts
+++ b/packages/ws/__tests__/centrifugo.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Centrifugo integration: the server API client against a local fake of
+ * Centrifugo's HTTP API, the HS256 connection token, the connect-proxy reply,
+ * and the adapter's DI registrations. The last suite runs against a real
+ * Centrifugo when CENTRIFUGO_URL is set (see the suite for the config it expects).
+ *
+ * @module @forinda/kickjs-ws/__tests__/centrifugo.test
+ */
+import 'reflect-metadata'
+import http from 'node:http'
+import { createHmac } from 'node:crypto'
+import type { AddressInfo } from 'node:net'
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { WebSocket } from 'ws'
+import { Container } from '@forinda/kickjs'
+import { WS_USER_BROADCASTER } from '@forinda/kickjs-ws'
+import {
+  CENTRIFUGO,
+  CentrifugoAdapter,
+  CentrifugoApiError,
+  centrifugoClient,
+  centrifugoConnect,
+  connectionToken,
+} from '../src/centrifugo'
+
+const cleanups: Array<() => unknown> = []
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()!()
+})
+
+interface Call {
+  path: string
+  apiKey: string | undefined
+  body: any
+}
+
+/** Centrifugo's HTTP API shape: 200 + `result`, or 200 + `error` (its default error mode). */
+async function fakeCentrifugo() {
+  const calls: Call[] = []
+  const server = http.createServer((req, res) => {
+    let raw = ''
+    req.on('data', (c) => (raw += c))
+    req.on('end', () => {
+      const body = JSON.parse(raw)
+      calls.push({ path: req.url!, apiKey: req.headers['x-api-key'] as string, body })
+      if (body.channel === 'boom') {
+        res.writeHead(500).end()
+        return
+      }
+      res.setHeader('Content-Type', 'application/json')
+      res.end(
+        JSON.stringify(
+          body.channel === 'unknown'
+            ? { error: { code: 102, message: 'unknown channel' } }
+            : { result: {} },
+        ),
+      )
+    })
+  })
+  await new Promise<void>((resolve) => server.listen(0, resolve))
+  cleanups.push(() => server.close())
+  const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+  return { url, calls }
+}
+
+describe('centrifugoClient', () => {
+  it('posts each method to /api/<method> with X-API-Key and the documented body', async () => {
+    const { url, calls } = await fakeCentrifugo()
+    const client = centrifugoClient({ url: `${url}/`, apiKey: 'k1' })
+
+    await client.publish('news', { title: 'hi' })
+    await client.broadcast(['a', 'b'], 1)
+    await client.subscribe('alice', 'news')
+    await client.disconnect('alice')
+
+    expect(calls).toEqual([
+      { path: '/api/publish', apiKey: 'k1', body: { channel: 'news', data: { title: 'hi' } } },
+      { path: '/api/broadcast', apiKey: 'k1', body: { channels: ['a', 'b'], data: 1 } },
+      { path: '/api/subscribe', apiKey: 'k1', body: { user: 'alice', channel: 'news' } },
+      { path: '/api/disconnect', apiKey: 'k1', body: { user: 'alice' } },
+    ])
+  })
+
+  it('throws on an error object in a 200 reply', async () => {
+    const { url } = await fakeCentrifugo()
+    const err = await centrifugoClient({ url, apiKey: 'k' })
+      .publish('unknown', 1)
+      .catch((e) => e)
+    expect(err).toBeInstanceOf(CentrifugoApiError)
+    expect(err).toMatchObject({ method: 'publish', code: 102 })
+    expect(err.message).toContain('unknown channel')
+  })
+
+  it('throws on a non-2xx reply', async () => {
+    const { url } = await fakeCentrifugo()
+    await expect(centrifugoClient({ url, apiKey: 'k' }).publish('boom', 1)).rejects.toMatchObject({
+      code: 500,
+    })
+  })
+})
+
+describe('connectionToken', () => {
+  const decode = (part: string) => JSON.parse(Buffer.from(part, 'base64url').toString())
+
+  it('signs HS256 over header.payload with the secret and carries the claims', () => {
+    const token = connectionToken({
+      secret: 's3cret',
+      sub: 'alice',
+      expiresInSeconds: 60,
+      info: { name: 'Alice' },
+      channels: ['news'],
+    })
+    const [header, payload, signature] = token.split('.')
+
+    expect(decode(header)).toEqual({ alg: 'HS256', typ: 'JWT' })
+    const expected = createHmac('sha256', 's3cret')
+      .update(`${header}.${payload}`)
+      .digest('base64url')
+    expect(signature).toBe(expected)
+
+    const claims = decode(payload)
+    expect(claims).toMatchObject({ sub: 'alice', info: { name: 'Alice' }, channels: ['news'] })
+    const now = Math.floor(Date.now() / 1000)
+    expect(claims.exp).toBeGreaterThanOrEqual(now + 59)
+    expect(claims.exp).toBeLessThanOrEqual(now + 60)
+  })
+
+  it('omits exp when no lifetime is given', () => {
+    const [, payload] = connectionToken({ secret: 's', sub: 'u' }).split('.')
+    expect(decode(payload)).toEqual({ sub: 'u' })
+  })
+})
+
+describe('centrifugoConnect', () => {
+  it('returns the user id as a string', async () => {
+    await expect(centrifugoConnect({}, () => ({ id: 42 as unknown as string }))).resolves.toEqual({
+      result: { user: '42' },
+    })
+  })
+
+  it('disconnects with 4401 when there is no user', async () => {
+    const rejected = { disconnect: { code: 4401, reason: 'unauthorized' } }
+    await expect(centrifugoConnect({}, async () => null)).resolves.toEqual(rejected)
+    await expect(centrifugoConnect({}, () => ({ id: '' }))).resolves.toEqual(rejected)
+  })
+
+  it('answers internal error 100 when the resolver throws', async () => {
+    await expect(
+      centrifugoConnect({}, () => {
+        throw new Error('db down')
+      }),
+    ).resolves.toEqual({ error: { code: 100, message: 'internal server error' } })
+  })
+})
+
+describe('CentrifugoAdapter', () => {
+  beforeEach(() => Container.reset())
+
+  async function start(options: { personalChannelNamespace?: string } = {}) {
+    const { url, calls } = await fakeCentrifugo()
+    const adapter = CentrifugoAdapter({ url, apiKey: 'k', ...options }) as any
+    await adapter.beforeStart({ container: Container.getInstance() })
+    return { calls, container: Container.getInstance() }
+  }
+
+  it('registers CENTRIFUGO and a user broadcaster publishing to #<user>', async () => {
+    const { calls, container } = await start()
+    expect(typeof container.resolve(CENTRIFUGO).publish).toBe('function')
+
+    const users = container.resolve(WS_USER_BROADCASTER)
+    expect(users.roomFor('alice')).toBe('#alice')
+    users.toUser('alice').send('ping', 1)
+    await new Promise((r) => setTimeout(r, 50))
+    expect(calls).toEqual([
+      {
+        path: '/api/publish',
+        apiKey: 'k',
+        body: { channel: '#alice', data: { event: 'ping', data: 1 } },
+      },
+    ])
+  })
+
+  it('uses <namespace>:#<user> when a personal channel namespace is set', async () => {
+    const { container } = await start({ personalChannelNamespace: 'personal' })
+    expect(container.resolve(WS_USER_BROADCASTER).roomFor('alice')).toBe('personal:#alice')
+  })
+})
+
+/**
+ * Needs a Centrifugo v6 on CENTRIFUGO_URL reachable at 127.0.0.1 (e.g.
+ * `docker run --network host`) started with:
+ *   CENTRIFUGO_HTTP_API_KEY=api-key
+ *   CENTRIFUGO_CLIENT_TOKEN_HMAC_SECRET_KEY=hmac-secret
+ *   CENTRIFUGO_CLIENT_ALLOWED_ORIGINS=*
+ *   CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_ALLOW_SUBSCRIBE_FOR_CLIENT=true
+ *   CENTRIFUGO_CLIENT_SUBSCRIBE_TO_USER_PERSONAL_CHANNEL_ENABLED=true
+ *   CENTRIFUGO_CLIENT_PROXY_CONNECT_ENABLED=true
+ *   CENTRIFUGO_CLIENT_PROXY_CONNECT_ENDPOINT=http://127.0.0.1:4799/centrifugo/connect
+ *   CENTRIFUGO_CLIENT_PROXY_CONNECT_HTTP_HEADERS=Cookie
+ */
+const CENTRIFUGO_URL = process.env.CENTRIFUGO_URL
+describe.skipIf(!CENTRIFUGO_URL)('Centrifugo (real server)', () => {
+  const wsUrl = `${CENTRIFUGO_URL?.replace(/^http/, 'ws')}/connection/websocket`
+
+  /** A raw client speaking Centrifugo's JSON protocol: newline-delimited replies per frame. */
+  async function connect(command: object, headers: Record<string, string> = {}) {
+    const ws = new WebSocket(wsUrl, { headers })
+    cleanups.push(() => ws.terminate())
+    const replies: any[] = []
+    ws.on('message', (raw) => {
+      for (const line of String(raw).split('\n').filter(Boolean)) {
+        const reply = JSON.parse(line)
+        if (Object.keys(reply).length === 0) ws.send('{}') // ping → pong
+        else replies.push(reply)
+      }
+    })
+    const closed = new Promise<number>((resolve) => ws.once('close', resolve))
+    await new Promise((resolve, reject) => {
+      ws.once('open', resolve)
+      ws.once('error', reject)
+    })
+    ws.send(JSON.stringify({ id: 1, connect: command }))
+    return { ws, replies, closed }
+  }
+
+  async function waitFor(check: () => boolean, ms = 3000): Promise<void> {
+    const until = Date.now() + ms
+    while (!check()) {
+      if (Date.now() > until) throw new Error('condition not met in time')
+      await new Promise((r) => setTimeout(r, 20))
+    }
+  }
+
+  const client = () => centrifugoClient({ url: CENTRIFUGO_URL!, apiKey: 'api-key' })
+
+  it('accepts a connectionToken and delivers a publish to a subscribed channel', async () => {
+    const token = connectionToken({ secret: 'hmac-secret', sub: 'alice', expiresInSeconds: 60 })
+    const { ws, replies } = await connect({ token })
+    await waitFor(() => replies.some((r) => r.id === 1))
+    expect(replies.find((r) => r.id === 1)).toHaveProperty('connect')
+
+    ws.send(JSON.stringify({ id: 2, subscribe: { channel: 'news' } }))
+    await waitFor(() => replies.some((r) => r.id === 2))
+    await client().publish('news', { title: 'hello' })
+
+    await waitFor(() => replies.some((r) => r.push?.channel === 'news'))
+    expect(replies.find((r) => r.push?.channel === 'news').push.pub.data).toEqual({
+      title: 'hello',
+    })
+  })
+
+  it('rejects a token signed with the wrong secret', async () => {
+    const token = connectionToken({ secret: 'wrong', sub: 'alice' })
+    const { replies, closed } = await connect({ token })
+    const outcome = await Promise.race([
+      closed.then((code) => ({ code })),
+      waitFor(() => replies.some((r) => r.id === 1)).then(() => replies.find((r) => r.id === 1)),
+    ])
+    expect(outcome).not.toHaveProperty('connect')
+  })
+
+  it('WS_USER_BROADCASTER reaches the user on their personal channel', async () => {
+    Container.reset()
+    const adapter = CentrifugoAdapter({ url: CENTRIFUGO_URL!, apiKey: 'api-key' }) as any
+    await adapter.beforeStart({ container: Container.getInstance() })
+
+    const token = connectionToken({ secret: 'hmac-secret', sub: 'bob', expiresInSeconds: 60 })
+    const { replies } = await connect({ token })
+    await waitFor(() => replies.some((r) => r.id === 1))
+
+    Container.getInstance().resolve(WS_USER_BROADCASTER).broadcastToUser('bob', 'ping', 7)
+    await waitFor(() => replies.some((r) => r.push?.channel === '#bob'))
+    expect(replies.find((r) => r.push?.channel === '#bob').push.pub.data).toEqual({
+      event: 'ping',
+      data: 7,
+    })
+  })
+
+  describe('connect proxy', () => {
+    beforeEach(async () => {
+      // The route an app would mount: forward the proxy body's request to
+      // centrifugoConnect with the app's resolveUser.
+      const server = http.createServer(async (req, res) => {
+        req.resume()
+        const reply = await centrifugoConnect(req, (r) => {
+          const sid = /sid=(\w+)/.exec(r.headers.cookie ?? '')?.[1]
+          return sid ? { id: sid } : null
+        })
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify(reply))
+      })
+      await new Promise<void>((resolve) => server.listen(4799, '127.0.0.1', resolve))
+      cleanups.push(() => server.close())
+    })
+
+    it('connects the user resolveUser returns, from the forwarded cookie', async () => {
+      const { replies } = await connect({}, { Cookie: 'sid=carol' })
+      await waitFor(() => replies.some((r) => r.id === 1))
+      expect(replies.find((r) => r.id === 1).connect).toBeDefined()
+    })
+
+    it('closes with 4401 when resolveUser returns null', async () => {
+      const { closed } = await connect({})
+      expect(await closed).toBe(4401)
+    })
+  })
+})

--- a/packages/ws/__tests__/socket-io.test.ts
+++ b/packages/ws/__tests__/socket-io.test.ts
@@ -1,0 +1,229 @@
+/**
+ * SocketIoAdapter against a real HTTP server and real socket.io-client
+ * connections, serving ordinary `@WsController` classes.
+ *
+ * @module @forinda/kickjs-ws/__tests__/socket-io.test
+ */
+import 'reflect-metadata'
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { io as connectClient, type Socket as ClientSocket } from 'socket.io-client'
+import Redis from 'ioredis'
+import { createAdapter } from '@socket.io/redis-adapter'
+import { Container } from '@forinda/kickjs'
+import { WsController, OnConnect, OnMessage, WS_USER_BROADCASTER } from '@forinda/kickjs-ws'
+import { SocketIoAdapter, SOCKET_IO, type SocketIoContext } from '../src/socket-io'
+
+const seen: string[] = []
+
+@WsController('/chat')
+class ChatController {
+  @OnConnect()
+  connect(ctx: SocketIoContext) {
+    seen.push('chat:connect')
+    ctx.join('lobby')
+  }
+
+  @OnMessage('echo')
+  echo(ctx: SocketIoContext) {
+    ctx.send('echo', ctx.data)
+  }
+
+  @OnMessage('room')
+  room(ctx: SocketIoContext) {
+    ctx.to('lobby').send('room', ctx.data)
+  }
+
+  @OnMessage('others')
+  others(ctx: SocketIoContext) {
+    ctx.broadcast('others', ctx.data)
+  }
+
+  @OnMessage('all')
+  all(ctx: SocketIoContext) {
+    ctx.broadcastAll('all', ctx.data)
+  }
+
+  @OnMessage('*')
+  unknown(ctx: SocketIoContext) {
+    ctx.send('unknown', ctx.event)
+  }
+}
+
+@WsController('/alerts')
+class AlertsController {}
+
+@WsController('/slow')
+class SlowController {
+  @OnConnect()
+  async connect() {
+    seen.push('slow:connect:start')
+    await new Promise((r) => setTimeout(r, 50))
+    seen.push('slow:connect:end')
+  }
+
+  @OnMessage('ping')
+  ping() {
+    seen.push('slow:ping')
+  }
+}
+void ChatController
+void AlertsController
+void SlowController
+
+const cleanups: Array<() => unknown> = []
+beforeEach(() => {
+  seen.length = 0
+  Container.reset()
+})
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()!()
+})
+
+async function boot(options: Record<string, unknown> = {}) {
+  const server = http.createServer()
+  const adapter = SocketIoAdapter(options as any) as any
+  await adapter.beforeStart({ container: Container.getInstance() })
+  await adapter.afterStart({ server })
+  await new Promise<void>((resolve) => server.listen(0, resolve))
+  const port = (server.address() as AddressInfo).port
+  cleanups.push(async () => {
+    await adapter.shutdown()
+    server.close()
+  })
+  return { server, adapter, origin: `http://127.0.0.1:${port}` }
+}
+
+/** A client that records every `event:data` it receives. */
+async function client(url: string, query: Record<string, string> = {}) {
+  const socket: ClientSocket = connectClient(url, {
+    transports: ['websocket'],
+    forceNew: true,
+    reconnection: false,
+    query,
+  })
+  const got: string[] = []
+  socket.onAny((event, data) => got.push(`${event}:${data}`))
+  cleanups.push(() => socket.disconnect())
+  await new Promise<void>((resolve, reject) => {
+    socket.once('connect', () => resolve())
+    socket.once('connect_error', reject)
+  })
+  return { socket, got }
+}
+
+async function waitFor(check: () => boolean, ms = 2000): Promise<void> {
+  const until = Date.now() + ms
+  while (!check()) {
+    if (Date.now() > until) throw new Error('condition not met in time')
+    await new Promise((r) => setTimeout(r, 10))
+  }
+}
+const settle = () => new Promise((r) => setTimeout(r, 100))
+
+const userFromQuery = {
+  resolveUser: (req: http.IncomingMessage) => {
+    const id = new URL(req.url!, 'http://x').searchParams.get('user')
+    return id ? { id } : null
+  },
+}
+
+describe('SocketIoAdapter routing', () => {
+  it('routes emits to @OnMessage handlers and replies with ctx.send', async () => {
+    const { origin } = await boot()
+    const a = await client(`${origin}/chat`)
+    a.socket.emit('echo', 'hi')
+    a.socket.emit('nope', 1)
+    await waitFor(() => a.got.length === 2)
+    expect(a.got).toEqual(['echo:hi', 'unknown:nope'])
+  })
+
+  it('to(room) and broadcastAll include the sender; broadcast skips it', async () => {
+    const { origin } = await boot()
+    const a = await client(`${origin}/chat`)
+    const b = await client(`${origin}/chat`)
+    await waitFor(() => seen.filter((s) => s === 'chat:connect').length === 2)
+    await settle()
+
+    a.socket.emit('room', 'r')
+    a.socket.emit('others', 'o')
+    a.socket.emit('all', 'x')
+    await waitFor(() => b.got.length === 3)
+    await settle()
+    expect(a.got).toEqual(['room:r', 'all:x'])
+    expect(b.got).toEqual(['room:r', 'others:o', 'all:x'])
+  })
+
+  it('holds events until an async @OnConnect settles', async () => {
+    const { origin } = await boot()
+    const s = await client(`${origin}/slow`)
+    s.socket.emit('ping')
+    await waitFor(() => seen.includes('slow:ping'))
+    expect(seen).toEqual(['slow:connect:start', 'slow:connect:end', 'slow:ping'])
+  })
+})
+
+describe('SocketIoAdapter auth', () => {
+  it('rejects with connect_error "Unauthorized" and never runs @OnConnect', async () => {
+    const { origin } = await boot({ auth: userFromQuery })
+    const socket = connectClient(`${origin}/chat`, {
+      transports: ['websocket'],
+      forceNew: true,
+      reconnection: false,
+    })
+    cleanups.push(() => socket.disconnect())
+    const err = await new Promise<Error>((resolve) => socket.once('connect_error', resolve))
+    expect(err.message).toBe('Unauthorized')
+    expect(seen).not.toContain('chat:connect')
+  })
+
+  it('WS_USER_BROADCASTER reaches the user in every namespace', async () => {
+    const { origin } = await boot({ auth: userFromQuery })
+    const chat = await client(`${origin}/chat`, { user: 'alice' })
+    const alerts = await client(`${origin}/alerts`, { user: 'alice' })
+    const bob = await client(`${origin}/chat`, { user: 'bob' })
+    await settle()
+
+    Container.getInstance().resolve(WS_USER_BROADCASTER).broadcastToUser('alice', 'ping', 1)
+    await waitFor(() => chat.got.length === 1 && alerts.got.length === 1)
+    await settle()
+    expect([chat.got, alerts.got, bob.got]).toEqual([['ping:1'], ['ping:1'], []])
+  })
+})
+
+describe('SocketIoAdapter lifecycle', () => {
+  it('registers SOCKET_IO and shuts down without closing the HTTP server', async () => {
+    const { server, adapter } = await boot()
+    expect(Container.getInstance().resolve(SOCKET_IO)).toBeDefined()
+    await adapter.shutdown()
+    expect(server.listening).toBe(true)
+  })
+})
+
+const REDIS_URL = process.env.REDIS_URL
+describe.skipIf(!REDIS_URL)('SocketIoAdapter across instances (@socket.io/redis-adapter)', () => {
+  it('delivers room and per-user emits to sockets on another instance', async () => {
+    const adapterFor = () => {
+      const pub = new Redis(REDIS_URL!)
+      const sub = pub.duplicate()
+      cleanups.push(() => {
+        pub.disconnect()
+        sub.disconnect()
+      })
+      return createAdapter(pub, sub, { key: `kickjs-test-${process.pid}` })
+    }
+    const one = await boot({ auth: userFromQuery, adapter: adapterFor() })
+    const two = await boot({ auth: userFromQuery, adapter: adapterFor() })
+    const alice = await client(`${one.origin}/chat`, { user: 'alice' })
+    const bob = await client(`${two.origin}/chat`, { user: 'bob' })
+    await settle()
+
+    bob.socket.emit('room', 'from-two')
+    await waitFor(() => alice.got.includes('room:from-two'))
+
+    // The last boot registered WS_USER_BROADCASTER, so this is instance two's.
+    Container.getInstance().resolve(WS_USER_BROADCASTER).broadcastToUser('alice', 'dm', 'hi')
+    await waitFor(() => alice.got.includes('dm:hi'))
+  })
+})

--- a/packages/ws/bench/server.mjs
+++ b/packages/ws/bench/server.mjs
@@ -21,9 +21,18 @@ OnMessage('echo')(BenchController.prototype, 'echo')
 OnMessage('fan')(BenchController.prototype, 'fan')
 WsController('/bench')(BenchController)
 
+// REDIS_URL set: instances share rooms through the Redis broker.
+let broker
+if (process.env.REDIS_URL) {
+  const { default: Redis } = await import('ioredis')
+  const { redisBroker } = await import('@forinda/kickjs-ws/redis')
+  const publisher = new Redis(process.env.REDIS_URL)
+  broker = redisBroker({ publisher, subscriber: publisher.duplicate() })
+}
+
 const port = Number(process.argv[2])
 const server = http.createServer()
-const adapter = WsAdapter({ heartbeatInterval: 0 })
+const adapter = WsAdapter({ heartbeatInterval: 0, broker })
 await adapter.beforeStart({ container: Container.getInstance() })
 await adapter.afterStart({ server })
 await new Promise((resolve) => server.listen(port, resolve))

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -26,6 +26,10 @@
     "./redis": {
       "import": "./dist/redis.mjs",
       "types": "./dist/redis.d.mts"
+    },
+    "./centrifugo": {
+      "import": "./dist/centrifugo.mjs",
+      "types": "./dist/centrifugo.d.mts"
     }
   },
   "files": [

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -22,6 +22,10 @@
     ".": {
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.mts"
+    },
+    "./redis": {
+      "import": "./dist/redis.mjs",
+      "types": "./dist/redis.d.mts"
     }
   },
   "files": [
@@ -44,6 +48,7 @@
     "@swc/core": "^1.16.1",
     "@types/node": "^26.4.1",
     "@types/ws": "^8.18.0",
+    "ioredis": "^5.10.1",
     "typescript": "^7.0.2",
     "vitest": "^5.0.0",
     "ws": "^8.21.3"

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -26,6 +26,10 @@
     "./redis": {
       "import": "./dist/redis.mjs",
       "types": "./dist/redis.d.mts"
+    },
+    "./socket.io": {
+      "import": "./dist/socket-io.mjs",
+      "types": "./dist/socket-io.d.mts"
     }
   },
   "files": [
@@ -45,10 +49,13 @@
   },
   "devDependencies": {
     "@forinda/kickjs": "workspace:*",
+    "@socket.io/redis-adapter": "^8.3.0",
     "@swc/core": "^1.16.1",
     "@types/node": "^26.4.1",
     "@types/ws": "^8.18.0",
     "ioredis": "^5.10.1",
+    "socket.io": "^4.8.3",
+    "socket.io-client": "^4.8.3",
     "typescript": "^7.0.2",
     "vitest": "^5.0.0",
     "ws": "^8.21.3"
@@ -72,7 +79,12 @@
   },
   "peerDependencies": {
     "@forinda/kickjs": ">=5.18.0",
+    "socket.io": "^4.0.0",
     "ws": "^8.0.0"
   },
-  "peerDependenciesMeta": {}
+  "peerDependenciesMeta": {
+    "socket.io": {
+      "optional": true
+    }
+  }
 }

--- a/packages/ws/src/centrifugo.ts
+++ b/packages/ws/src/centrifugo.ts
@@ -1,0 +1,207 @@
+/**
+ * Centrifugo integration. Centrifugo holds the client connections; KickJS
+ * issues connection tokens (or answers its connect proxy) and publishes
+ * through its server API.
+ *
+ * ```ts
+ * import { CentrifugoAdapter } from '@forinda/kickjs-ws/centrifugo'
+ *
+ * bootstrap({
+ *   modules,
+ *   adapters: [CentrifugoAdapter({ url: 'http://centrifugo:8000', apiKey: process.env.CENTRIFUGO_API_KEY! })],
+ * })
+ * ```
+ *
+ * `@WsController` / `@OnMessage` do not apply here: those handle sockets the
+ * Node process owns, and with Centrifugo it owns none.
+ *
+ * @module @forinda/kickjs-ws/centrifugo
+ */
+import { createHmac } from 'node:crypto'
+import { createLogger, createToken, defineAdapter } from '@forinda/kickjs'
+import { WS_USER_BROADCASTER, type WsAuthenticatedUser, type WsUserBroadcaster } from './interfaces'
+
+const log = createLogger('CentrifugoAdapter')
+
+export interface CentrifugoClientOptions {
+  /** Centrifugo base URL, e.g. `http://centrifugo:8000`. The client calls `<url>/api/<method>`. */
+  url: string
+  /** `http_api.key` from the Centrifugo config, sent as `X-API-Key`. */
+  apiKey: string
+  /** Defaults to the global `fetch`. */
+  fetch?: typeof fetch
+}
+
+/** Centrifugo server API — the subset KickJS services need. */
+export interface CentrifugoClient {
+  /** Publish `data` (any JSON value) to one channel. */
+  publish(channel: string, data: unknown): Promise<void>
+  /** Publish the same `data` to several channels in one call. */
+  broadcast(channels: string[], data: unknown): Promise<void>
+  /** Subscribe every connection of `user` to `channel`, server-side. */
+  subscribe(user: string, channel: string): Promise<void>
+  /** Disconnect every connection of `user`. */
+  disconnect(user: string): Promise<void>
+}
+
+/** Thrown when Centrifugo answers non-2xx, or 200 with an `error` object. */
+export class CentrifugoApiError extends Error {
+  constructor(
+    readonly method: string,
+    readonly code: number,
+    message: string,
+  ) {
+    super(`Centrifugo ${method} failed (${code}): ${message}`)
+    this.name = 'CentrifugoApiError'
+  }
+}
+
+export function centrifugoClient({
+  url,
+  apiKey,
+  fetch: fetchImpl = globalThis.fetch,
+}: CentrifugoClientOptions): CentrifugoClient {
+  const base = url.replace(/\/+$/, '')
+
+  const call = async (method: string, body: Record<string, unknown>): Promise<void> => {
+    const res = await fetchImpl(`${base}/api/${method}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey },
+      body: JSON.stringify(body),
+    })
+    if (!res.ok) throw new CentrifugoApiError(method, res.status, res.statusText || 'HTTP error')
+    // By default Centrifugo reports API errors with HTTP 200 and an `error`
+    // object in the body (internal/api/handler_gen.go); only the opt-in
+    // transport error mode maps them to HTTP status codes.
+    const reply = (await res.json().catch(() => ({}))) as {
+      error?: { code: number; message: string }
+    }
+    if (reply.error) throw new CentrifugoApiError(method, reply.error.code, reply.error.message)
+  }
+
+  return {
+    publish: (channel, data) => call('publish', { channel, data }),
+    broadcast: (channels, data) => call('broadcast', { channels, data }),
+    subscribe: (user, channel) => call('subscribe', { user, channel }),
+    disconnect: (user) => call('disconnect', { user }),
+  }
+}
+
+export interface ConnectionTokenOptions {
+  /** `client.token.hmac_secret_key` from the Centrifugo config. */
+  secret: string
+  /** User id. An empty string connects anonymously, if Centrifugo allows it. */
+  sub: string
+  /** Token lifetime. Omit for a token that never expires. */
+  expiresInSeconds?: number
+  /** Connection info, visible to other clients in presence and join/leave events. */
+  info?: unknown
+  /** Channels to subscribe the connection to server-side. */
+  channels?: string[]
+}
+
+const base64url = (input: string | Buffer): string => Buffer.from(input).toString('base64url')
+
+/**
+ * An HS256 connection JWT. Claims follow Centrifugo's `ConnectTokenClaims`
+ * (internal/jwtverify/token_verifier_jwt.go): `sub`, `exp`, `info`, `channels`.
+ */
+export function connectionToken({
+  secret,
+  sub,
+  expiresInSeconds,
+  info,
+  channels,
+}: ConnectionTokenOptions): string {
+  const claims: Record<string, unknown> = { sub }
+  if (expiresInSeconds !== undefined) {
+    claims.exp = Math.floor(Date.now() / 1000) + expiresInSeconds
+  }
+  if (info !== undefined) claims.info = info
+  if (channels !== undefined) claims.channels = channels
+
+  const unsigned = `${base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))}.${base64url(JSON.stringify(claims))}`
+  const signature = createHmac('sha256', secret).update(unsigned).digest('base64url')
+  return `${unsigned}.${signature}`
+}
+
+/** Body a connect proxy endpoint returns (internal/proxyproto/proxy.proto `ConnectResponse`). */
+export type CentrifugoConnectReply =
+  | { result: { user: string } }
+  | { disconnect: { code: number; reason: string } }
+  | { error: { code: number; message: string } }
+
+/**
+ * Answer Centrifugo's connect proxy with the same `resolveUser` a `WsAdapter`
+ * uses. A user connects; `null` or a user without an id disconnects with
+ * `4401` (the code `WsAdapter` closes with); a throwing resolver answers
+ * error `100`, Centrifugo's internal error, so the client may retry.
+ *
+ * Centrifugo forwards only the headers listed in
+ * `client.proxy.connect.http_headers` — add `Cookie` or `Authorization` there,
+ * or `resolveUser` sees none.
+ */
+export async function centrifugoConnect<Req>(
+  request: Req,
+  resolveUser: (request: Req) => Promise<WsAuthenticatedUser | null> | WsAuthenticatedUser | null,
+): Promise<CentrifugoConnectReply> {
+  try {
+    const user = await resolveUser(request)
+    if (!user || !user.id) return { disconnect: { code: 4401, reason: 'unauthorized' } }
+    return { result: { user: String(user.id) } }
+  } catch (err) {
+    log.error({ err }, 'Centrifugo connect proxy: resolveUser threw')
+    return { error: { code: 100, message: 'internal server error' } }
+  }
+}
+
+/** DI token for the {@link CentrifugoClient} registered by {@link CentrifugoAdapter}. */
+export const CENTRIFUGO = createToken<CentrifugoClient>('kick/ws/Centrifugo')
+
+export interface CentrifugoAdapterOptions extends CentrifugoClientOptions {
+  /**
+   * `client.subscribe_to_user_personal_channel.personal_channel_namespace`.
+   * Leave unset when that option is unset: the personal channel is then
+   * `#<user>`, otherwise `<namespace>:#<user>` (internal/config/container.go).
+   */
+  personalChannelNamespace?: string
+}
+
+/**
+ * Registers {@link CENTRIFUGO} and a `WS_USER_BROADCASTER` that publishes to
+ * the user's personal channel, so services written against `WsAdapter`'s
+ * broadcaster keep working. Enable
+ * `client.subscribe_to_user_personal_channel` in Centrifugo so users are
+ * subscribed to that channel on connect.
+ */
+export const CentrifugoAdapter = defineAdapter<CentrifugoAdapterOptions>({
+  name: 'CentrifugoAdapter',
+  build: (options) => {
+    const client = centrifugoClient(options)
+    const roomFor = (userId: string): string =>
+      options.personalChannelNamespace
+        ? `${options.personalChannelNamespace}:#${userId}`
+        : `#${userId}`
+
+    // The broadcaster interface is synchronous; a failed publish is logged,
+    // matching how WsAdapter treats a broker outage.
+    const broadcastToUser = (userId: string, event: string, data: unknown): void => {
+      client
+        .publish(roomFor(userId), { event, data })
+        .catch((err) => log.error({ err }, 'Centrifugo publish failed'))
+    }
+
+    const broadcaster: WsUserBroadcaster = {
+      roomFor,
+      broadcastToUser,
+      toUser: (id) => ({ send: (event, data) => broadcastToUser(id, event, data) }),
+    }
+
+    return {
+      beforeStart({ container }) {
+        container.registerInstance(CENTRIFUGO, client)
+        container.registerInstance(WS_USER_BROADCASTER, broadcaster)
+      },
+    }
+  },
+})

--- a/packages/ws/src/index.ts
+++ b/packages/ws/src/index.ts
@@ -19,6 +19,8 @@ export {
   type WsAdapterOptions,
   type WsAuthConfig,
   type WsAuthenticatedUser,
+  type WsBroker,
+  type WsBrokerMessage,
   type WsHandlerDefinition,
   type WsHandlerType,
   type WsUserBroadcaster,

--- a/packages/ws/src/interfaces.ts
+++ b/packages/ws/src/interfaces.ts
@@ -71,6 +71,41 @@ export interface WsAdapterOptions {
   maxPayload?: number
   /** Optional authenticated-handshake configuration. */
   auth?: WsAuthConfig
+  /**
+   * Relays broadcasts between instances. Without one, rooms, namespace
+   * broadcasts and per-user sends reach sockets in this process only.
+   * Use `redisBroker` from `@forinda/kickjs-ws/redis`, or implement
+   * {@link WsBroker} over any pub/sub.
+   */
+  broker?: WsBroker
+}
+
+/** A broadcast relayed between instances. Exactly one of `room` / `namespace` is set. */
+export interface WsBrokerMessage {
+  /** Id of the publishing instance — each instance skips its own messages. */
+  origin: string
+  /** Room broadcast: `ctx.to(room)`, `WS_ROOM_MANAGER`, per-user sends. */
+  room?: string
+  /** Namespace broadcast: `ctx.broadcast()` / `ctx.broadcastAll()`. */
+  namespace?: string
+  event: string
+  data: unknown
+  /** Socket id that must not receive it (the sender of `ctx.broadcast`). */
+  exclude?: string
+}
+
+/**
+ * Cross-instance pub/sub for {@link WsAdapter}. The adapter delivers every
+ * broadcast to its own sockets immediately, then publishes it; other
+ * instances deliver it to theirs. `data` must be JSON-serialisable — it
+ * already is, since it is sent to clients as JSON.
+ */
+export interface WsBroker {
+  publish(message: WsBrokerMessage): void | Promise<void>
+  /** Called once from the adapter's `beforeStart`; startup waits for it. */
+  subscribe(onMessage: (message: WsBrokerMessage) => void): void | Promise<void>
+  /** Called from the adapter's `shutdown`. Connections the caller passed in stay theirs to close. */
+  close?(): void | Promise<void>
 }
 
 /**
@@ -79,7 +114,8 @@ export interface WsAdapterOptions {
  * automatically; without it a controller can join the room manually and the
  * helper works the same.
  *
- * Reaches sockets in THIS process only.
+ * Reaches sockets in this process only, unless the adapter has a
+ * {@link WsAdapterOptions.broker}.
  */
 export interface WsUserBroadcaster {
   /** Send a single event to every socket bound to this user. */

--- a/packages/ws/src/redis.ts
+++ b/packages/ws/src/redis.ts
@@ -1,0 +1,75 @@
+/**
+ * Redis pub/sub broker for {@link WsAdapter} — rooms, namespace broadcasts and
+ * per-user sends reach sockets on every instance.
+ *
+ * ```ts
+ * import Redis from 'ioredis'
+ * import { WsAdapter } from '@forinda/kickjs-ws'
+ * import { redisBroker } from '@forinda/kickjs-ws/redis'
+ *
+ * const redis = new Redis(process.env.REDIS_URL!)
+ * WsAdapter({ broker: redisBroker({ publisher: redis, subscriber: redis.duplicate() }) })
+ * ```
+ *
+ * @module @forinda/kickjs-ws/redis
+ */
+import type { WsBroker, WsBrokerMessage } from './interfaces'
+
+/** The part of a Redis client the broker calls. An ioredis client fits as-is. */
+export interface RedisPubSubClient {
+  publish(channel: string, message: string): unknown
+  subscribe(channel: string): unknown
+  unsubscribe(channel: string): unknown
+  on(event: 'message', listener: (channel: string, message: string) => void): unknown
+  off?(event: 'message', listener: (channel: string, message: string) => void): unknown
+}
+
+export interface RedisBrokerOptions {
+  /** Connection used for `PUBLISH`. Can be shared with the rest of the app. */
+  publisher: RedisPubSubClient
+  /**
+   * A separate connection — a Redis connection in subscribe mode cannot run
+   * other commands. With ioredis, `publisher.duplicate()`.
+   */
+  subscriber: RedisPubSubClient
+  /** Channel shared by every instance of one app. Default `kickjs:ws`; change it to run two apps on one Redis. */
+  channel?: string
+}
+
+/**
+ * Both connections stay the caller's: `shutdown` unsubscribes but does not
+ * quit them, since the publisher is often the app's shared client.
+ */
+export function redisBroker({
+  publisher,
+  subscriber,
+  channel = 'kickjs:ws',
+}: RedisBrokerOptions): WsBroker {
+  let listener: ((channel: string, message: string) => void) | undefined
+
+  return {
+    async publish(message) {
+      await publisher.publish(channel, JSON.stringify(message))
+    },
+
+    async subscribe(onMessage) {
+      listener = (from, raw) => {
+        if (from !== channel) return
+        let message: WsBrokerMessage
+        try {
+          message = JSON.parse(raw)
+        } catch {
+          return // not ours — another publisher on the same channel
+        }
+        onMessage(message)
+      }
+      subscriber.on('message', listener)
+      await subscriber.subscribe(channel)
+    },
+
+    async close() {
+      if (listener) subscriber.off?.('message', listener)
+      await subscriber.unsubscribe(channel)
+    },
+  }
+}

--- a/packages/ws/src/room-manager.ts
+++ b/packages/ws/src/room-manager.ts
@@ -10,11 +10,24 @@ import type { WebSocket } from 'ws'
  * reach a user's sockets in every namespace — prefix names (`chat:lobby`) when
  * namespaces must not overlap.
  *
- * Membership lives in this process only. A second instance has its own rooms.
+ * Membership lives in this process only: `getSockets` and `getAllRooms`
+ * describe this instance. `broadcast` reaches other instances when the adapter
+ * has a broker.
  */
 export class RoomManager {
-  /** @param onSend Called with the number of frames each broadcast wrote. */
-  constructor(private readonly onSend?: (count: number) => void) {}
+  /**
+   * @param onSend Called with the number of frames each broadcast wrote.
+   * @param onBroadcast Relays each broadcast to other instances.
+   */
+  constructor(
+    private readonly onSend?: (count: number) => void,
+    private readonly onBroadcast?: (
+      room: string,
+      event: string,
+      data: any,
+      excludeId?: string,
+    ) => void,
+  ) {}
 
   /** socketId → set of room names */
   private socketRooms = new Map<string, Set<string>>()
@@ -74,8 +87,14 @@ export class RoomManager {
     return result
   }
 
-  /** Broadcast to all sockets in a room, optionally excluding one */
+  /** Broadcast to all sockets in a room, optionally excluding one — on every instance when a broker is set. */
   broadcast(room: string, event: string, data: any, excludeId?: string): void {
+    this.deliver(room, event, data, excludeId)
+    this.onBroadcast?.(room, event, data, excludeId)
+  }
+
+  /** Send to this instance's members of a room only. Relayed broadcasts land here. */
+  deliver(room: string, event: string, data: any, excludeId?: string): void {
     const sockets = this.roomSockets.get(room)
     if (!sockets) return
 

--- a/packages/ws/src/socket-io.ts
+++ b/packages/ws/src/socket-io.ts
@@ -1,0 +1,291 @@
+/**
+ * Socket.IO transport for the same `@WsController` classes {@link WsAdapter}
+ * serves. Pick it for what Socket.IO brings — client reconnection, long-polling
+ * fallback, acknowledgements — and scale it with Socket.IO's own adapters
+ * (`@socket.io/redis-adapter`) rather than a {@link WsBroker}.
+ *
+ * ```ts
+ * import { SocketIoAdapter } from '@forinda/kickjs-ws/socket.io'
+ *
+ * bootstrap({ modules, adapters: [SocketIoAdapter({ cors: { origin: 'https://app.example.com' } })] })
+ * ```
+ *
+ * @module @forinda/kickjs-ws/socket.io
+ */
+import type { IncomingMessage } from 'node:http'
+import { Server, type Namespace, type ServerOptions, type Socket } from 'socket.io'
+import {
+  createLogger,
+  createToken,
+  defineAdapter,
+  getClassMeta,
+  getClassMetaOrUndefined,
+} from '@forinda/kickjs'
+import {
+  WS_METADATA,
+  WS_USER_BROADCASTER,
+  wsControllerRegistry,
+  type WsAuthConfig,
+  type WsHandlerDefinition,
+  type WsUserBroadcaster,
+} from './interfaces'
+import { parseCookies } from './ws-context'
+
+const log = createLogger('SocketIoAdapter')
+
+/** Events held from a socket whose async `@OnConnect` has not settled. */
+const MAX_PENDING_BEFORE_CONNECT = 64
+
+/** DI token for the Socket.IO `Server`. */
+export const SOCKET_IO = createToken<Server>('kick/ws/SocketIo')
+
+/** Socket.IO server options (`cors`, `path`, `adapter`, …) plus the shared auth hook. */
+export interface SocketIoAdapterOptions extends Partial<ServerOptions> {
+  /**
+   * Same contract as {@link WsAdapterOptions.auth}, run as namespace
+   * middleware before the connection is accepted. A rejection reaches the
+   * client as a `connect_error` whose message is `Unauthorized`.
+   */
+  auth?: WsAuthConfig
+}
+
+/**
+ * What `@WsController` handlers receive under {@link SocketIoAdapter}. Mirrors
+ * `WsContext`, so a controller written against one runs on the other — with
+ * one difference: Socket.IO rooms belong to a namespace, where `ws` rooms are
+ * shared across namespaces.
+ */
+export class SocketIoContext {
+  /** Payload of the current event (set for `@OnMessage` handlers). */
+  data: any = null
+  /** Name of the current event (set for `@OnMessage` handlers). */
+  event = ''
+
+  private metadata = new Map<string, any>()
+
+  constructor(
+    readonly socket: Socket,
+    readonly server: Server,
+    /** The `@WsController` namespace, e.g. `/chat`. */
+    readonly namespace: string,
+  ) {}
+
+  get id(): string {
+    return this.socket.id
+  }
+
+  /** The handshake request — cookies, headers, query, client IP. */
+  get request(): IncomingMessage {
+    return this.socket.request
+  }
+
+  get cookies(): Record<string, string> {
+    return parseCookies(this.request.headers.cookie)
+  }
+
+  get<T = any>(key: string): T | undefined {
+    return this.metadata.get(key)
+  }
+
+  set(key: string, value: any): void {
+    this.metadata.set(key, value)
+  }
+
+  /** Emit to this socket. */
+  send(event: string, data: any): void {
+    this.socket.emit(event, data)
+  }
+
+  /** Emit to every socket in the namespace except this one. */
+  broadcast(event: string, data: any): void {
+    this.socket.broadcast.emit(event, data)
+  }
+
+  /** Emit to every socket in the namespace, this one included. */
+  broadcastAll(event: string, data: any): void {
+    this.socket.nsp.emit(event, data)
+  }
+
+  /** Join a room in this namespace. */
+  join(room: string): void {
+    void this.socket.join(room)
+  }
+
+  leave(room: string): void {
+    void this.socket.leave(room)
+  }
+
+  /** Rooms this socket joined, without Socket.IO's own per-socket room. */
+  rooms(): string[] {
+    return [...this.socket.rooms].filter((room) => room !== this.socket.id)
+  }
+
+  /** Emit to every socket in a room of this namespace, this one included. */
+  to(room: string): { send(event: string, data: any): void } {
+    return {
+      send: (event: string, data: any) => {
+        this.socket.nsp.to(room).emit(event, data)
+      },
+    }
+  }
+}
+
+/**
+ * Serves `@WsController` classes over Socket.IO. Namespaces map one-to-one
+ * (`@WsController('/chat')` → `io.of('/chat')`), `@OnMessage('send')` handles
+ * the client's `socket.emit('send', data)`, and `@OnMessage('*')` catches events
+ * no other handler claims.
+ *
+ * Registers {@link SOCKET_IO} and `WS_USER_BROADCASTER`. Not `WS_ROOM_MANAGER`:
+ * Socket.IO keeps its own rooms — reach them through `SOCKET_IO`.
+ */
+export const SocketIoAdapter = defineAdapter<SocketIoAdapterOptions>({
+  name: 'SocketIoAdapter',
+  build: ({ auth, ...serverOptions }) => {
+    const io = new Server(serverOptions)
+    const namespaces: Namespace[] = []
+    const userRoomPrefix = auth?.userRoomPrefix ?? 'user:'
+    const userRoom = (userId: string): string => userRoomPrefix + userId
+
+    const invoke = async (controller: any, method: string, ctx: SocketIoContext): Promise<void> => {
+      try {
+        await controller[method](ctx)
+      } catch (err) {
+        log.error({ err }, `Socket.IO handler error in ${method}`)
+      }
+    }
+    const invokeAll = (
+      controller: any,
+      handlers: WsHandlerDefinition[],
+      type: WsHandlerDefinition['type'],
+      ctx: SocketIoContext,
+    ): Promise<unknown> =>
+      Promise.all(
+        handlers.filter((h) => h.type === type).map((h) => invoke(controller, h.handlerName, ctx)),
+      )
+
+    // Socket.IO rooms are per namespace, so a user's sockets sit in `user:<id>`
+    // once per namespace they connected to. Emitting through each namespace
+    // also crosses instances when a Socket.IO adapter is configured.
+    const userBroadcaster: WsUserBroadcaster = {
+      roomFor: userRoom,
+      broadcastToUser: (userId, event, data) => {
+        for (const nsp of namespaces) nsp.to(userRoom(userId)).emit(event, data)
+      },
+      toUser: (userId) => ({
+        send: (event, data) => userBroadcaster.broadcastToUser(userId, event, data),
+      }),
+    }
+
+    const handleConnection = (
+      socket: Socket,
+      namespace: string,
+      handlers: WsHandlerDefinition[],
+      controller: any,
+    ): void => {
+      const ctx = new SocketIoContext(socket, io, namespace)
+      const user = socket.data.user
+      if (user) {
+        ctx.set('user', user)
+        ctx.set('userId', user.id)
+        if (auth?.autoJoinUserRoom !== false) ctx.join(userRoom(user.id))
+      }
+
+      const dispatch = (event: string, data: unknown): void => {
+        const handler =
+          handlers.find((h) => h.type === 'message' && h.event === event) ??
+          handlers.find((h) => h.type === 'message' && h.event === '*')
+        if (!handler) return
+        ctx.event = event
+        ctx.data = data
+        void invoke(controller, handler.handlerName, ctx)
+      }
+
+      // Listeners go on now — Socket.IO drops events nobody listens for — but
+      // events are held until every @OnConnect settles, so handlers never see a
+      // socket whose connect setup is unfinished. Same rule as WsAdapter.
+      let ready = false
+      const pending: Array<[string, unknown]> = []
+      socket.onAny((event: string, data: unknown) => {
+        if (ready) return dispatch(event, data)
+        if (pending.length >= MAX_PENDING_BEFORE_CONNECT) {
+          pending.length = 0
+          socket.disconnect(true)
+          return
+        }
+        pending.push([event, data])
+      })
+
+      socket.on('disconnect', () => {
+        pending.length = 0
+        void invokeAll(controller, handlers, 'disconnect', ctx)
+      })
+      socket.on('error', (err: Error) => {
+        ctx.data = { message: err.message, name: err.name }
+        void invokeAll(controller, handlers, 'error', ctx)
+      })
+
+      void invokeAll(controller, handlers, 'connect', ctx).then(() => {
+        if (!socket.connected) return
+        ready = true
+        for (const [event, data] of pending.splice(0)) dispatch(event, data)
+      })
+    }
+
+    return {
+      beforeStart({ container }) {
+        container.registerInstance(SOCKET_IO, io)
+        container.registerInstance(WS_USER_BROADCASTER, userBroadcaster)
+
+        for (const controllerClass of wsControllerRegistry) {
+          const namespace = getClassMetaOrUndefined<string>(
+            WS_METADATA.WS_CONTROLLER,
+            controllerClass,
+          )
+          if (namespace === undefined) continue
+          const handlers = getClassMeta<WsHandlerDefinition[]>(
+            WS_METADATA.WS_HANDLERS,
+            controllerClass,
+            [],
+          )
+
+          const nsp = io.of(namespace)
+          namespaces.push(nsp)
+
+          if (auth) {
+            nsp.use(async (socket, next) => {
+              try {
+                const resolved = await auth.resolveUser(socket.request)
+                if (!resolved?.id) return next(new Error('Unauthorized'))
+                socket.data.user = resolved
+                next()
+              } catch {
+                next(new Error('Unauthorized'))
+              }
+            })
+          }
+
+          nsp.on('connection', (socket) =>
+            handleConnection(socket, namespace, handlers, container.resolve(controllerClass)),
+          )
+          log.info(`Registered Socket.IO namespace: ${namespace} (${controllerClass.name})`)
+        }
+      },
+
+      afterStart({ server }) {
+        if (server) io.attach(server)
+      },
+
+      async shutdown() {
+        // Not io.close(): it also closes the HTTP server, which KickJS owns.
+        await Promise.allSettled(
+          namespaces.map(async (nsp) => {
+            nsp.disconnectSockets(true)
+            await nsp.adapter.close()
+          }),
+        )
+        io.engine?.close()
+      },
+    }
+  },
+})

--- a/packages/ws/src/ws-adapter.ts
+++ b/packages/ws/src/ws-adapter.ts
@@ -18,6 +18,7 @@ import {
   WS_USER_BROADCASTER,
   wsControllerRegistry,
   type WsAdapterOptions,
+  type WsBrokerMessage,
   type WsHandlerDefinition,
   type WsUserBroadcaster,
 } from './interfaces'
@@ -119,7 +120,48 @@ export const WsAdapter = defineAdapter<WsAdapterOptions, WsAdapterExtensions>({
     const countSent = (n: number): void => {
       messagesSent.value += n
     }
-    const roomManager = new RoomManager(countSent)
+
+    // Cross-instance fan-out. Every broadcast is delivered to this instance's
+    // sockets first, then published under this instance's id; other instances
+    // deliver it to theirs and every instance skips its own, so no socket gets
+    // a frame twice. Publishing is deferred and its failures logged: a broker
+    // outage must not throw out of a handler that only wanted to broadcast.
+    const broker = options.broker
+    const origin = randomUUID()
+    const relay = (message: Omit<WsBrokerMessage, 'origin'>): void => {
+      Promise.resolve()
+        .then(() => broker!.publish({ ...message, origin }))
+        .catch((err) => log.error({ err }, 'WS broker publish failed'))
+    }
+    const relayRoom = broker
+      ? (room: string, event: string, data: unknown, exclude?: string) =>
+          relay({ room, event, data, exclude })
+      : undefined
+    const relayNamespace = broker
+      ? (namespace: string, event: string, data: unknown, exclude?: string) =>
+          relay({ namespace, event, data, exclude })
+      : undefined
+
+    const roomManager = new RoomManager(countSent, relayRoom)
+
+    const onRelayed = (message: WsBrokerMessage): void => {
+      if (message.origin === origin) return
+      const { room, namespace, event, data, exclude } = message
+      if (room !== undefined) return roomManager.deliver(room, event, data, exclude)
+      if (namespace === undefined) return
+      const frame = JSON.stringify({ event, data })
+      let sent = 0
+      for (const entry of namespaces.values()) {
+        if (entry.namespace !== namespace) continue
+        for (const [id, socket] of entry.sockets) {
+          if (id !== exclude && socket.readyState === socket.OPEN) {
+            socket.send(frame)
+            sent++
+          }
+        }
+      }
+      if (sent) countSent(sent)
+    }
 
     const userRoom = (userId: string): string => userRoomPrefix + userId
 
@@ -228,6 +270,7 @@ export const WsAdapter = defineAdapter<WsAdapterOptions, WsAdapterExtensions>({
         entry.namespace,
         request,
         countSent,
+        relayNamespace,
       )
       entry.contexts.set(socketId, ctx)
 
@@ -337,7 +380,7 @@ export const WsAdapter = defineAdapter<WsAdapterOptions, WsAdapterExtensions>({
       messagesSent,
       wsErrors,
 
-      beforeStart({ container: containerArg }) {
+      async beforeStart({ container: containerArg }) {
         container = containerArg
 
         // The factory's mutate-name pattern means `this` inside lifecycle
@@ -385,6 +428,10 @@ export const WsAdapter = defineAdapter<WsAdapterOptions, WsAdapterExtensions>({
 
           log.info(`Registered WS namespace: ${fullPath} (${controllerClass.name})`)
         }
+
+        // Subscribed before the server takes connections, so no relayed
+        // broadcast is missed between listen and subscribe.
+        if (broker) await broker.subscribe(onRelayed)
       },
 
       afterStart({ server }) {
@@ -441,7 +488,7 @@ export const WsAdapter = defineAdapter<WsAdapterOptions, WsAdapterExtensions>({
         log.info(`WebSocket ready — ${namespaces.size} namespace(s), ${totalHandlers} handler(s)`)
       },
 
-      shutdown() {
+      async shutdown() {
         if (heartbeatTimer) {
           clearInterval(heartbeatTimer)
         }
@@ -456,6 +503,7 @@ export const WsAdapter = defineAdapter<WsAdapterOptions, WsAdapterExtensions>({
         }
 
         wss?.close()
+        await broker?.close?.()
       },
     }
   },

--- a/packages/ws/src/ws-context.ts
+++ b/packages/ws/src/ws-context.ts
@@ -2,6 +2,20 @@ import type { IncomingMessage } from 'node:http'
 import type { WebSocket, WebSocketServer } from 'ws'
 import type { RoomManager } from './room-manager'
 
+/** Raw `Cookie` header parse, shared by the ws and Socket.IO contexts. */
+export function parseCookies(header: string | undefined): Record<string, string> {
+  if (!header) return {}
+  const out: Record<string, string> = {}
+  for (const part of header.split(';')) {
+    const idx = part.indexOf('=')
+    if (idx === -1) continue
+    const k = part.slice(0, idx).trim()
+    const v = part.slice(idx + 1).trim()
+    if (k) out[k] = decodeURIComponent(v)
+  }
+  return out
+}
+
 /**
  * Context object passed to WebSocket handler methods.
  * Analogous to RequestContext for HTTP controllers.
@@ -60,17 +74,7 @@ export class WsContext {
 
   /** Parsed cookies from the upgrade request (raw `Cookie` header parse). */
   get cookies(): Record<string, string> {
-    const header = this.request.headers.cookie
-    if (!header) return {}
-    const out: Record<string, string> = {}
-    for (const part of header.split(';')) {
-      const idx = part.indexOf('=')
-      if (idx === -1) continue
-      const k = part.slice(0, idx).trim()
-      const v = part.slice(idx + 1).trim()
-      if (k) out[k] = decodeURIComponent(v)
-    }
-    return out
+    return parseCookies(this.request.headers.cookie)
   }
 
   /** Get a metadata value */

--- a/packages/ws/src/ws-context.ts
+++ b/packages/ws/src/ws-context.ts
@@ -43,6 +43,13 @@ export class WsContext {
     request: IncomingMessage,
     /** Called with the number of frames each send wrote — feeds `messagesSent`. */
     private readonly onSend?: (count: number) => void,
+    /** Relays namespace broadcasts to other instances when the adapter has a broker. */
+    private readonly onBroadcast?: (
+      namespace: string,
+      event: string,
+      data: any,
+      excludeId?: string,
+    ) => void,
   ) {
     this.id = id
     this.namespace = namespace
@@ -95,6 +102,7 @@ export class WsContext {
       }
     }
     if (sent) this.onSend?.(sent)
+    this.onBroadcast?.(this.namespace, event, data, this.id)
   }
 
   /** Send to all sockets in the same namespace including this one */
@@ -108,6 +116,7 @@ export class WsContext {
       }
     }
     if (sent) this.onSend?.(sent)
+    this.onBroadcast?.(this.namespace, event, data)
   }
 
   /** Join a room. Names are global across namespaces — see {@link RoomManager}. */

--- a/packages/ws/tsdown.config.ts
+++ b/packages/ws/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
     redis: 'src/redis.ts',
+    'socket-io': 'src/socket-io.ts',
   },
   format: ['esm'],
   platform: 'node',
@@ -16,6 +17,7 @@ export default defineConfig({
     '@forinda/kickjs',
     'reflect-metadata',
     'ws',
+    'socket.io',
     /^node:/,
   ],
   banner: { js: createBanner(pkg.name, pkg.version) },

--- a/packages/ws/tsdown.config.ts
+++ b/packages/ws/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
     redis: 'src/redis.ts',
+    centrifugo: 'src/centrifugo.ts',
   },
   format: ['esm'],
   platform: 'node',

--- a/packages/ws/tsdown.config.ts
+++ b/packages/ws/tsdown.config.ts
@@ -6,6 +6,7 @@ const pkg = readPkg(import.meta.dirname)
 export default defineConfig({
   entry: {
     index: 'src/index.ts',
+    redis: 'src/redis.ts',
   },
   format: ['esm'],
   platform: 'node',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,6 +686,9 @@ importers:
       '@forinda/kickjs':
         specifier: workspace:*
         version: link:../kickjs
+      '@socket.io/redis-adapter':
+        specifier: ^8.3.0
+        version: 8.3.0(socket.io-adapter@2.5.8)
       '@swc/core':
         specifier: ^1.16.1
         version: 1.16.1
@@ -698,6 +701,12 @@ importers:
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
+      socket.io:
+        specifier: ^4.8.3
+        version: 4.8.3
+      socket.io-client:
+        specifier: ^4.8.3
+        version: 4.8.3
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -2365,6 +2374,15 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
+  '@socket.io/redis-adapter@8.3.0':
+    resolution: {integrity: sha512-ly0cra+48hDmChxmIpnESKrc94LjRL80TEmZVscuQ/WWkRP81nNj8W8cCGMqbI4L6NCuAaPRSzZF1a9GlAxxnA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      socket.io-adapter: ^2.5.4
+
   '@swc/core-darwin-arm64@1.16.1':
     resolution: {integrity: sha512-zlJblJ8ncErD43lKdxjbUaUskJQf+LxiPXYcWXD8/8ZMV+7uuAT+CwjciLXpyZBd5Pq/S726bMpeeAwSeL1hhg==}
     engines: {node: '>=10'}
@@ -2604,6 +2622,9 @@ packages:
 
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -3087,6 +3108,10 @@ packages:
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -3235,6 +3260,10 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  base64id@2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
 
   baseline-browser-mapping@2.10.32:
     resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
@@ -3472,6 +3501,15 @@ packages:
   dataloader@2.2.3:
     resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
 
+  debug@4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -3573,6 +3611,17 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  engine.io-client@6.6.6:
+    resolution: {integrity: sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==}
+
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
+  engine.io@6.6.10:
+    resolution: {integrity: sha512-9/lX2bdlizlCXMHRMOIm03VBQHQYC7VvydcxtTAUJRxNW1QzM/2PMFSmr6h/lCiMHcyCP6abK+t9Q+j4vekk8Q==}
+    engines: {node: '>=10.2.0'}
 
   enhanced-resolve@5.24.3:
     resolution: {integrity: sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==}
@@ -4389,6 +4438,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -4427,6 +4480,9 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  notepack.io@3.0.1:
+    resolution: {integrity: sha512-TKC/8zH5pXIAMVQio2TvVDTtPRX+DJPHDqjRbxogtFiByHyzKmy96RA0JtCQJ+WouyyL4A10xomQzgbUT+1jCg==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -4918,6 +4974,21 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  socket.io-adapter@2.5.8:
+    resolution: {integrity: sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==}
+
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io@4.8.3:
+    resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
+    engines: {node: '>=10.2.0'}
+
   solid-js@1.9.15:
     resolution: {integrity: sha512-EeiY2xfpZJqPLjXspVEKjAII4yv8NyG//NxZ3IpOFHdUNnnTyL0uJOeS9LWGvA7cFCz5y94cjFwYlmw5Luncsg==}
 
@@ -5192,6 +5263,10 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  uid2@1.0.0:
+    resolution: {integrity: sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ==}
+    engines: {node: '>= 4.0.0'}
 
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
@@ -5514,6 +5589,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -6920,6 +6999,17 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@socket.io/component-emitter@3.1.2': {}
+
+  '@socket.io/redis-adapter@8.3.0(socket.io-adapter@2.5.8)':
+    dependencies:
+      debug: 4.3.7
+      notepack.io: 3.0.1
+      socket.io-adapter: 2.5.8
+      uid2: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@swc/core-darwin-arm64@1.16.1':
     optional: true
 
@@ -7120,6 +7210,10 @@ snapshots:
       '@types/node': 26.4.1
 
   '@types/cookiejar@2.1.5': {}
+
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 26.4.1
 
   '@types/deep-eql@4.0.2': {}
 
@@ -7521,6 +7615,11 @@ snapshots:
 
   abstract-logging@2.0.1: {}
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -7691,6 +7790,8 @@ snapshots:
       bare-path: 3.1.1
 
   base64-js@1.5.1: {}
+
+  base64id@2.0.0: {}
 
   baseline-browser-mapping@2.10.32: {}
 
@@ -7927,6 +8028,10 @@ snapshots:
 
   dataloader@2.2.3: {}
 
+  debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -8009,6 +8114,36 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  engine.io-client@6.6.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.21.3
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  engine.io-parser@5.2.3: {}
+
+  engine.io@6.6.10:
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/node': 26.4.1
+      '@types/ws': 8.18.1
+      accepts: 1.3.8
+      cookie: 0.7.2
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   enhanced-resolve@5.24.3:
     dependencies:
@@ -8829,6 +8964,8 @@ snapshots:
 
   nanoid@3.3.18: {}
 
+  negotiator@0.6.3: {}
+
   negotiator@1.0.0: {}
 
   node-abort-controller@3.1.1: {}
@@ -8851,6 +8988,8 @@ snapshots:
   node-releases@2.0.53: {}
 
   normalize-path@3.0.0: {}
+
+  notepack.io@3.0.1: {}
 
   object-assign@4.1.1: {}
 
@@ -9473,6 +9612,47 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  socket.io-adapter@2.5.8:
+    dependencies:
+      debug: 4.4.3
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-client@4.8.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-client: 6.6.6
+      socket.io-parser: 4.2.7
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.7:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  socket.io@4.8.3:
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io: 6.6.10
+      socket.io-adapter: 2.5.8
+      socket.io-parser: 4.2.7
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   solid-js@1.9.15:
     dependencies:
       csstype: 3.2.3
@@ -9809,6 +9989,8 @@ snapshots:
 
   ufo@1.6.4: {}
 
+  uid2@1.0.0: {}
+
   unconfig-core@7.5.0:
     dependencies:
       '@quansync/fs': 1.0.0
@@ -10072,6 +10254,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.3: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   xtend@4.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -695,6 +695,9 @@ importers:
       '@types/ws':
         specifier: ^8.18.0
         version: 8.18.1
+      ioredis:
+        specifier: ^5.10.1
+        version: 5.10.1
       typescript:
         specifier: ^7.0.2
         version: 7.0.2


### PR DESCRIPTION
## Why

Rooms and broadcasts reached only the process holding the sockets. With `bootstrap({ cluster })` or a second instance behind a load balancer, users on different nodes stopped seeing each other — the load test from #689 measured **reach 0.5** with two instances.

## What

```ts
import Redis from 'ioredis'
import { WsAdapter } from '@forinda/kickjs-ws'
import { redisBroker } from '@forinda/kickjs-ws/redis'

const redis = new Redis(process.env.REDIS_URL!)
WsAdapter({ broker: redisBroker({ publisher: redis, subscriber: redis.duplicate() }) })
```

- **`WsBroker`** (`publish`, `subscribe`, optional `close`) — new optional `broker` on `WsAdapter`. Implement it over any pub/sub.
- **How it works:** deliver to local sockets first, then publish with this instance's id. Other instances deliver to theirs; each skips its own messages, so no socket gets a frame twice.
- **Crosses instances:** `ctx.to(room)`, `WS_ROOM_MANAGER.broadcast`, `WS_USER_BROADCASTER` / `broadcastToUser`, `ctx.broadcast`, `ctx.broadcastAll`.
- **Stays local:** `ctx.send` (socket is here), `getStats().rooms`, `getSockets`, `getAllRooms`.
- **`RoomManager.broadcast`** now = local `deliver()` + relay. `deliver()` is new and local-only.
- **Failure mode:** publish is deferred and a rejection is logged — a Redis outage never throws into a handler; local sockets still get the broadcast.
- **Startup:** subscribes in `beforeStart`, before connections are accepted. `shutdown` calls `broker.close()`.
- **`@forinda/kickjs-ws/redis`**: `redisBroker({ publisher, subscriber, channel? })`. Client typed by shape — ioredis is a devDependency only, not a runtime dependency. It unsubscribes on close but never quits connections it was handed.

Without `broker`, behaviour is unchanged.

## Load test (10k-member room, local Redis, one session)

| Scenario | Frames/s | Reach | p50 | p99 |
| --- | --- | --- | --- | --- |
| 1 instance | 50k | 1.0 | 125ms | 178ms |
| 1 instance + Redis | 50k | 1.0 | 141ms | 184ms |
| 2 instances, no broker | 50k | **0.5** | 44ms | 92ms |
| 2 instances + Redis | 50k | **1.0** | 85ms | 201ms |
| 1 instance (overloaded) | 100k | 1.0 | 1.8s | 2.7s |
| 4 instances + Redis | 100k | 1.0 | 58ms | 203ms |

`bench/server.mjs` uses the broker when `REDIS_URL` is set. Numbers are in `docs/guide/benchmarks.md`.

## Known limits (documented)

- Redis pub/sub is at-most-once: an instance disconnected from Redis misses what was published meanwhile.
- One channel per app (`kickjs:ws` default) — set `channel` when apps share a Redis.

## Tests

- two adapters joined by an in-memory hub: room fan-out exactly once on every instance, `broadcast` excludes sender everywhere / `broadcastAll` includes it, `broadcastToUser` across instances, failed publish stays local and doesn't throw
- `redisBroker` unit test with a fake client (channel filter, non-JSON ignored, close unsubscribes)
- same cross-instance suite over **real Redis** when `REDIS_URL` is set — passed locally against `redis:6.2`; skipped in CI (no Redis service)
- sabotage: the 3 cross-instance tests fail with the relay removed
- ws 26/26, typecheck (src + tests), oxlint, format, docs build clean

Changeset: `@forinda/kickjs-ws` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wf3GNMSJUfME42a93d5j6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional cross-instance WebSocket broadcasting through configurable brokers, including Redis pub/sub.
  * Added Socket.IO support for existing WebSocket controllers, with authentication, namespaces, rooms, and broadcasting.
  * Added Centrifugo integration for external real-time servers, including publishing, authentication, and user channels.
  * Added support for custom brokers and exported broker types.
  * Broadcasts avoid duplicate delivery and continue working locally without a broker.

* **Bug Fixes**
  * Improved isolation of concurrent message data and handling of malformed cookies.

* **Documentation**
  * Added Socket.IO, Redis scaling, Centrifugo integration, operational guidance, and benchmark results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->