### PR TITLE
feat(ws): add @forinda/kickjs-ws/centrifugo

### DIFF
--- a/.changeset/calm-hubs-centrifugo.md
+++ b/.changeset/calm-hubs-centrifugo.md
@@ -1,0 +1,22 @@
+---
+'@forinda/kickjs-ws': minor
+---
+
+Add `@forinda/kickjs-ws/centrifugo` for apps that hand client connections to
+[Centrifugo](https://centrifugal.dev) instead of holding them in Node.
+
+- `centrifugoClient({ url, apiKey })` — `publish`, `broadcast`, `subscribe`,
+  `disconnect` over Centrifugo's server API. Throws `CentrifugoApiError` on a
+  non-2xx reply or on the `error` object Centrifugo returns with HTTP 200.
+- `connectionToken({ secret, sub, expiresInSeconds, info, channels })` — an
+  HS256 connection JWT signed with `node:crypto`; no JWT dependency.
+- `centrifugoConnect(request, resolveUser)` — the reply body for Centrifugo's
+  connect proxy, from the same `resolveUser` a `WsAdapter` uses: a user
+  connects, `null` disconnects with `4401`, a throwing resolver answers
+  internal error `100`.
+- `CentrifugoAdapter({ url, apiKey, personalChannelNamespace? })` — registers
+  the `CENTRIFUGO` client and a `WS_USER_BROADCASTER` that publishes to the
+  user's personal channel (`#<user>`), so services written against
+  `WsAdapter`'s broadcaster keep working unchanged.
+
+`@WsController` / `@OnMessage` do not apply: Centrifugo owns the sockets.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -52,6 +52,7 @@ const guideSidebar = [
       { text: 'Configuration', link: '/guide/configuration' },
       { text: 'WebSockets', link: '/guide/websockets' },
       { text: 'Socket.IO', link: '/guide/socketio' },
+      { text: 'Centrifugo', link: '/guide/centrifugo' },
       { text: 'Server-Sent Events', link: '/guide/sse' },
       { text: 'GraphQL (BYO adapter)', link: '/guide/graphql' },
       { text: 'gRPC / Connect RPC', link: '/guide/grpc' },

--- a/docs/guide/centrifugo.md
+++ b/docs/guide/centrifugo.md
@@ -1,0 +1,184 @@
+# Centrifugo
+
+[Centrifugo](https://centrifugal.dev) is a standalone real-time server. Clients connect to it, not to your Node process; your KickJS app authenticates those connections and publishes through Centrifugo's server API. `@forinda/kickjs-ws/centrifugo` covers the KickJS side.
+
+## When to choose it
+
+|                                          | `WsAdapter` + Redis broker | Centrifugo                                                      |
+| ---------------------------------------- | -------------------------- | --------------------------------------------------------------- |
+| Who holds the sockets                    | Your Node instances        | Centrifugo (Go)                                                 |
+| Client → server messages                 | `@OnMessage` handlers      | Your HTTP routes, or Centrifugo's RPC/publish proxies           |
+| Extra infrastructure                     | Redis                      | Centrifugo (plus its own Redis/NATS when you run several nodes) |
+| History, presence, recovery on reconnect | Build it yourself          | Built in                                                        |
+
+Start with [`WsAdapter`](./websockets.md) — it keeps handlers in your code and scales out with a [broker](./websockets.md#scaling-across-instances). Move to Centrifugo when connection count or delivery features outgrow what you want to run in Node.
+
+## What does not carry over
+
+Centrifugo owns the connections, so nothing that acts on a socket applies: `@WsController`, `@OnConnect`, `@OnMessage`, `@OnDisconnect`, `WsContext`, rooms (`ctx.join`, `ctx.to`) and `WS_ROOM_MANAGER`. Channels replace rooms; clients subscribe to them, or you subscribe users server-side with `subscribe(user, channel)`.
+
+`WS_USER_BROADCASTER` does carry over — see [Publishing from services](#publishing-from-services).
+
+## Centrifugo config
+
+Keys as Centrifugo v6 reads them (`config.json`, or `CENTRIFUGO_`-prefixed environment variables such as `CENTRIFUGO_HTTP_API_KEY`):
+
+```json
+{
+  "http_api": { "key": "<api key>" },
+  "client": {
+    "allowed_origins": ["https://app.example.com"],
+    "token": { "hmac_secret_key": "<hmac secret>" },
+    "subscribe_to_user_personal_channel": { "enabled": true },
+    "proxy": {
+      "connect": {
+        "enabled": true,
+        "endpoint": "http://api:3000/centrifugo/connect",
+        "http_headers": ["Cookie"]
+      }
+    }
+  },
+  "channel": {
+    "without_namespace": { "allow_subscribe_for_client": true }
+  }
+}
+```
+
+- `http_api.key` — what `CentrifugoAdapter` sends as `X-API-Key`.
+- `client.token.hmac_secret_key` — what `connectionToken` signs with. Needed only for the token flow.
+- `client.proxy.connect` — needed only for the proxy flow. Centrifugo forwards **only** the headers listed in `http_headers`; without `Cookie` your resolver sees no session.
+- `client.subscribe_to_user_personal_channel` — subscribes each user to `#<user>` on connect, which is where `WS_USER_BROADCASTER` publishes.
+
+## Register the adapter
+
+```ts
+import { bootstrap } from '@forinda/kickjs'
+import { CentrifugoAdapter } from '@forinda/kickjs-ws/centrifugo'
+
+bootstrap({
+  modules,
+  adapters: [
+    CentrifugoAdapter({
+      url: process.env.CENTRIFUGO_URL!, // e.g. http://centrifugo:8000
+      apiKey: process.env.CENTRIFUGO_API_KEY!,
+    }),
+  ],
+})
+```
+
+If you set `client.subscribe_to_user_personal_channel.personal_channel_namespace`, pass the same value as `personalChannelNamespace` so the broadcaster publishes to `<namespace>:#<user>`.
+
+## Authenticating connections
+
+Pick one of two flows.
+
+### Connection token
+
+Your app signs a short-lived JWT; the client passes it to Centrifugo.
+
+```ts
+import { Controller, Get, type RequestContext } from '@forinda/kickjs'
+import { connectionToken } from '@forinda/kickjs-ws/centrifugo'
+
+@Controller()
+export class RealtimeController {
+  @Get('/token')
+  async token(ctx: RequestContext) {
+    const user = await sessions.fromRequest(ctx.req) // your session lookup
+    if (!user) return ctx.json({ error: 'unauthorized' }, 401)
+
+    ctx.json({
+      token: connectionToken({
+        secret: process.env.CENTRIFUGO_HMAC_SECRET!,
+        sub: user.id,
+        expiresInSeconds: 15 * 60,
+        info: { name: user.name }, // visible to others in presence
+      }),
+    })
+  }
+}
+```
+
+`connectionToken` signs HS256 with `node:crypto` and sets the `sub`, `exp`, `info` and `channels` claims Centrifugo reads.
+
+### Connect proxy
+
+Centrifugo calls your app on every connection and uses the reply. Reuse the `resolveUser` you would give `WsAdapter`:
+
+```ts
+import { Controller, Post, type RequestContext } from '@forinda/kickjs'
+import { centrifugoConnect } from '@forinda/kickjs-ws/centrifugo'
+
+// Mount under /centrifugo so the path matches client.proxy.connect.endpoint
+@Controller()
+export class CentrifugoProxyController {
+  @Post('/connect')
+  async connect(ctx: RequestContext) {
+    ctx.json(await centrifugoConnect(ctx.req, resolveUser))
+  }
+}
+
+// The same shape as WsAuthConfig.resolveUser
+async function resolveUser(req: { headers: Record<string, string | string[] | undefined> }) {
+  const sid = parseCookie(req.headers.cookie).sid
+  return sid ? await sessions.verify(sid) : null
+}
+```
+
+| `resolveUser`               | Reply                                                        | Client sees                                      |
+| --------------------------- | ------------------------------------------------------------ | ------------------------------------------------ |
+| returns `{ id }`            | `{ result: { user: id } }`                                   | connected as that user                           |
+| returns `null` (or no `id`) | `{ disconnect: { code: 4401, reason: 'unauthorized' } }`     | socket closed with `4401`                        |
+| throws                      | `{ error: { code: 100, message: 'internal server error' } }` | connect error (Centrifugo's internal error code) |
+
+The route must be reachable from Centrifugo, and exempt from `csrf()` if you use it — Centrifugo sends no CSRF token.
+
+## Publishing from services
+
+`CentrifugoAdapter` registers two tokens:
+
+```ts
+import { Inject, Service } from '@forinda/kickjs'
+import { WS_USER_BROADCASTER, type WsUserBroadcaster } from '@forinda/kickjs-ws'
+import { CENTRIFUGO, type CentrifugoClient } from '@forinda/kickjs-ws/centrifugo'
+
+@Service()
+export class OrderEvents {
+  constructor(
+    @Inject(CENTRIFUGO) private readonly centrifugo: CentrifugoClient,
+    @Inject(WS_USER_BROADCASTER) private readonly users: WsUserBroadcaster,
+  ) {}
+
+  async shipped(order: { id: string; userId: string }) {
+    await this.centrifugo.publish(`orders:${order.id}`, { status: 'shipped' })
+    this.users.toUser(order.userId).send('order:shipped', { id: order.id })
+  }
+}
+```
+
+- `CENTRIFUGO` — `publish(channel, data)`, `broadcast(channels, data)`, `subscribe(user, channel)`, `disconnect(user)`. Each returns a promise and throws `CentrifugoApiError` (with `method` and `code`) when Centrifugo rejects the call.
+- `WS_USER_BROADCASTER` — the same interface `WsAdapter` registers. It publishes `{ event, data }` to the user's personal channel. Code written against `WsAdapter` works unchanged; like `WsAdapter`'s broker relay, a failed publish is logged rather than thrown.
+
+## Client
+
+Use Centrifugo's client SDK:
+
+<PmCommand add="centrifuge" />
+
+```ts
+import { Centrifuge } from 'centrifuge'
+
+const centrifuge = new Centrifuge('wss://realtime.example.com/connection/websocket', {
+  // Token flow; omit for the connect proxy flow
+  getToken: async () => (await fetch('/token').then((r) => r.json())).token,
+})
+
+// Server-side subscriptions, including the personal channel
+centrifuge.on('publication', (ctx) => console.log(ctx.channel, ctx.data))
+
+const orders = centrifuge.newSubscription('orders:42')
+orders.on('publication', (ctx) => console.log(ctx.data))
+orders.subscribe()
+
+centrifuge.connect()
+```

--- a/docs/guide/websockets.md
+++ b/docs/guide/websockets.md
@@ -293,6 +293,8 @@ Things to know:
 
 See [Benchmarks → WebSockets](./benchmarks.md#websockets) for measured numbers with and without a broker.
 
+To take connections out of Node entirely, see [Centrifugo](./centrifugo.md): clients connect to Centrifugo, and your app issues tokens and publishes through its API. `WS_USER_BROADCASTER` keeps working; `@WsController` handlers do not apply.
+
 ## Limits
 
 Know these before you design around the adapter:

--- a/packages/ws/__tests__/centrifugo.test.ts
+++ b/packages/ws/__tests__/centrifugo.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Centrifugo integration: the server API client against a local fake of
+ * Centrifugo's HTTP API, the HS256 connection token, the connect-proxy reply,
+ * and the adapter's DI registrations. The last suite runs against a real
+ * Centrifugo when CENTRIFUGO_URL is set (see the suite for the config it expects).
+ *
+ * @module @forinda/kickjs-ws/__tests__/centrifugo.test
+ */
+import 'reflect-metadata'
+import http from 'node:http'
+import { createHmac } from 'node:crypto'
+import type { AddressInfo } from 'node:net'
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { WebSocket } from 'ws'
+import { Container } from '@forinda/kickjs'
+import { WS_USER_BROADCASTER } from '@forinda/kickjs-ws'
+import {
+  CENTRIFUGO,
+  CentrifugoAdapter,
+  CentrifugoApiError,
+  centrifugoClient,
+  centrifugoConnect,
+  connectionToken,
+} from '../src/centrifugo'
+
+const cleanups: Array<() => unknown> = []
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()!()
+})
+
+interface Call {
+  path: string
+  apiKey: string | undefined
+  body: any
+}
+
+/** Centrifugo's HTTP API shape: 200 + `result`, or 200 + `error` (its default error mode). */
+async function fakeCentrifugo() {
+  const calls: Call[] = []
+  const server = http.createServer((req, res) => {
+    let raw = ''
+    req.on('data', (c) => (raw += c))
+    req.on('end', () => {
+      const body = JSON.parse(raw)
+      calls.push({ path: req.url!, apiKey: req.headers['x-api-key'] as string, body })
+      if (body.channel === 'boom') {
+        res.writeHead(500).end()
+        return
+      }
+      res.setHeader('Content-Type', 'application/json')
+      res.end(
+        JSON.stringify(
+          body.channel === 'unknown'
+            ? { error: { code: 102, message: 'unknown channel' } }
+            : { result: {} },
+        ),
+      )
+    })
+  })
+  await new Promise<void>((resolve) => server.listen(0, resolve))
+  cleanups.push(() => server.close())
+  const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+  return { url, calls }
+}
+
+describe('centrifugoClient', () => {
+  it('posts each method to /api/<method> with X-API-Key and the documented body', async () => {
+    const { url, calls } = await fakeCentrifugo()
+    const client = centrifugoClient({ url: `${url}/`, apiKey: 'k1' })
+
+    await client.publish('news', { title: 'hi' })
+    await client.broadcast(['a', 'b'], 1)
+    await client.subscribe('alice', 'news')
+    await client.disconnect('alice')
+
+    expect(calls).toEqual([
+      { path: '/api/publish', apiKey: 'k1', body: { channel: 'news', data: { title: 'hi' } } },
+      { path: '/api/broadcast', apiKey: 'k1', body: { channels: ['a', 'b'], data: 1 } },
+      { path: '/api/subscribe', apiKey: 'k1', body: { user: 'alice', channel: 'news' } },
+      { path: '/api/disconnect', apiKey: 'k1', body: { user: 'alice' } },
+    ])
+  })
+
+  it('throws on an error object in a 200 reply', async () => {
+    const { url } = await fakeCentrifugo()
+    const err = await centrifugoClient({ url, apiKey: 'k' })
+      .publish('unknown', 1)
+      .catch((e) => e)
+    expect(err).toBeInstanceOf(CentrifugoApiError)
+    expect(err).toMatchObject({ method: 'publish', code: 102 })
+    expect(err.message).toContain('unknown channel')
+  })
+
+  it('throws on a non-2xx reply', async () => {
+    const { url } = await fakeCentrifugo()
+    await expect(centrifugoClient({ url, apiKey: 'k' }).publish('boom', 1)).rejects.toMatchObject({
+      code: 500,
+    })
+  })
+})
+
+describe('connectionToken', () => {
+  const decode = (part: string) => JSON.parse(Buffer.from(part, 'base64url').toString())
+
+  it('signs HS256 over header.payload with the secret and carries the claims', () => {
+    const token = connectionToken({
+      secret: 's3cret',
+      sub: 'alice',
+      expiresInSeconds: 60,
+      info: { name: 'Alice' },
+      channels: ['news'],
+    })
+    const [header, payload, signature] = token.split('.')
+
+    expect(decode(header)).toEqual({ alg: 'HS256', typ: 'JWT' })
+    const expected = createHmac('sha256', 's3cret')
+      .update(`${header}.${payload}`)
+      .digest('base64url')
+    expect(signature).toBe(expected)
+
+    const claims = decode(payload)
+    expect(claims).toMatchObject({ sub: 'alice', info: { name: 'Alice' }, channels: ['news'] })
+    const now = Math.floor(Date.now() / 1000)
+    expect(claims.exp).toBeGreaterThanOrEqual(now + 59)
+    expect(claims.exp).toBeLessThanOrEqual(now + 60)
+  })
+
+  it('omits exp when no lifetime is given', () => {
+    const [, payload] = connectionToken({ secret: 's', sub: 'u' }).split('.')
+    expect(decode(payload)).toEqual({ sub: 'u' })
+  })
+})
+
+describe('centrifugoConnect', () => {
+  it('returns the user id as a string', async () => {
+    await expect(centrifugoConnect({}, () => ({ id: 42 as unknown as string }))).resolves.toEqual({
+      result: { user: '42' },
+    })
+  })
+
+  it('disconnects with 4401 when there is no user', async () => {
+    const rejected = { disconnect: { code: 4401, reason: 'unauthorized' } }
+    await expect(centrifugoConnect({}, async () => null)).resolves.toEqual(rejected)
+    await expect(centrifugoConnect({}, () => ({ id: '' }))).resolves.toEqual(rejected)
+  })
+
+  it('answers internal error 100 when the resolver throws', async () => {
+    await expect(
+      centrifugoConnect({}, () => {
+        throw new Error('db down')
+      }),
+    ).resolves.toEqual({ error: { code: 100, message: 'internal server error' } })
+  })
+})
+
+describe('CentrifugoAdapter', () => {
+  beforeEach(() => Container.reset())
+
+  async function start(options: { personalChannelNamespace?: string } = {}) {
+    const { url, calls } = await fakeCentrifugo()
+    const adapter = CentrifugoAdapter({ url, apiKey: 'k', ...options }) as any
+    await adapter.beforeStart({ container: Container.getInstance() })
+    return { calls, container: Container.getInstance() }
+  }
+
+  it('registers CENTRIFUGO and a user broadcaster publishing to #<user>', async () => {
+    const { calls, container } = await start()
+    expect(typeof container.resolve(CENTRIFUGO).publish).toBe('function')
+
+    const users = container.resolve(WS_USER_BROADCASTER)
+    expect(users.roomFor('alice')).toBe('#alice')
+    users.toUser('alice').send('ping', 1)
+    await new Promise((r) => setTimeout(r, 50))
+    expect(calls).toEqual([
+      {
+        path: '/api/publish',
+        apiKey: 'k',
+        body: { channel: '#alice', data: { event: 'ping', data: 1 } },
+      },
+    ])
+  })
+
+  it('uses <namespace>:#<user> when a personal channel namespace is set', async () => {
+    const { container } = await start({ personalChannelNamespace: 'personal' })
+    expect(container.resolve(WS_USER_BROADCASTER).roomFor('alice')).toBe('personal:#alice')
+  })
+})
+
+/**
+ * Needs a Centrifugo v6 on CENTRIFUGO_URL reachable at 127.0.0.1 (e.g.
+ * `docker run --network host`) started with:
+ *   CENTRIFUGO_HTTP_API_KEY=api-key
+ *   CENTRIFUGO_CLIENT_TOKEN_HMAC_SECRET_KEY=hmac-secret
+ *   CENTRIFUGO_CLIENT_ALLOWED_ORIGINS=*
+ *   CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_ALLOW_SUBSCRIBE_FOR_CLIENT=true
+ *   CENTRIFUGO_CLIENT_SUBSCRIBE_TO_USER_PERSONAL_CHANNEL_ENABLED=true
+ *   CENTRIFUGO_CLIENT_PROXY_CONNECT_ENABLED=true
+ *   CENTRIFUGO_CLIENT_PROXY_CONNECT_ENDPOINT=http://127.0.0.1:4799/centrifugo/connect
+ *   CENTRIFUGO_CLIENT_PROXY_CONNECT_HTTP_HEADERS=Cookie
+ */
+const CENTRIFUGO_URL = process.env.CENTRIFUGO_URL
+describe.skipIf(!CENTRIFUGO_URL)('Centrifugo (real server)', () => {
+  const wsUrl = `${CENTRIFUGO_URL?.replace(/^http/, 'ws')}/connection/websocket`
+
+  /** A raw client speaking Centrifugo's JSON protocol: newline-delimited replies per frame. */
+  async function connect(command: object, headers: Record<string, string> = {}) {
+    const ws = new WebSocket(wsUrl, { headers })
+    cleanups.push(() => ws.terminate())
+    const replies: any[] = []
+    ws.on('message', (raw) => {
+      for (const line of String(raw).split('\n').filter(Boolean)) {
+        const reply = JSON.parse(line)
+        if (Object.keys(reply).length === 0) ws.send('{}') // ping → pong
+        else replies.push(reply)
+      }
+    })
+    const closed = new Promise<number>((resolve) => ws.once('close', resolve))
+    await new Promise((resolve, reject) => {
+      ws.once('open', resolve)
+      ws.once('error', reject)
+    })
+    ws.send(JSON.stringify({ id: 1, connect: command }))
+    return { ws, replies, closed }
+  }
+
+  async function waitFor(check: () => boolean, ms = 3000): Promise<void> {
+    const until = Date.now() + ms
+    while (!check()) {
+      if (Date.now() > until) throw new Error('condition not met in time')
+      await new Promise((r) => setTimeout(r, 20))
+    }
+  }
+
+  const client = () => centrifugoClient({ url: CENTRIFUGO_URL!, apiKey: 'api-key' })
+
+  it('accepts a connectionToken and delivers a publish to a subscribed channel', async () => {
+    const token = connectionToken({ secret: 'hmac-secret', sub: 'alice', expiresInSeconds: 60 })
+    const { ws, replies } = await connect({ token })
+    await waitFor(() => replies.some((r) => r.id === 1))
+    expect(replies.find((r) => r.id === 1)).toHaveProperty('connect')
+
+    ws.send(JSON.stringify({ id: 2, subscribe: { channel: 'news' } }))
+    await waitFor(() => replies.some((r) => r.id === 2))
+    await client().publish('news', { title: 'hello' })
+
+    await waitFor(() => replies.some((r) => r.push?.channel === 'news'))
+    expect(replies.find((r) => r.push?.channel === 'news').push.pub.data).toEqual({
+      title: 'hello',
+    })
+  })
+
+  it('rejects a token signed with the wrong secret', async () => {
+    const token = connectionToken({ secret: 'wrong', sub: 'alice' })
+    const { replies, closed } = await connect({ token })
+    const outcome = await Promise.race([
+      closed.then((code) => ({ code })),
+      waitFor(() => replies.some((r) => r.id === 1)).then(() => replies.find((r) => r.id === 1)),
+    ])
+    expect(outcome).not.toHaveProperty('connect')
+  })
+
+  it('WS_USER_BROADCASTER reaches the user on their personal channel', async () => {
+    Container.reset()
+    const adapter = CentrifugoAdapter({ url: CENTRIFUGO_URL!, apiKey: 'api-key' }) as any
+    await adapter.beforeStart({ container: Container.getInstance() })
+
+    const token = connectionToken({ secret: 'hmac-secret', sub: 'bob', expiresInSeconds: 60 })
+    const { replies } = await connect({ token })
+    await waitFor(() => replies.some((r) => r.id === 1))
+
+    Container.getInstance().resolve(WS_USER_BROADCASTER).broadcastToUser('bob', 'ping', 7)
+    await waitFor(() => replies.some((r) => r.push?.channel === '#bob'))
+    expect(replies.find((r) => r.push?.channel === '#bob').push.pub.data).toEqual({
+      event: 'ping',
+      data: 7,
+    })
+  })
+
+  describe('connect proxy', () => {
+    beforeEach(async () => {
+      // The route an app would mount: forward the proxy body's request to
+      // centrifugoConnect with the app's resolveUser.
+      const server = http.createServer(async (req, res) => {
+        req.resume()
+        const reply = await centrifugoConnect(req, (r) => {
+          const sid = /sid=(\w+)/.exec(r.headers.cookie ?? '')?.[1]
+          return sid ? { id: sid } : null
+        })
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify(reply))
+      })
+      await new Promise<void>((resolve) => server.listen(4799, '127.0.0.1', resolve))
+      cleanups.push(() => server.close())
+    })
+
+    it('connects the user resolveUser returns, from the forwarded cookie', async () => {
+      const { replies } = await connect({}, { Cookie: 'sid=carol' })
+      await waitFor(() => replies.some((r) => r.id === 1))
+      expect(replies.find((r) => r.id === 1).connect).toBeDefined()
+    })
+
+    it('closes with 4401 when resolveUser returns null', async () => {
+      const { closed } = await connect({})
+      expect(await closed).toBe(4401)
+    })
+  })
+})

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -26,6 +26,10 @@
     "./redis": {
       "import": "./dist/redis.mjs",
       "types": "./dist/redis.d.mts"
+    },
+    "./centrifugo": {
+      "import": "./dist/centrifugo.mjs",
+      "types": "./dist/centrifugo.d.mts"
     }
   },
   "files": [

--- a/packages/ws/src/centrifugo.ts
+++ b/packages/ws/src/centrifugo.ts
@@ -1,0 +1,207 @@
+/**
+ * Centrifugo integration. Centrifugo holds the client connections; KickJS
+ * issues connection tokens (or answers its connect proxy) and publishes
+ * through its server API.
+ *
+ * ```ts
+ * import { CentrifugoAdapter } from '@forinda/kickjs-ws/centrifugo'
+ *
+ * bootstrap({
+ *   modules,
+ *   adapters: [CentrifugoAdapter({ url: 'http://centrifugo:8000', apiKey: process.env.CENTRIFUGO_API_KEY! })],
+ * })
+ * ```
+ *
+ * `@WsController` / `@OnMessage` do not apply here: those handle sockets the
+ * Node process owns, and with Centrifugo it owns none.
+ *
+ * @module @forinda/kickjs-ws/centrifugo
+ */
+import { createHmac } from 'node:crypto'
+import { createLogger, createToken, defineAdapter } from '@forinda/kickjs'
+import { WS_USER_BROADCASTER, type WsAuthenticatedUser, type WsUserBroadcaster } from './interfaces'
+
+const log = createLogger('CentrifugoAdapter')
+
+export interface CentrifugoClientOptions {
+  /** Centrifugo base URL, e.g. `http://centrifugo:8000`. The client calls `<url>/api/<method>`. */
+  url: string
+  /** `http_api.key` from the Centrifugo config, sent as `X-API-Key`. */
+  apiKey: string
+  /** Defaults to the global `fetch`. */
+  fetch?: typeof fetch
+}
+
+/** Centrifugo server API — the subset KickJS services need. */
+export interface CentrifugoClient {
+  /** Publish `data` (any JSON value) to one channel. */
+  publish(channel: string, data: unknown): Promise<void>
+  /** Publish the same `data` to several channels in one call. */
+  broadcast(channels: string[], data: unknown): Promise<void>
+  /** Subscribe every connection of `user` to `channel`, server-side. */
+  subscribe(user: string, channel: string): Promise<void>
+  /** Disconnect every connection of `user`. */
+  disconnect(user: string): Promise<void>
+}
+
+/** Thrown when Centrifugo answers non-2xx, or 200 with an `error` object. */
+export class CentrifugoApiError extends Error {
+  constructor(
+    readonly method: string,
+    readonly code: number,
+    message: string,
+  ) {
+    super(`Centrifugo ${method} failed (${code}): ${message}`)
+    this.name = 'CentrifugoApiError'
+  }
+}
+
+export function centrifugoClient({
+  url,
+  apiKey,
+  fetch: fetchImpl = globalThis.fetch,
+}: CentrifugoClientOptions): CentrifugoClient {
+  const base = url.replace(/\/+$/, '')
+
+  const call = async (method: string, body: Record<string, unknown>): Promise<void> => {
+    const res = await fetchImpl(`${base}/api/${method}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey },
+      body: JSON.stringify(body),
+    })
+    if (!res.ok) throw new CentrifugoApiError(method, res.status, res.statusText || 'HTTP error')
+    // By default Centrifugo reports API errors with HTTP 200 and an `error`
+    // object in the body (internal/api/handler_gen.go); only the opt-in
+    // transport error mode maps them to HTTP status codes.
+    const reply = (await res.json().catch(() => ({}))) as {
+      error?: { code: number; message: string }
+    }
+    if (reply.error) throw new CentrifugoApiError(method, reply.error.code, reply.error.message)
+  }
+
+  return {
+    publish: (channel, data) => call('publish', { channel, data }),
+    broadcast: (channels, data) => call('broadcast', { channels, data }),
+    subscribe: (user, channel) => call('subscribe', { user, channel }),
+    disconnect: (user) => call('disconnect', { user }),
+  }
+}
+
+export interface ConnectionTokenOptions {
+  /** `client.token.hmac_secret_key` from the Centrifugo config. */
+  secret: string
+  /** User id. An empty string connects anonymously, if Centrifugo allows it. */
+  sub: string
+  /** Token lifetime. Omit for a token that never expires. */
+  expiresInSeconds?: number
+  /** Connection info, visible to other clients in presence and join/leave events. */
+  info?: unknown
+  /** Channels to subscribe the connection to server-side. */
+  channels?: string[]
+}
+
+const base64url = (input: string | Buffer): string => Buffer.from(input).toString('base64url')
+
+/**
+ * An HS256 connection JWT. Claims follow Centrifugo's `ConnectTokenClaims`
+ * (internal/jwtverify/token_verifier_jwt.go): `sub`, `exp`, `info`, `channels`.
+ */
+export function connectionToken({
+  secret,
+  sub,
+  expiresInSeconds,
+  info,
+  channels,
+}: ConnectionTokenOptions): string {
+  const claims: Record<string, unknown> = { sub }
+  if (expiresInSeconds !== undefined) {
+    claims.exp = Math.floor(Date.now() / 1000) + expiresInSeconds
+  }
+  if (info !== undefined) claims.info = info
+  if (channels !== undefined) claims.channels = channels
+
+  const unsigned = `${base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))}.${base64url(JSON.stringify(claims))}`
+  const signature = createHmac('sha256', secret).update(unsigned).digest('base64url')
+  return `${unsigned}.${signature}`
+}
+
+/** Body a connect proxy endpoint returns (internal/proxyproto/proxy.proto `ConnectResponse`). */
+export type CentrifugoConnectReply =
+  | { result: { user: string } }
+  | { disconnect: { code: number; reason: string } }
+  | { error: { code: number; message: string } }
+
+/**
+ * Answer Centrifugo's connect proxy with the same `resolveUser` a `WsAdapter`
+ * uses. A user connects; `null` or a user without an id disconnects with
+ * `4401` (the code `WsAdapter` closes with); a throwing resolver answers
+ * error `100`, Centrifugo's internal error, so the client may retry.
+ *
+ * Centrifugo forwards only the headers listed in
+ * `client.proxy.connect.http_headers` — add `Cookie` or `Authorization` there,
+ * or `resolveUser` sees none.
+ */
+export async function centrifugoConnect<Req>(
+  request: Req,
+  resolveUser: (request: Req) => Promise<WsAuthenticatedUser | null> | WsAuthenticatedUser | null,
+): Promise<CentrifugoConnectReply> {
+  try {
+    const user = await resolveUser(request)
+    if (!user || !user.id) return { disconnect: { code: 4401, reason: 'unauthorized' } }
+    return { result: { user: String(user.id) } }
+  } catch (err) {
+    log.error({ err }, 'Centrifugo connect proxy: resolveUser threw')
+    return { error: { code: 100, message: 'internal server error' } }
+  }
+}
+
+/** DI token for the {@link CentrifugoClient} registered by {@link CentrifugoAdapter}. */
+export const CENTRIFUGO = createToken<CentrifugoClient>('kick/ws/Centrifugo')
+
+export interface CentrifugoAdapterOptions extends CentrifugoClientOptions {
+  /**
+   * `client.subscribe_to_user_personal_channel.personal_channel_namespace`.
+   * Leave unset when that option is unset: the personal channel is then
+   * `#<user>`, otherwise `<namespace>:#<user>` (internal/config/container.go).
+   */
+  personalChannelNamespace?: string
+}
+
+/**
+ * Registers {@link CENTRIFUGO} and a `WS_USER_BROADCASTER` that publishes to
+ * the user's personal channel, so services written against `WsAdapter`'s
+ * broadcaster keep working. Enable
+ * `client.subscribe_to_user_personal_channel` in Centrifugo so users are
+ * subscribed to that channel on connect.
+ */
+export const CentrifugoAdapter = defineAdapter<CentrifugoAdapterOptions>({
+  name: 'CentrifugoAdapter',
+  build: (options) => {
+    const client = centrifugoClient(options)
+    const roomFor = (userId: string): string =>
+      options.personalChannelNamespace
+        ? `${options.personalChannelNamespace}:#${userId}`
+        : `#${userId}`
+
+    // The broadcaster interface is synchronous; a failed publish is logged,
+    // matching how WsAdapter treats a broker outage.
+    const broadcastToUser = (userId: string, event: string, data: unknown): void => {
+      client
+        .publish(roomFor(userId), { event, data })
+        .catch((err) => log.error({ err }, 'Centrifugo publish failed'))
+    }
+
+    const broadcaster: WsUserBroadcaster = {
+      roomFor,
+      broadcastToUser,
+      toUser: (id) => ({ send: (event, data) => broadcastToUser(id, event, data) }),
+    }
+
+    return {
+      beforeStart({ container }) {
+        container.registerInstance(CENTRIFUGO, client)
+        container.registerInstance(WS_USER_BROADCASTER, broadcaster)
+      },
+    }
+  },
+})

--- a/packages/ws/tsdown.config.ts
+++ b/packages/ws/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
     redis: 'src/redis.ts',
+    centrifugo: 'src/centrifugo.ts',
   },
   format: ['esm'],
   platform: 'node',


### PR DESCRIPTION
## Why

`WsAdapter` + a broker (#692) scales sockets that live in Node. Some apps want the connections out of Node entirely — Centrifugo holds them and brings history, presence and recovery. This adds the KickJS side of that setup. Stacked on #692.

## What — `@forinda/kickjs-ws/centrifugo`

| Export | Does |
| --- | --- |
| `centrifugoClient({ url, apiKey, fetch? })` | `publish`, `broadcast`, `subscribe`, `disconnect` → `POST <url>/api/<method>` with `X-API-Key`. Throws `CentrifugoApiError` on non-2xx **and** on the `error` object Centrifugo returns with HTTP 200 by default. |
| `connectionToken({ secret, sub, expiresInSeconds?, info?, channels? })` | HS256 connection JWT via `node:crypto` — no JWT dependency. |
| `centrifugoConnect(request, resolveUser)` | Connect-proxy reply from the same `resolveUser` a `WsAdapter` takes: user → `result.user`; `null` → `disconnect 4401`; throw → `error 100`. Pure function called from the app's own route. |
| `CentrifugoAdapter({ url, apiKey, personalChannelNamespace? })` | Registers `CENTRIFUGO` (the client) and `WS_USER_BROADCASTER` publishing `{ event, data }` to `#<user>` (or `<ns>:#<user>`). Services written against `WsAdapter`'s broadcaster work unchanged. |

No runtime dependencies. `ws-adapter.ts` untouched. `@WsController` / `@OnMessage` / rooms do not apply — Centrifugo owns the sockets; the guide says so.

## Wire shapes, verified in Centrifugo v6 source

| Shape | Source |
| --- | --- |
| `/api/publish`, `/broadcast`, `/subscribe`, `/disconnect` routes | `internal/api/handler.go` |
| 200 + `{"error":{code,message}}` unless transport error mode | `internal/api/handler_gen.go`, `handler.go` (`X-Centrifugo-Error-Mode`) |
| `X-API-Key` (or `Authorization: apikey`) | `internal/middleware/auth.go` |
| request bodies (`channel`/`channels`/`user`, `data` raw JSON) | `internal/apiproto/api.proto`, `api.pb.go` |
| `ConnectResponse` `result` / `error` / `disconnect` | `internal/proxyproto/proxy.proto`, `internal/proxy/connect_handler.go` |
| token claims `sub`, `exp`, `info`, `channels` | `internal/jwtverify/token_verifier_jwt.go` |
| `client.token.hmac_secret_key`, `http_api.key`, `client.proxy.connect.{enabled,endpoint,http_headers}`, `client.subscribe_to_user_personal_channel`, `channel.without_namespace.allow_subscribe_for_client` | `internal/configtypes/types.go`, `namespace.go` |
| personal channel `#<user>` / `<ns>:#<user>` | `internal/config/container.go` |

## Docs

- new `docs/guide/centrifugo.md`: when to choose it vs `WsAdapter` + broker, what does not carry over, config with verified keys, token route, connect-proxy route, publishing via `CENTRIFUGO` / `WS_USER_BROADCASTER`, client SDK
- sidebar entry next to WebSockets / Socket.IO; pointer from websockets.md "Scaling across instances"

## Tests

- fake Centrifugo API over `node:http`: paths, `X-API-Key`, bodies, trailing-slash URL, 200-with-error and non-2xx
- token: HMAC recomputed over `header.payload`, claims, `exp` omitted when no lifetime
- connect proxy: user / `null` / missing id / throwing resolver
- adapter: `CENTRIFUGO` registered, broadcaster publishes to `#alice`, namespaced `personal:#alice`
- **real Centrifugo v6** (`centrifugo/centrifugo:v6`, gated on `CENTRIFUGO_URL`, skipped in CI) — passed locally: token connects and a publish reaches a subscribed channel; wrong-secret token rejected; `WS_USER_BROADCASTER` reaches `#bob` via personal-channel auto-subscribe; connect proxy connects a cookie user and closes `4401` without one
- sabotage: corrupting the signature fails 3 tests (unit + 2 e2e); changing the reject code fails 2 (unit + e2e)
- ws 33 passed / 8 skipped (Redis + Centrifugo suites without env), typecheck (src + tests), oxlint, format, docs build clean

Changeset: `@forinda/kickjs-ws` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wf3GNMSJUfME42a93d5j6
