### PR TITLE
feat(ws): serve @WsController classes over Socket.IO

### DIFF
--- a/.changeset/bright-sockets-bridge.md
+++ b/.changeset/bright-sockets-bridge.md
@@ -1,0 +1,29 @@
+---
+'@forinda/kickjs-ws': minor
+---
+
+`@forinda/kickjs-ws/socket.io` serves the same `@WsController` classes over
+Socket.IO, so choosing a transport no longer means rewriting controllers.
+
+```ts
+import { SocketIoAdapter } from '@forinda/kickjs-ws/socket.io'
+
+bootstrap({ modules, adapters: [SocketIoAdapter({ cors: { origin: 'https://app.example.com' } })] })
+```
+
+Namespaces map to `io.of(namespace)`, `@OnMessage('x')` handles the client's
+`socket.emit('x', data)`, and `SocketIoContext` mirrors `WsContext` (`send`,
+`broadcast`, `broadcastAll`, `join`, `to(room).send`, `get`/`set`, `cookies`).
+`auth.resolveUser` runs as namespace middleware and rejects with a
+`connect_error` of `Unauthorized`; authenticated sockets join `user:<id>`, and
+`WS_USER_BROADCASTER` reaches a user in every namespace. An async `@OnConnect`
+is awaited before events are delivered, as with `WsAdapter`.
+
+Every Socket.IO server option passes through, including `adapter` — with
+`@socket.io/redis-adapter`, emits and per-user sends cross instances. Shutdown
+disconnects sockets and closes the engine but leaves the HTTP server to KickJS,
+where `io.close()` would close it too.
+
+`socket.io` is an optional peer dependency, needed only for this subpath.
+Differences from `WsAdapter`: rooms are per namespace, `WS_ROOM_MANAGER` is not
+registered (inject `SOCKET_IO`), and acknowledgements go through `ctx.socket`.

--- a/docs/guide/socketio.md
+++ b/docs/guide/socketio.md
@@ -1,245 +1,179 @@
 # Socket.IO Integration
 
-KickJS ships with a `ws`-based WebSocket adapter (`@forinda/kickjs-ws`), but you can integrate **Socket.IO** for features like automatic reconnection, rooms, acknowledgements, and binary support.
+`SocketIoAdapter` serves your `@WsController` classes over [Socket.IO](https://socket.io) instead of raw WebSockets. The decorators are the same; the transport brings client reconnection, a long-polling fallback, and Socket.IO's own adapters for running more than one instance.
 
 ## Setup
 
-<PmCommand add="socket.io" />
-
-## Create a Socket.IO Adapter
-
-```ts
-// src/adapters/socketio.adapter.ts
-import { Server, type Socket } from 'socket.io'
-import {
-  createToken,
-  defineAdapter,
-  Logger,
-  type AdapterContext,
-  type Container,
-} from '@forinda/kickjs'
-
-const log = Logger.for('SocketIOAdapter')
-
-export interface SocketIOAdapterOptions {
-  /** CORS configuration */
-  cors?: {
-    origin: string | string[]
-    methods?: string[]
-    credentials?: boolean
-  }
-  /** Path for the Socket.IO endpoint (default: '/socket.io') */
-  path?: string
-  /** Custom namespaces to register */
-  namespaces?: SocketIONamespace[]
-}
-
-export interface SocketIONamespace {
-  /** Namespace path (e.g. '/chat', '/notifications') */
-  namespace: string
-  /** Handler setup function — receives the namespace and DI container */
-  setup: (nsp: any, container: Container) => void
-}
-
-/**
- * Typed DI token for injecting the Socket.IO server.
- * `container.resolve(SOCKET_IO)` returns `Server` without a manual generic.
- */
-export const SOCKET_IO = createToken<Server>('kick/socketio/server')
-
-export const SocketIOAdapter = defineAdapter<SocketIOAdapterOptions>({
-  name: 'SocketIOAdapter',
-  defaults: { path: '/socket.io' },
-  build: (options) => {
-    let io: Server | undefined
-
-    return {
-      afterStart({ server, container }: AdapterContext): void {
-        io = new Server(server, {
-          cors: options.cors ?? { origin: '*' },
-          path: options.path,
-        })
-
-        // Default namespace
-        io.on('connection', (socket: Socket) => {
-          log.info(`Connected: ${socket.id}`)
-          socket.on('disconnect', (reason) => {
-            log.info(`Disconnected: ${socket.id} (${reason})`)
-          })
-        })
-
-        // Custom namespaces
-        for (const ns of options.namespaces ?? []) {
-          const nsp = io.of(ns.namespace)
-          ns.setup(nsp, container)
-          log.info(`Namespace registered: ${ns.namespace}`)
-        }
-
-        // Register io instance in DI for injection
-        container.registerInstance(SOCKET_IO, io)
-        log.info(`Socket.IO listening at ${options.path}`)
-      },
-
-      async shutdown(): Promise<void> {
-        if (io) {
-          await new Promise<void>((resolve) => io!.close(() => resolve()))
-          log.info('Socket.IO server closed')
-        }
-      },
-    }
-  },
-})
-```
-
-## Register in Bootstrap
+<PmCommand add="@forinda/kickjs-ws socket.io" />
 
 ```ts
 import { bootstrap } from '@forinda/kickjs'
-import { SocketIOAdapter } from './adapters/socketio.adapter'
+import { SocketIoAdapter } from '@forinda/kickjs-ws/socket.io'
 import { modules } from './modules'
 
 bootstrap({
   modules,
   adapters: [
-    SocketIOAdapter({
+    SocketIoAdapter({
+      // Any Socket.IO server option: cors, path, pingInterval, adapter, …
       cors: { origin: 'http://localhost:5173', credentials: true },
-      namespaces: [
-        {
-          namespace: '/chat',
-          setup: (nsp, container) => {
-            nsp.on('connection', (socket) => {
-              console.log(`Chat connected: ${socket.id}`)
-
-              socket.on('message', (data) => {
-                // Broadcast to room or all
-                nsp.emit('message', {
-                  from: socket.id,
-                  ...data,
-                  timestamp: new Date().toISOString(),
-                })
-              })
-
-              socket.on('join-room', (room) => {
-                socket.join(room)
-                socket.to(room).emit('user-joined', { userId: socket.id })
-              })
-
-              socket.on('leave-room', (room) => {
-                socket.leave(room)
-                socket.to(room).emit('user-left', { userId: socket.id })
-              })
-            })
-          },
-        },
-        {
-          namespace: '/notifications',
-          setup: (nsp, container) => {
-            nsp.on('connection', (socket) => {
-              // Join user-specific room for targeted notifications
-              const userId = socket.handshake.auth?.userId
-              if (userId) socket.join(`user:${userId}`)
-            })
-          },
-        },
-      ],
     }),
   ],
 })
 ```
 
-## Inject Socket.IO in Services
+Use `SocketIoAdapter` **instead of** `WsAdapter`, not alongside it — both would serve the same controllers.
 
-Use the `SOCKET_IO` token to inject the io server anywhere:
+## Controllers
+
+```ts
+import { WsController, OnConnect, OnDisconnect, OnMessage } from '@forinda/kickjs-ws'
+import type { SocketIoContext } from '@forinda/kickjs-ws/socket.io'
+
+@WsController('/chat')
+export class ChatController {
+  @OnConnect()
+  connect(ctx: SocketIoContext) {
+    ctx.join('general')
+  }
+
+  @OnMessage('message')
+  message(ctx: SocketIoContext) {
+    ctx.to('general').send('message', { from: ctx.id, text: ctx.data.text })
+  }
+
+  @OnMessage('*')
+  unknown(ctx: SocketIoContext) {
+    ctx.send('error', { message: `Unknown event: ${ctx.event}` })
+  }
+
+  @OnDisconnect()
+  disconnect(ctx: SocketIoContext) {}
+}
+```
+
+How the pieces map:
+
+| KickJS                                   | Socket.IO                                                      |
+| ---------------------------------------- | -------------------------------------------------------------- |
+| `@WsController('/chat')`                 | `io.of('/chat')` — `@WsController()` is the main namespace `/` |
+| `@OnMessage('message')`                  | the client's `socket.emit('message', data)`                    |
+| `@OnMessage('*')`                        | any event no other handler claims                              |
+| `ctx.send(event, data)`                  | `socket.emit`                                                  |
+| `ctx.broadcast(event, data)`             | `socket.broadcast.emit` — the namespace, sender excluded       |
+| `ctx.broadcastAll(event, data)`          | `socket.nsp.emit` — the namespace, sender included             |
+| `ctx.join(room)` / `ctx.to(room).send()` | `socket.join` / `socket.nsp.to(room).emit` — sender included   |
+| `ctx.socket` / `ctx.server`              | the Socket.IO `Socket` / `Server`, for anything not mapped     |
+
+`SocketIoContext` mirrors `WsContext` (`id`, `data`, `event`, `namespace`, `request`, `cookies`, `get`/`set`, `rooms()`), so a controller written for one runs on the other — with the differences below.
+
+::: warning Differences from `WsAdapter`
+
+- **Rooms belong to a namespace.** With `ws`, `lobby` joined from `/chat` and from `/admin` is one room; with Socket.IO they are two.
+- **No `WS_ROOM_MANAGER`.** Socket.IO keeps its own rooms — inject `SOCKET_IO` to reach them from a service.
+- **Acknowledgements are not mapped.** A client callback arrives as an extra argument the handler does not see; use `ctx.socket.on(...)` for events that need one.
+
+:::
+
+As with `WsAdapter`, an `async` `@OnConnect` is awaited: events that arrive meanwhile are held (up to 64, then the socket is disconnected) and delivered once it settles.
+
+## Authentication
+
+`auth` takes the same `resolveUser` hook as `WsAdapter`, run as namespace middleware before the connection is accepted:
+
+```ts
+SocketIoAdapter({
+  auth: {
+    resolveUser: async (request) => {
+      const token = parseCookie(request.headers.cookie).sid
+      return token ? await sessions.verify(token) : null
+    },
+  },
+})
+```
+
+- Returning `null` or throwing rejects the connection; the client gets `connect_error` with `err.message === 'Unauthorized'`.
+- The user is available as `ctx.get('user')` and `ctx.get('userId')`.
+- Each authenticated socket joins `user:<id>` in its namespace (`autoJoinUserRoom: false` to opt out, `userRoomPrefix` to rename).
+
+`resolveUser` receives the handshake request, so it reads cookies, headers and the query string. A token sent through the client's `auth` option is on `ctx.socket.handshake.auth`, not the request.
+
+## Services
 
 ```ts
 import { Service, Inject } from '@forinda/kickjs'
-import { SOCKET_IO } from '../adapters/socketio.adapter'
+import { WS_USER_BROADCASTER, type WsUserBroadcaster } from '@forinda/kickjs-ws'
+import { SOCKET_IO } from '@forinda/kickjs-ws/socket.io'
 import type { Server } from 'socket.io'
 
 @Service()
-export class NotificationPushService {
-  constructor(@Inject(SOCKET_IO) private io: Server) {}
+export class NotificationService {
+  constructor(
+    @Inject(WS_USER_BROADCASTER) private users: WsUserBroadcaster,
+    @Inject(SOCKET_IO) private io: Server,
+  ) {}
 
-  /** Send a notification to a specific user */
-  notifyUser(userId: string, event: string, data: any) {
-    this.io.of('/notifications').to(`user:${userId}`).emit(event, data)
+  notify(userId: string, data: unknown) {
+    // Every namespace the user is connected to.
+    this.users.broadcastToUser(userId, 'notification', data)
   }
 
-  /** Broadcast to all connected clients */
-  broadcast(event: string, data: any) {
-    this.io.emit(event, data)
-  }
-
-  /** Send to a specific room */
-  toRoom(room: string, event: string, data: any) {
-    this.io.to(room).emit(event, data)
+  announce(data: unknown) {
+    this.io.of('/chat').to('general').emit('announcement', data)
   }
 }
 ```
 
-## Client-Side
+`WS_USER_BROADCASTER` is the same token `WsAdapter` registers, so code written against it does not change when you switch transports.
+
+## Running more than one instance
+
+Pass a Socket.IO adapter. With [`@socket.io/redis-adapter`](https://socket.io/docs/v4/redis-adapter/), room emits, namespace broadcasts and `WS_USER_BROADCASTER` reach sockets on every instance:
+
+<PmCommand add="@socket.io/redis-adapter ioredis" />
+
+```ts
+import Redis from 'ioredis'
+import { createAdapter } from '@socket.io/redis-adapter'
+import { SocketIoAdapter } from '@forinda/kickjs-ws/socket.io'
+
+const pub = new Redis(process.env.REDIS_URL!)
+
+SocketIoAdapter({ adapter: createAdapter(pub, pub.duplicate()) })
+```
+
+Unlike `WsAdapter`, Socket.IO's long-polling fallback needs **sticky sessions** at the load balancer — or `transports: ['websocket']` on the client to skip polling.
+
+## Client
 
 ```ts
 import { io } from 'socket.io-client'
 
-// Connect to default namespace
-const socket = io('http://localhost:3000')
+const chat = io('http://localhost:3000/chat', { withCredentials: true })
 
-// Connect to a specific namespace
-const chat = io('http://localhost:3000/chat')
-const notifications = io('http://localhost:3000/notifications', {
-  auth: { userId: 'user-123' },
+chat.on('connect_error', (err) => {
+  if (err.message === 'Unauthorized') redirectToLogin()
 })
-
-// Listen for events
-chat.on('message', (msg) => console.log('New message:', msg))
-notifications.on('alert', (alert) => console.log('Alert:', alert))
-
-// Send events
+chat.on('message', (msg) => console.log(msg))
 chat.emit('message', { text: 'Hello everyone!' })
-chat.emit('join-room', 'general')
 ```
 
-## Socket.IO vs ws
+## Socket.IO or ws?
 
-|                      | `@forinda/kickjs-ws`           | Socket.IO                              |
-| -------------------- | ------------------------------ | -------------------------------------- |
-| **Protocol**         | Raw WebSocket                  | Custom protocol over WebSocket/polling |
-| **Reconnection**     | Manual                         | Automatic                              |
-| **Rooms**            | Via `RoomManager`              | Built-in                               |
-| **Acknowledgements** | Manual                         | Built-in callbacks                     |
-| **Binary**           | Manual                         | Automatic                              |
-| **Fallback**         | WebSocket only                 | Long-polling fallback                  |
-| **Bundle size**      | ~50KB                          | ~300KB (client + server)               |
-| **Decorators**       | `@WsController`, `@OnMessage`  | Use adapter pattern above              |
-| **Best for**         | Lightweight, low-level control | Full-featured real-time apps           |
-
-## With Authentication
-
-```ts
-// Middleware for Socket.IO authentication
-io.use((socket, next) => {
-  const token = socket.handshake.auth?.token
-  if (!token) return next(new Error('Authentication required'))
-
-  try {
-    const user = jwt.verify(token, JWT_SECRET)
-    socket.data.user = user
-    next()
-  } catch {
-    next(new Error('Invalid token'))
-  }
-})
-
-// Access user in handlers
-io.on('connection', (socket) => {
-  console.log(`Authenticated user: ${socket.data.user.email}`)
-})
-```
+|                       | `WsAdapter` (`ws`)                                           | `SocketIoAdapter`                              |
+| --------------------- | ------------------------------------------------------------ | ---------------------------------------------- |
+| **Client**            | Any WebSocket client, `{ event, data }` JSON                 | `socket.io-client` only                        |
+| **Reconnection**      | Yours to write                                               | Built in                                       |
+| **Fallback**          | WebSocket only                                               | Long-polling                                   |
+| **Rooms**             | Shared across namespaces                                     | Per namespace                                  |
+| **Acknowledgements**  | —                                                            | Via `ctx.socket`                               |
+| **Several instances** | `broker` ([Redis](./websockets.md#scaling-across-instances)) | Socket.IO adapter (`@socket.io/redis-adapter`) |
+| **Sticky sessions**   | Not needed                                                   | Needed for polling                             |
+| **Decorators**        | `@WsController`, `@OnMessage`, …                             | The same                                       |
 
 ## Sharing auth with your HTTP routes
 
-Auth is [bring-your-own](./byo-recipes.md#auth), so the piece to share is a plain function you own — not a framework strategy. Keep token verification separate from the transport, and both sides call it:
+Auth is [bring-your-own](./byo-recipes.md#auth), so the piece to share is a plain function you own. Keep token verification separate from the transport, and both sides call it:
 
 ```ts
 // src/auth/verify-token.ts — no HTTP, no socket, just the token
@@ -256,16 +190,13 @@ export function verifyToken(token: string | undefined): AuthUser | null {
 }
 ```
 
-The HTTP side calls it from the `user` contributor ([Step 3 of the recipe](./byo-recipes.md#auth)); the socket side calls it from `io.use`:
+The HTTP side calls it from the `user` contributor ([Step 3 of the recipe](./byo-recipes.md#auth)); the socket side calls it from `resolveUser`:
 
 ```ts
-import { verifyToken } from './auth/verify-token'
-
-io.use((socket, next) => {
-  const user = verifyToken(socket.handshake.auth?.token)
-  if (!user) return next(new Error('Unauthorized'))
-  socket.data.user = user
-  next()
+SocketIoAdapter({
+  auth: {
+    resolveUser: (request) => verifyToken(parseCookie(request.headers.cookie).token),
+  },
 })
 ```
 

--- a/docs/guide/websockets.md
+++ b/docs/guide/websockets.md
@@ -16,6 +16,10 @@ bootstrap({
 
 Clients connect to: `ws://localhost:3000/ws/chat`
 
+::: tip Prefer Socket.IO?
+The same `@WsController` classes run on Socket.IO through `SocketIoAdapter` from `@forinda/kickjs-ws/socket.io` — see [Socket.IO Integration](./socketio.md).
+:::
+
 ## Decorators
 
 ### @WsController

--- a/packages/ws/README.md
+++ b/packages/ws/README.md
@@ -54,6 +54,19 @@ import { redisBroker } from '@forinda/kickjs-ws/redis'
 WsAdapter({ broker: redisBroker({ publisher: redis, subscriber: redis.duplicate() }) })
 ```
 
+## Socket.IO
+
+The same controllers run on Socket.IO (install `socket.io`):
+
+```ts
+import { SocketIoAdapter } from '@forinda/kickjs-ws/socket.io'
+
+bootstrap({ modules, adapters: [SocketIoAdapter({ cors: { origin: 'https://app.example.com' } })] })
+```
+
+Rooms are per namespace there, and `WS_ROOM_MANAGER` is replaced by the `SOCKET_IO` token.
+See [kickjs.app/guide/socketio](https://kickjs.app/guide/socketio).
+
 ## Documentation
 
 [kickjs.app/guide/websockets](https://kickjs.app/guide/websockets)

--- a/packages/ws/__tests__/socket-io.test.ts
+++ b/packages/ws/__tests__/socket-io.test.ts
@@ -1,0 +1,229 @@
+/**
+ * SocketIoAdapter against a real HTTP server and real socket.io-client
+ * connections, serving ordinary `@WsController` classes.
+ *
+ * @module @forinda/kickjs-ws/__tests__/socket-io.test
+ */
+import 'reflect-metadata'
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { io as connectClient, type Socket as ClientSocket } from 'socket.io-client'
+import Redis from 'ioredis'
+import { createAdapter } from '@socket.io/redis-adapter'
+import { Container } from '@forinda/kickjs'
+import { WsController, OnConnect, OnMessage, WS_USER_BROADCASTER } from '@forinda/kickjs-ws'
+import { SocketIoAdapter, SOCKET_IO, type SocketIoContext } from '../src/socket-io'
+
+const seen: string[] = []
+
+@WsController('/chat')
+class ChatController {
+  @OnConnect()
+  connect(ctx: SocketIoContext) {
+    seen.push('chat:connect')
+    ctx.join('lobby')
+  }
+
+  @OnMessage('echo')
+  echo(ctx: SocketIoContext) {
+    ctx.send('echo', ctx.data)
+  }
+
+  @OnMessage('room')
+  room(ctx: SocketIoContext) {
+    ctx.to('lobby').send('room', ctx.data)
+  }
+
+  @OnMessage('others')
+  others(ctx: SocketIoContext) {
+    ctx.broadcast('others', ctx.data)
+  }
+
+  @OnMessage('all')
+  all(ctx: SocketIoContext) {
+    ctx.broadcastAll('all', ctx.data)
+  }
+
+  @OnMessage('*')
+  unknown(ctx: SocketIoContext) {
+    ctx.send('unknown', ctx.event)
+  }
+}
+
+@WsController('/alerts')
+class AlertsController {}
+
+@WsController('/slow')
+class SlowController {
+  @OnConnect()
+  async connect() {
+    seen.push('slow:connect:start')
+    await new Promise((r) => setTimeout(r, 50))
+    seen.push('slow:connect:end')
+  }
+
+  @OnMessage('ping')
+  ping() {
+    seen.push('slow:ping')
+  }
+}
+void ChatController
+void AlertsController
+void SlowController
+
+const cleanups: Array<() => unknown> = []
+beforeEach(() => {
+  seen.length = 0
+  Container.reset()
+})
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()!()
+})
+
+async function boot(options: Record<string, unknown> = {}) {
+  const server = http.createServer()
+  const adapter = SocketIoAdapter(options as any) as any
+  await adapter.beforeStart({ container: Container.getInstance() })
+  await adapter.afterStart({ server })
+  await new Promise<void>((resolve) => server.listen(0, resolve))
+  const port = (server.address() as AddressInfo).port
+  cleanups.push(async () => {
+    await adapter.shutdown()
+    server.close()
+  })
+  return { server, adapter, origin: `http://127.0.0.1:${port}` }
+}
+
+/** A client that records every `event:data` it receives. */
+async function client(url: string, query: Record<string, string> = {}) {
+  const socket: ClientSocket = connectClient(url, {
+    transports: ['websocket'],
+    forceNew: true,
+    reconnection: false,
+    query,
+  })
+  const got: string[] = []
+  socket.onAny((event, data) => got.push(`${event}:${data}`))
+  cleanups.push(() => socket.disconnect())
+  await new Promise<void>((resolve, reject) => {
+    socket.once('connect', () => resolve())
+    socket.once('connect_error', reject)
+  })
+  return { socket, got }
+}
+
+async function waitFor(check: () => boolean, ms = 2000): Promise<void> {
+  const until = Date.now() + ms
+  while (!check()) {
+    if (Date.now() > until) throw new Error('condition not met in time')
+    await new Promise((r) => setTimeout(r, 10))
+  }
+}
+const settle = () => new Promise((r) => setTimeout(r, 100))
+
+const userFromQuery = {
+  resolveUser: (req: http.IncomingMessage) => {
+    const id = new URL(req.url!, 'http://x').searchParams.get('user')
+    return id ? { id } : null
+  },
+}
+
+describe('SocketIoAdapter routing', () => {
+  it('routes emits to @OnMessage handlers and replies with ctx.send', async () => {
+    const { origin } = await boot()
+    const a = await client(`${origin}/chat`)
+    a.socket.emit('echo', 'hi')
+    a.socket.emit('nope', 1)
+    await waitFor(() => a.got.length === 2)
+    expect(a.got).toEqual(['echo:hi', 'unknown:nope'])
+  })
+
+  it('to(room) and broadcastAll include the sender; broadcast skips it', async () => {
+    const { origin } = await boot()
+    const a = await client(`${origin}/chat`)
+    const b = await client(`${origin}/chat`)
+    await waitFor(() => seen.filter((s) => s === 'chat:connect').length === 2)
+    await settle()
+
+    a.socket.emit('room', 'r')
+    a.socket.emit('others', 'o')
+    a.socket.emit('all', 'x')
+    await waitFor(() => b.got.length === 3)
+    await settle()
+    expect(a.got).toEqual(['room:r', 'all:x'])
+    expect(b.got).toEqual(['room:r', 'others:o', 'all:x'])
+  })
+
+  it('holds events until an async @OnConnect settles', async () => {
+    const { origin } = await boot()
+    const s = await client(`${origin}/slow`)
+    s.socket.emit('ping')
+    await waitFor(() => seen.includes('slow:ping'))
+    expect(seen).toEqual(['slow:connect:start', 'slow:connect:end', 'slow:ping'])
+  })
+})
+
+describe('SocketIoAdapter auth', () => {
+  it('rejects with connect_error "Unauthorized" and never runs @OnConnect', async () => {
+    const { origin } = await boot({ auth: userFromQuery })
+    const socket = connectClient(`${origin}/chat`, {
+      transports: ['websocket'],
+      forceNew: true,
+      reconnection: false,
+    })
+    cleanups.push(() => socket.disconnect())
+    const err = await new Promise<Error>((resolve) => socket.once('connect_error', resolve))
+    expect(err.message).toBe('Unauthorized')
+    expect(seen).not.toContain('chat:connect')
+  })
+
+  it('WS_USER_BROADCASTER reaches the user in every namespace', async () => {
+    const { origin } = await boot({ auth: userFromQuery })
+    const chat = await client(`${origin}/chat`, { user: 'alice' })
+    const alerts = await client(`${origin}/alerts`, { user: 'alice' })
+    const bob = await client(`${origin}/chat`, { user: 'bob' })
+    await settle()
+
+    Container.getInstance().resolve(WS_USER_BROADCASTER).broadcastToUser('alice', 'ping', 1)
+    await waitFor(() => chat.got.length === 1 && alerts.got.length === 1)
+    await settle()
+    expect([chat.got, alerts.got, bob.got]).toEqual([['ping:1'], ['ping:1'], []])
+  })
+})
+
+describe('SocketIoAdapter lifecycle', () => {
+  it('registers SOCKET_IO and shuts down without closing the HTTP server', async () => {
+    const { server, adapter } = await boot()
+    expect(Container.getInstance().resolve(SOCKET_IO)).toBeDefined()
+    await adapter.shutdown()
+    expect(server.listening).toBe(true)
+  })
+})
+
+const REDIS_URL = process.env.REDIS_URL
+describe.skipIf(!REDIS_URL)('SocketIoAdapter across instances (@socket.io/redis-adapter)', () => {
+  it('delivers room and per-user emits to sockets on another instance', async () => {
+    const adapterFor = () => {
+      const pub = new Redis(REDIS_URL!)
+      const sub = pub.duplicate()
+      cleanups.push(() => {
+        pub.disconnect()
+        sub.disconnect()
+      })
+      return createAdapter(pub, sub, { key: `kickjs-test-${process.pid}` })
+    }
+    const one = await boot({ auth: userFromQuery, adapter: adapterFor() })
+    const two = await boot({ auth: userFromQuery, adapter: adapterFor() })
+    const alice = await client(`${one.origin}/chat`, { user: 'alice' })
+    const bob = await client(`${two.origin}/chat`, { user: 'bob' })
+    await settle()
+
+    bob.socket.emit('room', 'from-two')
+    await waitFor(() => alice.got.includes('room:from-two'))
+
+    // The last boot registered WS_USER_BROADCASTER, so this is instance two's.
+    Container.getInstance().resolve(WS_USER_BROADCASTER).broadcastToUser('alice', 'dm', 'hi')
+    await waitFor(() => alice.got.includes('dm:hi'))
+  })
+})

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -26,6 +26,10 @@
     "./redis": {
       "import": "./dist/redis.mjs",
       "types": "./dist/redis.d.mts"
+    },
+    "./socket.io": {
+      "import": "./dist/socket-io.mjs",
+      "types": "./dist/socket-io.d.mts"
     }
   },
   "files": [
@@ -45,10 +49,13 @@
   },
   "devDependencies": {
     "@forinda/kickjs": "workspace:*",
+    "@socket.io/redis-adapter": "^8.3.0",
     "@swc/core": "^1.16.1",
     "@types/node": "^26.4.1",
     "@types/ws": "^8.18.0",
     "ioredis": "^5.10.1",
+    "socket.io": "^4.8.3",
+    "socket.io-client": "^4.8.3",
     "typescript": "^7.0.2",
     "vitest": "^5.0.0",
     "ws": "^8.21.3"
@@ -72,7 +79,12 @@
   },
   "peerDependencies": {
     "@forinda/kickjs": ">=5.18.0",
+    "socket.io": "^4.0.0",
     "ws": "^8.0.0"
   },
-  "peerDependenciesMeta": {}
+  "peerDependenciesMeta": {
+    "socket.io": {
+      "optional": true
+    }
+  }
 }

--- a/packages/ws/src/socket-io.ts
+++ b/packages/ws/src/socket-io.ts
@@ -1,0 +1,291 @@
+/**
+ * Socket.IO transport for the same `@WsController` classes {@link WsAdapter}
+ * serves. Pick it for what Socket.IO brings — client reconnection, long-polling
+ * fallback, acknowledgements — and scale it with Socket.IO's own adapters
+ * (`@socket.io/redis-adapter`) rather than a {@link WsBroker}.
+ *
+ * ```ts
+ * import { SocketIoAdapter } from '@forinda/kickjs-ws/socket.io'
+ *
+ * bootstrap({ modules, adapters: [SocketIoAdapter({ cors: { origin: 'https://app.example.com' } })] })
+ * ```
+ *
+ * @module @forinda/kickjs-ws/socket.io
+ */
+import type { IncomingMessage } from 'node:http'
+import { Server, type Namespace, type ServerOptions, type Socket } from 'socket.io'
+import {
+  createLogger,
+  createToken,
+  defineAdapter,
+  getClassMeta,
+  getClassMetaOrUndefined,
+} from '@forinda/kickjs'
+import {
+  WS_METADATA,
+  WS_USER_BROADCASTER,
+  wsControllerRegistry,
+  type WsAuthConfig,
+  type WsHandlerDefinition,
+  type WsUserBroadcaster,
+} from './interfaces'
+import { parseCookies } from './ws-context'
+
+const log = createLogger('SocketIoAdapter')
+
+/** Events held from a socket whose async `@OnConnect` has not settled. */
+const MAX_PENDING_BEFORE_CONNECT = 64
+
+/** DI token for the Socket.IO `Server`. */
+export const SOCKET_IO = createToken<Server>('kick/ws/SocketIo')
+
+/** Socket.IO server options (`cors`, `path`, `adapter`, …) plus the shared auth hook. */
+export interface SocketIoAdapterOptions extends Partial<ServerOptions> {
+  /**
+   * Same contract as {@link WsAdapterOptions.auth}, run as namespace
+   * middleware before the connection is accepted. A rejection reaches the
+   * client as a `connect_error` whose message is `Unauthorized`.
+   */
+  auth?: WsAuthConfig
+}
+
+/**
+ * What `@WsController` handlers receive under {@link SocketIoAdapter}. Mirrors
+ * `WsContext`, so a controller written against one runs on the other — with
+ * one difference: Socket.IO rooms belong to a namespace, where `ws` rooms are
+ * shared across namespaces.
+ */
+export class SocketIoContext {
+  /** Payload of the current event (set for `@OnMessage` handlers). */
+  data: any = null
+  /** Name of the current event (set for `@OnMessage` handlers). */
+  event = ''
+
+  private metadata = new Map<string, any>()
+
+  constructor(
+    readonly socket: Socket,
+    readonly server: Server,
+    /** The `@WsController` namespace, e.g. `/chat`. */
+    readonly namespace: string,
+  ) {}
+
+  get id(): string {
+    return this.socket.id
+  }
+
+  /** The handshake request — cookies, headers, query, client IP. */
+  get request(): IncomingMessage {
+    return this.socket.request
+  }
+
+  get cookies(): Record<string, string> {
+    return parseCookies(this.request.headers.cookie)
+  }
+
+  get<T = any>(key: string): T | undefined {
+    return this.metadata.get(key)
+  }
+
+  set(key: string, value: any): void {
+    this.metadata.set(key, value)
+  }
+
+  /** Emit to this socket. */
+  send(event: string, data: any): void {
+    this.socket.emit(event, data)
+  }
+
+  /** Emit to every socket in the namespace except this one. */
+  broadcast(event: string, data: any): void {
+    this.socket.broadcast.emit(event, data)
+  }
+
+  /** Emit to every socket in the namespace, this one included. */
+  broadcastAll(event: string, data: any): void {
+    this.socket.nsp.emit(event, data)
+  }
+
+  /** Join a room in this namespace. */
+  join(room: string): void {
+    void this.socket.join(room)
+  }
+
+  leave(room: string): void {
+    void this.socket.leave(room)
+  }
+
+  /** Rooms this socket joined, without Socket.IO's own per-socket room. */
+  rooms(): string[] {
+    return [...this.socket.rooms].filter((room) => room !== this.socket.id)
+  }
+
+  /** Emit to every socket in a room of this namespace, this one included. */
+  to(room: string): { send(event: string, data: any): void } {
+    return {
+      send: (event: string, data: any) => {
+        this.socket.nsp.to(room).emit(event, data)
+      },
+    }
+  }
+}
+
+/**
+ * Serves `@WsController` classes over Socket.IO. Namespaces map one-to-one
+ * (`@WsController('/chat')` → `io.of('/chat')`), `@OnMessage('send')` handles
+ * the client's `socket.emit('send', data)`, and `@OnMessage('*')` catches events
+ * no other handler claims.
+ *
+ * Registers {@link SOCKET_IO} and `WS_USER_BROADCASTER`. Not `WS_ROOM_MANAGER`:
+ * Socket.IO keeps its own rooms — reach them through `SOCKET_IO`.
+ */
+export const SocketIoAdapter = defineAdapter<SocketIoAdapterOptions>({
+  name: 'SocketIoAdapter',
+  build: ({ auth, ...serverOptions }) => {
+    const io = new Server(serverOptions)
+    const namespaces: Namespace[] = []
+    const userRoomPrefix = auth?.userRoomPrefix ?? 'user:'
+    const userRoom = (userId: string): string => userRoomPrefix + userId
+
+    const invoke = async (controller: any, method: string, ctx: SocketIoContext): Promise<void> => {
+      try {
+        await controller[method](ctx)
+      } catch (err) {
+        log.error({ err }, `Socket.IO handler error in ${method}`)
+      }
+    }
+    const invokeAll = (
+      controller: any,
+      handlers: WsHandlerDefinition[],
+      type: WsHandlerDefinition['type'],
+      ctx: SocketIoContext,
+    ): Promise<unknown> =>
+      Promise.all(
+        handlers.filter((h) => h.type === type).map((h) => invoke(controller, h.handlerName, ctx)),
+      )
+
+    // Socket.IO rooms are per namespace, so a user's sockets sit in `user:<id>`
+    // once per namespace they connected to. Emitting through each namespace
+    // also crosses instances when a Socket.IO adapter is configured.
+    const userBroadcaster: WsUserBroadcaster = {
+      roomFor: userRoom,
+      broadcastToUser: (userId, event, data) => {
+        for (const nsp of namespaces) nsp.to(userRoom(userId)).emit(event, data)
+      },
+      toUser: (userId) => ({
+        send: (event, data) => userBroadcaster.broadcastToUser(userId, event, data),
+      }),
+    }
+
+    const handleConnection = (
+      socket: Socket,
+      namespace: string,
+      handlers: WsHandlerDefinition[],
+      controller: any,
+    ): void => {
+      const ctx = new SocketIoContext(socket, io, namespace)
+      const user = socket.data.user
+      if (user) {
+        ctx.set('user', user)
+        ctx.set('userId', user.id)
+        if (auth?.autoJoinUserRoom !== false) ctx.join(userRoom(user.id))
+      }
+
+      const dispatch = (event: string, data: unknown): void => {
+        const handler =
+          handlers.find((h) => h.type === 'message' && h.event === event) ??
+          handlers.find((h) => h.type === 'message' && h.event === '*')
+        if (!handler) return
+        ctx.event = event
+        ctx.data = data
+        void invoke(controller, handler.handlerName, ctx)
+      }
+
+      // Listeners go on now — Socket.IO drops events nobody listens for — but
+      // events are held until every @OnConnect settles, so handlers never see a
+      // socket whose connect setup is unfinished. Same rule as WsAdapter.
+      let ready = false
+      const pending: Array<[string, unknown]> = []
+      socket.onAny((event: string, data: unknown) => {
+        if (ready) return dispatch(event, data)
+        if (pending.length >= MAX_PENDING_BEFORE_CONNECT) {
+          pending.length = 0
+          socket.disconnect(true)
+          return
+        }
+        pending.push([event, data])
+      })
+
+      socket.on('disconnect', () => {
+        pending.length = 0
+        void invokeAll(controller, handlers, 'disconnect', ctx)
+      })
+      socket.on('error', (err: Error) => {
+        ctx.data = { message: err.message, name: err.name }
+        void invokeAll(controller, handlers, 'error', ctx)
+      })
+
+      void invokeAll(controller, handlers, 'connect', ctx).then(() => {
+        if (!socket.connected) return
+        ready = true
+        for (const [event, data] of pending.splice(0)) dispatch(event, data)
+      })
+    }
+
+    return {
+      beforeStart({ container }) {
+        container.registerInstance(SOCKET_IO, io)
+        container.registerInstance(WS_USER_BROADCASTER, userBroadcaster)
+
+        for (const controllerClass of wsControllerRegistry) {
+          const namespace = getClassMetaOrUndefined<string>(
+            WS_METADATA.WS_CONTROLLER,
+            controllerClass,
+          )
+          if (namespace === undefined) continue
+          const handlers = getClassMeta<WsHandlerDefinition[]>(
+            WS_METADATA.WS_HANDLERS,
+            controllerClass,
+            [],
+          )
+
+          const nsp = io.of(namespace)
+          namespaces.push(nsp)
+
+          if (auth) {
+            nsp.use(async (socket, next) => {
+              try {
+                const resolved = await auth.resolveUser(socket.request)
+                if (!resolved?.id) return next(new Error('Unauthorized'))
+                socket.data.user = resolved
+                next()
+              } catch {
+                next(new Error('Unauthorized'))
+              }
+            })
+          }
+
+          nsp.on('connection', (socket) =>
+            handleConnection(socket, namespace, handlers, container.resolve(controllerClass)),
+          )
+          log.info(`Registered Socket.IO namespace: ${namespace} (${controllerClass.name})`)
+        }
+      },
+
+      afterStart({ server }) {
+        if (server) io.attach(server)
+      },
+
+      async shutdown() {
+        // Not io.close(): it also closes the HTTP server, which KickJS owns.
+        await Promise.allSettled(
+          namespaces.map(async (nsp) => {
+            nsp.disconnectSockets(true)
+            await nsp.adapter.close()
+          }),
+        )
+        io.engine?.close()
+      },
+    }
+  },
+})

--- a/packages/ws/src/ws-context.ts
+++ b/packages/ws/src/ws-context.ts
@@ -2,6 +2,20 @@ import type { IncomingMessage } from 'node:http'
 import type { WebSocket, WebSocketServer } from 'ws'
 import type { RoomManager } from './room-manager'
 
+/** Raw `Cookie` header parse, shared by the ws and Socket.IO contexts. */
+export function parseCookies(header: string | undefined): Record<string, string> {
+  if (!header) return {}
+  const out: Record<string, string> = {}
+  for (const part of header.split(';')) {
+    const idx = part.indexOf('=')
+    if (idx === -1) continue
+    const k = part.slice(0, idx).trim()
+    const v = part.slice(idx + 1).trim()
+    if (k) out[k] = decodeURIComponent(v)
+  }
+  return out
+}
+
 /**
  * Context object passed to WebSocket handler methods.
  * Analogous to RequestContext for HTTP controllers.
@@ -60,17 +74,7 @@ export class WsContext {
 
   /** Parsed cookies from the upgrade request (raw `Cookie` header parse). */
   get cookies(): Record<string, string> {
-    const header = this.request.headers.cookie
-    if (!header) return {}
-    const out: Record<string, string> = {}
-    for (const part of header.split(';')) {
-      const idx = part.indexOf('=')
-      if (idx === -1) continue
-      const k = part.slice(0, idx).trim()
-      const v = part.slice(idx + 1).trim()
-      if (k) out[k] = decodeURIComponent(v)
-    }
-    return out
+    return parseCookies(this.request.headers.cookie)
   }
 
   /** Get a metadata value */

--- a/packages/ws/tsdown.config.ts
+++ b/packages/ws/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
     redis: 'src/redis.ts',
+    'socket-io': 'src/socket-io.ts',
   },
   format: ['esm'],
   platform: 'node',
@@ -16,6 +17,7 @@ export default defineConfig({
     '@forinda/kickjs',
     'reflect-metadata',
     'ws',
+    'socket.io',
     /^node:/,
   ],
   banner: { js: createBanner(pkg.name, pkg.version) },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,6 +686,9 @@ importers:
       '@forinda/kickjs':
         specifier: workspace:*
         version: link:../kickjs
+      '@socket.io/redis-adapter':
+        specifier: ^8.3.0
+        version: 8.3.0(socket.io-adapter@2.5.8)
       '@swc/core':
         specifier: ^1.16.1
         version: 1.16.1
@@ -698,6 +701,12 @@ importers:
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
+      socket.io:
+        specifier: ^4.8.3
+        version: 4.8.3
+      socket.io-client:
+        specifier: ^4.8.3
+        version: 4.8.3
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -2365,6 +2374,15 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
+  '@socket.io/redis-adapter@8.3.0':
+    resolution: {integrity: sha512-ly0cra+48hDmChxmIpnESKrc94LjRL80TEmZVscuQ/WWkRP81nNj8W8cCGMqbI4L6NCuAaPRSzZF1a9GlAxxnA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      socket.io-adapter: ^2.5.4
+
   '@swc/core-darwin-arm64@1.16.1':
     resolution: {integrity: sha512-zlJblJ8ncErD43lKdxjbUaUskJQf+LxiPXYcWXD8/8ZMV+7uuAT+CwjciLXpyZBd5Pq/S726bMpeeAwSeL1hhg==}
     engines: {node: '>=10'}
@@ -2604,6 +2622,9 @@ packages:
 
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -3087,6 +3108,10 @@ packages:
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -3235,6 +3260,10 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  base64id@2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
 
   baseline-browser-mapping@2.10.32:
     resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
@@ -3472,6 +3501,15 @@ packages:
   dataloader@2.2.3:
     resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
 
+  debug@4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -3573,6 +3611,17 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  engine.io-client@6.6.6:
+    resolution: {integrity: sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==}
+
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
+  engine.io@6.6.10:
+    resolution: {integrity: sha512-9/lX2bdlizlCXMHRMOIm03VBQHQYC7VvydcxtTAUJRxNW1QzM/2PMFSmr6h/lCiMHcyCP6abK+t9Q+j4vekk8Q==}
+    engines: {node: '>=10.2.0'}
 
   enhanced-resolve@5.24.3:
     resolution: {integrity: sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==}
@@ -4389,6 +4438,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -4427,6 +4480,9 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  notepack.io@3.0.1:
+    resolution: {integrity: sha512-TKC/8zH5pXIAMVQio2TvVDTtPRX+DJPHDqjRbxogtFiByHyzKmy96RA0JtCQJ+WouyyL4A10xomQzgbUT+1jCg==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -4918,6 +4974,21 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  socket.io-adapter@2.5.8:
+    resolution: {integrity: sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==}
+
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io@4.8.3:
+    resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
+    engines: {node: '>=10.2.0'}
+
   solid-js@1.9.15:
     resolution: {integrity: sha512-EeiY2xfpZJqPLjXspVEKjAII4yv8NyG//NxZ3IpOFHdUNnnTyL0uJOeS9LWGvA7cFCz5y94cjFwYlmw5Luncsg==}
 
@@ -5192,6 +5263,10 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  uid2@1.0.0:
+    resolution: {integrity: sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ==}
+    engines: {node: '>= 4.0.0'}
 
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
@@ -5514,6 +5589,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -6920,6 +6999,17 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@socket.io/component-emitter@3.1.2': {}
+
+  '@socket.io/redis-adapter@8.3.0(socket.io-adapter@2.5.8)':
+    dependencies:
+      debug: 4.3.7
+      notepack.io: 3.0.1
+      socket.io-adapter: 2.5.8
+      uid2: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@swc/core-darwin-arm64@1.16.1':
     optional: true
 
@@ -7120,6 +7210,10 @@ snapshots:
       '@types/node': 26.4.1
 
   '@types/cookiejar@2.1.5': {}
+
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 26.4.1
 
   '@types/deep-eql@4.0.2': {}
 
@@ -7521,6 +7615,11 @@ snapshots:
 
   abstract-logging@2.0.1: {}
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -7691,6 +7790,8 @@ snapshots:
       bare-path: 3.1.1
 
   base64-js@1.5.1: {}
+
+  base64id@2.0.0: {}
 
   baseline-browser-mapping@2.10.32: {}
 
@@ -7927,6 +8028,10 @@ snapshots:
 
   dataloader@2.2.3: {}
 
+  debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -8009,6 +8114,36 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  engine.io-client@6.6.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.21.3
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  engine.io-parser@5.2.3: {}
+
+  engine.io@6.6.10:
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/node': 26.4.1
+      '@types/ws': 8.18.1
+      accepts: 1.3.8
+      cookie: 0.7.2
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   enhanced-resolve@5.24.3:
     dependencies:
@@ -8829,6 +8964,8 @@ snapshots:
 
   nanoid@3.3.18: {}
 
+  negotiator@0.6.3: {}
+
   negotiator@1.0.0: {}
 
   node-abort-controller@3.1.1: {}
@@ -8851,6 +8988,8 @@ snapshots:
   node-releases@2.0.53: {}
 
   normalize-path@3.0.0: {}
+
+  notepack.io@3.0.1: {}
 
   object-assign@4.1.1: {}
 
@@ -9473,6 +9612,47 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  socket.io-adapter@2.5.8:
+    dependencies:
+      debug: 4.4.3
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-client@4.8.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-client: 6.6.6
+      socket.io-parser: 4.2.7
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.7:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  socket.io@4.8.3:
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io: 6.6.10
+      socket.io-adapter: 2.5.8
+      socket.io-parser: 4.2.7
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   solid-js@1.9.15:
     dependencies:
       csstype: 3.2.3
@@ -9809,6 +9989,8 @@ snapshots:
 
   ufo@1.6.4: {}
 
+  uid2@1.0.0: {}
+
   unconfig-core@7.5.0:
     dependencies:
       '@quansync/fs': 1.0.0
@@ -10072,6 +10254,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.3: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
> Stacked on #692 (`feat/ws-redis-broker`). GitHub retargets this to `main` once #692 merges.

## Why

Choosing Socket.IO meant leaving the decorators behind: the guide had users hand-write an adapter and wire `io.of()` handlers themselves. Transport should be a choice at bootstrap, like picking a schema library, not a rewrite of every controller.

## What

```ts
import { SocketIoAdapter } from '@forinda/kickjs-ws/socket.io'

bootstrap({ modules, adapters: [SocketIoAdapter({ cors: { origin: 'https://app.example.com' } })] })
```

| KickJS | Socket.IO |
| --- | --- |
| `@WsController('/chat')` | `io.of('/chat')` |
| `@OnMessage('send')` / `'*'` | client `socket.emit('send', data)` / unclaimed events |
| `ctx.send` | `socket.emit` |
| `ctx.broadcast` / `broadcastAll` | `socket.broadcast.emit` / `socket.nsp.emit` |
| `ctx.join` / `ctx.to(room).send` | `socket.join` / `socket.nsp.to(room).emit` |

- **`SocketIoContext`** mirrors `WsContext` — one controller runs on either transport.
- **Auth:** same `resolveUser` hook, as namespace middleware; rejection → `connect_error` `Unauthorized`; sockets join `user:<id>`.
- **DI:** `SOCKET_IO` (the `Server`) and `WS_USER_BROADCASTER` (emits to the user room in every namespace). Services on `WS_USER_BROADCASTER` don't change when switching transport.
- **Async `@OnConnect`** awaited before events are delivered (hold capped at 64), matching `WsAdapter`.
- **Scaling:** every Socket.IO server option passes through, including `adapter` — `@socket.io/redis-adapter` makes emits and per-user sends cross instances.
- **Shutdown** doesn't call `io.close()`, which would close KickJS's HTTP server.
- `socket.io` is an **optional peer**. `parseCookies` is shared between the two contexts.

### Differences from `WsAdapter` (documented)

- rooms are per namespace (ws rooms are global)
- no `WS_ROOM_MANAGER` — use `SOCKET_IO`
- acknowledgements not mapped — use `ctx.socket`
- polling fallback needs sticky sessions (or `transports: ['websocket']`)

## Docs

`docs/guide/socketio.md` rewritten around the adapter: setup, mapping, differences, auth, services, multi-instance, client, ws-vs-Socket.IO table. Tip in the WebSockets guide, section in the ws README.

## Tests

Real `socket.io-client` connections against a real HTTP server:
- routing + catch-all, `to(room)` / `broadcast` / `broadcastAll` sender semantics
- events held until async `@OnConnect` settles
- auth rejection → `connect_error` `Unauthorized`, `@OnConnect` not run
- `WS_USER_BROADCASTER` reaches the user in two namespaces, not other users
- `SOCKET_IO` registered; shutdown leaves the HTTP server listening
- **cross-instance** room and per-user delivery via `@socket.io/redis-adapter` when `REDIS_URL` is set — passed locally against `redis:6.2`, skipped in CI

Sabotage: removing the connect hold or emitting the user broadcast in only one namespace fails the matching test. A `destroyUpgrade: false` override was dropped after sabotage showed its test couldn't fail — engine.io only ends upgrades nothing has written to.

ws 33/33, typecheck (src + tests), oxlint, format, docs build clean. Changeset: `@forinda/kickjs-ws` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wf3GNMSJUfME42a93d5j6
